### PR TITLE
feat(crouton-flow): add locked position support to prevent dagre overrides

### DIFF
--- a/packages/crouton-flow/app/components/Flow.vue
+++ b/packages/crouton-flow/app/components/Flow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, resolveComponent, watch, markRaw } from 'vue'
+import { computed, nextTick, provide, ref, resolveComponent, watch, markRaw } from 'vue'
 import { useThrottleFn } from '@vueuse/core'
 import { VueFlow, useVueFlow } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
@@ -147,6 +147,8 @@ const emit = defineEmits<{
   'update:rows': [rows: Record<string, unknown>[]]
   /** Emitted when selection changes (enables v-model:selected) */
   'update:selected': [selectedNodeIds: string[]]
+  /** Emitted when a node is unlocked (position lock removed) */
+  nodeUnlock: [nodeId: string]
 }>()
 
 // Validate props
@@ -412,9 +414,15 @@ const positionedNodes = computed(() => {
 // data has no position field. This cache preserves last known positions.
 // Seed from savedPositions so they survive data refreshes and dagre never overrides them.
 const positionCache = new Map<string, { x: number; y: number }>()
+
+// Locked node IDs: nodes with saved positions that dagre must never override.
+// Seeded from savedPositions; drag-stop also locks the node.
+const lockedNodeIds = ref<Set<string>>(new Set())
+
 if (props.savedPositions) {
   for (const [id, pos] of Object.entries(props.savedPositions)) {
     positionCache.set(id, { ...pos })
+    lockedNodeIds.value.add(id)
   }
 }
 
@@ -423,6 +431,7 @@ watch(() => props.savedPositions, (newPositions) => {
   if (!newPositions) return
   for (const [id, pos] of Object.entries(newPositions)) {
     positionCache.set(id, { ...pos })
+    lockedNodeIds.value.add(id)
   }
 }, { deep: true })
 
@@ -447,9 +456,10 @@ const initialLayoutApplied = ref(false)
 const layoutedNodes = computed(() => {
   const nodes = cachedNodes.value
   const edges = dataEdges.value
+  const locked = lockedNodeIds.value
 
   if (!initialLayoutApplied.value && needsLayout(nodes)) {
-    const result = applyLayout(nodes, edges)
+    const result = applyLayout(nodes, edges, locked)
     // Cache the layout positions
     for (const node of result) {
       if (node.position) positionCache.set(node.id, { ...node.position })
@@ -460,7 +470,7 @@ const layoutedNodes = computed(() => {
 
   // Check if any nodes are at (0,0) after initial layout — these are newly added nodes
   if (initialLayoutApplied.value && nodes.some(n => !n.position || (n.position.x === 0 && n.position.y === 0))) {
-    const result = applyLayoutToNew(nodes, edges)
+    const result = applyLayoutToNew(nodes, edges, locked)
     // Cache new positions
     for (const node of result) {
       if (node.position && !positionCache.has(node.id)) {
@@ -525,8 +535,8 @@ const finalNodes = computed(() => {
       const needsLayoutResult = needsLayout(nodes)
 
       if (needsLayoutResult && !layoutAppliedToYjs.value) {
-        // Initial layout — all nodes need positioning
-        const layoutedNodesResult = applyLayout(nodes, edges)
+        // Initial layout — all nodes need positioning (locked nodes keep theirs)
+        const layoutedNodesResult = applyLayout(nodes, edges, lockedNodeIds.value)
 
         nextTick(() => {
           for (const node of layoutedNodesResult) {
@@ -635,8 +645,9 @@ onNodeDragStop((event: NodeDragEvent) => {
     }
   }
 
-  // Update position cache so data refreshes don't reset this node
+  // Update position cache and lock the node so dagre never overrides it
   positionCache.set(node.id, { ...position })
+  lockedNodeIds.value.add(node.id)
 
   if (props.sync && syncState) {
     syncState.updatePosition(node.id, position)
@@ -717,10 +728,37 @@ const customNodeComponent = computed(() => {
   return null
 })
 
+// ============================================
+// LOCK / UNLOCK
+// ============================================
+
+/**
+ * Unlock a node: removes its saved position so dagre can re-layout it.
+ * Also removes the position from the position store (flow_configs).
+ */
+function unlockNode(nodeId: string) {
+  lockedNodeIds.value.delete(nodeId)
+  positionCache.delete(nodeId)
+  // Reset the node's position to (0,0) so the next layout pass picks it up
+  const node = findNode(nodeId)
+  if (node) {
+    node.position = { x: 0, y: 0 }
+  }
+  // Force a re-layout for the unlocked node
+  initialLayoutApplied.value = false
+  emit('nodeUnlock', nodeId)
+}
+
+// Provide lock state and unlock handler to child node components
+provide('croutonFlowLockedIds', lockedNodeIds)
+provide('croutonFlowUnlockNode', unlockNode)
+
 // Expose sync state and container detection for external access
 defineExpose({
   syncState,
   containerDetection,
+  lockedNodeIds,
+  unlockNode,
 })
 </script>
 

--- a/packages/crouton-flow/app/components/Node.vue
+++ b/packages/crouton-flow/app/components/Node.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, inject, ref } from 'vue'
+import type { Ref } from 'vue'
 import { Handle, Position } from '@vue-flow/core'
 
 /**
@@ -37,6 +38,12 @@ const { t } = useI18n()
 const { open } = useCrouton()
 const isHovered = ref(false)
 
+// Lock state — injected from parent CroutonFlow
+const lockedIds = inject<Ref<Set<string>>>('croutonFlowLockedIds', ref(new Set()))
+const unlockNode = inject<(id: string) => void>('croutonFlowUnlockNode', () => {})
+
+const isLocked = computed(() => lockedIds.value.has(nodeId.value))
+
 const nodeId = computed(() => String(props.data?.id || ''))
 
 function handleEdit(event: Event) {
@@ -50,6 +57,13 @@ function handleDelete(event: Event) {
   event.stopPropagation()
   if (props.collection && nodeId.value) {
     open('delete', props.collection, [nodeId.value])
+  }
+}
+
+function handleUnlock(event: Event) {
+  event.stopPropagation()
+  if (nodeId.value) {
+    unlockNode(nodeId.value)
   }
 }
 
@@ -92,11 +106,55 @@ const subtitle = computed(() => {
       class="crouton-flow-handle"
     />
 
+    <!-- Lock indicator (always visible when locked) -->
+    <div
+      v-if="isLocked"
+      class="crouton-flow-node__lock"
+      :title="$t('flow.node.locked', 'Position locked')"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="10"
+        height="10"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </svg>
+    </div>
+
     <!-- Action buttons (show on hover) -->
     <div
       v-if="collection && isHovered"
       class="crouton-flow-node__actions"
     >
+      <!-- Unlock button (only shown for locked nodes) -->
+      <button
+        v-if="isLocked"
+        class="crouton-flow-node__action crouton-flow-node__action--unlock"
+        :title="$t('flow.node.unlock', 'Unlock position')"
+        @click="handleUnlock"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+          <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+        </svg>
+      </button>
       <button
         class="crouton-flow-node__action crouton-flow-node__action--edit"
         :title="$t('flow.node.edit')"
@@ -214,6 +272,18 @@ const subtitle = computed(() => {
 .crouton-flow-node__action--delete {
   @apply text-red-600 dark:text-red-400;
   @apply hover:bg-red-50 dark:hover:bg-red-900/30;
+}
+
+.crouton-flow-node__action--unlock {
+  @apply text-amber-600 dark:text-amber-400;
+  @apply hover:bg-amber-50 dark:hover:bg-amber-900/30;
+}
+
+.crouton-flow-node__lock {
+  @apply absolute -top-1.5 -left-1.5 w-4 h-4 rounded-full flex items-center justify-center;
+  @apply bg-amber-100 dark:bg-amber-900/50 text-amber-600 dark:text-amber-400;
+  @apply border border-amber-300 dark:border-amber-700;
+  @apply z-10 pointer-events-none;
 }
 
 .crouton-flow-node__content {

--- a/packages/crouton-flow/app/composables/useFlowLayout.ts
+++ b/packages/crouton-flow/app/composables/useFlowLayout.ts
@@ -75,9 +75,15 @@ export function useFlowLayout(options: UseFlowLayoutOptions = {}) {
 
   /**
    * Apply dagre layout to nodes
-   * Returns new node array with updated positions
+   * Returns new node array with updated positions.
+   * Locked nodes (IDs in lockedIds) keep their existing position — dagre
+   * still includes them for edge routing, but the result is discarded.
+   *
+   * @param nodes - Current nodes
+   * @param edges - Current edges
+   * @param lockedIds - Set of node IDs whose positions must not be overridden
    */
-  const applyLayout = (nodes: Node[], edges: Edge[]): Node[] => {
+  const applyLayout = (nodes: Node[], edges: Edge[], lockedIds?: ReadonlySet<string>): Node[] => {
     if (nodes.length === 0) return []
 
     // Create a new dagre graph
@@ -112,6 +118,16 @@ export function useFlowLayout(options: UseFlowLayoutOptions = {}) {
 
     // Apply calculated positions back to nodes
     return nodes.map((node) => {
+      // Locked nodes keep their current position
+      if (lockedIds?.has(node.id)) {
+        return {
+          ...node,
+          _needsLayout: undefined,
+          targetPosition: isHorizontal ? 'left' : 'top',
+          sourcePosition: isHorizontal ? 'right' : 'bottom'
+        } as Node
+      }
+
       const nodeWithPosition = dagreGraph.node(node.id)
 
       if (!nodeWithPosition) {
@@ -137,11 +153,14 @@ export function useFlowLayout(options: UseFlowLayoutOptions = {}) {
   }
 
   /**
-   * Layout only nodes that need it, preserving existing positions
-   * This is useful when adding new nodes - we layout only the new ones
-   * and keep existing nodes where they are
+   * Layout only nodes that need it, preserving existing positions.
+   * Locked nodes are always preserved.
+   *
+   * @param nodes - Current nodes
+   * @param edges - Current edges
+   * @param lockedIds - Set of node IDs whose positions must not be overridden
    */
-  const applyLayoutToNew = (nodes: Node[], edges: Edge[]): Node[] => {
+  const applyLayoutToNew = (nodes: Node[], edges: Edge[], lockedIds?: ReadonlySet<string>): Node[] => {
     // Separate nodes that need layout from those that don't
     const nodesNeedingLayout: Node[] = []
     const positionedNodes: Node[] = []
@@ -149,8 +168,12 @@ export function useFlowLayout(options: UseFlowLayoutOptions = {}) {
     for (const node of nodes) {
       const needsLayoutFlag = (node as Node & { _needsLayout?: boolean })._needsLayout
       const isAtOrigin = !node.position || (node.position.x === 0 && node.position.y === 0)
+      const isLocked = lockedIds?.has(node.id)
 
-      if (needsLayoutFlag || isAtOrigin) {
+      // Locked nodes are always treated as positioned — dagre must not move them
+      if (isLocked) {
+        positionedNodes.push(node)
+      } else if (needsLayoutFlag || isAtOrigin) {
         nodesNeedingLayout.push(node)
       } else {
         positionedNodes.push(node)


### PR DESCRIPTION
## Summary

Nodes with saved positions are now considered "locked" — dagre never overrides their positions during layout passes. This preserves user-arranged node positions across data refreshes and re-layouts.

### Changes

**`useFlowLayout.ts`**
- `applyLayout()` and `applyLayoutToNew()` accept optional `lockedIds: ReadonlySet<string>` parameter
- Locked nodes are included in the dagre graph (for edge routing) but their computed positions are discarded
- `applyLayoutToNew` always treats locked nodes as "positioned"

**`Flow.vue`**
- New `lockedNodeIds` reactive Set, seeded from `savedPositions` prop
- Drag-stop adds the node to `lockedNodeIds`
- `unlockNode(id)` function: removes from lock set + position cache, resets position to (0,0), triggers re-layout
- `provide('croutonFlowLockedIds')` and `provide('croutonFlowUnlockNode')` for child components
- Exposed `lockedNodeIds` and `unlockNode` on component instance
- New `nodeUnlock` emit event

**`Node.vue`**
- Lock indicator: small amber badge (top-left) with lock icon, always visible on locked nodes
- Unlock action: amber unlock button in hover action menu, calls injected `unlockNode`
- Uses provide/inject pattern — custom node components can use the same injection keys