### PR TITLE
feat(thinkgraph): CI typecheck integration with ThinkGraph webhook

### DIFF
--- a/.github/workflows/thinkgraph-ci.yml
+++ b/.github/workflows/thinkgraph-ci.yml
@@ -1,0 +1,88 @@
+name: ThinkGraph CI Typecheck
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'apps/**'
+      - 'pnpm-lock.yaml'
+
+jobs:
+  typecheck:
+    name: Typecheck & Report to ThinkGraph
+    # Only run on thinkgraph/* branches (Pi agent PRs)
+    if: startsWith(github.head_ref, 'thinkgraph/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build MCP Server
+        run: pnpm --filter @fyit/crouton-mcp build
+
+      - name: Type check MCP Server
+        id: typecheck
+        continue-on-error: true
+        run: |
+          pnpm --filter @fyit/crouton-mcp typecheck 2>&1 | tee /tmp/typecheck-output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Report result to ThinkGraph
+        if: always() && steps.typecheck.outcome != 'skipped'
+        env:
+          THINKGRAPH_WEBHOOK_SECRET: ${{ secrets.THINKGRAPH_WEBHOOK_SECRET }}
+          THINKGRAPH_TEAM_ID: ${{ secrets.THINKGRAPH_TEAM_ID }}
+          THINKGRAPH_API_URL: ${{ secrets.THINKGRAPH_API_URL }}
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [ "${{ steps.typecheck.outcome }}" = "success" ]; then
+            STATUS="pass"
+            ERROR=""
+          else
+            STATUS="fail"
+            ERROR=$(cat /tmp/typecheck-output.txt | tail -200)
+          fi
+
+          # Only call webhook if secrets are configured
+          if [ -z "$THINKGRAPH_API_URL" ] || [ -z "$THINKGRAPH_TEAM_ID" ]; then
+            echo "ThinkGraph webhook not configured (missing THINKGRAPH_API_URL or THINKGRAPH_TEAM_ID). Skipping."
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg branch "$BRANCH" \
+            --arg status "$STATUS" \
+            --arg check "typecheck" \
+            --arg error "$ERROR" \
+            --arg runUrl "$RUN_URL" \
+            '{branch: $branch, status: $status, check: $check, error: $error, runUrl: $runUrl}')
+
+          echo "Sending CI result to ThinkGraph..."
+          echo "Branch: $BRANCH"
+          echo "Status: $STATUS"
+
+          curl -sf -X POST \
+            "${THINKGRAPH_API_URL}/api/teams/${THINKGRAPH_TEAM_ID}/dispatch/ci-webhook" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Secret: ${THINKGRAPH_WEBHOOK_SECRET}" \
+            -d "$PAYLOAD" \
+            && echo "Webhook sent successfully" \
+            || echo "Warning: Webhook call failed (non-critical)"
+
+      - name: Fail if typecheck failed
+        if: steps.typecheck.outcome == 'failure'
+        run: exit 1

--- a/apps/thinkgraph/server/api/teams/[id]/dispatch/ci-webhook.post.ts
+++ b/apps/thinkgraph/server/api/teams/[id]/dispatch/ci-webhook.post.ts
@@ -1,0 +1,158 @@
+import { eq, and } from 'drizzle-orm'
+import { updateThinkgraphWorkItem, createThinkgraphWorkItem } from '~~/layers/thinkgraph/collections/workitems/server/database/queries'
+import * as tables from '~~/layers/thinkgraph/collections/workitems/server/database/schema'
+
+/**
+ * CI Webhook for receiving typecheck/CI results from GitHub Actions.
+ *
+ * POST /api/teams/[id]/dispatch/ci-webhook
+ * Headers: X-Webhook-Secret: <shared secret>
+ * Body: {
+ *   branch: string,         // Git branch name (maps to workItem.worktree)
+ *   status: 'pass' | 'fail',
+ *   check: string,          // e.g. 'typecheck', 'lint', 'test'
+ *   error?: string,         // Error output if failed
+ *   runUrl?: string,        // GitHub Actions run URL
+ * }
+ *
+ * On pass: updates work item artifacts with { type: 'ci', check, status: 'pass' }
+ * On fail: creates a child work item with the error details
+ */
+export default defineEventHandler(async (event) => {
+  // Verify webhook secret
+  const config = useRuntimeConfig()
+  const expectedSecret = config.webhookSecret || config.public?.webhookSecret
+  if (expectedSecret) {
+    const providedSecret = getHeader(event, 'x-webhook-secret')
+    if (providedSecret !== expectedSecret) {
+      throw createError({ status: 401, statusText: 'Invalid webhook secret' })
+    }
+  }
+
+  const { id: teamId } = getRouterParams(event)
+  if (!teamId) {
+    throw createError({ status: 400, statusText: 'Missing team ID' })
+  }
+
+  const body = await readBody(event)
+  const { branch, status, check, error: errorOutput, runUrl } = body
+
+  if (!branch || !status || !check) {
+    throw createError({ status: 400, statusText: 'Missing required fields: branch, status, check' })
+  }
+
+  if (!['pass', 'fail'].includes(status)) {
+    throw createError({ status: 400, statusText: 'Status must be "pass" or "fail"' })
+  }
+
+  // Find work item by worktree (branch name)
+  const db = useDB()
+  const [workItem] = await (db as any)
+    .select()
+    .from(tables.thinkgraphWorkItems)
+    .where(
+      and(
+        eq(tables.thinkgraphWorkItems.teamId, teamId),
+        eq(tables.thinkgraphWorkItems.worktree, branch),
+      ),
+    )
+    .limit(1)
+
+  if (!workItem) {
+    // Not an error — branch may not be associated with a work item
+    return {
+      success: false,
+      message: `No work item found for branch "${branch}"`,
+    }
+  }
+
+  const ciArtifact = {
+    type: 'ci',
+    check,
+    status,
+    runUrl: runUrl || null,
+    timestamp: new Date().toISOString(),
+  }
+
+  if (status === 'pass') {
+    // Merge CI artifact into existing artifacts
+    const existingArtifacts = Array.isArray(workItem.artifacts)
+      ? workItem.artifacts
+      : (typeof workItem.artifacts === 'string' ? (() => { try { return JSON.parse(workItem.artifacts) } catch { return [] } })() : [])
+
+    // Remove previous CI artifacts for the same check, then add new one
+    const filteredArtifacts = existingArtifacts.filter(
+      (a: any) => !(a.type === 'ci' && a.check === check),
+    )
+    filteredArtifacts.push(ciArtifact)
+
+    await updateThinkgraphWorkItem(
+      workItem.id,
+      teamId,
+      'system',
+      { artifacts: filteredArtifacts },
+      { role: 'admin' },
+    )
+
+    return {
+      success: true,
+      workItemId: workItem.id,
+      action: 'artifact_updated',
+      artifact: ciArtifact,
+    }
+  }
+  else {
+    // status === 'fail' — create a child work item with the error
+    const truncatedError = errorOutput
+      ? (errorOutput.length > 4000 ? errorOutput.slice(-4000) : errorOutput)
+      : 'Typecheck failed (no error output captured)'
+
+    const childWorkItem = await createThinkgraphWorkItem({
+      id: crypto.randomUUID().replace(/-/g, '').slice(0, 21),
+      teamId,
+      projectId: workItem.projectId,
+      parentId: workItem.id,
+      title: `CI ${check} failed on branch ${branch}`,
+      type: 'fix',
+      status: 'queued',
+      assignee: workItem.assignee || 'pi',
+      brief: `The \`${check}\` CI check failed on branch \`${branch}\`.\n\n**Run URL:** ${runUrl || 'N/A'}\n\n**Error output:**\n\`\`\`\n${truncatedError}\n\`\`\`\n\nFix the errors and push to the branch.`,
+      output: null,
+      worktree: branch,
+      skill: 'generate',
+      artifacts: JSON.stringify([ciArtifact]),
+      path: `${workItem.path}`,
+      depth: (workItem.depth || 0) + 1,
+      order: Date.now(),
+      owner: workItem.owner,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as any)
+
+    // Also update the parent's artifacts with the failure
+    const existingArtifacts = Array.isArray(workItem.artifacts)
+      ? workItem.artifacts
+      : (typeof workItem.artifacts === 'string' ? (() => { try { return JSON.parse(workItem.artifacts) } catch { return [] } })() : [])
+
+    const filteredArtifacts = existingArtifacts.filter(
+      (a: any) => !(a.type === 'ci' && a.check === check),
+    )
+    filteredArtifacts.push(ciArtifact)
+
+    await updateThinkgraphWorkItem(
+      workItem.id,
+      teamId,
+      'system',
+      { artifacts: filteredArtifacts },
+      { role: 'admin' },
+    )
+
+    return {
+      success: true,
+      workItemId: workItem.id,
+      action: 'child_created',
+      childWorkItemId: childWorkItem.id,
+      artifact: ciArtifact,
+    }
+  }
+})


### PR DESCRIPTION
## What

Adds a GitHub Action + webhook endpoint that integrates CI typecheck results with ThinkGraph work items.

## How it works

1. **GitHub Action** (`.github/workflows/thinkgraph-ci.yml`):
   - Triggers on PRs to `main` from `thinkgraph/*` branches (Pi agent PRs)
   - Runs `pnpm typecheck` (MCP server build + typecheck)
   - Sends result to ThinkGraph via the CI webhook

2. **CI Webhook** (`/api/teams/[id]/dispatch/ci-webhook`):
   - Receives `{ branch, status, check, error?, runUrl? }`
   - Looks up the work item by matching `worktree` field to branch name
   - **On pass**: Updates work item artifacts with `{ type: 'ci', check: 'typecheck', status: 'pass' }`
   - **On fail**: Creates a child work item with error details (type: 'fix', assignee: 'pi') AND updates parent artifacts with failure status

## Required GitHub Secrets

- `THINKGRAPH_API_URL` — Base URL of ThinkGraph app (e.g., `https://thinkgraph.pages.dev`)
- `THINKGRAPH_TEAM_ID` — Team ID for the webhook call
- `THINKGRAPH_WEBHOOK_SECRET` — Shared secret (same as existing `webhookSecret` runtime config)

## Files changed

- `.github/workflows/thinkgraph-ci.yml` — New workflow
- `apps/thinkgraph/server/api/teams/[id]/dispatch/ci-webhook.post.ts` — New webhook endpoint