### PR TITLE
fix(thinkgraph): fix chat panel scrolling

### DIFF
--- a/apps/thinkgraph/app/components/GraphEditor.vue
+++ b/apps/thinkgraph/app/components/GraphEditor.vue
@@ -430,7 +430,7 @@ function exportGraph() {
       <!-- Chat panel (side panel) -->
       <div
         v-if="showChat"
-        class="w-[380px] border-l border-default flex-shrink-0"
+        class="w-[380px] border-l border-default flex-shrink-0 overflow-hidden"
       >
         <ChatPanel
           :node-id="chatNodeId"


### PR DESCRIPTION
## Problem
The chat panel in GraphEditor couldn't scroll its messages area. Messages would overflow beyond the visible area with no way to scroll.

## Root Cause
The chat panel wrapper `div` in `GraphEditor.vue` was missing `overflow-hidden`. Without it, the `ChatPanel` component's internal flex layout (`h-full flex flex-col` with `flex-1 overflow-y-auto` on the messages area) couldn't properly constrain its height within the parent flex container.

## Fix
Added `overflow-hidden` to the chat panel wrapper div, allowing the internal flex layout to work correctly and enable scrolling in the messages area.

## Changes
- `apps/thinkgraph/app/components/GraphEditor.vue` — Added `overflow-hidden` class to chat panel wrapper div