### PR TITLE
feat(thinkgraph): add worker-sync deploy variant for Pi worker updates

### DIFF
--- a/apps/thinkgraph-worker/src/session-manager.ts
+++ b/apps/thinkgraph-worker/src/session-manager.ts
@@ -843,7 +843,39 @@ Your job is to review the work produced by ancestor work items and provide feedb
   }
 
   private deployInstructions(payload: DispatchPayload): string {
-    return `## Instructions — Deploy
+    if (payload.skill === 'worker-sync') {
+      return this.workerSyncInstructions()
+    }
+    return this.cloudflareDeployInstructions()
+  }
+
+  /** Deploy instructions for syncing the Pi worker (pull + rebuild) */
+  private workerSyncInstructions(): string {
+    return `## Instructions — Worker Sync
+
+Your job is to update the Pi worker to the latest main branch.
+
+1. Pull the latest changes from main:
+   \`\`\`bash
+   cd ~/nuxt-crouton
+   git pull origin main
+   \`\`\`
+2. Rebuild the thinkgraph-worker:
+   \`\`\`bash
+   cd apps/thinkgraph-worker
+   pnpm build
+   \`\`\`
+3. Verify the build succeeded (check exit code and output)
+4. If the build fails, read the error output and report it in your output — do NOT attempt to fix code
+5. Report the git SHA that was pulled and whether the build succeeded
+
+**IMPORTANT**: Do NOT restart the worker process — the PM will handle that separately.
+`
+  }
+
+  /** Deploy instructions for Cloudflare Pages deployment */
+  private cloudflareDeployInstructions(): string {
+    return `## Instructions — Deploy (Cloudflare Pages)
 
 Your job is to deploy the crouton app to Cloudflare Pages.
 


### PR DESCRIPTION
Adds a `worker-sync` skill variant for deploy nodes in the thinkgraph worker session manager.

When a deploy node is dispatched with `skill: 'worker-sync'`, the agent will:
1. `cd ~/nuxt-crouton && git pull origin main`
2. `cd apps/thinkgraph-worker && pnpm build`
3. Report the pulled SHA and build result

The existing Cloudflare Pages deploy instructions are preserved as the default for deploy nodes without the worker-sync skill.