### PR TITLE
feat(thinkgraph): add generate_image tool to pm-tools

### DIFF
--- a/apps/thinkgraph-worker/src/pm-tools.ts
+++ b/apps/thinkgraph-worker/src/pm-tools.ts
@@ -8,6 +8,8 @@
 import { Type } from '@sinclair/typebox'
 import { ofetch } from 'ofetch'
 import { execFileSync } from 'node:child_process'
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
 import type { ToolDefinition, AgentToolResult } from '@mariozechner/pi-coding-agent'
 import type { WorkerConfig } from './config.js'
 
@@ -202,6 +204,158 @@ export function createPMTools(
           return textResult(JSON.stringify({ ok: true, prUrl, workItemId }))
         } catch (err: any) {
           console.error(`[pm-tools] create_pr failed:`, err.message)
+          return textResult(JSON.stringify({ ok: false, error: err.message }))
+        }
+      },
+    },
+    {
+      name: 'generate_image',
+      label: 'Generate Image',
+      description: 'Generate an image using Flux (Replicate) or DALL-E with a text prompt. Downloads the result and attaches it as an artifact on the work item. Requires REPLICATE_API_TOKEN or OPENAI_API_KEY in the worker environment.',
+      parameters: Type.Object({
+        prompt: Type.String({ description: 'Text prompt describing the image to generate' }),
+        style: Type.Optional(Type.Union([
+          Type.Literal('realistic'),
+          Type.Literal('illustration'),
+          Type.Literal('ui-mockup'),
+        ], { description: 'Style preset to apply. Modifies the prompt for better results.' })),
+        size: Type.Optional(Type.String({ description: 'Image size. For DALL-E: "1024x1024", "1792x1024", "1024x1792". For Flux: "1:1", "16:9", "9:16". Defaults to square.' })),
+      }),
+      execute: async (_toolCallId, params) => {
+        const replicateToken = process.env.REPLICATE_API_TOKEN
+        const openaiKey = process.env.OPENAI_API_KEY
+
+        if (!replicateToken && !openaiKey) {
+          return textResult(JSON.stringify({
+            ok: false,
+            error: 'No image generation API configured. Set REPLICATE_API_TOKEN or OPENAI_API_KEY in the worker environment.',
+          }))
+        }
+
+        // Build enhanced prompt based on style
+        let enhancedPrompt = params.prompt
+        if (params.style === 'realistic') {
+          enhancedPrompt = `Photorealistic, high quality photograph: ${params.prompt}`
+        } else if (params.style === 'illustration') {
+          enhancedPrompt = `Digital illustration, clean vector style: ${params.prompt}`
+        } else if (params.style === 'ui-mockup') {
+          enhancedPrompt = `UI/UX mockup, clean modern interface design, Figma-style: ${params.prompt}`
+        }
+
+        let imageUrl: string
+        let provider: string
+
+        try {
+          if (replicateToken) {
+            // Use Replicate Flux model
+            provider = 'replicate-flux'
+            const aspectRatio = params.size || '1:1'
+
+            // Create prediction
+            const prediction = await ofetch('https://api.replicate.com/v1/models/black-forest-labs/flux-schnell/predictions', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${replicateToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: {
+                input: {
+                  prompt: enhancedPrompt,
+                  aspect_ratio: aspectRatio,
+                  num_outputs: 1,
+                  output_format: 'webp',
+                  output_quality: 90,
+                },
+              },
+            })
+
+            // Poll for completion (flux-schnell is fast, usually < 10s)
+            let result = prediction
+            const maxAttempts = 60
+            for (let i = 0; i < maxAttempts; i++) {
+              if (result.status === 'succeeded') break
+              if (result.status === 'failed' || result.status === 'canceled') {
+                throw new Error(`Replicate prediction ${result.status}: ${result.error || 'unknown error'}`)
+              }
+              await new Promise(resolve => setTimeout(resolve, 1000))
+              result = await ofetch(`https://api.replicate.com/v1/predictions/${result.id}`, {
+                headers: { 'Authorization': `Bearer ${replicateToken}` },
+              })
+            }
+
+            if (result.status !== 'succeeded') {
+              throw new Error('Replicate prediction timed out after 60s')
+            }
+
+            imageUrl = Array.isArray(result.output) ? result.output[0] : result.output
+          } else {
+            // Use OpenAI DALL-E 3
+            provider = 'openai-dalle3'
+            const dalleSize = params.size || '1024x1024'
+
+            const response = await ofetch('https://api.openai.com/v1/images/generations', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${openaiKey}`,
+                'Content-Type': 'application/json',
+              },
+              body: {
+                model: 'dall-e-3',
+                prompt: enhancedPrompt,
+                n: 1,
+                size: dalleSize,
+                response_format: 'url',
+              },
+            })
+
+            imageUrl = response.data[0].url
+          }
+
+          // Download the image to a local file
+          const imageBuffer = await ofetch(imageUrl, { responseType: 'arrayBuffer' })
+          const ext = provider === 'replicate-flux' ? 'webp' : 'png'
+          const filename = `generated-${Date.now()}.${ext}`
+          const outputDir = join(config.workDir, 'generated-images')
+          mkdirSync(outputDir, { recursive: true })
+          const localPath = join(outputDir, filename)
+          writeFileSync(localPath, Buffer.from(imageBuffer as ArrayBuffer))
+
+          // Attach as artifact on the work item
+          const artifact = {
+            type: 'image',
+            url: imageUrl,
+            localPath,
+            prompt: params.prompt,
+            enhancedPrompt,
+            style: params.style || null,
+            provider,
+            createdAt: new Date().toISOString(),
+          }
+
+          try {
+            const items = await ofetch(baseUrl, { headers, query: { ids: workItemId } })
+            const item = Array.isArray(items) ? items[0] : null
+            const existingArtifacts = item?.artifacts || []
+            const artifacts = Array.isArray(existingArtifacts) ? existingArtifacts : []
+            artifacts.push(artifact)
+
+            await ofetch(`${baseUrl}/${workItemId}`, {
+              method: 'PATCH',
+              headers,
+              body: { artifacts },
+            })
+          } catch (artifactErr: any) {
+            console.error(`[pm-tools] generate_image: image generated but artifact save failed:`, artifactErr.message)
+          }
+
+          console.log(`[pm-tools] generate_image: created ${localPath} via ${provider}`)
+          return textResult(JSON.stringify({
+            ok: true,
+            artifact,
+            workItemId,
+          }))
+        } catch (err: any) {
+          console.error(`[pm-tools] generate_image failed:`, err.message)
           return textResult(JSON.stringify({ ok: false, error: err.message }))
         }
       },


### PR DESCRIPTION
## Summary

Adds a `generate_image` tool to the ThinkGraph worker's PM tools, enabling Pi agents to generate images during work item sessions.

### Features
- **Dual provider support**: Replicate (Flux-schnell) preferred, OpenAI (DALL-E 3) fallback
- **Style presets**: `realistic`, `illustration`, `ui-mockup` — each enhances the prompt appropriately
- **Configurable size**: Aspect ratio for Flux (`1:1`, `16:9`, `9:16`), pixel dimensions for DALL-E (`1024x1024`, etc.)
- **Artifact attachment**: Generated image is saved locally and attached to the work item as a `type: 'image'` artifact
- **Robust polling**: 60s timeout with 1s intervals for Replicate async predictions

### Environment Variables Required
- `REPLICATE_API_TOKEN` — for Flux (preferred)
- `OPENAI_API_KEY` — for DALL-E 3 (fallback)

### Tool Parameters
| Param | Type | Required | Description |
|-------|------|----------|-------------|
| `prompt` | string | ✅ | Text prompt for image generation |
| `style` | `realistic` \| `illustration` \| `ui-mockup` | ❌ | Style preset |
| `size` | string | ❌ | Size/aspect ratio |

Work item: uW-5_G2PtI-iUVpATQgth