### PR TITLE
feat(thinkgraph): wire Cloudflare Pages preview URL to work items

### DIFF
--- a/.github/workflows/thinkgraph-deploy-preview.yml
+++ b/.github/workflows/thinkgraph-deploy-preview.yml
@@ -1,0 +1,59 @@
+name: ThinkGraph Deploy Preview URL
+
+on:
+  deployment_status:
+
+jobs:
+  notify:
+    name: Send preview URL to ThinkGraph
+    runs-on: ubuntu-latest
+    # Only run when: deployment succeeded, it's a preview (not production),
+    # and the branch matches thinkgraph/* naming convention
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment != 'production' &&
+      startsWith(github.event.deployment.ref, 'thinkgraph/')
+    steps:
+      - name: Extract branch and deploy URL
+        id: extract
+        run: |
+          BRANCH="${{ github.event.deployment.ref }}"
+          DEPLOY_URL="${{ github.event.deployment_status.environment_url }}"
+
+          # Fallback: try target_url if environment_url is empty
+          if [ -z "$DEPLOY_URL" ]; then
+            DEPLOY_URL="${{ github.event.deployment_status.target_url }}"
+          fi
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
+          echo "Branch: $BRANCH"
+          echo "Deploy URL: $DEPLOY_URL"
+
+      - name: Send deploy URL to ThinkGraph
+        if: steps.extract.outputs.deploy_url != ''
+        env:
+          THINKGRAPH_WEBHOOK_SECRET: ${{ secrets.THINKGRAPH_WEBHOOK_SECRET }}
+          THINKGRAPH_TEAM_ID: ${{ secrets.THINKGRAPH_TEAM_ID }}
+          THINKGRAPH_API_URL: ${{ secrets.THINKGRAPH_API_URL }}
+        run: |
+          if [ -z "$THINKGRAPH_API_URL" ] || [ -z "$THINKGRAPH_TEAM_ID" ]; then
+            echo "ThinkGraph webhook not configured (missing THINKGRAPH_API_URL or THINKGRAPH_TEAM_ID). Skipping."
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg branch "${{ steps.extract.outputs.branch }}" \
+            --arg deployUrl "${{ steps.extract.outputs.deploy_url }}" \
+            '{branch: $branch, deployUrl: $deployUrl}')
+
+          echo "Sending deploy URL to ThinkGraph..."
+          echo "$PAYLOAD" | jq .
+
+          curl -sf -X POST \
+            "${THINKGRAPH_API_URL}/api/teams/${THINKGRAPH_TEAM_ID}/dispatch/deploy-webhook" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Secret: ${THINKGRAPH_WEBHOOK_SECRET}" \
+            -d "$PAYLOAD" \
+            && echo "Deploy URL sent successfully" \
+            || echo "Warning: Webhook call failed (non-critical)"

--- a/apps/thinkgraph/server/api/teams/[id]/dispatch/deploy-webhook.post.ts
+++ b/apps/thinkgraph/server/api/teams/[id]/dispatch/deploy-webhook.post.ts
@@ -1,0 +1,74 @@
+import { eq, and } from 'drizzle-orm'
+import { updateThinkgraphWorkItem } from '~~/layers/thinkgraph/collections/workitems/server/database/queries'
+import * as tables from '~~/layers/thinkgraph/collections/workitems/server/database/schema'
+
+/**
+ * Deploy Webhook for receiving Cloudflare Pages preview URLs from GitHub Actions.
+ *
+ * POST /api/teams/[id]/dispatch/deploy-webhook
+ * Headers: X-Webhook-Secret: <shared secret>
+ * Body: {
+ *   branch: string,       // Git branch name (maps to workItem.worktree)
+ *   deployUrl: string,     // Cloudflare Pages preview URL
+ * }
+ *
+ * Looks up the work item by its worktree field (branch name),
+ * then sets the deployUrl field on it.
+ */
+export default defineEventHandler(async (event) => {
+  // Verify webhook secret
+  const config = useRuntimeConfig()
+  const expectedSecret = config.webhookSecret || config.public?.webhookSecret
+  if (expectedSecret) {
+    const providedSecret = getHeader(event, 'x-webhook-secret')
+    if (providedSecret !== expectedSecret) {
+      throw createError({ status: 401, statusText: 'Invalid webhook secret' })
+    }
+  }
+
+  const { id: teamId } = getRouterParams(event)
+  if (!teamId) {
+    throw createError({ status: 400, statusText: 'Missing team ID' })
+  }
+
+  const body = await readBody(event)
+  const { branch, deployUrl } = body
+
+  if (!branch || !deployUrl) {
+    throw createError({ status: 400, statusText: 'Missing required fields: branch, deployUrl' })
+  }
+
+  // Find work item by worktree (branch name)
+  const db = useDB()
+  const [workItem] = await (db as any)
+    .select()
+    .from(tables.thinkgraphWorkItems)
+    .where(
+      and(
+        eq(tables.thinkgraphWorkItems.teamId, teamId),
+        eq(tables.thinkgraphWorkItems.worktree, branch),
+      ),
+    )
+    .limit(1)
+
+  if (!workItem) {
+    return {
+      success: false,
+      message: `No work item found for branch "${branch}"`,
+    }
+  }
+
+  await updateThinkgraphWorkItem(
+    workItem.id,
+    teamId,
+    'system',
+    { deployUrl },
+    { role: 'admin' },
+  )
+
+  return {
+    success: true,
+    workItemId: workItem.id,
+    deployUrl,
+  }
+})


### PR DESCRIPTION
## Summary

When a PR branch gets a Cloudflare Pages preview deploy, the preview URL now appears on the ThinkGraph work item automatically.

### Changes

1. **New webhook endpoint** (`/api/teams/[id]/dispatch/deploy-webhook`) — accepts `{ branch, deployUrl }`, looks up the work item by its `worktree` field, and sets `deployUrl`.

2. **New GitHub Action** (`.github/workflows/thinkgraph-deploy-preview.yml`) — triggers on `deployment_status` events from Cloudflare Pages. Filters for:
   - Successful deployments only
   - Non-production (preview) environments
   - Branches matching `thinkgraph/*` convention

### How it works

```
Cloudflare Pages deploys preview → GitHub deployment_status event
→ Workflow extracts branch + preview URL
→ POSTs to ThinkGraph deploy-webhook
→ Work item's deployUrl field is updated
```

### Prerequisites

The following GitHub repo secrets must be configured (same ones used by `thinkgraph-ci.yml`):
- `THINKGRAPH_API_URL`
- `THINKGRAPH_TEAM_ID`
- `THINKGRAPH_WEBHOOK_SECRET`