### PR TITLE
feat(thinkgraph): add reset-to-queued button for stuck active items

### DIFF
--- a/apps/thinkgraph/app/components/ProjectAssistant.vue
+++ b/apps/thinkgraph/app/components/ProjectAssistant.vue
@@ -236,6 +236,12 @@ watch(messages, () => {
             >
               Status summary
             </button>
+            <button
+              class="text-xs px-2 py-1 rounded-full bg-amber-100 hover:bg-amber-200 dark:bg-amber-900/30 dark:hover:bg-amber-900/50 text-amber-700 dark:text-amber-400 transition-colors"
+              @click="input = 'Reset all stuck active items back to queued'; onSubmit()"
+            >
+              Reset stuck items
+            </button>
           </template>
         </div>
       </div>

--- a/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
@@ -696,6 +696,7 @@ if (import.meta.client) {
 
           <div v-if="selectedIds.size > 0" class="ml-auto flex items-center gap-1">
             <span class="text-xs text-muted mr-1">{{ selectedIds.size }} selected</span>
+            <UButton size="xs" variant="soft" color="warning" icon="i-lucide-rotate-ccw" label="Reset" @click="bulkUpdateStatus('queued')" />
             <UButton size="xs" variant="soft" color="green" icon="i-lucide-check" label="Done" @click="bulkUpdateStatus('done')" />
             <UButton size="xs" variant="soft" color="red" icon="i-lucide-trash-2" label="Delete" @click="bulkDelete" />
           </div>
@@ -864,13 +865,21 @@ if (import.meta.client) {
           </div>
 
           <!-- Actions -->
-          <div class="flex gap-2 pt-4 border-t border-default">
+          <div class="flex flex-wrap gap-2 pt-4 border-t border-default">
             <UButton
               v-if="selectedItem.status === 'queued' || selectedItem.status === 'blocked'"
               icon="i-lucide-send"
               label="Dispatch"
               :loading="dispatching"
               @click="openDispatch(selectedItem.id)"
+            />
+            <UButton
+              v-if="selectedItem.status === 'active'"
+              icon="i-lucide-rotate-ccw"
+              label="Reset to Queued"
+              variant="soft"
+              color="warning"
+              @click="updateItem(selectedItem.id, { status: 'queued' })"
             />
             <UButton
               v-if="selectedItem.status !== 'done'"


### PR DESCRIPTION
## Problem
When Pi rejects a dispatch (503/max sessions), work items get stuck in `active` status with no way to reset them from the UI.

## Changes
- **Detail panel**: Added "Reset to Queued" button (amber, with rotate-ccw icon) that appears only when an item has `active` status
- **Project assistant**: Added "Reset stuck items" quick action button that asks the assistant to reset all stuck active items back to queued (uses existing `batchUpdateStatus` tool)
- **List view bulk actions**: Added "Reset" bulk action button to reset selected items to queued status

## Files changed
- `apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue` — detail panel + list bulk actions
- `apps/thinkgraph/app/components/ProjectAssistant.vue` — assistant quick action