### PR TITLE
feat(crouton-flow): auto-group nodes on sustained drag overlap

### DIFF
--- a/apps/thinkgraph/app/components/GraphEditor.vue
+++ b/apps/thinkgraph/app/components/GraphEditor.vue
@@ -133,6 +133,19 @@ function onNodeClick(nodeId: string, data: Record<string, unknown>, event?: Mous
   if (!event?.shiftKey) showPath.value = true
 }
 
+// ─── Auto-group handler ───
+function onAutoGrouped(result: { groupNode: Record<string, unknown>; nodes: Record<string, unknown>[] }) {
+  // The group was created visually on the canvas.
+  // For sync mode, the nodes will be re-rendered with their new parentNode.
+  // We show a toast so the user knows what happened.
+  toast.add({
+    title: 'Nodes grouped',
+    description: 'Drag nodes out of the group to ungroup them.',
+    color: 'info',
+    duration: 3000,
+  })
+}
+
 // ─── Quick add done ───
 async function onQuickAddDone() {
   showQuickAdd.value = false
@@ -367,6 +380,7 @@ function exportGraph() {
           :flow-config="flowConfig"
           :additional-edges="additionalEdges"
           :background-pattern-color="isDark ? '#3a3530' : '#d4cfc8'"
+          :auto-group="{ enabled: true, hoverDelay: 1000 }"
           sync
           minimap
           :selected="selectedNodeIds"
@@ -374,6 +388,7 @@ function exportGraph() {
           @node-delete="onNodeDelete"
           @selection-change="onSelectionChange"
           @connect-end="onConnectEnd"
+          @auto-grouped="onAutoGrouped"
         />
         <div
           v-else

--- a/packages/crouton-flow/app/components/Flow.vue
+++ b/packages/crouton-flow/app/components/Flow.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, resolveComponent, watch, markRaw } from 'vue'
+import { computed, nextTick, onUnmounted, ref, resolveComponent, watch, markRaw } from 'vue'
 import { useThrottleFn } from '@vueuse/core'
 import { VueFlow, useVueFlow } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
 import { Controls } from '@vue-flow/controls'
 import { MiniMap } from '@vue-flow/minimap'
 import type { Node, NodeDragEvent, OnConnectStartParams } from '@vue-flow/core'
-import type { FlowConfig, FlowPosition, FlowDataMode, NodeTypeRegistration, FlowContainerOptions } from '../types/flow'
+import type { FlowConfig, FlowPosition, FlowDataMode, NodeTypeRegistration, FlowContainerOptions, FlowAutoGroupOptions } from '../types/flow'
 import { useFlowData } from '../composables/useFlowData'
 import { useFlowLayout } from '../composables/useFlowLayout'
 import { useDebouncedPositionUpdate } from '../composables/useFlowMutation'
@@ -16,8 +16,10 @@ import { useFlowSync } from '../composables/useFlowSync'
 import { useFlowDragDrop } from '../composables/useFlowDragDrop'
 import { useFlowSyncBridge } from '../composables/useFlowSyncBridge'
 import { useFlowContainerDetection, type ContainerChangeEvent } from '../composables/useFlowContainerDetection'
+import { useFlowAutoGroup, type AutoGroupResult } from '../composables/useFlowAutoGroup'
 import CroutonFlowNode from './Node.vue'
 import CroutonFlowGhostNode from './GhostNode.vue'
+import CroutonFlowGroupNode from './GroupNode.vue'
 
 // Import default styles
 import '@vue-flow/core/dist/style.css'
@@ -95,6 +97,8 @@ interface Props {
   nodeTypeComponents?: Record<string, NodeTypeRegistration>
   /** Container detection options — enable card-over-group overlap detection on drag stop */
   containerOptions?: FlowContainerOptions
+  /** Auto-group options — drag a node over another for 1s+ to create a group */
+  autoGroup?: FlowAutoGroupOptions
   /** Data mode: 'collection' (default) or 'ephemeral' (skip collection mutations) */
   dataMode?: FlowDataMode
   /** Pre-loaded node positions from flow_configs (avoids extra fetch) */
@@ -141,6 +145,8 @@ const emit = defineEmits<{
   nodeContainerChange: [event: ContainerChangeEvent]
   /** Emitted when nodes are deleted (keyboard delete or programmatic removal) */
   nodeDelete: [nodeIds: string[]]
+  /** Emitted when nodes are auto-grouped (drag overlap for 1s+) */
+  autoGrouped: [result: AutoGroupResult]
   /** Emitted when a connection drag ends without connecting to a target handle */
   connectEnd: [event: { sourceNodeId: string; sourceHandleType: string; position: FlowPosition; mouseEvent: MouseEvent }]
   /** Emitted in ephemeral mode when nodes change (enables v-model:rows) */
@@ -184,6 +190,7 @@ const positionSync = (props.sync && props.flowId && props.dataMode === 'ephemera
 const nodeTypes = computed(() => {
   const types: Record<string, any> = {
     ghost: markRaw(CroutonFlowGhostNode),
+    resizableGroup: markRaw(CroutonFlowGroupNode),
   }
   if (props.nodeTypeComponents) {
     for (const [typeName, reg] of Object.entries(props.nodeTypeComponents)) {
@@ -199,6 +206,21 @@ const nodeTypes = computed(() => {
 const containerDetection = props.containerOptions?.enabled && props.nodeTypeComponents
   ? useFlowContainerDetection({ nodeTypeComponents: props.nodeTypeComponents })
   : null
+
+// ============================================
+// AUTO-GROUP (drag overlap → group creation)
+// ============================================
+const autoGroupDetection = props.autoGroup?.enabled
+  ? useFlowAutoGroup({
+      hoverDelay: props.autoGroup.hoverDelay,
+      overlapThreshold: props.autoGroup.overlapThreshold,
+    })
+  : null
+
+// Clean up auto-group timers on unmount
+onUnmounted(() => {
+  autoGroupDetection?.dispose()
+})
 
 // ============================================
 // VUEFLOW INSTANCE
@@ -613,7 +635,14 @@ const syncDragPosition = useThrottleFn((event: NodeDragEvent) => {
   }
 }, 50)
 
-onNodeDrag(syncDragPosition)
+onNodeDrag((event: NodeDragEvent) => {
+  syncDragPosition(event)
+
+  // Auto-group: track hover overlap
+  if (autoGroupDetection) {
+    autoGroupDetection.handleDrag(finalNodes.value, event)
+  }
+})
 
 // Handle node drag end - final position sync + container detection
 onNodeDragStop((event: NodeDragEvent) => {
@@ -623,6 +652,26 @@ onNodeDragStop((event: NodeDragEvent) => {
   const position: FlowPosition = {
     x: Math.round(node.position.x),
     y: Math.round(node.position.y)
+  }
+
+  // Auto-group detection (if enabled) — takes priority over container detection
+  if (autoGroupDetection) {
+    const autoResult = autoGroupDetection.handleDragStop(finalNodes.value, event)
+    if (autoResult) {
+      emit('autoGrouped', autoResult)
+      // In ephemeral mode, emit updated rows so the parent can update its nodes
+      if (props.dataMode === 'ephemeral' && props.rows) {
+        emit('update:rows', autoResult.nodes as unknown as Record<string, unknown>[])
+      }
+      // Position cache: update both child positions in the new group
+      for (const n of autoResult.nodes) {
+        if (n.parentNode === autoResult.groupNode.id) {
+          positionCache.set(n.id, { ...n.position })
+        }
+      }
+      positionCache.set(autoResult.groupNode.id, { ...autoResult.groupNode.position })
+      return // Skip normal position update — group creation handles it
+    }
   }
 
   // Container detection (if enabled)
@@ -717,10 +766,11 @@ const customNodeComponent = computed(() => {
   return null
 })
 
-// Expose sync state and container detection for external access
+// Expose sync state, container detection, and auto-group for external access
 defineExpose({
   syncState,
   containerDetection,
+  autoGroupDetection,
 })
 </script>
 
@@ -1006,5 +1056,42 @@ defineExpose({
 
 .crouton-flow-dark .vue-flow__controls-button svg {
   fill: #e5e5e5;
+}
+
+/* ─── Auto-group shake animation ─── */
+/* Target the inner content of the node (first child), not the .vue-flow__node
+   wrapper, because Vue Flow uses transform: translate() on the wrapper for positioning. */
+.crouton-flow-auto-group-target > .vue-flow__node-default,
+.crouton-flow-auto-group-target > div {
+  animation: crouton-flow-shake 0.4s ease-in-out infinite;
+}
+
+.crouton-flow-auto-group-target {
+  z-index: 10 !important;
+}
+
+/* Dashed outline ring around the shaking node */
+.crouton-flow-auto-group-target::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border: 2px dashed var(--color-primary-500, #3b82f6);
+  border-radius: 12px;
+  pointer-events: none;
+  animation: crouton-flow-pulse-ring 1.2s ease-in-out infinite;
+}
+
+@keyframes crouton-flow-shake {
+  0%, 100% { transform: rotate(0deg); }
+  15% { transform: rotate(-1.5deg) translateX(-2px); }
+  30% { transform: rotate(1.5deg) translateX(2px); }
+  45% { transform: rotate(-1deg) translateX(-1px); }
+  60% { transform: rotate(1deg) translateX(1px); }
+  75% { transform: rotate(-0.5deg); }
+}
+
+@keyframes crouton-flow-pulse-ring {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
 }
 </style>

--- a/packages/crouton-flow/app/components/GroupNode.vue
+++ b/packages/crouton-flow/app/components/GroupNode.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+/**
+ * CroutonFlowGroupNode — visual container (like FigJam sections).
+ *
+ * Created by useFlowAutoGroup when two nodes are grouped via drag overlap.
+ * Renders as a dashed, semi-transparent rectangle with a label header.
+ * Resizable via @vue-flow/node-resizer.
+ */
+import { NodeResizer } from '@vue-flow/node-resizer'
+import '@vue-flow/node-resizer/dist/style.css'
+
+interface Props {
+  data: {
+    label: string
+    [key: string]: unknown
+  }
+  selected?: boolean
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <div
+    class="crouton-flow-group"
+    :class="{ 'crouton-flow-group--selected': selected }"
+  >
+    <NodeResizer
+      :min-width="250"
+      :min-height="150"
+      color="transparent"
+    />
+    <div class="crouton-flow-group__header">
+      <span class="crouton-flow-group__label">{{ data.label }}</span>
+    </div>
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+@reference "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
+
+.crouton-flow-group {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  border-radius: 12px;
+  border: 2px dashed #9ca3af;
+  background-color: rgba(219, 234, 254, 0.3);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+:where(.dark, .dark *) .crouton-flow-group {
+  background-color: rgba(30, 58, 138, 0.15);
+  border-color: #4b5563;
+}
+
+.crouton-flow-group--selected {
+  border-color: var(--color-primary-500, #3b82f6);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary-500, #3b82f6) 15%, transparent);
+}
+
+.crouton-flow-group__header {
+  position: absolute;
+  top: 8px;
+  left: 12px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.crouton-flow-group__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+:where(.dark, .dark *) .crouton-flow-group__label {
+  color: #9ca3af;
+}
+</style>

--- a/packages/crouton-flow/app/composables/useFlowAutoGroup.ts
+++ b/packages/crouton-flow/app/composables/useFlowAutoGroup.ts
@@ -1,0 +1,299 @@
+import { ref, type Ref } from 'vue'
+import type { Node, NodeDragEvent } from '@vue-flow/core'
+import { useFlowGroupManager, type UseFlowGroupManagerOptions } from './useFlowGroupManager'
+
+export interface UseFlowAutoGroupOptions {
+  /** How long (ms) the dragged node must hover over a target before triggering (default: 1000) */
+  hoverDelay?: number
+  /** Overlap threshold as fraction of node area (0–1, default: 0.3) */
+  overlapThreshold?: number
+  /** Default node width for overlap calculation (default: 200) */
+  nodeWidth?: number
+  /** Default node height for overlap calculation (default: 80) */
+  nodeHeight?: number
+  /** Group manager options forwarded to useFlowGroupManager */
+  groupManagerOptions?: UseFlowGroupManagerOptions
+}
+
+export interface AutoGroupResult {
+  /** The newly created group node */
+  groupNode: Node
+  /** Updated nodes array with both nodes parented to the group */
+  nodes: Node[]
+}
+
+/**
+ * Auto-group nodes on sustained drag overlap.
+ *
+ * When a node is dragged over another node for `hoverDelay` ms, the target
+ * node shakes to signal an impending group. On drop, both nodes are wrapped
+ * in a new group container.
+ *
+ * Uses DOM class toggling for the shake animation so it works with any
+ * custom node component (ThinkgraphDecisionsNode, etc.).
+ *
+ * @example
+ * ```ts
+ * const { handleDrag, handleDragStop, shakingNodeId, groupManager } = useFlowAutoGroup()
+ *
+ * onNodeDrag((event) => handleDrag(currentNodes, event))
+ * onNodeDragStop((event) => {
+ *   const result = handleDragStop(currentNodes, event)
+ *   if (result) {
+ *     // result.nodes contains the updated nodes array with the group
+ *   }
+ * })
+ * ```
+ */
+export function useFlowAutoGroup(options: UseFlowAutoGroupOptions = {}) {
+  const {
+    hoverDelay = 1000,
+    overlapThreshold = 0.3,
+    nodeWidth = 200,
+    nodeHeight = 80,
+    groupManagerOptions = {},
+  } = options
+
+  const groupManager = useFlowGroupManager({
+    groupNodeType: 'resizableGroup',
+    ...groupManagerOptions,
+  })
+
+  /** ID of the node currently shaking (visual feedback) */
+  const shakingNodeId: Ref<string | null> = ref(null)
+
+  // Internal state
+  let hoverTimer: ReturnType<typeof setTimeout> | null = null
+  let currentTargetId: string | null = null
+  let isShaking = false
+
+  // ─── DOM class toggling ───
+  function setShakeDOM(nodeId: string | null) {
+    // Remove from all nodes first
+    if (typeof document !== 'undefined') {
+      document.querySelectorAll('.crouton-flow-auto-group-target').forEach((el) => {
+        el.classList.remove('crouton-flow-auto-group-target')
+      })
+      if (nodeId) {
+        const el = document.querySelector(`[data-id="${CSS.escape(nodeId)}"]`)
+        if (el) el.classList.add('crouton-flow-auto-group-target')
+      }
+    }
+  }
+
+  function clearHover() {
+    if (hoverTimer) {
+      clearTimeout(hoverTimer)
+      hoverTimer = null
+    }
+    currentTargetId = null
+    isShaking = false
+    shakingNodeId.value = null
+    setShakeDOM(null)
+  }
+
+  /**
+   * Get the bounding box of a node in absolute coordinates.
+   * For child nodes inside a group, converts to absolute by adding parent position.
+   */
+  function getNodeBounds(node: Node, allNodes: Node[]) {
+    let x = node.position.x
+    let y = node.position.y
+
+    // Convert to absolute if inside a parent
+    if (node.parentNode) {
+      const parent = allNodes.find(n => n.id === node.parentNode)
+      if (parent) {
+        x += parent.position.x
+        y += parent.position.y
+      }
+    }
+
+    const style = node.style as Record<string, string> | undefined
+    const w = node.dimensions?.width
+      ?? (style?.width ? parseInt(style.width) : nodeWidth)
+    const h = node.dimensions?.height
+      ?? (style?.height ? parseInt(style.height) : nodeHeight)
+
+    return { x, y, w, h }
+  }
+
+  /**
+   * Check if two rectangles overlap by at least `overlapThreshold` of the smaller one.
+   */
+  function rectsOverlap(
+    a: { x: number; y: number; w: number; h: number },
+    b: { x: number; y: number; w: number; h: number },
+  ): boolean {
+    const overlapX = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x))
+    const overlapY = Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y))
+    const overlapArea = overlapX * overlapY
+    const smallerArea = Math.min(a.w * a.h, b.w * b.h)
+    return smallerArea > 0 && overlapArea / smallerArea >= overlapThreshold
+  }
+
+  /**
+   * Find the node under the dragged node (if any).
+   * Skips group/container nodes and the dragged node itself.
+   */
+  function findOverlapTarget(nodes: Node[], draggedNode: Node): Node | null {
+    const dragBounds = getNodeBounds(draggedNode, nodes)
+
+    for (const node of nodes) {
+      if (node.id === draggedNode.id) continue
+      // Skip nodes that are already groups/containers
+      if (node.type === 'resizableGroup') continue
+      // Skip ghost nodes
+      if (node.data?.isGhost) continue
+      // Skip nodes already in the same group as the dragged node
+      if (draggedNode.parentNode && node.parentNode === draggedNode.parentNode) continue
+
+      const targetBounds = getNodeBounds(node, nodes)
+      if (rectsOverlap(dragBounds, targetBounds)) {
+        return node
+      }
+    }
+    return null
+  }
+
+  /**
+   * Call during onNodeDrag to track hover overlap.
+   */
+  function handleDrag(currentNodes: Node[], event: NodeDragEvent) {
+    const { node } = event
+    const target = findOverlapTarget(currentNodes, node)
+
+    if (!target) {
+      // No overlap — clear any pending hover
+      clearHover()
+      return
+    }
+
+    if (target.id === currentTargetId) {
+      // Still hovering over the same target — timer is running (or already shaking)
+      return
+    }
+
+    // New target — reset timer
+    clearHover()
+    currentTargetId = target.id
+
+    hoverTimer = setTimeout(() => {
+      // Sustained hover reached — trigger shake
+      isShaking = true
+      shakingNodeId.value = currentTargetId
+      setShakeDOM(currentTargetId)
+    }, hoverDelay)
+  }
+
+  /**
+   * Call during onNodeDragStop. If a shake was active, creates a group
+   * wrapping the dragged node and the target node.
+   *
+   * Returns `AutoGroupResult` if a group was created, `null` otherwise.
+   */
+  function handleDragStop(currentNodes: Node[], event: NodeDragEvent): AutoGroupResult | null {
+    if (!isShaking || !currentTargetId) {
+      clearHover()
+      return null
+    }
+
+    const { node: draggedNode } = event
+    const targetNodeId = currentTargetId
+
+    // Clear state immediately
+    clearHover()
+
+    // Find both nodes
+    const targetNode = currentNodes.find(n => n.id === targetNodeId)
+    if (!targetNode) return null
+
+    // Don't group a node with itself
+    if (draggedNode.id === targetNodeId) return null
+
+    // Calculate group position and size to encompass both nodes
+    const dragBounds = getNodeBounds(draggedNode, currentNodes)
+    const targetBounds = getNodeBounds(targetNode, currentNodes)
+
+    const padding = 40
+    const headerHeight = 45
+
+    const groupX = Math.min(dragBounds.x, targetBounds.x) - padding
+    const groupY = Math.min(dragBounds.y, targetBounds.y) - padding - headerHeight
+    const groupRight = Math.max(dragBounds.x + dragBounds.w, targetBounds.x + targetBounds.w) + padding
+    const groupBottom = Math.max(dragBounds.y + dragBounds.h, targetBounds.y + targetBounds.h) + padding
+    const groupW = groupRight - groupX
+    const groupH = groupBottom - groupY
+
+    // Create group node
+    const groupNode = groupManager.createGroup('Group', { x: groupX, y: groupY })
+
+    // Override dimensions to fit the children
+    groupNode.style = {
+      ...(groupNode.style as Record<string, string>),
+      width: `${groupW}px`,
+      height: `${groupH}px`,
+    }
+
+    // Re-parent both nodes into the group (convert to relative positions)
+    const updatedNodes = currentNodes.map((n) => {
+      if (n.id === draggedNode.id) {
+        const bounds = getNodeBounds(n, currentNodes)
+        return {
+          ...n,
+          parentNode: groupNode.id,
+          extent: 'parent' as const,
+          position: {
+            x: bounds.x - groupX,
+            y: bounds.y - groupY,
+          },
+          data: { ...n.data, grouped: true },
+        }
+      }
+      if (n.id === targetNodeId) {
+        const bounds = getNodeBounds(n, currentNodes)
+        return {
+          ...n,
+          parentNode: groupNode.id,
+          extent: 'parent' as const,
+          position: {
+            x: bounds.x - groupX,
+            y: bounds.y - groupY,
+          },
+          data: { ...n.data, grouped: true },
+        }
+      }
+      return n
+    })
+
+    // Add the group node (must come before its children in the array)
+    const finalNodes = [groupNode, ...updatedNodes]
+
+    return {
+      groupNode,
+      nodes: finalNodes,
+    }
+  }
+
+  /**
+   * Cleanup — call on component unmount.
+   */
+  function dispose() {
+    clearHover()
+  }
+
+  return {
+    /** Reactive ID of the currently shaking node (null if none) */
+    shakingNodeId,
+    /** The underlying group manager (for manual group operations) */
+    groupManager,
+    /** Call on every onNodeDrag event */
+    handleDrag,
+    /** Call on onNodeDragStop — returns group result or null */
+    handleDragStop,
+    /** Manually clear any pending hover/shake state */
+    clearHover,
+    /** Cleanup timers */
+    dispose,
+  }
+}

--- a/packages/crouton-flow/app/types/flow.ts
+++ b/packages/crouton-flow/app/types/flow.ts
@@ -128,3 +128,17 @@ export interface UseFlowGroupManagerOptions {
   /** Default dimensions for new group nodes */
   defaultGroupDimensions?: { width: number, height: number }
 }
+
+/**
+ * Auto-group options for CroutonFlow
+ * When enabled, dragging a node over another for 1+ seconds shakes the target
+ * and creates a group on drop.
+ */
+export interface FlowAutoGroupOptions {
+  /** Enable auto-group on sustained drag overlap (default: false) */
+  enabled: boolean
+  /** Hover duration in ms before triggering (default: 1000) */
+  hoverDelay?: number
+  /** Overlap threshold as fraction 0–1 (default: 0.3) */
+  overlapThreshold?: number
+}


### PR DESCRIPTION
## Auto-group nodes on drag overlap

When dragging a node over another node for 1+ seconds, the target node shakes to indicate it will become a group. On drop, both nodes are wrapped in a new parent group node (like FigJam sections).

### Changes

**New files:**
- `packages/crouton-flow/app/composables/useFlowAutoGroup.ts` — Core composable handling hover detection, timer, shake animation, and group creation
- `packages/crouton-flow/app/components/GroupNode.vue` — Resizable container component with dashed border and label header

**Modified files:**
- `packages/crouton-flow/app/components/Flow.vue` — Added `autoGroup` prop, wired composable into drag events, registered `resizableGroup` node type, added shake/pulse CSS animations
- `packages/crouton-flow/app/types/flow.ts` — Added `FlowAutoGroupOptions` interface
- `apps/thinkgraph/app/components/GraphEditor.vue` — Enabled auto-group on the ThinkGraph canvas with `autoGrouped` event handler

### How it works

1. **Drag detection**: During `onNodeDrag`, checks bounding-box overlap between dragged node and all other nodes (30% overlap threshold)
2. **Sustained hover**: After 1 second of continuous overlap, triggers shake animation via DOM class toggle (`.crouton-flow-auto-group-target`)
3. **Visual feedback**: Target node shakes with a subtle jitter + dashed pulse ring outline
4. **Group creation**: On drop while shaking, calls `useFlowGroupManager.createGroup()` and re-parents both nodes into the new group
5. **CSS approach**: Uses DOM class toggling so the animation works with any custom node component (ThinkgraphDecisionsNode, etc.)