### PR TITLE
refactor: replace thinkgraphDecisions with thinkgraphWorkItems in server code

### DIFF
--- a/apps/thinkgraph/server/mcp/tools/create-node.ts
+++ b/apps/thinkgraph/server/mcp/tools/create-node.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { createThinkgraphDecision, getAllThinkgraphDecisions } from '~~/layers/thinkgraph/collections/decisions/server/database/queries'
+import { createThinkgraphWorkItem, getAllThinkgraphWorkItems } from '~~/layers/thinkgraph/collections/workitems/server/database/queries'
 import { resolveTeamId } from '../utils/resolve-team'
 
 export default defineMcpTool({
@@ -23,14 +23,14 @@ export default defineMcpTool({
 
       // Validate parent exists if specified
       if (parentId) {
-        const all = await getAllThinkgraphDecisions(resolvedTeamId)
+        const all = await getAllThinkgraphWorkItems(resolvedTeamId)
         const parent = all.find((d: any) => d.id === parentId)
         if (!parent) {
           return { content: [{ type: 'text' as const, text: `Parent node "${parentId}" not found` }], isError: true }
         }
       }
 
-      const node = await createThinkgraphDecision({
+      const node = await createThinkgraphWorkItem({
         content,
         nodeType,
         pathType: '',
@@ -51,7 +51,7 @@ export default defineMcpTool({
       } as any)
 
       // Signal real-time update — use original slug/id since clients key rooms by slug
-      signalCollectionChange(teamId, 'thinkgraphDecisions')
+      signalCollectionChange(teamId, 'thinkgraphWorkItems')
 
       return {
         content: [{

--- a/apps/thinkgraph/server/mcp/tools/store-artifact.ts
+++ b/apps/thinkgraph/server/mcp/tools/store-artifact.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { getAllThinkgraphDecisions, updateThinkgraphDecision } from '~~/layers/thinkgraph/collections/decisions/server/database/queries'
+import { getAllThinkgraphWorkItems, updateThinkgraphWorkItem } from '~~/layers/thinkgraph/collections/workitems/server/database/queries'
 import { resolveTeamId } from '../utils/resolve-team'
 
 export default defineMcpTool({
@@ -23,7 +23,7 @@ export default defineMcpTool({
 
       const resolvedTeamId = await resolveTeamId(teamId)
 
-      const all = await getAllThinkgraphDecisions(resolvedTeamId)
+      const all = await getAllThinkgraphWorkItems(resolvedTeamId)
       const node = all.find((d: any) => d.id === nodeId)
       if (!node) {
         return { content: [{ type: 'text' as const, text: `Node "${nodeId}" not found` }], isError: true }
@@ -43,10 +43,10 @@ export default defineMcpTool({
 
       const updatedArtifacts = [...existingArtifacts, newArtifact]
 
-      await updateThinkgraphDecision(nodeId, resolvedTeamId, 'mcp', { artifacts: updatedArtifacts as any }, { role: 'admin' })
+      await updateThinkgraphWorkItem(nodeId, resolvedTeamId, 'mcp', { artifacts: updatedArtifacts as any }, { role: 'admin' })
 
       // Signal real-time update — use original slug/id since clients key rooms by slug
-      signalCollectionChange(teamId, 'thinkgraphDecisions')
+      signalCollectionChange(teamId, 'thinkgraphWorkItems')
 
       return {
         content: [{

--- a/apps/thinkgraph/server/mcp/tools/update-node.ts
+++ b/apps/thinkgraph/server/mcp/tools/update-node.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { getAllThinkgraphDecisions, updateThinkgraphDecision } from '~~/layers/thinkgraph/collections/decisions/server/database/queries'
+import { getAllThinkgraphWorkItems, updateThinkgraphWorkItem } from '~~/layers/thinkgraph/collections/workitems/server/database/queries'
 import { resolveTeamId } from '../utils/resolve-team'
 
 export default defineMcpTool({
@@ -38,7 +38,7 @@ export default defineMcpTool({
       }
 
       // Validate node and parent exist
-      const all = await getAllThinkgraphDecisions(resolvedTeamId)
+      const all = await getAllThinkgraphWorkItems(resolvedTeamId)
       const node = all.find((d: any) => d.id === nodeId)
       if (!node) {
         return { content: [{ type: 'text' as const, text: `Node "${nodeId}" not found` }], isError: true }
@@ -54,10 +54,10 @@ export default defineMcpTool({
         }
       }
 
-      const result = await updateThinkgraphDecision(nodeId, resolvedTeamId, 'mcp', updates, { role: 'admin' })
+      const result = await updateThinkgraphWorkItem(nodeId, resolvedTeamId, 'mcp', updates, { role: 'admin' })
 
       // Signal real-time update — use original slug/id since clients key rooms by slug
-      signalCollectionChange(teamId, 'thinkgraphDecisions')
+      signalCollectionChange(teamId, 'thinkgraphWorkItems')
 
       return {
         content: [{

--- a/apps/thinkgraph/server/utils/dispatch-services/pi-agent.ts
+++ b/apps/thinkgraph/server/utils/dispatch-services/pi-agent.ts
@@ -3,7 +3,7 @@ import { buildDispatchContext } from '../context-builder'
 import { createTerminalSession } from '../terminal-sessions'
 import type { DispatchContext, DispatchResult } from '../dispatch-registry'
 import type { H3Event } from 'h3'
-import { updateThinkgraphDecision } from '~~/layers/thinkgraph/collections/decisions/server/database/queries'
+import { updateThinkgraphWorkItem } from '~~/layers/thinkgraph/collections/workitems/server/database/queries'
 
 registerDispatchService({
   id: 'pi-agent',
@@ -33,9 +33,9 @@ registerDispatchService({
       throw createError({ status: 500, statusText: 'Pi Agent requires dispatch metadata' })
     }
 
-    const targetNode = meta.allDecisions.find((d: any) => d.id === meta.decisionId)
+    const targetNode = meta.allWorkItems.find((d: any) => d.id === meta.workItemId)
     if (!targetNode) {
-      throw createError({ status: 404, statusText: 'Decision not found' })
+      throw createError({ status: 404, statusText: 'Work item not found' })
     }
 
     const depth = (context.options?.depth as string) || 'concise'
@@ -48,12 +48,12 @@ registerDispatchService({
     // Build the full context for the Pi worker
     const builtContext = buildDispatchContext(
       {
-        id: meta.decisionId,
+        id: meta.workItemId,
         content: targetNode.content,
         nodeType: targetNode.nodeType,
         parentId: targetNode.parentId,
       },
-      meta.allDecisions,
+      meta.allWorkItems,
     )
 
     // Store handoff metadata on the node's artifacts for the Pi worker to read
@@ -68,22 +68,22 @@ registerDispatchService({
       context: builtContext,
       teamSlug: meta.teamSlug,
       graphId: meta.graphId,
-      nodeId: meta.decisionId,
+      nodeId: meta.workItemId,
       nodeContent: targetNode.content,
       nodeType: targetNode.nodeType,
       mode: sessionMode,
     }
 
     // Create terminal session so the UI can start showing status immediately
-    createTerminalSession(meta.decisionId, sessionMode as 'legacy' | 'rich')
+    createTerminalSession(meta.workItemId, sessionMode as 'legacy' | 'rich')
 
     // Update node: set status to 'dispatching' and store handoff metadata
     const existingArtifacts = Array.isArray(targetNode.artifacts) ? targetNode.artifacts : []
     // Remove any previous handoff artifacts
     const cleanedArtifacts = existingArtifacts.filter((a: any) => a?.type !== 'handoff')
 
-    await updateThinkgraphDecision(
-      meta.decisionId,
+    await updateThinkgraphWorkItem(
+      meta.workItemId,
       meta.teamId,
       'system',
       {
@@ -94,7 +94,7 @@ registerDispatchService({
     )
 
     // Signal change so Yjs broadcasts to Pi worker
-    signalCollectionChange(meta.teamId, 'thinkgraphDecisions')
+    signalCollectionChange(meta.teamId, 'thinkgraphWorkItems')
 
     // Signal async — Pi worker picks up via Yjs and creates nodes via HTTP API
     return {
@@ -105,3 +105,4 @@ registerDispatchService({
     } as DispatchResult & { _async: boolean }
   },
 })
+


### PR DESCRIPTION
Replaces all remaining `thinkgraphDecisions` references with `thinkgraphWorkItems` in 4 server-side files:

- `server/mcp/tools/store-artifact.ts` — imports + function calls + signalCollectionChange
- `server/mcp/tools/update-node.ts` — imports + function calls + signalCollectionChange
- `server/mcp/tools/create-node.ts` — imports + function calls + signalCollectionChange
- `server/utils/dispatch-services/pi-agent.ts` — imports + function calls + signalCollectionChange + meta.allDecisions→allWorkItems + meta.decisionId→workItemId