### PR TITLE
feat(thinkgraph): add nodeId filter to chatconversations GET endpoint

### DIFF
--- a/apps/thinkgraph/layers/thinkgraph/collections/chatconversations/server/api/teams/[id]/thinkgraph-chatconversations/index.get.ts
+++ b/apps/thinkgraph/layers/thinkgraph/collections/chatconversations/server/api/teams/[id]/thinkgraph-chatconversations/index.get.ts
@@ -20,7 +20,8 @@ export default defineEventHandler(async (event) => {
     return result
   }
 
-  const result = await getAllThinkgraphChatConversations(team.id)
+  const nodeId = query.nodeId ? String(query.nodeId) : undefined
+  const result = await getAllThinkgraphChatConversations(team.id, nodeId)
   dbTimer.end()
   return result
 })

--- a/apps/thinkgraph/layers/thinkgraph/collections/chatconversations/server/database/queries.ts
+++ b/apps/thinkgraph/layers/thinkgraph/collections/chatconversations/server/database/queries.ts
@@ -5,10 +5,15 @@ import * as tables from './schema'
 import type { ThinkgraphChatConversation, NewThinkgraphChatConversation } from '../../types'
 import { user } from '~~/server/db/schema'
 
-export async function getAllThinkgraphChatConversations(teamId: string) {
+export async function getAllThinkgraphChatConversations(teamId: string, nodeId?: string) {
   const db = useDB()
 
   const ownerUser = alias(user as any, 'ownerUser')
+
+  const conditions = [eq(tables.thinkgraphChatConversations.teamId, teamId)]
+  if (nodeId) {
+    conditions.push(eq(tables.thinkgraphChatConversations.nodeId, nodeId))
+  }
 
   const chatConversations = await (db as any)
     .select({
@@ -22,7 +27,7 @@ export async function getAllThinkgraphChatConversations(teamId: string) {
     } as any)
     .from(tables.thinkgraphChatConversations)
     .leftJoin(ownerUser, eq(tables.thinkgraphChatConversations.owner, ownerUser.id))
-    .where(eq(tables.thinkgraphChatConversations.teamId, teamId))
+    .where(and(...conditions))
     .orderBy(desc(tables.thinkgraphChatConversations.order))
 
   // Post-query processing for JSON fields (repeater/json types)


### PR DESCRIPTION
## Summary

Adds optional `nodeId` query parameter filtering to the chatconversations GET endpoint.

### Changes

**`server/database/queries.ts`**
- `getAllThinkgraphChatConversations(teamId, nodeId?)` now accepts an optional `nodeId` parameter
- When provided, adds `eq(thinkgraphChatConversations.nodeId, nodeId)` to the WHERE clause using `and()`

**`index.get.ts`**
- Reads `query.nodeId` from the query string and passes it to the query function

### Usage

```
GET /api/teams/:id/thinkgraph-chatconversations?nodeId=abc123
```

Returns only conversations associated with the given node. Without `nodeId`, returns all conversations (existing behavior preserved).