### PR TITLE
fix: add debug logging to trace webhook signal race condition

### DIFF
--- a/apps/thinkgraph-worker/src/session-manager.ts
+++ b/apps/thinkgraph-worker/src/session-manager.ts
@@ -140,7 +140,7 @@ export class AgentSessionManager {
       const isPM = payload.collectionPath === 'thinkgraph-workitems'
       const tools = isPM
         ? createPMTools(this.config, payload.nodeId, payload.teamId || this.config.teamId, {
-          onSignal: (signal) => { earlySession.lastSignal = signal },
+          onSignal: (signal) => { console.log(`[session-manager] onSignal captured: ${signal} for ${payload.nodeId}`); earlySession.lastSignal = signal },
         })
         : createThinkGraphTools(this.config, payload.graphId, payload.nodeId)
 
@@ -1391,6 +1391,7 @@ Use the \`create_node\` tool. Each node has three parts:
 
       // Forward the agent's signal directly — captured via onSignal callback
       // when the agent calls update_workitem. No extra HTTP read needed.
+      console.log(`[session-manager] sendCallback for ${session.nodeId}: lastSignal=${session.lastSignal}`)
       if (isPM && session.lastSignal) {
         body.signal = session.lastSignal
       }


### PR DESCRIPTION
## What

Add 2 debug console.logs to `session-manager.ts` to trace the signal forwarding chain from Pi worker to webhook.

### Changes

1. **`onSignal` callback** (~line 144): Log when signal is captured, showing the signal value and nodeId
2. **`sendCallback`** (~line 1394): Log the `lastSignal` value just before it's forwarded in the callback body

### Why

The webhook at `webhook.post.ts` sometimes reads stale DB state. These logs will reveal whether:
- The `onSignal` callback is firing at all
- The `lastSignal` value is present when `sendCallback` runs
- There's a timing gap between signal capture and callback

### Scope

Investigation only — no logic changes. 2 console.log additions.