### PR TITLE
feat: add action-log artifact type for work item lifecycle tracking

### DIFF
--- a/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
@@ -191,6 +191,21 @@ async function handleCreate() {
   }
 }
 
+// ─── Action log helper ───
+function createActionLog(action: string, detail: string, actor: 'pi' | 'human' | 'system' = 'human') {
+  return { type: 'action-log' as const, action, detail, timestamp: new Date().toISOString(), actor }
+}
+
+async function appendActionLog(id: string, action: string, detail: string, actor: 'pi' | 'human' | 'system' = 'human') {
+  const item = items.value.find(n => n.id === id)
+  if (!item) return
+  const existing = Array.isArray(item.artifacts) ? item.artifacts : []
+  await $fetch(`/api/teams/${teamId.value}/thinkgraph-workitems/${id}`, {
+    method: 'PATCH',
+    body: { artifacts: [...existing, createActionLog(action, detail, actor)] },
+  })
+}
+
 // ─── Update work item ───
 async function updateItem(id: string, data: Partial<ThinkgraphWorkItem>) {
   if (!teamId.value) return
@@ -430,6 +445,7 @@ async function respondAndRedispatch(id: string) {
   try {
     const formattedAnswers = formatAnswers()
     const updatedBrief = `${item.brief || item.title}\n\n---\n**Human answers:**\n${formattedAnswers}`
+    await appendActionLog(id, 'human-answer', `Answered ${Object.keys(orangeAnswers.value).length} question(s) and re-dispatched`)
     await updateItem(id, {
       brief: updatedBrief,
       status: 'queued',
@@ -724,6 +740,31 @@ const stageAccordionItems = computed(() => {
       value: `${so.stage}-${so.timestamp}`,
     }
   })
+})
+
+// ─── Action log (from artifacts) ───
+const ACTION_ICONS: Record<string, string> = {
+  'dispatch': 'i-lucide-send',
+  'stage-advance': 'i-lucide-arrow-right',
+  'signal-change': 'i-lucide-circle-dot',
+  'human-answer': 'i-lucide-message-circle',
+  'reset': 'i-lucide-rotate-ccw',
+  'pipeline-reset': 'i-lucide-refresh-ccw',
+  'dismiss': 'i-lucide-x-circle',
+}
+
+const ACTOR_LABEL: Record<string, string> = {
+  pi: 'Pi',
+  human: 'Human',
+  system: 'System',
+}
+
+const actionLogs = computed(() => {
+  if (!selectedItem.value?.artifacts) return []
+  const artifacts = Array.isArray(selectedItem.value.artifacts) ? selectedItem.value.artifacts : []
+  return artifacts
+    .filter((a: any) => a.type === 'action-log')
+    .sort((a: any, b: any) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
 })
 
 // ─── Keyboard shortcuts ───
@@ -1085,7 +1126,7 @@ if (import.meta.client) {
                 size="sm"
                 variant="soft"
                 color="red"
-                @click="updateItem(selectedItem.id, { status: 'done' })"
+                @click="async () => { await appendActionLog(selectedItem!.id, 'dismiss', 'Rejected red signal'); updateItem(selectedItem!.id, { status: 'done' }) }"
               />
             </div>
           </div>
@@ -1134,7 +1175,7 @@ if (import.meta.client) {
                 variant="soft"
                 color="red"
                 size="sm"
-                @click="updateItem(selectedItem.id, { status: 'done', signal: 'red' })"
+                @click="async () => { await appendActionLog(selectedItem!.id, 'dismiss', 'Dismissed orange signal'); updateItem(selectedItem!.id, { status: 'done', signal: 'red' }) }"
               />
             </div>
           </div>
@@ -1146,6 +1187,29 @@ if (import.meta.client) {
               <UAccordion :items="stageAccordionItems" type="multiple" />
             </div>
             <p v-else class="text-xs text-muted/60 italic">No previous stages</p>
+          </div>
+
+          <!-- Action Log Timeline -->
+          <div v-if="actionLogs.length > 0" class="mb-4">
+            <p class="text-xs font-medium text-muted mb-2">Action Log</p>
+            <div class="space-y-0.5">
+              <div
+                v-for="(log, idx) in actionLogs"
+                :key="idx"
+                class="flex items-center gap-2 py-1 text-xs text-muted"
+              >
+                <UIcon
+                  :name="ACTION_ICONS[log.action] || 'i-lucide-activity'"
+                  class="size-3 shrink-0"
+                />
+                <span class="text-[10px] tabular-nums opacity-60 shrink-0">
+                  {{ new Date(log.timestamp).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) }}
+                  {{ new Date(log.timestamp).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }) }}
+                </span>
+                <span class="truncate">{{ log.detail }}</span>
+                <span class="text-[10px] opacity-40 shrink-0">{{ ACTOR_LABEL[log.actor] || log.actor }}</span>
+              </div>
+            </div>
           </div>
 
           <!-- Retrospective -->
@@ -1205,7 +1269,7 @@ if (import.meta.client) {
               label="Reset to Queued"
               variant="soft"
               color="warning"
-              @click="updateItem(selectedItem.id, { status: 'queued' })"
+              @click="async () => { await appendActionLog(selectedItem!.id, 'reset', 'Reset from active to queued'); updateItem(selectedItem!.id, { status: 'queued' }) }"
             />
             <UButton
               v-if="selectedItem.stage"
@@ -1213,7 +1277,7 @@ if (import.meta.client) {
               label="Reset Pipeline"
               variant="soft"
               color="neutral"
-              @click="updateItem(selectedItem.id, { status: 'queued', stage: 'analyst', signal: null, assignee: 'pi', output: null, retrospective: null })"
+              @click="async () => { await appendActionLog(selectedItem!.id, 'pipeline-reset', `Pipeline reset from ${selectedItem!.stage} to analyst`); updateItem(selectedItem!.id, { status: 'queued', stage: 'analyst', signal: null, assignee: 'pi', output: null, retrospective: null }) }"
             />
             <UButton
               v-if="selectedItem.status !== 'done'"
@@ -1221,7 +1285,7 @@ if (import.meta.client) {
               label="Mark Done"
               variant="soft"
               color="green"
-              @click="updateItem(selectedItem.id, { status: 'done' })"
+              @click="async () => { await appendActionLog(selectedItem!.id, 'dismiss', 'Manually marked as done'); updateItem(selectedItem!.id, { status: 'done' }) }"
             />
             <UButton
               icon="i-lucide-trash-2"

--- a/apps/thinkgraph/server/api/teams/[id]/dispatch/webhook.post.ts
+++ b/apps/thinkgraph/server/api/teams/[id]/dispatch/webhook.post.ts
@@ -39,9 +39,22 @@ export default defineEventHandler(async (event) => {
   // Read current item state
   const [currentState] = await getThinkgraphWorkItemsByIds(teamId, [workItemId])
 
+  // Helper to create action-log artifacts
+  function actionLog(action: string, detail: string) {
+    return { type: 'action-log' as const, action, detail, timestamp: new Date().toISOString(), actor: 'system' as const }
+  }
+
   // Use signal from callback body (forwarded by Pi worker) or fall back to DB
   const agentSignal = callbackSignal || currentState?.signal
   console.log(`[webhook] ${workItemId}: status=${status}, callbackSignal=${callbackSignal}, dbSignal=${currentState?.signal}, agentSignal=${agentSignal}`)
+
+  // Log signal change
+  if (callbackSignal && callbackSignal !== currentState?.signal) {
+    const existingArtifacts = Array.isArray(currentState?.artifacts) ? currentState.artifacts : []
+    await updateThinkgraphWorkItem(workItemId, teamId, 'system', {
+      artifacts: [...existingArtifacts, actionLog('signal-change', `Signal set to ${callbackSignal}`)],
+    }, { role: 'admin' })
+  }
 
   // Respect the agent's signal — don't let session completion override it
   if (status === 'done' && (agentSignal === 'orange' || agentSignal === 'red')) {
@@ -104,6 +117,13 @@ export default defineEventHandler(async (event) => {
         : null
 
       if (nextStage) {
+        // Log the stage advance
+        const [itemForLog] = await getThinkgraphWorkItemsByIds(teamId, [workItemId])
+        const logArtifacts = Array.isArray(itemForLog?.artifacts) ? itemForLog.artifacts : []
+        await updateThinkgraphWorkItem(workItemId, teamId, 'system', {
+          artifacts: [...logArtifacts, actionLog('stage-advance', `${currentItem.stage} → ${nextStage}`)],
+        }, { role: 'admin' })
+
         try {
           if (nextStage === 'launcher') {
             // Launcher stage: wait for CI results, don't dispatch to Pi

--- a/apps/thinkgraph/server/api/teams/[id]/dispatch/work-item.post.ts
+++ b/apps/thinkgraph/server/api/teams/[id]/dispatch/work-item.post.ts
@@ -79,13 +79,22 @@ export default defineEventHandler(async (event) => {
   const existingArtifacts = Array.isArray(targetItem.artifacts) ? targetItem.artifacts : []
   const cleanedArtifacts = existingArtifacts.filter((a: any) => a?.type !== 'handoff')
 
+  // Action log entry for dispatch
+  const dispatchLog = {
+    type: 'action-log' as const,
+    action: 'dispatch',
+    detail: `Dispatched to ${provider} at stage ${stage}`,
+    timestamp: new Date().toISOString(),
+    actor: 'human' as const,
+  }
+
   await updateThinkgraphWorkItem(
     workItemId,
     team.id,
     user.id,
     {
       status: 'active',
-      artifacts: [...cleanedArtifacts, handoffMeta],
+      artifacts: [...cleanedArtifacts, handoffMeta, dispatchLog],
     },
     { role: membership.role },
   )


### PR DESCRIPTION
## Summary

Adds an `action-log` artifact type to track significant work item lifecycle events. Each entry stores `{ type: 'action-log', action, detail, timestamp, actor }`.

### Logged events

| Source | Events | Actor |
|--------|--------|-------|
| `webhook.post.ts` | Stage advances, signal changes | `system` |
| `work-item.post.ts` | Dispatches | `human` |
| `[projectId].vue` | Resets, pipeline resets, dismissals, human answers | `human` |

### UI

Compact timeline rendered in the detail panel slideover, below the Pipeline History accordion. Each entry is one line: icon + timestamp + detail + actor. Most recent at top.

### Changes
- `apps/thinkgraph/server/api/teams/[id]/dispatch/webhook.post.ts` — action-log for stage advances and signal changes
- `apps/thinkgraph/server/api/teams/[id]/dispatch/work-item.post.ts` — action-log for dispatches
- `apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue` — action-log for client-side actions + timeline rendering