### PR TITLE
chore(thinkgraph): add canary comment for pipeline smoke test

### DIFF
--- a/apps/thinkgraph/nuxt.config.ts
+++ b/apps/thinkgraph/nuxt.config.ts
@@ -1,3 +1,4 @@
+// canary: pelican
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 


### PR DESCRIPTION
Adds `// canary: pelican` as line 1 of `apps/thinkgraph/nuxt.config.ts`. No functional change — pipeline smoke test.