### PR TITLE
chore(thinkgraph): add pipeline version marker

### DIFF
--- a/apps/thinkgraph/server/api/teams/[id]/dispatch/webhook.post.ts
+++ b/apps/thinkgraph/server/api/teams/[id]/dispatch/webhook.post.ts
@@ -1,3 +1,4 @@
+// pipeline-version: 2
 import { updateThinkgraphWorkItem, getAllThinkgraphWorkItems, getThinkgraphWorkItemsByIds } from '~~/layers/thinkgraph/collections/workitems/server/database/queries'
 
 /**


### PR DESCRIPTION
Adds `// pipeline-version: 2` as line 1 of `apps/thinkgraph/server/api/teams/[id]/dispatch/webhook.post.ts`.