### PR TITLE
chore(thinkgraph): add build timestamp comment

### DIFF
--- a/apps/thinkgraph/nuxt.config.ts
+++ b/apps/thinkgraph/nuxt.config.ts
@@ -1,3 +1,4 @@
+// built: 2026-03-20
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 


### PR DESCRIPTION
Adds `// built: 2026-03-20` as line 1 of `apps/thinkgraph/nuxt.config.ts`.