### PR TITLE
feat(thinkgraph): add wrench emoji to project title

### DIFF
--- a/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
@@ -769,7 +769,7 @@ if (import.meta.client) {
           <UIcon name="i-lucide-arrow-left" class="size-4" />
         </NuxtLink>
         <div>
-          <h1 class="text-sm font-semibold">{{ project?.name || 'Project' }}</h1>
+          <h1 class="text-sm font-semibold">🔧 {{ project?.name || 'Project' }}</h1>
           <p v-if="project?.clientName" class="text-xs text-muted">{{ project.clientName }}</p>
         </div>
       </div>


### PR DESCRIPTION
Prepends 🔧 emoji to the project title in the ThinkGraph project page.

**File**: `apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue`, line 772
**Change**: `{{ project?.name || 'Project' }}` → `🔧 {{ project?.name || 'Project' }}`