### PR TITLE
feat(thinkgraph): add template badge pills to project list cards

### DIFF
--- a/apps/thinkgraph/app/pages/admin/[team]/projects.vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/projects.vue
@@ -33,6 +33,19 @@ const STATUS_PILL: Record<string, string> = {
 
 const STATUS_ORDER = ['active', 'waiting', 'blocked', 'done'] as const
 
+// Group template counts by projectId
+const templateCountsByProject = computed(() => {
+  const map: Record<string, Record<string, number>> = {}
+  for (const item of nodes.value || []) {
+    if (!item.projectId || !item.template) continue
+    if (!map[item.projectId]) map[item.projectId] = {}
+    map[item.projectId][item.template] = (map[item.projectId][item.template] || 0) + 1
+  }
+  return map
+})
+
+const TEMPLATE_ORDER = ['idea', 'research', 'task', 'feature', 'meta'] as const
+
 const isCreateOpen = ref(false)
 const createForm = reactive({ name: '', clientName: '', appId: '', description: '' })
 const createPending = ref(false)
@@ -146,6 +159,19 @@ const statusStyle = (status: string) => {
             :class="STATUS_PILL[status]"
           >
             {{ statusCountsByProject[project.id]?.[status] }} {{ status }}
+          </span>
+        </div>
+
+        <!-- Template counts -->
+        <div v-if="templateCountsByProject[project.id]" class="flex items-center gap-1 mt-1">
+          <span
+            v-for="template in TEMPLATE_ORDER"
+            :key="template"
+            v-show="templateCountsByProject[project.id]?.[template]"
+            class="text-[10px] font-medium px-1.5 py-0.5 rounded-full"
+            :class="TEMPLATE_BADGE[template]"
+          >
+            {{ templateCountsByProject[project.id]?.[template] }} {{ template }}
           </span>
         </div>
       </NuxtLink>


### PR DESCRIPTION
Adds a second row of count pills to project cards on the projects list page, showing counts by template (idea, research, task, feature, meta) using `TEMPLATE_BADGE` colors from `thinkgraph-config.ts`.

**Changes:**
- Added `templateCountsByProject` computed that groups node counts by `item.template` per project
- Added `TEMPLATE_ORDER` array for consistent pill ordering
- Added template pills row below existing status pills, using same styling pattern
- Only shows templates with count ≥ 1 (via `v-show`)
- Skips nodes where `template` is undefined