### PR TITLE
feat(thinkgraph): add per-node chat threads in detail slideover

### DIFF
--- a/.thinkgraph/nodes/RPrYoBQcZF5PlAhlk5M54.md
+++ b/.thinkgraph/nodes/RPrYoBQcZF5PlAhlk5M54.md
@@ -1,0 +1,15 @@
+# Build node-level chat in ThinkGraph detail panel
+
+## Summary
+Added per-node conversation threads embedded in the node detail slideover with slash command support and conversation history integration during dispatch.
+
+## Changes
+- **New component**: `apps/thinkgraph/app/components/NodeChatPanel.vue` — Embedded chat panel for the slideover detail view
+- **Modified**: `apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue` — Integrated NodeChatPanel, wired slash commands, included chat history in dispatch
+
+## Features
+- Per-node chat threads persisted via `chatconversations` collection
+- Slash commands: `/break-down` and `/send-to-pi` trigger existing actions
+- Action buttons in chat header for break-down and dispatch
+- Conversation history (last 20 messages) automatically included when dispatching to Pi
+- Conversation history included in respondAndRedispatch flow

--- a/apps/thinkgraph/app/components/NodeChatPanel.vue
+++ b/apps/thinkgraph/app/components/NodeChatPanel.vue
@@ -1,0 +1,260 @@
+<script setup lang="ts">
+/**
+ * NodeChatPanel — embedded per-node chat for the detail slideover.
+ *
+ * Features:
+ * - Persists messages via chatconversations collection
+ * - Slash commands: /break-down, /send-to-pi
+ * - Action buttons inside chat for break-down and dispatch
+ * - Exports conversation history for dispatch context
+ */
+
+const props = defineProps<{
+  nodeId: string
+  nodeName?: string
+}>()
+
+const emit = defineEmits<{
+  'break-down': []
+  'send-to-pi': []
+}>()
+
+const { teamId } = useTeamContext()
+
+const {
+  messages,
+  input,
+  handleSubmit,
+  isLoading,
+  error,
+  clearMessages,
+  exportMessages,
+  importMessages,
+} = useChat({
+  api: `/api/teams/${teamId.value}/thinkgraph-nodes/chat`,
+  body: computed(() => ({
+    nodeId: props.nodeId,
+    graphId: '',
+  })),
+  onFinish: () => {
+    saveConversation()
+  },
+})
+
+// ─── Persistence ───
+const conversationId = ref<string | null>(null)
+const isLoadingConversation = ref(false)
+const apiBase = computed(() => `/api/teams/${teamId.value}/thinkgraph-chatconversations`)
+
+async function loadConversation(nodeId: string) {
+  isLoadingConversation.value = true
+  conversationId.value = null
+  clearMessages()
+  try {
+    const result = await $fetch<any>(apiBase.value, {
+      query: { nodeId },
+    })
+    if (result?.id) {
+      conversationId.value = result.id
+      if (Array.isArray(result.messages) && result.messages.length > 0) {
+        importMessages(result.messages)
+      }
+    }
+  }
+  catch {
+    // No conversation yet — that's fine
+  }
+  finally {
+    isLoadingConversation.value = false
+  }
+}
+
+async function saveConversation() {
+  const exported = exportMessages()
+  if (!exported?.length) return
+  try {
+    if (conversationId.value) {
+      await $fetch(`${apiBase.value}/${conversationId.value}`, {
+        method: 'PATCH',
+        body: {
+          messages: exported,
+          messageCount: exported.length,
+          lastMessageAt: new Date().toISOString(),
+        },
+      })
+    }
+    else {
+      const result = await $fetch<any>(apiBase.value, {
+        method: 'POST',
+        body: {
+          nodeId: props.nodeId,
+          title: props.nodeName || 'Chat',
+          messages: exported,
+          messageCount: exported.length,
+          lastMessageAt: new Date().toISOString(),
+        },
+      })
+      if (result?.id) {
+        conversationId.value = result.id
+      }
+    }
+  }
+  catch (e) {
+    console.warn('Failed to save conversation:', e)
+  }
+}
+
+// ─── Slash commands ───
+function onSubmit() {
+  const trimmed = input.value.trim()
+  if (!trimmed) return
+
+  if (trimmed === '/break-down') {
+    input.value = ''
+    emit('break-down')
+    return
+  }
+  if (trimmed === '/send-to-pi') {
+    input.value = ''
+    emit('send-to-pi')
+    return
+  }
+
+  handleSubmit()
+}
+
+// ─── Format helper ───
+function formatContent(content: string): string {
+  return content.replace(/DECISION:\s*\{[^}]+\}/g, '').trim()
+}
+
+// ─── Auto-scroll ───
+const messagesEl = ref<HTMLElement>()
+watch(messages, () => {
+  nextTick(() => {
+    if (messagesEl.value) {
+      messagesEl.value.scrollTop = messagesEl.value.scrollHeight
+    }
+  })
+}, { deep: true })
+
+// ─── Load on mount / nodeId change ───
+watch(() => props.nodeId, async (newId, oldId) => {
+  if (oldId && messages.value.length > 0) {
+    saveConversation()
+  }
+  await loadConversation(newId)
+}, { immediate: true })
+
+// ─── Public API for parent to get conversation history ───
+defineExpose({
+  getConversationHistory: () => exportMessages(),
+})
+</script>
+
+<template>
+  <div class="flex flex-col border border-default rounded-lg overflow-hidden bg-default" style="height: 380px;">
+    <!-- Header -->
+    <div class="flex items-center justify-between px-3 py-2 border-b border-default bg-neutral-50 dark:bg-neutral-800/50 shrink-0">
+      <div class="flex items-center gap-2">
+        <UIcon name="i-lucide-message-square-text" class="size-3.5 text-violet-500" />
+        <span class="text-xs font-medium">Chat</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <UButton
+          icon="i-lucide-git-branch"
+          size="xs"
+          variant="ghost"
+          color="neutral"
+          title="Break down"
+          @click="emit('break-down')"
+        />
+        <UButton
+          icon="i-lucide-send"
+          size="xs"
+          variant="ghost"
+          color="neutral"
+          title="Send to Pi"
+          @click="emit('send-to-pi')"
+        />
+      </div>
+    </div>
+
+    <!-- Messages -->
+    <div ref="messagesEl" class="flex-1 overflow-y-auto p-3 space-y-2 min-h-0">
+      <div
+        v-if="isLoadingConversation"
+        class="h-full flex items-center justify-center text-neutral-400"
+      >
+        <UIcon name="i-lucide-loader-2" class="size-4 animate-spin" />
+      </div>
+
+      <div
+        v-else-if="messages.length === 0"
+        class="h-full flex flex-col items-center justify-center text-neutral-400 dark:text-neutral-600"
+      >
+        <UIcon name="i-lucide-sparkles" class="size-6 mb-2 opacity-50" />
+        <p class="text-xs text-center">Ask about this node</p>
+        <p class="text-[10px] mt-1 opacity-60">
+          Try <code class="bg-neutral-200 dark:bg-neutral-700 px-1 rounded">/break-down</code>
+          or <code class="bg-neutral-200 dark:bg-neutral-700 px-1 rounded">/send-to-pi</code>
+        </p>
+      </div>
+
+      <template v-else>
+        <div
+          v-for="msg in messages"
+          :key="msg.id"
+          class="flex"
+          :class="msg.role === 'user' ? 'justify-end' : 'justify-start'"
+        >
+          <div
+            class="max-w-[85%] rounded-lg px-2.5 py-1.5 text-xs"
+            :class="msg.role === 'user'
+              ? 'bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900'
+              : 'bg-neutral-100 dark:bg-neutral-800 text-neutral-800 dark:text-neutral-200'"
+          >
+            <p class="whitespace-pre-wrap leading-relaxed">{{ formatContent(msg.content) }}</p>
+          </div>
+        </div>
+      </template>
+
+      <div v-if="isLoading" class="flex justify-start">
+        <div class="bg-neutral-100 dark:bg-neutral-800 rounded-lg px-2.5 py-1.5">
+          <UIcon name="i-lucide-loader-2" class="size-3 animate-spin text-neutral-400" />
+        </div>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div v-if="error" class="px-3 pb-1">
+      <div class="text-[10px] text-red-500 bg-red-50 dark:bg-red-900/10 rounded px-2 py-1">
+        {{ error.message || 'Something went wrong' }}
+      </div>
+    </div>
+
+    <!-- Input -->
+    <form
+      class="flex items-end gap-1.5 px-3 py-2 border-t border-default shrink-0"
+      @submit.prevent="onSubmit"
+    >
+      <UTextarea
+        v-model="input"
+        placeholder="Ask about this node… or /break-down, /send-to-pi"
+        :rows="1"
+        autoresize
+        class="flex-1"
+        size="xs"
+        :disabled="isLoadingConversation"
+        @keydown.enter.exact.prevent="onSubmit"
+      />
+      <UButton
+        type="submit"
+        icon="i-lucide-arrow-up"
+        size="xs"
+        :loading="isLoading"
+        :disabled="!input.trim() || isLoadingConversation"
+      />
+    </form>
+  </div>
+</template>

--- a/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ThinkgraphNode } from '~~/layers/thinkgraph/collections/nodes/types'
 import ThinkgraphNodesNodeComponent from '~/components/ThinkgraphNodesNode.vue'
+import NodeChatPanel from '~/components/NodeChatPanel.vue'
 
 // Explicitly register so CroutonFlow's resolveComponent() can find it
 // CroutonFlow: "thinkgraphNodes" → PascalCase "ThinkgraphNodes" + "Node" → "ThinkgraphNodesNode"
@@ -508,7 +509,16 @@ async function dispatchNode(id: string) {
   const steps = Array.isArray(item.steps) && item.steps.length > 0
     ? item.steps
     : TEMPLATE_STEPS[item.template || 'task'] || ['analyst', 'builder', 'reviewer', 'merger']
-  await updateItem(id, { status: 'queued', assignee: 'pi', steps })
+
+  // Include conversation history in the brief when dispatching
+  const chatHistory = getChatHistory()
+  const updates: Partial<ThinkgraphNode> = { status: 'queued', assignee: 'pi', steps }
+  if (chatHistory) {
+    const existingBrief = item.brief || item.title
+    updates.brief = `${existingBrief}\n\n---\n**Conversation context:**\n${chatHistory}`
+  }
+
+  await updateItem(id, updates)
   await openDispatch(id)
 }
 
@@ -578,7 +588,9 @@ async function respondAndRedispatch(id: string) {
   redispatching.value = true
   try {
     const formattedAnswers = formatAnswers()
-    const updatedBrief = `${item.brief || item.title}\n\n---\n**Human answers:**\n${formattedAnswers}`
+    const chatHistory = getChatHistory()
+    const chatSection = chatHistory ? `\n\n---\n**Conversation context:**\n${chatHistory}` : ''
+    const updatedBrief = `${item.brief || item.title}\n\n---\n**Human answers:**\n${formattedAnswers}${chatSection}`
     await updateItem(id, {
       brief: updatedBrief,
       status: 'queued',
@@ -805,6 +817,19 @@ async function promoteToTask(id: string, template: string) {
 
 // ─── Flow ref for programmatic control ───
 const flowRef = ref<any>(null)
+
+// ─── Node chat panel ref ───
+const nodeChatPanelRef = ref<InstanceType<typeof NodeChatPanel> | null>(null)
+
+function getChatHistory(): string {
+  if (!nodeChatPanelRef.value) return ''
+  const history = nodeChatPanelRef.value.getConversationHistory()
+  if (!history?.length) return ''
+  return history
+    .map((m: any) => `[${m.role}]: ${m.content}`)
+    .slice(-20) // Last 20 messages max
+    .join('\n')
+}
 
 // ─── Assistant actions ───
 async function assistantCreateItem(data: { title: string; type: string; brief: string }) {
@@ -1497,6 +1522,17 @@ if (import.meta.client) {
               </UAccordion>
             </div>
             <p v-else class="text-xs text-muted/60 italic">No previous stages</p>
+          </div>
+
+          <!-- Per-node chat -->
+          <div class="mb-4">
+            <NodeChatPanel
+              ref="nodeChatPanelRef"
+              :node-id="selectedItem.id"
+              :node-name="selectedItem.title"
+              @break-down="decomposeNode(selectedItem.id)"
+              @send-to-pi="dispatchNode(selectedItem.id)"
+            />
           </div>
 
           <!-- Retrospective -->


### PR DESCRIPTION
## Summary

Adds per-node conversation threads embedded in the ThinkGraph project detail slideover panel.

## Changes

### New: `NodeChatPanel.vue`
- Embedded chat component designed for the detail slideover (compact 380px height)
- Uses existing `useChat` composable with the thinkgraph-nodes chat endpoint
- Persists messages via the `chatconversations` collection (load/save)
- Slash commands: `/break-down` triggers decompose, `/send-to-pi` triggers dispatch
- Action buttons in header for quick access to break-down and dispatch
- Exposes `getConversationHistory()` for parent components to read chat context

### Modified: Project page (`[projectId].vue`)
- Embeds `NodeChatPanel` in the detail slideover between pipeline history and retrospective
- `dispatchNode()` now includes last 20 chat messages as conversation context in the brief
- `respondAndRedispatch()` also includes chat context when re-dispatching with human answers

## How it works
1. Open any node's detail panel → chat panel appears with the node's conversation thread
2. Type messages to discuss the node with AI (uses existing chat endpoint with full thinking path context)
3. Use `/break-down` or `/send-to-pi` slash commands, or click header action buttons
4. When dispatching to Pi, recent conversation history is automatically appended to the brief