### PR TITLE
fix(root): add NODE_OPTIONS to CI typecheck to prevent OOM

### DIFF
--- a/.github/workflows/thinkgraph-ci.yml
+++ b/.github/workflows/thinkgraph-ci.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Typecheck
         id: typecheck
         continue-on-error: true
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
         run: |
           pnpm typecheck 2>&1 | tee /tmp/typecheck-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"

--- a/.thinkgraph/nodes/2CdeD809x6iaJZOOS2V7H.md
+++ b/.thinkgraph/nodes/2CdeD809x6iaJZOOS2V7H.md
@@ -1,0 +1,10 @@
+# Typecheck OOM on large monorepo in CI
+
+**Status:** done
+**Type:** meta
+
+## Summary
+Added `NODE_OPTIONS: '--max-old-space-size=8192'` to the Typecheck step in `.github/workflows/thinkgraph-ci.yml` to prevent JS heap OOM errors during CI typecheck runs.
+
+## Changes
+- `.github/workflows/thinkgraph-ci.yml` — added `env.NODE_OPTIONS` to Typecheck step, matching the pattern used in all deploy workflows.


### PR DESCRIPTION
## Summary

The ThinkGraph CI typecheck workflow (`.github/workflows/thinkgraph-ci.yml`) was missing `NODE_OPTIONS: '--max-old-space-size=8192'` on its typecheck step, causing JS heap OOM errors when running `pnpm typecheck` in CI.

All deploy workflows already set this env var. This PR adds it to the CI typecheck step to match.

## Changes

- `.github/workflows/thinkgraph-ci.yml` — added `env.NODE_OPTIONS: '--max-old-space-size=8192'` to the Typecheck step