### PR TITLE
refactor(thinkgraph): extract chat persistence into useChatPersistence composable

### DIFF
--- a/.thinkgraph/nodes/6g2rzd_4WrEsX75cIkgNv.md
+++ b/.thinkgraph/nodes/6g2rzd_4WrEsX75cIkgNv.md
@@ -1,0 +1,25 @@
+# NodeChatPanel duplicates ChatPanel persistence logic
+
+**Status:** done
+**Type:** idea
+
+## Summary
+
+Extracted duplicate chat persistence logic from `ChatPanel.vue` and `NodeChatPanel.vue` into a shared `useChatPersistence` composable.
+
+## Changes
+
+- **New:** `apps/thinkgraph/app/composables/useChatPersistence.ts` — shared load/save conversation logic
+- **Modified:** `apps/thinkgraph/app/components/ChatPanel.vue` — uses `useChatPersistence` composable
+- **Modified:** `apps/thinkgraph/app/components/NodeChatPanel.vue` — uses `useChatPersistence` composable
+
+## Design
+
+The composable accepts:
+- `teamId` ref for API base path
+- `callbacks` object with `clearMessages`, `exportMessages`, `importMessages` from `useChat`
+- Optional `onClear` hook (used by ChatPanel to reset `addedIds`)
+
+Returns `conversationId`, `isLoadingConversation`, `loadConversation(nodeId)`, and `saveConversation(nodeId, title)`.
+
+Each component wraps `saveConversation` to pass its own nodeId/title. ChatPanel maps `null` nodeId to `'__global__'`.

--- a/apps/thinkgraph/app/components/ChatPanel.vue
+++ b/apps/thinkgraph/app/components/ChatPanel.vue
@@ -39,81 +39,18 @@ const {
 })
 
 // ─── Persistence ────────────────────────────────────────────────
-const conversationId = ref<string | null>(null)
-const isLoadingConversation = ref(false)
+const { isLoadingConversation, loadConversation: _loadConversation, saveConversation: _saveConversation } = useChatPersistence({
+  teamId,
+  callbacks: { clearMessages, exportMessages, importMessages },
+  onClear: () => { addedIds.value = new Set() },
+})
 
-const apiBase = computed(() => `/api/teams/${teamId.value}/thinkgraph-chatconversations`)
-
-/**
- * Load an existing conversation for the current nodeId.
- * If no nodeId is provided, we use a special "global" key.
- */
-async function loadConversation(nodeId: string | null | undefined) {
-  isLoadingConversation.value = true
-  conversationId.value = null
-  clearMessages()
-  addedIds.value = new Set()
-
-  try {
-    const lookupId = nodeId || '__global__'
-    const result = await $fetch<any>(apiBase.value, {
-      query: { nodeId: lookupId },
-    })
-
-    if (result && result.id) {
-      conversationId.value = result.id
-      if (result.messages && Array.isArray(result.messages) && result.messages.length > 0) {
-        importMessages(result.messages)
-      }
-    }
-  } catch {
-    // No existing conversation found — that's fine, start fresh
-  } finally {
-    isLoadingConversation.value = false
-  }
+function loadConversation(nodeId: string | null | undefined) {
+  return _loadConversation(nodeId || '__global__')
 }
 
-/**
- * Save the current conversation — creates or updates.
- * Fire-and-forget: does not block the UI.
- */
-async function saveConversation() {
-  const exported = exportMessages()
-  if (!exported || exported.length === 0) return
-
-  const nodeIdValue = props.nodeId || '__global__'
-
-  try {
-    if (conversationId.value) {
-      // Update existing conversation
-      await $fetch(`${apiBase.value}/${conversationId.value}`, {
-        method: 'PATCH',
-        body: {
-          messages: exported,
-          messageCount: exported.length,
-          lastMessageAt: new Date().toISOString(),
-        },
-      })
-    } else {
-      // Create new conversation
-      const result = await $fetch<any>(apiBase.value, {
-        method: 'POST',
-        body: {
-          nodeId: nodeIdValue,
-          title: props.nodeName || 'Chat',
-          messages: exported,
-          messageCount: exported.length,
-          lastMessageAt: new Date().toISOString(),
-        },
-      })
-      if (result && result.id) {
-        conversationId.value = result.id
-      }
-    }
-  } catch (e) {
-    // Silently fail — don't disrupt the chat experience
-    console.warn('Failed to save conversation:', e)
-  }
+function saveConversation() {
+  return _saveConversation(props.nodeId || '__global__', props.nodeName || 'Chat')
 }
 
 // ─── Decision Extraction ────────────────────────────────────────

--- a/apps/thinkgraph/app/components/NodeChatPanel.vue
+++ b/apps/thinkgraph/app/components/NodeChatPanel.vue
@@ -53,66 +53,13 @@ const {
 })
 
 // ─── Persistence ───
-const conversationId = ref<string | null>(null)
-const isLoadingConversation = ref(false)
-const apiBase = computed(() => `/api/teams/${teamId.value}/thinkgraph-chatconversations`)
+const { isLoadingConversation, loadConversation, saveConversation: _saveConversation } = useChatPersistence({
+  teamId,
+  callbacks: { clearMessages, exportMessages, importMessages },
+})
 
-async function loadConversation(nodeId: string) {
-  isLoadingConversation.value = true
-  conversationId.value = null
-  clearMessages()
-  try {
-    const result = await $fetch<any>(apiBase.value, {
-      query: { nodeId },
-    })
-    if (result?.id) {
-      conversationId.value = result.id
-      if (Array.isArray(result.messages) && result.messages.length > 0) {
-        importMessages(result.messages)
-      }
-    }
-  }
-  catch {
-    // No conversation yet — that's fine
-  }
-  finally {
-    isLoadingConversation.value = false
-  }
-}
-
-async function saveConversation() {
-  const exported = exportMessages()
-  if (!exported?.length) return
-  try {
-    if (conversationId.value) {
-      await $fetch(`${apiBase.value}/${conversationId.value}`, {
-        method: 'PATCH',
-        body: {
-          messages: exported,
-          messageCount: exported.length,
-          lastMessageAt: new Date().toISOString(),
-        },
-      })
-    }
-    else {
-      const result = await $fetch<any>(apiBase.value, {
-        method: 'POST',
-        body: {
-          nodeId: props.nodeId,
-          title: props.nodeName || 'Chat',
-          messages: exported,
-          messageCount: exported.length,
-          lastMessageAt: new Date().toISOString(),
-        },
-      })
-      if (result?.id) {
-        conversationId.value = result.id
-      }
-    }
-  }
-  catch (e) {
-    console.warn('Failed to save conversation:', e)
-  }
+function saveConversation() {
+  return _saveConversation(props.nodeId, props.nodeName || 'Chat')
 }
 
 // ─── Slash commands ───

--- a/apps/thinkgraph/app/composables/useChatPersistence.ts
+++ b/apps/thinkgraph/app/composables/useChatPersistence.ts
@@ -7,8 +7,8 @@
 
 interface ChatCallbacks {
   clearMessages: () => void
-  exportMessages: () => any[]
-  importMessages: (messages: any[]) => void
+  exportMessages: () => AIMessage[]
+  importMessages: (messages: AIMessage[]) => void
 }
 
 interface UseChatPersistenceOptions {
@@ -50,8 +50,13 @@ export function useChatPersistence(options: UseChatPersistenceOptions) {
         }
       }
     }
-    catch {
-      // No existing conversation — start fresh
+    catch (e: unknown) {
+      // 404 is expected (no existing conversation) — start fresh
+      const status = (e as { status?: number; statusCode?: number })?.status
+        ?? (e as { status?: number; statusCode?: number })?.statusCode
+      if (status !== 404) {
+        console.warn('Failed to load conversation:', e)
+      }
     }
     finally {
       isLoadingConversation.value = false
@@ -99,7 +104,6 @@ export function useChatPersistence(options: UseChatPersistenceOptions) {
   }
 
   return {
-    conversationId,
     isLoadingConversation,
     loadConversation,
     saveConversation,

--- a/apps/thinkgraph/app/composables/useChatPersistence.ts
+++ b/apps/thinkgraph/app/composables/useChatPersistence.ts
@@ -1,0 +1,107 @@
+/**
+ * useChatPersistence — shared load/save logic for chat conversations.
+ *
+ * Used by both ChatPanel (global chat) and NodeChatPanel (per-node chat)
+ * to persist messages via the thinkgraph-chatconversations API.
+ */
+
+interface ChatCallbacks {
+  clearMessages: () => void
+  exportMessages: () => any[]
+  importMessages: (messages: any[]) => void
+}
+
+interface UseChatPersistenceOptions {
+  /** Team ID for API base path */
+  teamId: Ref<string> | ComputedRef<string>
+  /** Callbacks from useChat instance */
+  callbacks: ChatCallbacks
+  /** Optional hook called after clearing messages (e.g., reset addedIds) */
+  onClear?: () => void
+}
+
+export function useChatPersistence(options: UseChatPersistenceOptions) {
+  const { teamId, callbacks, onClear } = options
+
+  const conversationId = ref<string | null>(null)
+  const isLoadingConversation = ref(false)
+
+  const apiBase = computed(() => `/api/teams/${teamId.value}/thinkgraph-chatconversations`)
+
+  /**
+   * Load an existing conversation for a given nodeId.
+   * Pass '__global__' for the global chat panel.
+   */
+  async function loadConversation(nodeId: string) {
+    isLoadingConversation.value = true
+    conversationId.value = null
+    callbacks.clearMessages()
+    onClear?.()
+
+    try {
+      const result = await $fetch<any>(apiBase.value, {
+        query: { nodeId },
+      })
+
+      if (result?.id) {
+        conversationId.value = result.id
+        if (Array.isArray(result.messages) && result.messages.length > 0) {
+          callbacks.importMessages(result.messages)
+        }
+      }
+    }
+    catch {
+      // No existing conversation — start fresh
+    }
+    finally {
+      isLoadingConversation.value = false
+    }
+  }
+
+  /**
+   * Save the current conversation — creates or updates.
+   * Fire-and-forget: does not block the UI.
+   */
+  async function saveConversation(nodeId: string, title?: string) {
+    const exported = callbacks.exportMessages()
+    if (!exported?.length) return
+
+    try {
+      if (conversationId.value) {
+        await $fetch(`${apiBase.value}/${conversationId.value}`, {
+          method: 'PATCH',
+          body: {
+            messages: exported,
+            messageCount: exported.length,
+            lastMessageAt: new Date().toISOString(),
+          },
+        })
+      }
+      else {
+        const result = await $fetch<any>(apiBase.value, {
+          method: 'POST',
+          body: {
+            nodeId,
+            title: title || 'Chat',
+            messages: exported,
+            messageCount: exported.length,
+            lastMessageAt: new Date().toISOString(),
+          },
+        })
+        if (result?.id) {
+          conversationId.value = result.id
+        }
+      }
+    }
+    catch (e) {
+      console.warn('Failed to save conversation:', e)
+    }
+  }
+
+  return {
+    conversationId,
+    isLoadingConversation,
+    loadConversation,
+    saveConversation,
+  }
+}


### PR DESCRIPTION
## Summary

Extract duplicate load/save conversation logic from `ChatPanel.vue` and `NodeChatPanel.vue` into a shared `useChatPersistence` composable.

## Changes

- **New:** `apps/thinkgraph/app/composables/useChatPersistence.ts` — shared composable for chat conversation persistence
- **Modified:** `apps/thinkgraph/app/components/ChatPanel.vue` — replaced inline persistence with composable
- **Modified:** `apps/thinkgraph/app/components/NodeChatPanel.vue` — replaced inline persistence with composable

## Design

The composable accepts `teamId`, `callbacks` (clearMessages, exportMessages, importMessages from useChat), and an optional `onClear` hook. Returns refs and functions for load/save.

Each component wraps `saveConversation` to pass its own nodeId and title. ChatPanel maps null nodeId to `'__global__'`. Component-specific logic (slash commands, decision extraction) stays in the components.

Net result: -131 lines removed, +147 added (composable + simplified components). No behavioral changes.