### PR TITLE
fix(thinkgraph): strip duplicate conversation sections from brief on re-dispatch

### DIFF
--- a/.thinkgraph/nodes/OFK6upLG7COD-DFWIogLO.md
+++ b/.thinkgraph/nodes/OFK6upLG7COD-DFWIogLO.md
@@ -1,0 +1,15 @@
+# Chat history may bloat brief field over time
+
+**ID:** OFK6upLG7COD-DFWIogLO
+**Type:** task
+**Status:** done
+
+## Problem
+
+Each dispatch appends conversation context and human answers to the brief. If a node is dispatched multiple times, the brief grows with duplicate sections endlessly.
+
+## Solution
+
+Added `stripAppendedSections()` helper that removes previously appended `**Conversation context:**` and `**Human answers:**` sections from the brief before appending fresh ones. Applied in both `dispatchNode()` and `respondAndRedispatch()`.
+
+The regex `/\n\n---\n\*\*(?:Conversation context|Human answers):\*\*[\s\S]*/g` matches from the first `---` separator with a known section header through the end of the string, ensuring all prior appended sections are replaced rather than accumulated.

--- a/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
@@ -570,7 +570,7 @@ async function dispatchNode(id: string) {
   const chatHistory = getChatHistory()
   const updates: Partial<ThinkgraphNode> = { status: 'queued', assignee: 'pi', steps }
   if (chatHistory) {
-    const existingBrief = item.brief || item.title
+    const existingBrief = stripAppendedSections(item.brief || item.title)
     updates.brief = `${existingBrief}\n\n---\n**Conversation context:**\n${chatHistory}`
   }
 
@@ -646,7 +646,8 @@ async function respondAndRedispatch(id: string) {
     const formattedAnswers = formatAnswers()
     const chatHistory = getChatHistory()
     const chatSection = chatHistory ? `\n\n---\n**Conversation context:**\n${chatHistory}` : ''
-    const updatedBrief = `${item.brief || item.title}\n\n---\n**Human answers:**\n${formattedAnswers}${chatSection}`
+    const existingBrief = stripAppendedSections(item.brief || item.title)
+    const updatedBrief = `${existingBrief}\n\n---\n**Human answers:**\n${formattedAnswers}${chatSection}`
     await updateItem(id, {
       brief: updatedBrief,
       status: 'queued',
@@ -923,6 +924,11 @@ const flowRef = ref<any>(null)
 
 // ─── Node chat panel ref ───
 const nodeChatPanelRef = ref<InstanceType<typeof NodeChatPanel> | null>(null)
+
+/** Strip previously appended Conversation context / Human answers sections from a brief */
+function stripAppendedSections(brief: string): string {
+  return brief.replace(/\n\n---\n\*\*(?:Conversation context|Human answers):\*\*[\s\S]*/g, '')
+}
 
 function getChatHistory(): string {
   if (!nodeChatPanelRef.value) return ''


### PR DESCRIPTION
## Problem

`dispatchNode()` and `respondAndRedispatch()` append conversation context and human answers to the brief field on every dispatch. Since previous sections are never stripped, the brief grows with duplicate sections on each re-dispatch.

## Fix

Added `stripAppendedSections()` helper that uses a single regex to remove existing `---\n**Conversation context:**` and `---\n**Human answers:**` sections before appending fresh ones. Applied in both dispatch paths.

- No schema changes needed
- No data loss — chat messages are persisted separately in the `chatconversations` collection
- ~5 lines of code total