### PR TITLE
feat(crouton): Graph Validation System (thinkgraph check)

### DIFF
--- a/.thinkgraph/nodes/mV8BkQKOgWXDCkKa1OLj5.md
+++ b/.thinkgraph/nodes/mV8BkQKOgWXDCkKa1OLj5.md
@@ -1,0 +1,24 @@
+# Graph Validation System (thinkgraph check)
+
+**Status**: done
+**Type**: idea
+**Stage**: builder
+
+## What was built
+
+Graph validation system that detects integrity issues across ThinkGraph projects (Phase 1B of convergence brief).
+
+### New files
+- `server/utils/validate-graph.ts` — Core `validateGraph(teamId, projectId)` utility with 5 validation checks
+- `server/api/teams/[id]/thinkgraph-nodes/validate.get.ts` — API endpoint
+- `server/mcp/tools/check-graph.ts` — MCP tool (10th tool)
+
+### Modified files
+- `app/components/ThinkgraphNodesNode.vue` — Visual warning badge + outline for nodes with issues
+
+## Validation checks
+1. Broken `contextNodeIds` → error severity
+2. Broken `dependsOn` refs → error severity
+3. Orphaned nodes (no parent, depth > 0) → warning
+4. Stale active status (no sessionId heuristic) → warning
+5. Duplicate titles at same depth → warning

--- a/apps/thinkgraph/app/components/ThinkgraphNodesNode.vue
+++ b/apps/thinkgraph/app/components/ThinkgraphNodesNode.vue
@@ -189,14 +189,14 @@ function handleContextMenu(event: MouseEvent | Event) {
     <Handle type="target" :position="Position.Top" class="node-handle" />
 
     <!-- Validation badge -->
-    <div
-      v-if="hasWarnings"
-      class="node-card__validation-badge"
-      :class="{ 'node-card__validation-badge--error': hasErrors }"
-      :title="validationTooltip"
-    >
-      <UIcon :name="hasErrors ? 'i-lucide-alert-circle' : 'i-lucide-alert-triangle'" class="size-3" />
-    </div>
+    <UTooltip v-if="hasWarnings" :text="validationTooltip">
+      <div
+        class="node-card__validation-badge"
+        :class="{ 'node-card__validation-badge--error': hasErrors }"
+      >
+        <UIcon :name="hasErrors ? 'i-lucide-alert-circle' : 'i-lucide-alert-triangle'" class="size-3" />
+      </div>
+    </UTooltip>
 
     <!-- Header: status + assignee -->
     <div class="flex items-center gap-1 mb-1 opacity-70">

--- a/apps/thinkgraph/app/components/ThinkgraphNodesNode.vue
+++ b/apps/thinkgraph/app/components/ThinkgraphNodesNode.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Handle, Position } from '@vue-flow/core'
 import type { ThinkgraphNode } from '~~/layers/thinkgraph/collections/nodes/types'
+import type { ValidationIssue } from '~~/server/utils/validate-graph'
 import { STATUS_CONFIG, getTemplateConfig, getTemplateBadge, STAGE_LABELS } from '~/utils/thinkgraph-config'
 
 interface Props {
@@ -29,8 +30,23 @@ const projectActions = inject<{
   openContextMenu?: (nodeId: string, event: MouseEvent) => void
 } | null>('projectActions', null)
 
+// Validation issues map — provided by parent canvas (keyed by nodeId)
+const validationIssuesMap = inject<Ref<Map<string, ValidationIssue[]>> | null>('validationIssues', null)
+
 const isHovered = ref(false)
 const node = computed(() => props.data as unknown as ThinkgraphNode)
+
+// Validation state for this node
+const nodeIssues = computed(() => {
+  if (!validationIssuesMap?.value) return []
+  return validationIssuesMap.value.get(node.value.id) || []
+})
+const hasErrors = computed(() => nodeIssues.value.some(i => i.severity === 'error'))
+const hasWarnings = computed(() => nodeIssues.value.length > 0)
+const validationTooltip = computed(() => {
+  if (nodeIssues.value.length === 0) return ''
+  return nodeIssues.value.map(i => `${i.severity === 'error' ? '❌' : '⚠️'} ${i.message}`).join('\n')
+})
 
 const templateStyle = computed(() => getTemplateConfig(node.value.template || 'idea'))
 const statusConfig = computed(() => STATUS_CONFIG[node.value.status] || STATUS_CONFIG.idle)
@@ -163,6 +179,7 @@ function handleContextMenu(event: MouseEvent | Event) {
     :class="[
       `node-card--${node.template || 'idea'}`,
       { 'node-card--selected': selected, 'node-card--dragging': dragging, 'node-card--done': isDone },
+      { 'node-card--validation-error': hasErrors, 'node-card--validation-warning': hasWarnings && !hasErrors },
       statusConfig.class,
     ]"
     @mouseenter="isHovered = true"
@@ -170,6 +187,16 @@ function handleContextMenu(event: MouseEvent | Event) {
     @contextmenu="handleContextMenu"
   >
     <Handle type="target" :position="Position.Top" class="node-handle" />
+
+    <!-- Validation badge -->
+    <div
+      v-if="hasWarnings"
+      class="node-card__validation-badge"
+      :class="{ 'node-card__validation-badge--error': hasErrors }"
+      :title="validationTooltip"
+    >
+      <UIcon :name="hasErrors ? 'i-lucide-alert-circle' : 'i-lucide-alert-triangle'" class="size-3" />
+    </div>
 
     <!-- Header: status + assignee -->
     <div class="flex items-center gap-1 mb-1 opacity-70">
@@ -430,6 +457,29 @@ function handleContextMenu(event: MouseEvent | Event) {
 .node-card__dispatch--disabled {
   @apply opacity-30 cursor-not-allowed;
   &:hover { transform: none; color: inherit; }
+}
+
+/* Validation indicators */
+.node-card--validation-error {
+  outline: 2px solid rgba(239, 68, 68, 0.7);
+  outline-offset: 1px;
+}
+
+.node-card--validation-warning {
+  outline: 2px dashed rgba(245, 158, 11, 0.6);
+  outline-offset: 1px;
+}
+
+.node-card__validation-badge {
+  @apply absolute -top-2 -left-2 z-20;
+  @apply w-5 h-5 rounded-full flex items-center justify-center;
+  @apply bg-amber-100 text-amber-600 dark:bg-amber-900 dark:text-amber-300;
+  @apply shadow-sm cursor-help;
+  @apply transition-transform duration-150 hover:scale-110;
+}
+
+.node-card__validation-badge--error {
+  @apply bg-red-100 text-red-600 dark:bg-red-900 dark:text-red-300;
 }
 
 .node-card__actions {

--- a/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ThinkgraphNode } from '~~/layers/thinkgraph/collections/nodes/types'
+import type { ValidationIssue } from '~~/server/utils/validate-graph'
 import ThinkgraphNodesNodeComponent from '~/components/ThinkgraphNodesNode.vue'
 import NodeChatPanel from '~/components/NodeChatPanel.vue'
 
@@ -120,8 +121,34 @@ async function refreshItems() {
   }
 }
 
+// ─── Graph validation ───
+const validationIssues = ref<Map<string, ValidationIssue[]>>(new Map())
+
+async function refreshValidation() {
+  if (!teamId.value || !projectId.value) return
+  try {
+    const result = await $fetch<{ issues: ValidationIssue[] }>(`/api/teams/${teamId.value}/thinkgraph-nodes/validate`, {
+      query: { projectId: projectId.value },
+    })
+    const grouped = new Map<string, ValidationIssue[]>()
+    for (const issue of result.issues) {
+      const existing = grouped.get(issue.nodeId) || []
+      existing.push(issue)
+      grouped.set(issue.nodeId, existing)
+    }
+    validationIssues.value = grouped
+  }
+  catch {
+    validationIssues.value = new Map()
+  }
+}
+
+provide('validationIssues', validationIssues)
+
 onMounted(async () => {
   await Promise.all([ensureFlowConfig(), refreshItems()])
+  // Run validation after items are loaded (non-blocking)
+  refreshValidation()
 })
 
 // Auto-refresh on mutations

--- a/apps/thinkgraph/server/api/teams/[id]/thinkgraph-nodes/validate.get.ts
+++ b/apps/thinkgraph/server/api/teams/[id]/thinkgraph-nodes/validate.get.ts
@@ -1,0 +1,13 @@
+import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { validateGraph } from '~~/server/utils/validate-graph'
+
+export default defineEventHandler(async (event) => {
+  const { team } = await resolveTeamAndCheckMembership(event)
+
+  const query = getQuery(event)
+  const projectId = query.projectId ? String(query.projectId) : undefined
+
+  const result = await validateGraph(team.id, projectId)
+
+  return result
+})

--- a/apps/thinkgraph/server/mcp/tools/check-graph.ts
+++ b/apps/thinkgraph/server/mcp/tools/check-graph.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { resolveTeamId } from '../utils/resolve-team'
+import { validateGraph } from '~~/server/utils/validate-graph'
+
+export default defineMcpTool({
+  description: 'Check the thinking graph for integrity issues. Detects broken references (contextNodeIds, dependsOn), orphaned nodes, duplicate titles, and stale active nodes. Returns a summary of issues with severity levels.',
+  inputSchema: {
+    teamId: z.string().describe('Team ID or slug'),
+    graphId: z.string().optional().describe('Project/graph ID to check (if omitted, checks all nodes for the team)'),
+  },
+  async handler({ teamId, graphId }) {
+    try {
+      const resolvedTeamId = await resolveTeamId(teamId)
+      const result = await validateGraph(resolvedTeamId, graphId)
+
+      if (result.issues.length === 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `✅ Graph is clean — ${result.stats.totalNodes} nodes checked, no issues found.`,
+          }],
+        }
+      }
+
+      // Group issues by type for readability
+      const errors = result.issues.filter(i => i.severity === 'error')
+      const warnings = result.issues.filter(i => i.severity === 'warning')
+
+      let text = `## Graph Validation Report\n\n`
+      text += `**${result.stats.totalNodes} nodes** checked | ${result.stats.errors} errors | ${result.stats.warnings} warnings\n\n`
+
+      if (errors.length > 0) {
+        text += `### ❌ Errors\n\n`
+        for (const issue of errors) {
+          text += `- **${issue.nodeTitle}** [${issue.nodeId}]: ${issue.message}\n`
+        }
+        text += '\n'
+      }
+
+      if (warnings.length > 0) {
+        text += `### ⚠️ Warnings\n\n`
+        for (const issue of warnings) {
+          text += `- **${issue.nodeTitle}** [${issue.nodeId}]: ${issue.message}\n`
+        }
+        text += '\n'
+      }
+
+      return { content: [{ type: 'text' as const, text }] }
+    }
+    catch (error: any) {
+      return {
+        content: [{ type: 'text' as const, text: `Error running graph validation: ${error.message}` }],
+        isError: true,
+      }
+    }
+  },
+})

--- a/apps/thinkgraph/server/utils/validate-graph.ts
+++ b/apps/thinkgraph/server/utils/validate-graph.ts
@@ -1,0 +1,171 @@
+/**
+ * Graph validation utility for ThinkGraph.
+ * Detects integrity issues: broken refs, orphans, duplicates, stale nodes.
+ */
+import { getAllThinkgraphNodes } from '~~/layers/thinkgraph/collections/nodes/server/database/queries'
+
+export type ValidationSeverity = 'error' | 'warning'
+
+export type ValidationIssueType =
+  | 'broken-context-ref'
+  | 'broken-depends-on-ref'
+  | 'orphaned-node'
+  | 'duplicate-title'
+  | 'stale-active'
+
+export interface ValidationIssue {
+  severity: ValidationSeverity
+  nodeId: string
+  nodeTitle: string
+  issueType: ValidationIssueType
+  message: string
+  /** Related node IDs (e.g. the broken ref target) */
+  relatedIds?: string[]
+}
+
+export interface ValidationResult {
+  issues: ValidationIssue[]
+  stats: {
+    totalNodes: number
+    errors: number
+    warnings: number
+    checkedAt: string
+  }
+}
+
+/** 24 hours in milliseconds — used for stale node detection */
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Validate graph integrity for a team/project.
+ * Loads all nodes once and runs all checks in-memory.
+ */
+export async function validateGraph(
+  teamId: string,
+  projectId?: string,
+): Promise<ValidationResult> {
+  const allNodes = await getAllThinkgraphNodes(teamId, projectId)
+  const nodeIds = new Set(allNodes.map((n: any) => n.id))
+  const issues: ValidationIssue[] = []
+
+  for (const node of allNodes) {
+    const n = node as any
+    const title = n.title || n.content || '(untitled)'
+
+    // 1. Broken contextNodeIds
+    const contextIds = parseJsonArray(n.contextNodeIds)
+    for (const refId of contextIds) {
+      if (!nodeIds.has(refId)) {
+        issues.push({
+          severity: 'error',
+          nodeId: n.id,
+          nodeTitle: title,
+          issueType: 'broken-context-ref',
+          message: `contextNodeIds references non-existent node "${refId}"`,
+          relatedIds: [refId],
+        })
+      }
+    }
+
+    // 2. Broken dependsOn refs
+    const dependsOnIds = parseJsonArray(n.dependsOn)
+    for (const refId of dependsOnIds) {
+      if (!nodeIds.has(refId)) {
+        issues.push({
+          severity: 'error',
+          nodeId: n.id,
+          nodeTitle: title,
+          issueType: 'broken-depends-on-ref',
+          message: `dependsOn references non-existent node "${refId}"`,
+          relatedIds: [refId],
+        })
+      }
+    }
+
+    // 3. Orphaned nodes — no parentId and not a root (depth > 0)
+    if (!n.parentId && (n.depth ?? 0) > 0) {
+      issues.push({
+        severity: 'warning',
+        nodeId: n.id,
+        nodeTitle: title,
+        issueType: 'orphaned-node',
+        message: `Node at depth ${n.depth} has no parent — likely orphaned`,
+      })
+    }
+
+    // 4. Stale active status
+    // No updatedAt column — use sessionId presence as a heuristic:
+    // if status is active/working but no sessionId, it's likely stale.
+    // Also check nodes that are active/working with no pipeline progress.
+    if (n.status === 'active' || n.status === 'working') {
+      // We can't do time-based detection without timestamps.
+      // Use heuristic: active nodes without a sessionId are likely stale dispatches.
+      if (!n.sessionId) {
+        issues.push({
+          severity: 'warning',
+          nodeId: n.id,
+          nodeTitle: title,
+          issueType: 'stale-active',
+          message: `Node is "${n.status}" but has no active session — possibly stale`,
+        })
+      }
+    }
+  }
+
+  // 5. Duplicate titles at same depth (batch check)
+  const byDepthAndTitle = new Map<string, string[]>()
+  for (const node of allNodes) {
+    const n = node as any
+    const key = `${n.projectId}:${n.depth ?? 0}:${(n.title || '').toLowerCase().trim()}`
+    if (!byDepthAndTitle.has(key)) {
+      byDepthAndTitle.set(key, [])
+    }
+    byDepthAndTitle.get(key)!.push(n.id)
+  }
+
+  for (const [key, ids] of byDepthAndTitle) {
+    if (ids.length > 1) {
+      const title = key.split(':').slice(2).join(':')
+      for (const id of ids) {
+        const n = allNodes.find((node: any) => node.id === id) as any
+        issues.push({
+          severity: 'warning',
+          nodeId: id,
+          nodeTitle: n?.title || title,
+          issueType: 'duplicate-title',
+          message: `Duplicate title "${n?.title || title}" at depth ${n?.depth ?? 0} (${ids.length} nodes)`,
+          relatedIds: ids.filter(otherId => otherId !== id),
+        })
+      }
+    }
+  }
+
+  const errors = issues.filter(i => i.severity === 'error').length
+  const warnings = issues.filter(i => i.severity === 'warning').length
+
+  return {
+    issues,
+    stats: {
+      totalNodes: allNodes.length,
+      errors,
+      warnings,
+      checkedAt: new Date().toISOString(),
+    },
+  }
+}
+
+/** Safely parse a JSON array field that may be string, array, object, or null */
+function parseJsonArray(value: unknown): string[] {
+  if (!value) return []
+  if (Array.isArray(value)) return value.filter(v => typeof v === 'string')
+  if (typeof value === 'object') return Object.keys(value)
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      if (Array.isArray(parsed)) return parsed.filter((v: unknown) => typeof v === 'string')
+      if (typeof parsed === 'object' && parsed !== null) return Object.keys(parsed)
+    }
+    catch { /* ignore */ }
+  }
+  return []
+}

--- a/apps/thinkgraph/server/utils/validate-graph.ts
+++ b/apps/thinkgraph/server/utils/validate-graph.ts
@@ -33,8 +33,19 @@ export interface ValidationResult {
   }
 }
 
-/** 24 hours in milliseconds — used for stale node detection */
-const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
+/** Shape of a node row returned by getAllThinkgraphNodes (with joined fields) */
+interface GraphNode {
+  id: string
+  title?: string
+  content?: string
+  parentId?: string
+  depth?: number
+  projectId?: string
+  status?: string
+  sessionId?: string
+  contextNodeIds?: string[] | string | null
+  dependsOn?: string[] | string | null
+}
 
 /**
  * Validate graph integrity for a team/project.
@@ -44,12 +55,12 @@ export async function validateGraph(
   teamId: string,
   projectId?: string,
 ): Promise<ValidationResult> {
-  const allNodes = await getAllThinkgraphNodes(teamId, projectId)
-  const nodeIds = new Set(allNodes.map((n: any) => n.id))
+  const allNodes = await getAllThinkgraphNodes(teamId, projectId) as GraphNode[]
+  const nodeIds = new Set(allNodes.map(n => n.id))
+  const nodeById = new Map(allNodes.map(n => [n.id, n]))
   const issues: ValidationIssue[] = []
 
-  for (const node of allNodes) {
-    const n = node as any
+  for (const n of allNodes) {
     const title = n.title || n.content || '(untitled)'
 
     // 1. Broken contextNodeIds
@@ -96,10 +107,7 @@ export async function validateGraph(
     // 4. Stale active status
     // No updatedAt column — use sessionId presence as a heuristic:
     // if status is active/working but no sessionId, it's likely stale.
-    // Also check nodes that are active/working with no pipeline progress.
     if (n.status === 'active' || n.status === 'working') {
-      // We can't do time-based detection without timestamps.
-      // Use heuristic: active nodes without a sessionId are likely stale dispatches.
       if (!n.sessionId) {
         issues.push({
           severity: 'warning',
@@ -114,8 +122,7 @@ export async function validateGraph(
 
   // 5. Duplicate titles at same depth (batch check)
   const byDepthAndTitle = new Map<string, string[]>()
-  for (const node of allNodes) {
-    const n = node as any
+  for (const n of allNodes) {
     const key = `${n.projectId}:${n.depth ?? 0}:${(n.title || '').toLowerCase().trim()}`
     if (!byDepthAndTitle.has(key)) {
       byDepthAndTitle.set(key, [])
@@ -127,7 +134,7 @@ export async function validateGraph(
     if (ids.length > 1) {
       const title = key.split(':').slice(2).join(':')
       for (const id of ids) {
-        const n = allNodes.find((node: any) => node.id === id) as any
+        const n = nodeById.get(id)
         issues.push({
           severity: 'warning',
           nodeId: id,


### PR DESCRIPTION
## Graph Validation System — Phase 1B

Adds a graph validation system that detects integrity issues across ThinkGraph projects.

### New files
- **`server/utils/validate-graph.ts`** — Core `validateGraph(teamId, projectId)` utility
- **`server/api/teams/[id]/thinkgraph-nodes/validate.get.ts`** — API endpoint
- **`server/mcp/tools/check-graph.ts`** — 10th MCP tool

### Modified
- **`app/components/ThinkgraphNodesNode.vue`** — Visual warning badge + red/orange outline for nodes with issues

### Validation checks
| Check | Severity | Description |
|-------|----------|-------------|
| Broken contextNodeIds | error | References to non-existent nodes |
| Broken dependsOn refs | error | Dependency refs to non-existent nodes |
| Orphaned nodes | warning | No parent but depth > 0 |
| Stale active status | warning | Active/working with no sessionId |
| Duplicate titles | warning | Same title at same depth level |

### Notes
- No `updatedAt` column exists — stale detection uses sessionId absence as heuristic
- Visual indicators use inject/provide pattern (parent canvas provides `validationIssues` map)
- All checks run in a single `getAllThinkgraphNodes` call