### PR TITLE
fix(thinkgraph): warn reviewer that worktree may be on main, not review branch

### DIFF
--- a/apps/thinkgraph-worker/src/session-manager.ts
+++ b/apps/thinkgraph-worker/src/session-manager.ts
@@ -710,6 +710,11 @@ These contain the project's coding conventions and the full review checklist (se
   git diff main...<branch-name> --stat
   git diff main...<branch-name>
   \`\`\`
+- **Important**: The worktree is typically checked out to \`main\`, not the review branch. If you read files directly (via \`Read\` tool or \`cat\`), you'll see the \`main\` versions, not the branch changes. To read branch file contents without switching branches:
+  \`\`\`bash
+  git show origin/<branch-name>:path/to/file
+  \`\`\`
+  Alternatively, run \`git checkout <branch-name>\` to switch — but note this changes the worktree state for any concurrent workers.
 - Read the FULL changed files, not just the diff — you need surrounding context for unused imports, broken references, duplicated logic
 
 ### Step 3: Screenshot Issues (if visual)


### PR DESCRIPTION
Adds a note to the reviewer instructions (Step 2: Gather the Diff) warning that the worktree is typically checked out to `main`, not the review branch. Suggests using `git show origin/<branch>:path/to/file` to read branch contents without switching, or `git checkout` with a caveat about concurrent workers.