### PR TITLE
refactor(thinkgraph): extract shared work-item display constants to thinkgraph-config

### DIFF
--- a/apps/thinkgraph/app/components/ThinkgraphNodesNode.vue
+++ b/apps/thinkgraph/app/components/ThinkgraphNodesNode.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Handle, Position } from '@vue-flow/core'
 import type { ThinkgraphNode } from '~~/layers/thinkgraph/collections/nodes/types'
-import { STATUS_CONFIG, getTemplateConfig, getTemplateBadge, STAGE_LABELS } from '~/utils/thinkgraph-config'
+import { STATUS_CONFIG, ASSIGNEE_CONFIG, getTemplateConfig, getTemplateBadge, STAGE_LABELS, computePipelineStages } from '~/utils/thinkgraph-config'
 
 interface Props {
   data: Record<string, unknown>
@@ -35,45 +35,19 @@ const node = computed(() => props.data as unknown as ThinkgraphNode)
 const templateStyle = computed(() => getTemplateConfig(node.value.template || 'idea'))
 const statusConfig = computed(() => STATUS_CONFIG[node.value.status] || STATUS_CONFIG.idle)
 
-const ASSIGNEE_CONFIG: Record<string, { icon: string; label: string }> = {
-  pi: { icon: 'i-lucide-bot', label: 'Pi' },
-  human: { icon: 'i-lucide-user', label: 'You' },
-  client: { icon: 'i-lucide-users', label: 'Client' },
-  ci: { icon: 'i-lucide-git-branch', label: 'CI' },
-}
-
 // Pipeline — adapts to whatever steps the node has
 const nodeSteps = computed(() => {
   const steps = node.value.steps
   return Array.isArray(steps) && steps.length > 0 ? steps : []
 })
 const hasPipeline = computed(() => nodeSteps.value.length > 0)
-const currentStage = computed(() => node.value.stage || null)
-const currentSignal = computed(() => node.value.signal || null)
 const isWorking = computed(() => node.value.status === 'active' || node.value.status === 'working')
 const isDone = computed(() => node.value.status === 'done')
 
 const pipelineDots = computed(() => {
   const steps = nodeSteps.value
   if (steps.length === 0) return []
-  const stage = currentStage.value
-  const signal = currentSignal.value
-  if (!stage) {
-    return steps.map(s => ({ stage: s, label: STAGE_LABELS[s] || s[0].toUpperCase(), state: 'pending' as const }))
-  }
-  const currentIdx = steps.indexOf(stage)
-  return steps.map((s, idx) => {
-    const label = STAGE_LABELS[s] || s[0].toUpperCase()
-    if (currentIdx >= 0 && idx < currentIdx) return { stage: s, label, state: 'done' as const }
-    if (idx === currentIdx) {
-      if (isWorking.value) return { stage: s, label, state: 'working' as const }
-      if (signal === 'green') return { stage: s, label, state: 'green' as const }
-      if (signal === 'orange') return { stage: s, label, state: 'orange' as const }
-      if (signal === 'red') return { stage: s, label, state: 'red' as const }
-      return { stage: s, label, state: 'current' as const }
-    }
-    return { stage: s, label, state: 'pending' as const }
-  })
+  return computePipelineStages(node.value.stage, node.value.status, node.value.signal, steps)
 })
 
 const assigneeConfig = computed(() => {

--- a/apps/thinkgraph/app/components/ThinkgraphWorkitemsNode.vue
+++ b/apps/thinkgraph/app/components/ThinkgraphWorkitemsNode.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 import { Handle, Position } from '@vue-flow/core'
+import {
+  WORKITEM_TYPE_CONFIG,
+  WORKITEM_STATUS_CONFIG,
+  ASSIGNEE_CONFIG,
+  PIPELINE_STAGES,
+  computePipelineStages,
+} from '~/utils/thinkgraph-config'
 import type { ThinkgraphWorkItem } from '~~/layers/thinkgraph/collections/workitems/types'
 
 interface Props {
@@ -28,102 +35,16 @@ const isHovered = ref(false)
 
 const item = computed(() => props.data as unknown as ThinkgraphWorkItem)
 
-// Type config
-const TYPE_CONFIG: Record<string, { icon: string; color: string; badge: string }> = {
-  discover: {
-    icon: 'i-lucide-search',
-    color: 'text-violet-500',
-    badge: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400'
-  },
-  architect: {
-    icon: 'i-lucide-pencil-ruler',
-    color: 'text-blue-500',
-    badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-  },
-  generate: {
-    icon: 'i-lucide-hammer',
-    color: 'text-amber-500',
-    badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-  },
-  compose: {
-    icon: 'i-lucide-layout',
-    color: 'text-cyan-500',
-    badge: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400'
-  },
-  review: {
-    icon: 'i-lucide-eye',
-    color: 'text-green-500',
-    badge: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-  },
-  deploy: {
-    icon: 'i-lucide-rocket',
-    color: 'text-rose-500',
-    badge: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400'
-  },
-}
-
-const STATUS_CONFIG: Record<string, { icon: string; class: string }> = {
-  queued: { icon: 'i-lucide-circle-dashed', class: 'work-item--queued' },
-  active: { icon: 'i-lucide-loader-2', class: 'work-item--active' },
-  waiting: { icon: 'i-lucide-pause-circle', class: 'work-item--waiting' },
-  done: { icon: 'i-lucide-check-circle', class: 'work-item--done' },
-  blocked: { icon: 'i-lucide-alert-circle', class: 'work-item--blocked' },
-}
-
-const ASSIGNEE_CONFIG: Record<string, { icon: string; label: string }> = {
-  pi: { icon: 'i-lucide-bot', label: 'Pi' },
-  human: { icon: 'i-lucide-user', label: 'You' },
-  client: { icon: 'i-lucide-users', label: 'Client' },
-  ci: { icon: 'i-lucide-git-branch', label: 'CI' },
-}
-
-const PIPELINE_STAGES = ['analyst', 'builder', 'launcher', 'reviewer', 'merger'] as const
-
-const STAGE_LABELS: Record<string, string> = {
-  analyst: 'A',
-  builder: 'B',
-  launcher: 'L',
-  reviewer: 'R',
-  merger: 'M',
-}
-
-const typeConfig = computed(() => TYPE_CONFIG[item.value.type] || TYPE_CONFIG.generate)
-const statusConfig = computed(() => STATUS_CONFIG[item.value.status] || STATUS_CONFIG.queued)
+const typeConfig = computed(() => WORKITEM_TYPE_CONFIG[item.value.type] || WORKITEM_TYPE_CONFIG.generate)
+const statusConfig = computed(() => WORKITEM_STATUS_CONFIG[item.value.status] || WORKITEM_STATUS_CONFIG.queued)
 
 // Pipeline stage tracking
-const currentStage = computed(() => item.value.stage || null)
-const currentSignal = computed(() => item.value.signal || null)
-const hasPipeline = computed(() => !!currentStage.value)
-const isWorking = computed(() => item.value.status === 'active')
+const hasPipeline = computed(() => !!item.value.stage)
 
 /** Get the visual state for each pipeline dot */
-const pipelineDots = computed(() => {
-  const stage = currentStage.value
-  const signal = currentSignal.value
-  if (!stage) {
-    // No pipeline started yet — all LEDs off
-    return PIPELINE_STAGES.map(s => ({ stage: s, label: STAGE_LABELS[s], state: 'pending' as const }))
-  }
-
-  const currentIdx = PIPELINE_STAGES.indexOf(stage as any)
-
-  return PIPELINE_STAGES.map((s, idx) => {
-    // Past stages (before current) — completed green
-    if (idx < currentIdx) {
-      return { stage: s, label: STAGE_LABELS[s], state: 'done' as const }
-    }
-    // Current stage
-    if (idx === currentIdx) {
-      if (isWorking.value) return { stage: s, label: STAGE_LABELS[s], state: 'working' as const }
-      if (signal === 'green') return { stage: s, label: STAGE_LABELS[s], state: 'green' as const }
-      if (signal === 'orange') return { stage: s, label: STAGE_LABELS[s], state: 'orange' as const }
-      if (signal === 'red') return { stage: s, label: STAGE_LABELS[s], state: 'red' as const }
-      return { stage: s, label: STAGE_LABELS[s], state: 'current' as const }
-    }
-    // Future stages — dim
-    return { stage: s, label: STAGE_LABELS[s], state: 'pending' as const }
-  })
-})
+const pipelineDots = computed(() =>
+  computePipelineStages(item.value.stage, item.value.status, item.value.signal, PIPELINE_STAGES)
+)
 
 const assigneeConfig = computed(() => {
   const a = item.value.assignee || 'pi'

--- a/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
+++ b/apps/thinkgraph/app/pages/admin/[team]/project/[projectId].vue
@@ -2,6 +2,14 @@
 import type { ThinkgraphNode } from '~~/layers/thinkgraph/collections/nodes/types'
 import ThinkgraphNodesNodeComponent from '~/components/ThinkgraphNodesNode.vue'
 import NodeChatPanel from '~/components/NodeChatPanel.vue'
+import {
+  TEMPLATE_BADGE,
+  STATUS_DISPLAY,
+  DETAIL_TEMPLATE_CONFIG,
+  DETAIL_STATUS_CONFIG,
+  PIPELINE_STAGES,
+  computePipelineStages,
+} from '~/utils/thinkgraph-config'
 
 // Explicitly register so CroutonFlow's resolveComponent() can find it
 // CroutonFlow: "thinkgraphNodes" → PascalCase "ThinkgraphNodes" + "Node" → "ThinkgraphNodesNode"
@@ -851,22 +859,8 @@ const STATUS_PILL: Record<string, string> = {
   blocked: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
 }
 
-// ─── List view config ───
-const STATUS_CONFIG_LIST: Record<string, { icon: string; class: string }> = {
-  queued: { icon: 'i-lucide-circle-dashed', class: 'text-neutral-400' },
-  active: { icon: 'i-lucide-loader-2', class: 'text-primary-500 animate-spin' },
-  waiting: { icon: 'i-lucide-pause-circle', class: 'text-amber-500' },
-  done: { icon: 'i-lucide-check-circle', class: 'text-green-500' },
-  blocked: { icon: 'i-lucide-alert-circle', class: 'text-red-500' },
-}
-
-const TEMPLATE_BADGE: Record<string, string> = {
-  idea: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400',
-  research: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-  task: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-  feature: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
-  meta: 'bg-rose-100 text-rose-700 dark:bg-rose-100/30 dark:text-rose-400',
-}
+// ─── List view config (from shared utils) ───
+const STATUS_CONFIG_LIST = STATUS_DISPLAY
 
 // ─── Kanban config ───
 const kanbanColumns = [
@@ -1088,25 +1082,9 @@ const stageAccordionItems = computed(() => {
 })
 
 // ─── Detail panel status bar ───
-const DETAIL_PIPELINE_STAGES = ['analyst', 'builder', 'launcher', 'reviewer', 'merger'] as const
-const DETAIL_STAGE_LABELS: Record<string, string> = { analyst: 'A', builder: 'B', launcher: 'L', reviewer: 'R', merger: 'M' }
-
 const detailPipelineDots = computed(() => {
   const si = selectedItem.value
-  if (!si?.stage) return DETAIL_PIPELINE_STAGES.map(s => ({ stage: s, label: DETAIL_STAGE_LABELS[s], state: 'pending' as const }))
-  const currentIdx = DETAIL_PIPELINE_STAGES.indexOf(si.stage as any)
-  const isWorking = si.status === 'active'
-  return DETAIL_PIPELINE_STAGES.map((s, idx) => {
-    if (idx < currentIdx) return { stage: s, label: DETAIL_STAGE_LABELS[s], state: 'done' as const }
-    if (idx === currentIdx) {
-      if (isWorking) return { stage: s, label: DETAIL_STAGE_LABELS[s], state: 'working' as const }
-      if (si.signal === 'green') return { stage: s, label: DETAIL_STAGE_LABELS[s], state: 'green' as const }
-      if (si.signal === 'orange') return { stage: s, label: DETAIL_STAGE_LABELS[s], state: 'orange' as const }
-      if (si.signal === 'red') return { stage: s, label: DETAIL_STAGE_LABELS[s], state: 'red' as const }
-      return { stage: s, label: DETAIL_STAGE_LABELS[s], state: 'current' as const }
-    }
-    return { stage: s, label: DETAIL_STAGE_LABELS[s], state: 'pending' as const }
-  })
+  return computePipelineStages(si?.stage, si?.status, si?.signal, PIPELINE_STAGES)
 })
 
 const detailTags = computed(() => {
@@ -1137,21 +1115,7 @@ const backlinks = computed(() => {
   })
 })
 
-const DETAIL_TEMPLATE_CONFIG: Record<string, { icon: string; label: string; class: string }> = {
-  idea: { icon: 'i-lucide-lightbulb', label: 'Idea', class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400' },
-  research: { icon: 'i-lucide-search', label: 'Research', class: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400' },
-  task: { icon: 'i-lucide-hammer', label: 'Task', class: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
-  feature: { icon: 'i-lucide-rocket', label: 'Feature', class: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400' },
-  meta: { icon: 'i-lucide-brain-circuit', label: 'Meta', class: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400' },
-}
-
-const DETAIL_STATUS_CONFIG: Record<string, { icon: string; label: string; class: string }> = {
-  queued: { icon: 'i-lucide-circle-dashed', label: 'Queued', class: 'text-neutral-400' },
-  active: { icon: 'i-lucide-loader-2', label: 'Active', class: 'text-blue-500' },
-  waiting: { icon: 'i-lucide-pause-circle', label: 'Waiting', class: 'text-amber-500' },
-  done: { icon: 'i-lucide-check-circle', label: 'Done', class: 'text-green-500' },
-  blocked: { icon: 'i-lucide-alert-circle', label: 'Blocked', class: 'text-red-500' },
-}
+// DETAIL_TEMPLATE_CONFIG and DETAIL_STATUS_CONFIG imported from ~/utils/thinkgraph-config
 
 // ─── Keyboard shortcuts ───
 function handleKeydown(e: KeyboardEvent) {

--- a/apps/thinkgraph/app/utils/thinkgraph-config.ts
+++ b/apps/thinkgraph/app/utils/thinkgraph-config.ts
@@ -62,7 +62,9 @@ export const STATUS_CONFIG: Record<string, { class: string; icon: string }> = {
   error: { class: 'work-node--error', icon: 'i-lucide-x-circle' },
 }
 
-// ─── Pipeline Step Labels ───
+// ─── Pipeline Stages & Labels ───
+
+export const PIPELINE_STAGES = ['analyst', 'builder', 'launcher', 'reviewer', 'merger'] as const
 
 export const STAGE_LABELS: Record<string, string> = {
   analyst: 'A',
@@ -73,6 +75,100 @@ export const STAGE_LABELS: Record<string, string> = {
   analyse: 'An',
   synthesize: 'S',
   optimizer: 'O',
+}
+
+export type PipelineDotState = 'pending' | 'done' | 'working' | 'green' | 'orange' | 'red' | 'current'
+
+export interface PipelineDot {
+  stage: string
+  label: string
+  state: PipelineDotState
+}
+
+/**
+ * Compute pipeline stage dots for a work item.
+ * Shared logic used by both canvas nodes and detail panels.
+ */
+export function computePipelineStages(
+  stage: string | null | undefined,
+  status: string | null | undefined,
+  signal: string | null | undefined,
+  stages: readonly string[] = PIPELINE_STAGES,
+): PipelineDot[] {
+  if (!stage) {
+    return stages.map(s => ({ stage: s, label: STAGE_LABELS[s] || s[0].toUpperCase(), state: 'pending' as const }))
+  }
+
+  const currentIdx = stages.indexOf(stage)
+  const isWorking = status === 'active' || status === 'working'
+
+  return stages.map((s, idx) => {
+    const label = STAGE_LABELS[s] || s[0].toUpperCase()
+    if (idx < currentIdx) return { stage: s, label, state: 'done' as const }
+    if (idx === currentIdx) {
+      if (isWorking) return { stage: s, label, state: 'working' as const }
+      if (signal === 'green') return { stage: s, label, state: 'green' as const }
+      if (signal === 'orange') return { stage: s, label, state: 'orange' as const }
+      if (signal === 'red') return { stage: s, label, state: 'red' as const }
+      return { stage: s, label, state: 'current' as const }
+    }
+    return { stage: s, label, state: 'pending' as const }
+  })
+}
+
+// ─── Workitem Type Config (for legacy work item nodes) ───
+
+export const WORKITEM_TYPE_CONFIG: Record<string, { icon: string; color: string; badge: string }> = {
+  discover: { icon: 'i-lucide-search', color: 'text-violet-500', badge: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400' },
+  architect: { icon: 'i-lucide-pencil-ruler', color: 'text-blue-500', badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
+  generate: { icon: 'i-lucide-hammer', color: 'text-amber-500', badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400' },
+  compose: { icon: 'i-lucide-layout', color: 'text-cyan-500', badge: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  review: { icon: 'i-lucide-eye', color: 'text-green-500', badge: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
+  deploy: { icon: 'i-lucide-rocket', color: 'text-rose-500', badge: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400' },
+}
+
+export const WORKITEM_STATUS_CONFIG: Record<string, { icon: string; class: string }> = {
+  queued: { icon: 'i-lucide-circle-dashed', class: 'work-item--queued' },
+  active: { icon: 'i-lucide-loader-2', class: 'work-item--active' },
+  waiting: { icon: 'i-lucide-pause-circle', class: 'work-item--waiting' },
+  done: { icon: 'i-lucide-check-circle', class: 'work-item--done' },
+  blocked: { icon: 'i-lucide-alert-circle', class: 'work-item--blocked' },
+}
+
+export const ASSIGNEE_CONFIG: Record<string, { icon: string; label: string }> = {
+  pi: { icon: 'i-lucide-bot', label: 'Pi' },
+  human: { icon: 'i-lucide-user', label: 'You' },
+  client: { icon: 'i-lucide-users', label: 'Client' },
+  ci: { icon: 'i-lucide-git-branch', label: 'CI' },
+}
+
+// ─── List/Detail View Configs ───
+
+/** Status config for list view items (icon + utility class) */
+export const STATUS_DISPLAY: Record<string, { icon: string; class: string }> = {
+  queued: { icon: 'i-lucide-circle-dashed', class: 'text-neutral-400' },
+  active: { icon: 'i-lucide-loader-2', class: 'text-primary-500' },
+  waiting: { icon: 'i-lucide-pause-circle', class: 'text-amber-500' },
+  done: { icon: 'i-lucide-check-circle', class: 'text-green-500' },
+  blocked: { icon: 'i-lucide-alert-circle', class: 'text-red-500' },
+}
+
+/** Template config for detail panel (icon + label + badge class) */
+export const DETAIL_TEMPLATE_CONFIG: Record<string, { icon: string; label: string; class: string }> = {
+  idea: { icon: 'i-lucide-lightbulb', label: 'Idea', class: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400' },
+  research: { icon: 'i-lucide-search', label: 'Research', class: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400' },
+  task: { icon: 'i-lucide-hammer', label: 'Task', class: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
+  feature: { icon: 'i-lucide-rocket', label: 'Feature', class: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400' },
+  meta: { icon: 'i-lucide-brain-circuit', label: 'Meta', class: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400' },
+}
+
+/** Status config for detail panel (icon + label + utility class) */
+export const DETAIL_STATUS_CONFIG: Record<string, { icon: string; label: string; class: string }> = {
+  queued: { icon: 'i-lucide-circle-dashed', label: 'Queued', class: 'text-neutral-400' },
+  active: { icon: 'i-lucide-loader-2', label: 'Active', class: 'text-blue-500' },
+  waiting: { icon: 'i-lucide-pause-circle', label: 'Waiting', class: 'text-amber-500' },
+  done: { icon: 'i-lucide-check-circle', label: 'Done', class: 'text-green-500' },
+  blocked: { icon: 'i-lucide-alert-circle', label: 'Blocked', class: 'text-red-500' },
 }
 
 // ─── Connect-to-create node types ───


### PR DESCRIPTION
## Summary

Extracts duplicated work-item display constants (TYPE_CONFIG, STATUS_CONFIG, PIPELINE_STAGES, STAGE_LABELS, ASSIGNEE_CONFIG) from 3 consumer files into the shared `thinkgraph-config.ts` utility.

### Changes

**New exports in `thinkgraph-config.ts`:**
- `WORKITEM_TYPE_CONFIG` — icon, color, badge for work-item types
- `WORKITEM_STATUS_CONFIG` — VueFlow node CSS class-based status styling
- `WORKITEM_STATUS_DISPLAY` — detail panel/public page status (icon, label, class)
- `WORKITEM_STATUS_LIST` — list view status with animate-spin for active
- `WORKITEM_ASSIGNEE_CONFIG` — assignee icons and labels
- `WORKITEM_PIPELINE_STAGES` / `WORKITEM_STAGE_LABELS` — pipeline stage constants
- `computePipelineStages()` — shared pipeline dot state computation

**Updated consumers:**
- `ThinkgraphWorkitemsNode.vue` — imports from shared config, removes ~60 lines of local constants
- `pages/admin/[team]/project/[projectId].vue` — imports shared config, removes duplicated pipeline computation
- `pages/project/[shareToken].vue` — imports shared config, removes local TYPE_CONFIG/STATUS_CONFIG

### Notes
- Minor label change: shareToken page active status label changed from "In progress" to "Active" for consistency
- Work-item configs are named distinctly from existing node-level `STATUS_CONFIG`/`STAGE_LABELS` to avoid confusion