### PR TITLE
feat(thinkgraph): add launcher fast-path for non-app changes

### DIFF
--- a/.thinkgraph/nodes/vEMwZKD4_DCnTOZHRDlxT.md
+++ b/.thinkgraph/nodes/vEMwZKD4_DCnTOZHRDlxT.md
@@ -1,0 +1,9 @@
+# Launcher preflight checks assume app deployment
+
+**Status**: done
+**Type**: meta
+**Stage**: builder
+
+## Summary
+
+Added a fast-path to `launcherInstructions()` in `session-manager.ts` so that non-app work items (infra, agent code, idea nodes) skip deploy preflight checks. The launcher agent now checks `git diff main..HEAD --stat` first — if no `apps/` files changed, it verifies CI status and signals green without running deploy checks.

--- a/apps/thinkgraph-worker/src/session-manager.ts
+++ b/apps/thinkgraph-worker/src/session-manager.ts
@@ -878,15 +878,37 @@ Use \`update_workitem\` to set your signal:
   private launcherInstructions(): string {
     return `## Instructions — Launcher
 
-The launcher stage normally waits for CI results automatically. If you've been dispatched here, it means the automated CI path didn't trigger. Run deploy preflight checks instead.
+The launcher stage normally waits for CI results automatically. If you've been dispatched here, it means the automated CI path didn't trigger.
 
-### Step 1: Read Deploy Knowledge
+### Step 1: Determine if app code was changed
+
+Check which files were modified on this branch:
+
+\`\`\`bash
+git diff main..HEAD --stat
+\`\`\`
+
+Look at the output. If **no files under \`apps/\`** were modified (e.g., only \`packages/\`, config files, or agent code changed), go to **Step 2A (fast path)**. If files under \`apps/\` were modified, go to **Step 2B (deploy preflight)**.
+
+### Step 2A: Fast path — no app changes
+
+No deploy checks are needed. Just verify CI passed:
+
+\`\`\`bash
+gh run list --branch "$(git branch --show-current)" --workflow thinkgraph-ci.yml --limit 3 --json status,conclusion,headBranch
+\`\`\`
+
+- If the latest run shows \`conclusion: "success"\` → signal **green**, set \`status\` to \`"done"\`, set \`output\` to "No app changes — CI passed"
+- If the latest run shows \`conclusion: "failure"\` → signal **red**, set \`status\` to \`"blocked"\`, set \`output\` to the failure details
+- If no CI run exists or it's still in progress → signal **orange**, set \`status\` to \`"waiting"\`, set \`output\` to "CI not yet complete — waiting for results"
+
+### Step 2B: Deploy preflight — app changes detected
+
+Read the deploy skill and run full preflight checks:
 
 \`\`\`bash
 cat ~/nuxt-crouton/.claude/skills/deploy/SKILL.md
 \`\`\`
-
-### Step 2: Run Preflight Checks
 
 Follow the preflight checks from the deploy skill:
 - Check \`wrangler.toml\` for TODO placeholders
@@ -896,7 +918,7 @@ Follow the preflight checks from the deploy skill:
 
 ### Step 3: Signal
 
-If preflight passes:
+If preflight passes (or fast path CI passed):
 - Set \`signal\` to \`"green"\`, \`status\` to \`"done"\`
 - Set \`output\` to preflight summary
 


### PR DESCRIPTION
## What

Adds a fast-path to `launcherInstructions()` in `session-manager.ts` so that non-app work items (infra, agent code, idea nodes) skip deploy preflight checks.

## How

The launcher agent now:
1. Checks `git diff main..HEAD --stat` to see which files changed
2. If NO files under `apps/` were modified → fast path: verify CI status via `gh run list`, signal green with "No app changes — CI passed"
3. If files under `apps/` WERE modified → existing deploy preflight flow

Uses the stateless approach — the prompt instructs the agent to check the diff itself, no signature changes needed.

## Files changed

- `apps/thinkgraph-worker/src/session-manager.ts` — `launcherInstructions()` method