### PR TITLE
fix(thinkgraph): launcher checks CI status before manual preflight

### DIFF
--- a/apps/thinkgraph-worker/src/session-manager.ts
+++ b/apps/thinkgraph-worker/src/session-manager.ts
@@ -527,7 +527,7 @@ ${payload.prompt ? `## Brief\n\n${payload.prompt}\n\n` : ''}`
         body = this.reviewerInstructions(payload)
         break
       case 'launcher':
-        body = this.launcherInstructions()
+        body = this.launcherInstructions(payload)
         break
       case 'merger':
         body = this.mergerInstructions(payload)
@@ -875,10 +875,30 @@ Use \`update_workitem\` to set your signal:
 - Set \`output\` to what went wrong`
   }
 
-  private launcherInstructions(): string {
+  private launcherInstructions(payload: DispatchPayload): string {
+    const branchName = `thinkgraph/${payload.nodeId}`
     return `## Instructions — Launcher
 
-The launcher stage normally waits for CI results automatically. If you've been dispatched here, it means the automated CI path didn't trigger. Run deploy preflight checks instead.
+### Step 0: Check if CI Already Ran
+
+Before running any manual checks, see if CI has already completed for this branch:
+
+\`\`\`bash
+cd ~/nuxt-crouton
+gh run list --branch ${branchName} --workflow thinkgraph-ci.yml --limit 1
+\`\`\`
+
+**If CI passed** (status: completed, conclusion: success):
+- Set \`signal\` to \`"green"\`, \`status\` to \`"done"\`
+- Set \`output\` to the CI run summary (run ID, URL, conclusion)
+- You're done — no need for manual preflight.
+
+**If CI failed** (status: completed, conclusion: failure):
+- Set \`signal\` to \`"orange"\`, \`status\` to \`"waiting"\`, \`assignee\` to \`"human"\`
+- Set \`output\` to the failure details (run URL, failed jobs)
+- You're done — no need for manual preflight.
+
+**If no CI runs found** for this branch, continue to Step 1 below.
 
 ### Step 1: Read Deploy Knowledge
 
@@ -886,9 +906,9 @@ The launcher stage normally waits for CI results automatically. If you've been d
 cat ~/nuxt-crouton/.claude/skills/deploy/SKILL.md
 \`\`\`
 
-### Step 2: Run Preflight Checks
+### Step 2: Run Manual Preflight Checks
 
-Follow the preflight checks from the deploy skill:
+CI hasn't run for this branch yet. Run preflight checks manually:
 - Check \`wrangler.toml\` for TODO placeholders
 - Check CF stubs exist in \`server/utils/_cf-stubs/\`
 - Check \`nuxt.config.ts\` has nitro aliases for papaparse and passkey stubs


### PR DESCRIPTION
Restructures launcher instructions to check CI status first (`gh run list`) before falling back to manual preflight checks. Previously, the instructions incorrectly stated "the automated CI path didn't trigger" even when CI had already completed.

**Changes:**
- Pass `payload` to `launcherInstructions()` so it can reference the branch name
- Add Step 0: check CI status via `gh run list --branch <branch> --workflow thinkgraph-ci.yml`
- If CI passed → signal green immediately with summary
- If CI failed → signal orange with failure details  
- Only fall back to manual preflight if no CI runs found
- Remove misleading "automated CI path didn't trigger" preamble