### PR TITLE
fix(thinkgraph): add git reset before checkout in merger instructions

### DIFF
--- a/apps/thinkgraph-worker/src/session-manager.ts
+++ b/apps/thinkgraph-worker/src/session-manager.ts
@@ -856,6 +856,8 @@ gh pr merge <number> --squash --delete-branch
 ### Step 5: Update local main
 
 \`\`\`bash
+# Clean up any merge state left by branch deletion before switching
+git reset --hard HEAD 2>/dev/null || true
 git checkout main
 git pull origin main
 \`\`\`


### PR DESCRIPTION
After squash-merge deletes the local branch via `gh pr merge --squash --delete-branch`, git can leave `.git/MERGE_HEAD` or dirty index state from the prior merge operation intact. The subsequent `git checkout main` fails because git sees unresolved merge state.

**Fix:** Added `git reset --hard HEAD 2>/dev/null || true` before `git checkout main` in the merger Step 5 instructions in `session-manager.ts`.

Single-line addition to a prompt template string. No runtime code changes.