### PR TITLE
fix(crouton): route 'analyse' stage to discoverInstructions

### DIFF
--- a/.thinkgraph/nodes/qfbXYB1Atk9trpCDqk25B.md
+++ b/.thinkgraph/nodes/qfbXYB1Atk9trpCDqk25B.md
@@ -1,0 +1,10 @@
+# Discover tasks don't need worktree setup
+
+## Problem
+Discover nodes use step `'analyse'` but `buildPMPrompt`'s switch in `session-manager.ts` only handled `'analyst'`, causing `analyse` to fall through to the default case which runs `builderInstructions()` with full worktree setup — inappropriate for pure analysis tasks.
+
+## Fix
+Added `case 'analyse':` to the switch statement in `buildPMPrompt()` that routes to `discoverInstructions()` — a method that already existed at line 1556 but was dead code.
+
+## Files Changed
+- `apps/thinkgraph-worker/src/session-manager.ts` — added `case 'analyse'` to stage switch

--- a/apps/thinkgraph-worker/src/session-manager.ts
+++ b/apps/thinkgraph-worker/src/session-manager.ts
@@ -742,6 +742,9 @@ ${payload.prompt ? `## Brief\n\n${payload.prompt}\n\n` : ''}`
 
     let body: string
     switch (stage) {
+      case 'analyse':
+        body = this.discoverInstructions(payload)
+        break
       case 'analyst':
         body = this.analystInstructions(payload)
         break


### PR DESCRIPTION
## Problem

Discover nodes use step `'analyse'` but `buildPMPrompt`'s switch in `session-manager.ts` only handled `'analyst'`, causing `analyse` to fall through to the default case → `builderInstructions()` with full git worktree setup. This is inappropriate for pure analysis/discovery tasks.

## Fix

Added `case 'analyse':` to the switch statement that routes to `discoverInstructions()` — a method that already existed (line 1556) but was dead code.

## Changes

- `apps/thinkgraph-worker/src/session-manager.ts` — 3 lines added (case + body assignment + break)