### PR TITLE
KDS spike + github-tasks skill + venue runbooks (PR-based flow)

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -140,13 +140,15 @@ For changes spanning multiple packages: `feat(crouton-cli,crouton-core): descrip
 
 **Keep the subject line under 72 characters.**
 
-**Use the body for context when the change isn't obvious:**
-```
-refactor(crouton-core): simplify team permission checks
+**Use the body for context when the change isn't obvious.**
 
-Replaced nested conditionals with a permission map lookup.
-The old approach was O(n²) for teams with many roles.
-```
+### Two audiences in the body (REQUIRED)
+
+Keep the conventional subject line, then write the body for **both** readers (full convention lives in the `github-tasks` skill):
+- **👤 For humans** — a short, plain-language summary of what changed and why it matters (one line is fine for small commits).
+- **🤖 For agents** — the precise specifics: files/symbols touched, behaviour changes, follow-ups.
+
+Diagrams belong in PR/issue bodies (which render Mermaid), **not** in commit messages — keep commit text lean.
 
 ## HEREDOC Format (MANDATORY)
 
@@ -156,8 +158,13 @@ Always use this format to preserve formatting:
 git commit -m "$(cat <<'EOF'
 feat(crouton-core): add useTeamMembers composable
 
-Provides reactive team member list with role filtering
-and invite status tracking.
+👤 For humans
+Team settings can now show a live member list that filters by role and
+flags who still has a pending invite — no manual refresh needed.
+
+🤖 For agents
+- New app/composables/useTeamMembers.ts — reactive list, role filter
+- Surfaces invite status from member.status; used by TeamSettings.vue
 EOF
 )"
 ```

--- a/.claude/skills/ecosystem-check/SKILL.md
+++ b/.claude/skills/ecosystem-check/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: ecosystem-check
+description: Before building new infrastructure or a non-trivial capability, check whether the Nuxt ecosystem, UnJS, Vite, or other OSS already solves it — within our constraints (Nuxt, OSS, self-hostable, no mandatory SaaS). Use when weighing build-vs-adopt or starting new infra/tooling.
+allowed-tools: Bash, Read, Grep, Glob, WebSearch, WebFetch
+---
+
+# Check the ecosystem before you build
+
+Before writing new infrastructure or a non-trivial capability, **assume it may already be solved** and check — in order — before committing to a build.
+
+> Real example (this repo): we nearly hand-rolled a "runtime ports" layer so crouton could run off Cloudflare. Turned out **db0 + NuxtHub multi-vendor already do it** — `NITRO_PRESET=node-server` emits libSQL + fs + fs-lite automatically. A feared 26-package core rewrite became a 2-line fix. Checking first saved it. (And we rejected **Turso Cloud** because it's SaaS — chose self-hosted libSQL to honour the OSS constraint.)
+
+## Where to look (in order)
+1. **Already installed** — check the dep tree *first*; it may already ship what you need. `node -e "require.resolve('<pkg>')"`, scan `package.json` / lockfile. (db0 was already there.)
+2. **Nuxt ecosystem** — Nuxt modules, NuxtHub, Nuxt UI, VueUse. (CLAUDE.md already mandates VueUse / Nuxt UI first.)
+3. **UnJS** — the layer under Nitro/Nuxt: `db0` (SQL), `unstorage` (KV/blob/cache), `nitro`, `ofetch`, `h3`, `consola`, `unctx`, `defu`… Most "platform" concerns live here and are usually already in the tree.
+4. **Vite ecosystem** — Vite plugins for build/dev-time concerns.
+5. **Wider OSS** — only then, a well-maintained OSS library.
+6. **Build it ourselves** — last resort, when nothing fits or the fit is poor.
+
+## Filter by our constraints (hard gates)
+- **Nuxt-native / Nitro-compatible** — works with our stack and both runtime targets.
+- **OSS & self-hostable** — prefer a library/repo over a service. **No mandatory SaaS** in the critical path (e.g. self-hosted libSQL/`sqld`, not Turso Cloud).
+- **License** — permissive (MIT/Apache) preferred; check copyleft (AGPL) implications before adopting.
+- **Maintained** — recent releases, real usage; not abandoned.
+- **Config over code** — if an existing tool does the job by *configuration* (like db0 connectors selected by preset), that beats a custom abstraction.
+
+## Verify, don't assume
+- Ecosystem facts are **version-sensitive** — confirm the current state with `WebSearch` / `WebFetch` and the tool's own docs, **not memory**.
+- **Prove it locally** before committing to the approach (we regenerated the NuxtHub config under the node preset to confirm it emits libSQL).
+
+## Capture the decision
+When the check changes the plan, record it on the relevant issue/doc: *what already solves it and why* — or *why nothing fit and we're building*. Keeps the build-vs-adopt reasoning visible for the next person.

--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: github-tasks
+description: Track work as GitHub issues in this monorepo — create epics + child/sub-issues, label them consistently by package/app, and tie them into the commit workflow. Use when planning a feature, breaking work into tasks, or asked to "track this in GitHub", "make issues", "set up tracking".
+allowed-tools: mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__issue_read, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Bash, Read, Grep
+---
+
+# GitHub Task Tracking
+
+The canonical task tracker for this repo is **GitHub Issues** (`pmcp/nuxt-crouton`). This skill defines how to create and label them consistently so every task maps to a real part of the monorepo.
+
+## Core rules
+
+1. **Every issue maps to a package or an app — never "root".** If it feels like root-level work (CI, deploy, ops), label it with the **app it serves** (e.g. CI that builds fanfare → `app:fanfare`). There is deliberately no `root` label.
+2. **Exactly one `type:*` label** per issue — except an **epic**, which carries `epic` instead of a type.
+3. **Component label = where the source actually changes** (mirrors the commit-scope convention):
+   - `pkg:<name>` for package source (`packages/*`, e.g. `pkg:crouton-sales`)
+   - `app:<name>` for app/deployment/ops work (`apps/*`, e.g. `app:fanfare`)
+   - `worker:<name>` for `workers/*`
+   - Package work that also lands a schema/config change in an app gets **both** (e.g. `pkg:crouton-sales` + `app:fanfare`).
+4. Use meta labels where they apply: `epic`, `spike`, `needs-triage`.
+
+## Structure
+
+- **Epic** — one tracking issue per initiative. Body: goals, a checklist of workstreams, links to design docs. Labels: `epic` + the primary `pkg:`/`app:` it spans.
+- **Child issues** — one per workstream, each linked as a **sub-issue** of the epic so GitHub shows a progress bar.
+- Keep issue bodies tight: scope, acceptance criteria, links to `docs/`.
+
+## How to create them (tools)
+
+Issues, sub-issues, and labels are managed through the GitHub MCP tools:
+
+- Create / update: `mcp__github__issue_write` (`method: create|update`, pass `labels: [...]`).
+- Link a child under a parent: `mcp__github__sub_issue_write` (`method: add`, `issue_number` = parent, `sub_issue_id` = the child's **id** from its create response — not its number).
+- Read / list: `mcp__github__issue_read`, `mcp__github__list_issues`, `mcp__github__search_issues`.
+
+**Labels must already exist** before you can apply them — applying an unknown label errors. New labels are added via labels-as-code (below), not by the API.
+
+**Projects v2 boards can't be created or managed via these tools** (UI-only). Tell the user to create the board in the web/iOS app; if they enable the project's "Auto-add" workflow, issues you create land on the board automatically.
+
+## Labels-as-code
+
+The label taxonomy lives in **`.github/labels.yml`** and mirrors the workspace: `pkg:*` for every `packages/*`, `app:*` for every `apps/*`, `worker:*` for `workers/*`, plus `type:*` and meta labels. It's synced **non-destructively** by `.github/workflows/labels.yml` (`skip_delete`) on changes to `main` or via `workflow_dispatch`.
+
+To add or change a label: edit `.github/labels.yml`, commit, and let the workflow sync it on merge to `main`. When a new package or app is added, add its `pkg:`/`app:` label here too.
+
+## Fit into the task workflow
+
+GitHub issues slot into the repo's task-execution flow (see `CLAUDE.md`):
+
+1. **Pick / open an issue** — the issue is the unit of work. For a multi-step initiative, open an epic + sub-issues first.
+2. **Mark in progress** — assign yourself / set the Project Status to In Progress (if a board exists).
+3. **Do the work** — follow `CLAUDE.md` patterns; run `pnpm typecheck`.
+4. **Commit referencing the issue** — use the `/commit` skill; include the issue number in the body (e.g. `(#60)`), or `Closes #60` to auto-close on merge.
+5. **Close the issue** (or tick its box in the epic) when the acceptance criteria are met.
+
+Issues are the source of truth for *what* to do; `docs/PROGRESS_TRACKER.md` (if used) becomes an optional phase-level rollup, not the per-task tracker.
+
+## Quick reference
+
+| Want | Label(s) |
+|------|----------|
+| New feature in a package | `type:feat` `pkg:<name>` |
+| Feature touching a package + app schema/config | `type:feat` `pkg:<name>` `app:<name>` |
+| App/deployment/ops/CI work | `type:chore`/`type:docs` `app:<name>` |
+| Cross-cutting initiative | `epic` `pkg:<name>` (+ `app:<name>`) |
+| Time-boxed proof-of-concept | `spike` `type:feat` `<component>` |

--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -49,11 +49,12 @@ GitHub issues slot into the repo's task-execution flow (see `CLAUDE.md`):
 
 1. **Pick / open an issue** — the issue is the unit of work. For a multi-step initiative, open an epic + sub-issues first.
 2. **Mark in progress** — assign yourself / set the Project Status to In Progress (if a board exists).
-3. **Do the work** — follow `CLAUDE.md` patterns; run `pnpm typecheck`.
-4. **Commit referencing the issue** — use the `/commit` skill; include the issue number in the body (e.g. `(#60)`), or `Closes #60` to auto-close on merge.
-5. **Close the issue** (or tick its box in the epic) when the acceptance criteria are met.
+3. **Branch + do the work** — work on a feature branch; follow `CLAUDE.md` patterns; run `pnpm typecheck`.
+4. **Commit** — use the `/commit` skill, referencing the issue in the body (e.g. `(#NN)`).
+5. **Open a PR** — early is fine. Put `Closes #NN` in the body so the issue auto-closes on merge. Let CI run and fix failures (the PR can be watched/autofixed).
+6. **Squash-merge** → the issue closes automatically and the branch is deleted. Don't push feature work straight to `main`.
 
-Issues are the source of truth for *what* to do; `docs/PROGRESS_TRACKER.md` (if used) becomes an optional phase-level rollup, not the per-task tracker.
+Work lands via **PRs**, not direct pushes to `main`. Issues are the source of truth for *what* to do; `docs/PROGRESS_TRACKER.md` (if used) becomes an optional phase-level rollup, not the per-task tracker.
 
 ## Quick reference
 

--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -8,6 +8,18 @@ allowed-tools: mcp__github__issue_write, mcp__github__sub_issue_write, mcp__gith
 
 The canonical task tracker for this repo is **GitHub Issues** (`pmcp/nuxt-crouton`). This skill defines how to create and label them consistently so every task maps to a real part of the monorepo.
 
+## Writing for two audiences (REQUIRED — applies to issues, PRs, and commits)
+
+Everything that lands in GitHub is written for **two readers**, in this order:
+
+### 👤 For humans (first — and it must be genuinely easy to read)
+Lead with this. Plain language a busy person skims in seconds: *what changed, why it matters, what to expect* — impact over mechanics. Short sentences, no unexplained jargon, no raw file paths unless they're the point. Use a **diagram only when it makes the change easier to understand** (a flow, a before/after, an architecture or state change). Mermaid renders in issue/PR bodies — use it there. **Never add a diagram for decoration**; if it doesn't earn its space, leave it out.
+
+### 🤖 For agents
+A precise, structured block an AI can act on without guessing: scope, exact files/paths and symbols, behaviour changes, acceptance criteria, follow-ups, links to issues/docs.
+
+Use explicit headings (`## 👤 For humans` / `## 🤖 For agents`) so both are obvious. Scale to the change — a one-line human summary is fine for something small — but **always include both**.
+
 ## Core rules
 
 1. **Every issue maps to a package or an app — never "root".** If it feels like root-level work (CI, deploy, ops), label it with the **app it serves** (e.g. CI that builds fanfare → `app:fanfare`). There is deliberately no `root` label.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ Addon packages must register in `croutonApps` (in `app/app.config.ts`) to be det
 - Start simple, add complexity only when proven necessary
 - ALWAYS check VueUse composables first before writing custom utilities
 - Check Nuxt UI templates before building from scratch
+- Before building new **infrastructure/capability**, run the `ecosystem-check` skill — check Nuxt / UnJS / Vite / OSS prior art first (it's often already solved, e.g. db0, unstorage). Honour constraints: Nuxt-native, OSS, self-hostable, no mandatory SaaS.
 
 ### 2. Composables First, Readable Code Always
 Prefer composables for reusable logic. Keep inline logic readable. Avoid over-engineered functional pipelines.
@@ -302,6 +303,7 @@ docs/
 | Skill | `.claude/skills/sync-docs/SKILL.md` | Doc sync before commits |
 | Skill | `.claude/skills/i18n-audit.md` | Translation audit + fix |
 | Skill | `.claude/skills/github-tasks/SKILL.md` | GitHub issue tracking (epics, labels, workflow) |
+| Skill | `.claude/skills/ecosystem-check/SKILL.md` | Check Nuxt/UnJS/Vite/OSS prior art before building |
 | Agent | `.claude/agents/sync-checker.md` | Doc sync verification |
 | MCP Server | `packages/nuxt-crouton-mcp-server/` | AI collection generation |
 | Themes | `packages/nuxt-crouton-themes/` | Swappable UI themes |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,10 @@ Every task in `/docs/PROGRESS_TRACKER.md` follows this 5-step flow:
 5. Git Commit           → ALWAYS use /commit skill — NEVER git commit directly
 ```
 
+### GitHub Issue Tracking
+
+Tasks are tracked as **GitHub issues** (`pmcp/nuxt-crouton`) — see the `github-tasks` skill. The issue is the unit of work: open an **epic + sub-issues** for an initiative, label each by **package or app** (never `root`; exactly one `type:*`), reference the issue number in the commit (`(#NN)` or `Closes #NN`), and close it when the acceptance criteria are met. `docs/PROGRESS_TRACKER.md` becomes an optional phase-level rollup, not the per-task tracker.
+
 ### Commit Format (enforced by /commit skill)
 ```
 <type>(<scope>): <description>
@@ -297,6 +301,7 @@ docs/
 | Skill | `.claude/skills/crouton.md` | Collection generation workflow |
 | Skill | `.claude/skills/sync-docs/SKILL.md` | Doc sync before commits |
 | Skill | `.claude/skills/i18n-audit.md` | Translation audit + fix |
+| Skill | `.claude/skills/github-tasks/SKILL.md` | GitHub issue tracking (epics, labels, workflow) |
 | Agent | `.claude/agents/sync-checker.md` | Doc sync verification |
 | MCP Server | `packages/nuxt-crouton-mcp-server/` | AI collection generation |
 | Themes | `packages/nuxt-crouton-themes/` | Swappable UI themes |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Every task in `/docs/PROGRESS_TRACKER.md` follows this 5-step flow:
 
 ### GitHub Issue Tracking
 
-Tasks are tracked as **GitHub issues** (`pmcp/nuxt-crouton`) — see the `github-tasks` skill. The issue is the unit of work: open an **epic + sub-issues** for an initiative, label each by **package or app** (never `root`; exactly one `type:*`), reference the issue number in the commit (`(#NN)` or `Closes #NN`), and close it when the acceptance criteria are met. `docs/PROGRESS_TRACKER.md` becomes an optional phase-level rollup, not the per-task tracker.
+Tasks are tracked as **GitHub issues** (`pmcp/nuxt-crouton`) — see the `github-tasks` skill. The issue is the unit of work: open an **epic + sub-issues** for an initiative, label each by **package or app** (never `root`; exactly one `type:*`). Work lands via a **PR** on a feature branch (commit with `/commit`, reference `(#NN)`, put `Closes #NN` in the PR body to auto-close on merge) — not direct pushes to `main`. `docs/PROGRESS_TRACKER.md` becomes an optional phase-level rollup, not the per-task tracker.
 
 ### Commit Format (enforced by /commit skill)
 ```

--- a/apps/fanfare/app/pages/kds/[eventId].vue
+++ b/apps/fanfare/app/pages/kds/[eventId].vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+/**
+ * KDS (kitchen display) — spike for the `display` output driver (#60).
+ * Subscribes to an event's order feed and lets staff "bump" orders when done.
+ * Bump is client-side for the spike (sessionStorage); productionizing it into
+ * the salesPrintqueues lifecycle (pending → shown → bumped) is the follow-up.
+ */
+definePageMeta({ layout: false })
+
+interface KdsItem { title: string; quantity: number; remarks: string | null }
+interface KdsOrder {
+  id: string
+  number: number | null
+  clientName: string | null
+  owner: string
+  isPersonnel: boolean
+  status: string
+  createdAt: string
+  items: KdsItem[]
+}
+
+const route = useRoute()
+const eventId = computed(() => route.params.eventId as string)
+
+const { data, refresh } = await useFetch<{ orders: KdsOrder[] }>(
+  () => `/api/kds/${eventId.value}/orders`,
+  { default: () => ({ orders: [] }) }
+)
+
+// Bumped order ids persist per-session so a refresh doesn't resurrect them.
+const STORAGE_KEY = `kds-bumped-${eventId.value}`
+const bumped = ref<Set<string>>(new Set())
+onMounted(() => {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (raw) bumped.value = new Set(JSON.parse(raw))
+  } catch { /* ignore */ }
+})
+function bump(id: string) {
+  bumped.value = new Set([...bumped.value, id])
+  try { sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...bumped.value])) } catch { /* ignore */ }
+}
+
+const active = computed(() => (data.value?.orders ?? []).filter(o => !bumped.value.has(o.id)))
+
+// Poll every 2s; pause when the tab is hidden.
+let timer: ReturnType<typeof setInterval> | null = null
+function tick() { if (document.visibilityState !== 'hidden') refresh() }
+onMounted(() => { timer = setInterval(tick, 2000); document.addEventListener('visibilitychange', tick) })
+onUnmounted(() => { if (timer) clearInterval(timer); document.removeEventListener('visibilitychange', tick) })
+
+const now = ref(Date.now())
+onMounted(() => { const t = setInterval(() => (now.value = Date.now()), 1000); onUnmounted(() => clearInterval(t)) })
+function ago(iso: string) {
+  const s = Math.max(0, Math.floor((now.value - new Date(iso).getTime()) / 1000))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  return `${m}m ${s % 60}s`
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-slate-950 text-slate-100 p-5">
+    <header class="flex items-center justify-between mb-5">
+      <div class="flex items-center gap-3">
+        <span class="text-2xl">🍳</span>
+        <h1 class="text-xl font-bold tracking-tight">Kitchen Display</h1>
+        <span class="text-xs px-2 py-1 rounded bg-slate-800 text-slate-400 font-mono">{{ eventId }}</span>
+      </div>
+      <div class="flex items-center gap-2 text-sm text-slate-400">
+        <span class="inline-block size-2 rounded-full bg-emerald-400 animate-pulse" />
+        live · {{ active.length }} active
+      </div>
+    </header>
+
+    <div v-if="active.length === 0" class="flex flex-col items-center justify-center text-center text-slate-500 py-32">
+      <span class="text-5xl mb-3">✅</span>
+      <p class="text-lg">All caught up — no open orders.</p>
+    </div>
+
+    <TransitionGroup
+      name="order"
+      tag="div"
+      class="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(260px,1fr))]"
+    >
+      <div
+        v-for="o in active"
+        :key="o.id"
+        class="rounded-2xl bg-slate-900 border border-slate-800 shadow-lg overflow-hidden flex flex-col"
+      >
+        <div
+          class="flex items-center justify-between px-4 py-3 border-b border-slate-800"
+          :class="o.isPersonnel ? 'bg-amber-500/15' : 'bg-slate-800/60'"
+        >
+          <div class="flex items-baseline gap-2">
+            <span class="text-2xl font-extrabold">#{{ o.number ?? '—' }}</span>
+            <span v-if="o.isPersonnel" class="text-[11px] font-bold uppercase text-amber-400">staff</span>
+          </div>
+          <span class="text-xs text-slate-400 tabular-nums">{{ ago(o.createdAt) }}</span>
+        </div>
+
+        <div class="px-4 py-3 flex-1">
+          <p v-if="o.clientName" class="text-sm text-slate-400 mb-2">{{ o.clientName }}</p>
+          <ul class="space-y-1.5">
+            <li v-for="(it, i) in o.items" :key="i" class="flex gap-2 text-[15px]">
+              <span class="font-bold text-emerald-400 tabular-nums min-w-[1.5rem]">{{ it.quantity }}×</span>
+              <span class="flex-1">
+                {{ it.title }}
+                <span v-if="it.remarks" class="block text-xs text-amber-300/90">↳ {{ it.remarks }}</span>
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <button
+          class="px-4 py-3 text-sm font-bold uppercase tracking-wide bg-emerald-600 hover:bg-emerald-500 active:bg-emerald-700 transition-colors"
+          @click="bump(o.id)"
+        >
+          ✓ Bump
+        </button>
+      </div>
+    </TransitionGroup>
+  </div>
+</template>
+
+<style scoped>
+.order-enter-active, .order-leave-active { transition: all .35s ease; }
+.order-enter-from { opacity: 0; transform: translateY(-10px) scale(.97); }
+.order-leave-to { opacity: 0; transform: scale(.92); }
+</style>

--- a/apps/fanfare/server/api/kds/[eventId]/orders.get.ts
+++ b/apps/fanfare/server/api/kds/[eventId]/orders.get.ts
@@ -1,0 +1,58 @@
+/**
+ * KDS (kitchen-display) order feed — spike for the `display` output driver (#60).
+ *
+ * App-level read model: returns recent orders for an event with their items
+ * resolved to product titles, so a screen (iPad) can render them instead of
+ * printing. Rides the existing sales tables; no package changes.
+ */
+import { desc, eq, inArray } from 'drizzle-orm'
+import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
+import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
+import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  if (!eventId) {
+    throw createError({ status: 400, statusText: 'eventId is required' })
+  }
+
+  const db = useDB()
+
+  const orders = await db
+    .select()
+    .from(salesOrders)
+    .where(eq(salesOrders.eventId, eventId))
+    .orderBy(desc(salesOrders.createdAt))
+    .limit(50)
+
+  if (orders.length === 0) {
+    return { orders: [] }
+  }
+
+  const orderIds = orders.map(o => o.id)
+  const [items, products] = await Promise.all([
+    db.select().from(salesOrderitems).where(inArray(salesOrderitems.orderId, orderIds)),
+    db.select().from(salesProducts).where(eq(salesProducts.eventId, eventId))
+  ])
+
+  const titleById = new Map(products.map(p => [p.id, p.title]))
+  const itemsByOrder = new Map<string, Array<{ title: string, quantity: number, remarks: string | null }>>()
+  for (const it of items) {
+    const arr = itemsByOrder.get(it.orderId) ?? []
+    arr.push({ title: titleById.get(it.productId) ?? 'Item', quantity: it.quantity, remarks: it.remarks })
+    itemsByOrder.set(it.orderId, arr)
+  }
+
+  return {
+    orders: orders.map(o => ({
+      id: o.id,
+      number: o.eventOrderNumber,
+      clientName: o.clientName,
+      owner: o.owner,
+      isPersonnel: o.isPersonnel,
+      status: o.status,
+      createdAt: o.createdAt,
+      items: itemsByOrder.get(o.id) ?? []
+    }))
+  }
+})

--- a/docs/setup/litestream-backup-setup.md
+++ b/docs/setup/litestream-backup-setup.md
@@ -1,0 +1,80 @@
+# Litestream Backup — Pi SQLite → R2/S3
+
+Runbook for continuous backup of the venue Pi's SQLite database (issue #64). Litestream streams the WAL to object storage every few seconds, giving point-in-time restore if the Pi/SD card dies. The Pi stays the authoritative writer; this is disaster recovery, not a live cloud mirror (see `docs/architecture/venue-local-first-architecture.md` → "Sync model").
+
+> Scope note: this assumes the app runs on the Pi via the `node-server` target (#63) with a local SQLite file. Until that lands, this is reference config.
+
+## Prerequisites
+
+- SQLite in **WAL mode** (Litestream requires it):
+  ```sql
+  PRAGMA journal_mode = WAL;
+  ```
+- An R2 (or S3) bucket + credentials, set as env on the Pi:
+  `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`.
+
+## Config
+
+`/etc/litestream.yml`:
+
+```yaml
+dbs:
+  - path: /data/app.db
+    replicas:
+      - type: s3
+        bucket: fanfare-venue-backup
+        path: kassa
+        endpoint: https://<accountid>.r2.cloudflarestorage.com
+        region: auto
+        # creds from LITESTREAM_ACCESS_KEY_ID / LITESTREAM_SECRET_ACCESS_KEY
+        sync-interval: 1s
+        retention: 72h
+        snapshot-interval: 1h
+```
+
+## Run as a service
+
+Litestream ships a systemd unit; enable it to replicate continuously:
+
+```bash
+sudo systemctl enable --now litestream
+sudo systemctl status litestream     # confirm "replicating"
+```
+
+Or as a sidecar in docker-compose alongside the app container (shared volume on `/data`):
+
+```yaml
+litestream:
+  image: litestream/litestream
+  command: replicate
+  volumes:
+    - app-data:/data
+    - ./litestream.yml:/etc/litestream.yml:ro
+  environment:
+    - LITESTREAM_ACCESS_KEY_ID
+    - LITESTREAM_SECRET_ACCESS_KEY
+  restart: unless-stopped
+```
+
+Boot order on the Pi: **migrate → start app → litestream replicate**.
+
+## Restore (spare Pi / disaster recovery)
+
+```bash
+# pull the latest snapshot+WAL back into a fresh DB file
+litestream restore -o /data/app.db \
+  s3://fanfare-venue-backup/kassa
+# then start the app pointing at /data/app.db
+```
+
+Restore is point-in-time to the last synced WAL frame (seconds of potential loss at most).
+
+## Verify
+
+- [ ] `litestream replicate` reports the db and a healthy replica.
+- [ ] Object storage shows generations + WAL segments accumulating.
+- [ ] A test `litestream restore` to a scratch path reproduces the current data.
+
+## Egress note
+
+Litestream's only outbound traffic is to the R2/S3 endpoint — allow it through the RUT firewall as part of the **Pi-only WAN egress** rule (see `venue-network-setup.md`). It's small (KB of WAL frames), so it's cheap on a metered 5G SIM.

--- a/docs/setup/litestream-backup-setup.md
+++ b/docs/setup/litestream-backup-setup.md
@@ -1,6 +1,6 @@
-# Litestream Backup — Pi SQLite → R2/S3
+# Litestream Backup — Pi SQLite → self-hosted object storage (hardcore OSS)
 
-Runbook for continuous backup of the venue Pi's SQLite database (issue #64). Litestream streams the WAL to object storage every few seconds, giving point-in-time restore if the Pi/SD card dies. The Pi stays the authoritative writer; this is disaster recovery, not a live cloud mirror (see `docs/architecture/venue-local-first-architecture.md` → "Sync model").
+Runbook for continuous backup of the venue Pi's SQLite database (issue #64). Litestream streams the WAL to object storage every few seconds, giving point-in-time restore if the Pi/SD card dies. The Pi stays the authoritative writer; this is disaster recovery, not a live cloud mirror (see `docs/architecture/venue-local-first-architecture.md` → "Sync model"). Hardcore-OSS: the backup target is **self-hosted** object storage (MinIO or any S3-compatible) or `restic` — **no Turso, no R2, no SaaS**.
 
 > Scope note: this assumes the app runs on the Pi via the `node-server` target (#63) with a local SQLite file. Until that lands, this is reference config.
 
@@ -10,7 +10,7 @@ Runbook for continuous backup of the venue Pi's SQLite database (issue #64). Lit
   ```sql
   PRAGMA journal_mode = WAL;
   ```
-- An R2 (or S3) bucket + credentials, set as env on the Pi:
+- A bucket on **self-hosted MinIO** (or any S3-compatible store you run — no SaaS) + credentials, set as env on the Pi:
   `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`.
 
 ## Config
@@ -24,7 +24,7 @@ dbs:
       - type: s3
         bucket: fanfare-venue-backup
         path: kassa
-        endpoint: https://<accountid>.r2.cloudflarestorage.com
+        endpoint: https://minio.example.internal   # self-hosted MinIO / any S3-compatible
         region: auto
         # creds from LITESTREAM_ACCESS_KEY_ID / LITESTREAM_SECRET_ACCESS_KEY
         sync-interval: 1s
@@ -75,6 +75,10 @@ Restore is point-in-time to the last synced WAL frame (seconds of potential loss
 - [ ] Object storage shows generations + WAL segments accumulating.
 - [ ] A test `litestream restore` to a scratch path reproduces the current data.
 
+## No-server alternative: restic
+
+If you'd rather not run an S3 server at all, **`restic`** can snapshot the (WAL-checkpointed) SQLite file to a local disk, an SFTP target, or any S3-compatible store — fully OSS. Litestream is preferred for continuous, second-level replication; `restic` is fine for periodic snapshots.
+
 ## Egress note
 
-Litestream's only outbound traffic is to the R2/S3 endpoint — allow it through the RUT firewall as part of the **Pi-only WAN egress** rule (see `venue-network-setup.md`). It's small (KB of WAL frames), so it's cheap on a metered 5G SIM.
+Litestream's only outbound traffic is to your MinIO/S3-compatible endpoint — allow it through the RUT firewall as part of the **Pi-only WAN egress** rule (see `venue-network-setup.md`). It's small (KB of WAL frames), so it's cheap on a metered 5G SIM.

--- a/docs/setup/venue-network-setup.md
+++ b/docs/setup/venue-network-setup.md
@@ -1,0 +1,89 @@
+# Venue Network Setup — Raspberry Pi + Teltonika RUT956
+
+Runbook for the local-first venue rig (issue #65). Wires up the RUT956 so the Pi serves the app on the LAN, **users never consume the venue's 5G**, and only the Pi reaches the internet (for sync/backup). See `docs/architecture/venue-local-first-architecture.md` for the rationale.
+
+## Goal
+
+```
+  Tablets/phones ──Wi-Fi──▶ Pi + printers (LAN)        POS works, no internet needed
+                 ──✗ blocked at RUT firewall──▶ 5G       no surfing on venue data
+        └── own cellular ──▶ internet                     user's own data
+
+  Pi ──(allowed: static IP only)──▶ 5G ──▶ Cloudflare     constant sync / backup
+  Admin ──WireGuard via RUT──▶ Pi                          manage / push updates
+```
+
+## 1. Static addressing
+
+Give the Pi and every printer a fixed LAN IP (DHCP static lease or static config):
+
+| Device | Example IP |
+|--------|-----------|
+| RUT956 (gateway) | `192.168.1.1` |
+| Raspberry Pi | `192.168.1.10` |
+| Kitchen printer 1 | `192.168.1.71` |
+| Receipt printer | `192.168.1.72` |
+
+RutOS: **Network → DHCP → Static Leases** — bind each MAC to its IP.
+
+## 2. mDNS (avahi) so tablets use a name
+
+Run Avahi on the Pi so tablets hit `https://kassa.local` instead of an IP:
+
+```bash
+sudo apt install -y avahi-daemon
+sudo hostnamectl set-hostname kassa
+```
+
+## 3. Firewall — reserve the 5G for the Pi (the key step)
+
+Block client devices from the WAN; allow only the Pi out. Two equivalent approaches:
+
+**A. Traffic rule (simplest)** — RutOS **Network → Firewall → Traffic Rules**:
+- Rule 1 — *Pi to internet (allow)*: Source LAN `192.168.1.10` → Dest WAN → **Accept**.
+- Rule 2 — *Block clients to internet*: Source LAN `192.168.1.0/24` → Dest WAN → **Reject**. Order it **after** Rule 1.
+
+**B. Guest VLAN** — put tablets on a guest Wi-Fi/VLAN with "no internet" and only LAN access to the Pi/printers; keep the Pi on the main LAN with WAN access.
+
+UCI equivalent (A):
+```
+# allow the Pi out
+uci add firewall rule; uci set firewall.@rule[-1].name='pi-wan'
+uci set firewall.@rule[-1].src='lan'; uci set firewall.@rule[-1].dest='wan'
+uci set firewall.@rule[-1].src_ip='192.168.1.10'; uci set firewall.@rule[-1].target='ACCEPT'
+# block everyone else
+uci add firewall rule; uci set firewall.@rule[-1].name='lan-no-wan'
+uci set firewall.@rule[-1].src='lan'; uci set firewall.@rule[-1].dest='wan'
+uci set firewall.@rule[-1].target='REJECT'
+uci commit firewall; /etc/init.d/firewall restart
+```
+
+**Result:** the client Wi-Fi has no internet route. iOS/Android then fall back to **cellular for internet while staying on Wi-Fi for the LAN** (POS). A one-time "Wi-Fi has no Internet — stay connected?" prompt may appear; choose stay. The LAN/POS path is unaffected.
+
+## 4. HTTPS on the LAN (Caddy on the Pi)
+
+Secure cookies, passkeys, and PWA features need a secure context. Front the app with Caddy:
+
+```caddyfile
+# /etc/caddy/Caddyfile
+kassa.local {
+  reverse_proxy 127.0.0.1:3000
+  tls internal          # local CA; install Caddy's root cert on the tablets
+}
+```
+
+- **Local CA:** `tls internal` issues a cert from Caddy's root — install that root on each tablet (Settings → trust profile) once.
+- **Real cert (alternative):** point a public hostname's DNS-01 record at the LAN IP and let Caddy get a Let's Encrypt cert (needs the Pi's egress, which is allowed).
+- Set `BETTER_AUTH_URL=https://kassa.local`. If a public hostname must also work on-site, add both to `BETTER_AUTH_TRUSTED_ORIGINS` and use split-horizon DNS.
+
+## 5. Remote admin (WireGuard)
+
+For pushing updates / checking the Pi remotely, use the RUT's built-in WireGuard server rather than exposing any inbound port. Add an admin peer; route the LAN subnet so you reach `192.168.1.10` over the tunnel.
+
+## Checklist
+
+- [ ] Pi + printers on static IPs; `kassa.local` resolves on the LAN.
+- [ ] Firewall: only the Pi egresses to WAN; client subnet blocked from WAN.
+- [ ] A tablet on the Wi-Fi reaches the POS but uses its own cellular for the web.
+- [ ] `https://kassa.local` serves with a trusted cert; login works.
+- [ ] WireGuard admin access verified.

--- a/packages/crouton-auth/server/utils/team.ts
+++ b/packages/crouton-auth/server/utils/team.ts
@@ -7,20 +7,12 @@
 import type { H3Event } from 'h3'
 import { createError, getRouterParam } from 'h3'
 import { useRuntimeConfig } from '#imports'
-import { drizzle } from 'drizzle-orm/d1'
 import { sql, eq, and } from 'drizzle-orm'
 import { organization, member as memberTable } from '../database/schema/auth'
 import type { Team, Member, User } from '../../types'
 import { mapOrganizationToTeam } from '../../shared/utils/auth'
 import { useServerAuth, requireServerSession } from './useServerAuth'
 import type { CroutonAuthConfig } from '../../types/config'
-
-// D1Database type from Cloudflare workers-types
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type D1Database = any
-
-// hubDatabase is a NuxtHub auto-import, declare it for TypeScript
-declare function hubDatabase(): D1Database
 
 // Extended session type with organization plugin properties
 interface OrganizationSession {
@@ -314,8 +306,7 @@ export async function getOrCreateDefaultOrganization(event: H3Event): Promise<Te
 
   // Team doesn't exist - create it using direct DB access
   // (We're in request context, so database is available)
-  const d1 = hubDatabase()
-  const db = drizzle(d1)
+  const db = useDB()
 
   const now = new Date().toISOString()
   const orgId = crypto.randomUUID()
@@ -483,8 +474,7 @@ export async function getOrganizationMembershipDirect(
   organizationId: string,
   userId: string
 ): Promise<{ role: 'owner' | 'admin' | 'member' } | null> {
-  const d1 = hubDatabase()
-  const db = drizzle(d1)
+  const db = useDB()
 
   const result = await db
     .select({ role: member.role })


### PR DESCRIPTION
## 👤 For humans

Follow-on work from the local-first / fulfillment planning (epic #59). Nothing here touches shared packages except one tiny, verified fix. Merging gives you:

- **A working "kitchen display" demo** — orders appear on a screen and staff tap **Bump**. Proven in the fanfare app.
- **A GitHub way-of-working** — skills for issue tracking (epics + labels + PRs), dual-audience writing, and "check the ecosystem before building".
- **Two venue setup guides** — the Pi + RUT network, and database backup — both fully self-hosted (no paid services).
- **A step toward offline** — the database layer now works on a local open-source database, not just Cloudflare (a small fix; the rest is built-in).

Heads-up: the red `code-review` and `Cloudflare Pages` checks are pre-existing/environmental (an API credit balance and the docs deploy), not caused by this PR.

## 🤖 For agents

Closes #60, #62, #64, #65.

- **#60 spike** (`app:fanfare`): `apps/fanfare/server/api/kds/[eventId]/orders.get.ts` + `app/pages/kds/[eventId].vue` (poll + bump). Productionize into `salesPrintqueues` = #61.
- **#62 runtime-ports residual** (`crouton-auth`): `team.ts` two `hubDatabase()`+`drizzle(d1)` sites → `useDB()`; audited — no other runtime D1 coupling (db0/NuxtHub handle driver selection by preset). Verified: team paths 200 on dev.
- **Workflow/skills** (`root`): `github-tasks`, `ecosystem-check` skills; `commit` skill dual-audience; `CLAUDE.md` wiring.
- **Runbooks** (`docs`): `venue-network-setup.md` (#65), `litestream-backup-setup.md` (#64, hardcore-OSS: MinIO/restic, no R2/Turso).

Gated / out of scope here: #63 (node build + cf-stubs + drainer), #66 (CI both presets, depends on #63).

https://claude.ai/code/session_01Wm8gxLLYtEPYiVuUn5aBkf