### PR TITLE
Auto-install + build on web session start (fast cold starts)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Installs workspace dependencies and builds the @fyit/crouton-* packages so
+# apps boot and tests/linters run. The container state is cached into the
+# environment snapshot after this completes, so later sessions start fast.
+#
+# Local (non-web) sessions are skipped — local dev manages its own setup.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# CLAUDE_PROJECT_DIR is set by the harness in a real invocation; fall back to
+# the repo root relative to this script so the hook is also runnable directly.
+cd "${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+echo "[session-start] pnpm install…"
+pnpm install
+
+# Apps (e.g. fanfare) won't boot until the crouton packages' dist exists — the
+# dev server errors on a missing crouton-core/dist. Build them once here.
+echo "[session-start] pnpm build:packages…"
+pnpm build:packages
+
+echo "[session-start] done."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
     ]
   },
   "mcpServers": {

--- a/docs/setup/web-session-setup.md
+++ b/docs/setup/web-session-setup.md
@@ -1,0 +1,41 @@
+# Fast session startup — Claude Code on the web
+
+Each web session runs in a **fresh container** (repo cloned anew). The container is **snapshotted after the SessionStart hook finishes** and reused for later sessions (~7 days), so the expensive setup is paid **once**. For this monorepo the cost is `pnpm install` + building the `@fyit/crouton-*` packages (apps won't boot without their `dist`).
+
+## What's automated (in the repo)
+
+`.claude/hooks/session-start.sh` (registered in `.claude/settings.json` → `hooks.SessionStart`) runs on web sessions only and does:
+
+```bash
+pnpm install
+pnpm build:packages   # apps (e.g. fanfare) need the crouton dist to boot
+```
+
+It's idempotent and skipped on local (non-web) sessions (`$CLAUDE_CODE_REMOTE`). After the first run it's cached into the snapshot, so subsequent sessions start fast.
+
+> **Activation:** once this hook is on the **default branch**, all future web sessions use it.
+
+## Environment config (one-time, in the web UI — not the repo)
+
+Set in the environment settings:
+
+- **`BETTER_AUTH_SECRET`** — a 32+ character secret. Apps like `fanfare` need it to boot. (Optionally `BETTER_AUTH_URL`.) Keep secrets in the env config, not in the hook or a committed `.env`.
+- *(Alternative)* If you'd rather, the same `pnpm install && pnpm build:packages` can live in the environment **setup script** instead of the SessionStart hook. Both get snapshot-cached; the hook keeps it version-controlled, so we use the hook.
+
+## Running an app in a session
+
+```bash
+cd apps/fanfare && pnpm dev      # uses hub:db sqlite locally; needs BETTER_AUTH_SECRET
+```
+
+If you edit a **dist-consumed** package (e.g. `crouton-core`, `crouton-sales`), rebuild just that one so the app picks it up:
+
+```bash
+pnpm --filter @fyit/crouton-core build
+```
+
+## Recommended way to start a work session
+
+1. **Sync the branch:** `git fetch origin && git reset --hard origin/main`
+2. **Paste the handoff prompt** (continue the active issue — e.g. #61) so context isn't re-derived.
+3. The SessionStart hook has already installed + built everything; you can run tests/lint/dev immediately.


### PR DESCRIPTION
## 👤 For humans

New Claude-Code-on-the-web sessions start in a fresh container, so they kept needing `pnpm install` + a build of the crouton packages before anything could run (the dev server crashes without the built `dist`). This adds a **SessionStart hook** that does that automatically — and the result is cached into the container snapshot, so after the first run **future sessions start fast**. Plus a short setup doc.

Activates once it's on `main`. You'll also want to set **`BETTER_AUTH_SECRET`** in the environment config so apps boot.

## 🤖 For agents

- `.claude/hooks/session-start.sh`: web-only (`CLAUDE_CODE_REMOTE`), idempotent — `pnpm install` + `pnpm build:packages`; project dir falls back to repo root when `CLAUDE_PROJECT_DIR` is unset (runnable directly). Validated end-to-end (install + build complete).
- `.claude/settings.json`: registered under `hooks.SessionStart`; existing `PreToolUse` package-gate + `mcpServers` untouched.
- `docs/setup/web-session-setup.md`: snapshot caching, env config, sync/run tips.

Synchronous mode (guarantees deps ready before the session acts; can switch to async for faster startup if desired). No issue to close — pure tooling.

https://claude.ai/code/session_01Wm8gxLLYtEPYiVuUn5aBkf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm8gxLLYtEPYiVuUn5aBkf)_