### PR TITLE
Build fanfare for both Cloudflare and the Pi in CI (#66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,52 @@ jobs:
       - name: Type check MCP Server
         run: pnpm --filter @fyit/crouton-mcp typecheck
 
+  build-fanfare:
+    # Dual-target smoke test: fanfare must build for both the Cloudflare
+    # (cloud) and node-server (venue/Pi) presets, or the unused path silently
+    # rots. The build itself is the smoke test — node-server boot was proven in
+    # #63. Scoped to fanfare to stay fast; typecheck is intentionally NOT gated
+    # here (fanfare carries a known pre-existing baseline of type errors).
+    name: Build fanfare (${{ matrix.preset }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [cloudflare-pages, node-server]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build fanfare's workspace dependencies
+        # '^...' selects fanfare's transitive workspace deps (excludes fanfare
+        # itself). They are dist-consumed, so they must be built before the app.
+        run: pnpm --filter "fanfare^..." build
+
+      - name: Prepare Nuxt
+        # postinstall (nuxt prepare) is skipped above via --ignore-scripts.
+        run: npx nuxt prepare
+        working-directory: apps/fanfare
+
+      - name: Build fanfare (${{ matrix.preset }})
+        run: npx nuxt build
+        working-directory: apps/fanfare
+        env:
+          NITRO_PRESET: ${{ matrix.preset }}
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          # Build-time prerender needs a secret present; value is irrelevant in CI.
+          BETTER_AUTH_SECRET: ci-placeholder
+
   docs-check:
     name: Documentation Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 👤 For humans

Adds an automatic safety check: every change now builds **fanfare both ways** — for Cloudflare (the cloud target) and for node-server (the venue/Pi target) — so the offline/venue path can't silently rot while everyone works against Cloudflare. The build itself is the smoke test (node-server boot was already proven in #63).

```mermaid
flowchart LR
  PR[Push / PR] --> CI[CI: build-fanfare matrix]
  CI -->|NITRO_PRESET=cloudflare-pages| CF[Cloud build ✓]
  CI -->|NITRO_PRESET=node-server| NS[Venue / Pi build ✓]
```

## 🤖 For agents

CI-only change to `.github/workflows/ci.yml`.

- New `build-fanfare` job, `strategy.matrix.preset: [cloudflare-pages, node-server]`, `fail-fast: false`.
- Reuses existing CI setup (pnpm/action-setup, setup-node `cache: pnpm`, `pnpm install --frozen-lockfile --ignore-scripts`).
- Builds fanfare's transitive workspace deps with `pnpm --filter "fanfare^..." build` (they're dist-consumed), then `npx nuxt prepare` (postinstall is skipped by `--ignore-scripts`), then `npx nuxt build` with `NITRO_PRESET` from the matrix.
- `BETTER_AUTH_SECRET: ci-placeholder` satisfies build-time prerender; `NODE_OPTIONS=--max-old-space-size=8192` for headroom.
- **Build-only, scoped to fanfare on purpose.** Typecheck is intentionally NOT gated — fanfare carries a ~52-error pre-existing baseline (e.g. `ProductOption` duplicate in crouton-sales) that's out of scope here.

### Verified locally before pushing
- `NITRO_PRESET=node-server npx nuxt build` → ✓ build complete
- `NITRO_PRESET=cloudflare-pages npx nuxt build` → ✓ build complete (generates `_worker.js`)
- `pnpm --filter "fanfare^..." build` → builds the 20 transitive workspace deps
- `ci.yml` parses as valid YAML

### Heads-up on unrelated CI reds
`code-review` (Anthropic billing) and the `nuxt-crouton-docs` Cloudflare Pages deploy fail on every push — independent of this change.

Closes #66

https://claude.ai/code/session_01QD9d9NpUhMgukArNL9HzNF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD9d9NpUhMgukArNL9HzNF)_