### PR TITLE
Official CI deploy for fanfare + trust preview origins for auth

### DIFF
--- a/.github/workflows/deploy-fanfare.yml
+++ b/.github/workflows/deploy-fanfare.yml
@@ -1,0 +1,90 @@
+name: Deploy Fanfare
+
+# One-click production deploy for fanfare (https://kassa.friendlyinter.net),
+# modelled on deploy-velo.yml / deploy-triage.yml. Manual trigger only for now;
+# to auto-deploy on merge, add a `push: { branches: [main], paths: [...] }`
+# trigger alongside workflow_dispatch.
+on:
+  workflow_dispatch:
+
+# Never run two production deploys at once; let an in-flight one finish.
+concurrency:
+  group: fanfare-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Cache layer builds
+        id: layer-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/crouton-auth/dist
+            packages/crouton-core/dist
+            packages/crouton/dist
+          key: layer-builds-${{ hashFiles('packages/crouton-auth/**/*.ts', 'packages/crouton-core/**/*.ts', 'packages/crouton/**/*.ts') }}
+
+      - name: Build module packages
+        if: steps.layer-cache.outputs.cache-hit != 'true'
+        run: |
+          pnpm --filter '@fyit/crouton-auth' build
+          pnpm --filter '@fyit/crouton-core' build
+          pnpm --filter '@fyit/crouton' build
+
+      # Single production environment — fanfare's wrangler.toml has no [env.preview].
+      - name: Run database migrations
+        run: npx wrangler d1 migrations apply fanfare-db --remote
+        working-directory: apps/fanfare
+
+      - name: Prepare Nuxt (generate tsconfig)
+        run: npx nuxt prepare
+        working-directory: apps/fanfare
+
+      - name: Build
+        working-directory: apps/fanfare
+        env:
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          NITRO_PRESET: 'cloudflare-pages'
+          BETTER_AUTH_URL: https://kassa.friendlyinter.net
+          BETTER_AUTH_SECRET: prerender-placeholder
+        run: npx nuxt build
+
+      # Wrangler 4.64+ rejects an `env` block in the redirected config Nitro copies
+      # into dist/_worker.js/wrangler.json (fanfare has KV). Strip it (no-op if absent).
+      - name: Strip env from redirected wrangler config
+        working-directory: apps/fanfare
+        run: |
+          CONFIG="dist/_worker.js/wrangler.json"
+          if [ -f "$CONFIG" ] && grep -q '"env"' "$CONFIG"; then
+            node -e "
+              const fs = require('fs');
+              const cfg = JSON.parse(fs.readFileSync('$CONFIG', 'utf8'));
+              delete cfg.env;
+              fs.writeFileSync('$CONFIG', JSON.stringify(cfg, null, 2));
+            "
+          fi
+
+      - name: Deploy to Cloudflare Pages (production)
+        working-directory: apps/fanfare
+        run: npx wrangler pages deploy dist/ --commit-dirty=true

--- a/apps/fanfare/wrangler.toml
+++ b/apps/fanfare/wrangler.toml
@@ -20,6 +20,12 @@ migrations_dir = "server/db/migrations/sqlite"
 binding = "KV"
 id = "b3183976e74846ff9913e1b6c641d951"
 
-# Environment variables (set in Cloudflare dashboard or via wrangler secret)
-# [vars]
-# NUXT_PUBLIC_SITE_URL = "https://fanfare.pages.dev"
+# Environment variables (non-secret). Applied to every `wrangler pages deploy`
+# — production AND branch previews — so they're present at runtime.
+[vars]
+# Origins better-auth accepts for sign-in (CSRF/CORS). The baseURL host is
+# trusted automatically; this adds the custom domain + every *.pages.dev preview
+# alias, so member login works on PR preview links too — not just the PIN flow.
+# Wildcards are supported by better-auth. Read at runtime in
+# crouton-auth/server/lib/auth.ts (process.env.BETTER_AUTH_TRUSTED_ORIGINS).
+BETTER_AUTH_TRUSTED_ORIGINS = "https://kassa.friendlyinter.net,https://fanfare.pages.dev,https://*.fanfare.pages.dev"


### PR DESCRIPTION
Closes #93.

## 👤 For humans
Two things to make fanfare deploy properly:
1. **One-click production deploy** in GitHub Actions (like velo/triage) — **Actions → Deploy Fanfare → Run workflow** ships to `kassa.friendlyinter.net`. No more local `wrangler`.
2. **Member login now works on preview links too** — adds the custom domain + every `*.fanfare.pages.dev` preview alias to better-auth's trusted origins, so signing in from a preview URL isn't rejected (the PIN flow already worked).

## 🧪 How to test
- **Deploy:** merge → Actions → Deploy Fanfare → Run workflow (from `main`) → it builds + deploys → open `https://kassa.friendlyinter.net`.
- **Preview auth:** on the next PR preview, the "Team member? Log in" sign-in completes (not just opens/closes).

## 🤖 For agents
- `.github/workflows/deploy-fanfare.yml`: `workflow_dispatch`; `environment: production`; repo-level `CLOUDFLARE_*`; build module pkgs → `wrangler d1 migrations apply fanfare-db --remote` → `nuxt prepare` → `nuxt build` (cloudflare-pages, `BETTER_AUTH_URL=https://kassa.friendlyinter.net`) → KV env-strip → `wrangler pages deploy dist/`. Auto-on-merge omitted (easy follow-up).
- `apps/fanfare/wrangler.toml`: `[vars] BETTER_AUTH_TRUSTED_ORIGINS = kassa.friendlyinter.net, fanfare.pages.dev, *.fanfare.pages.dev` — applied at runtime on every deploy; read in `crouton-auth/server/lib/auth.ts`. (The preview workflow's build-time var couldn't reach the Worker runtime; this fixes it for real.)

**Verify after merge:** confirm `wrangler pages deploy` actually applies wrangler.toml `[vars]` for this project; if not, set `BETTER_AUTH_TRUSTED_ORIGINS` in the CF dashboard (Pages → fanfare → Settings → Environment variables, Production + Preview) as the guaranteed fallback.