### PR TITLE
Add epic acceptance-rollup convention (one QA checklist per epic)

### DIFF
--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -32,6 +32,16 @@ Write it as:
 
 Keep it tight and skimmable. A `mermaid` flow is welcome when the steps branch or the state change is the point — never for decoration.
 
+### Epic acceptance rollup (the epic is the verification unit)
+
+Sub-issues are the **work** unit; the **epic** is the **verification** unit. When all of an epic's sub-issues have merged (the feature has "landed in the app"), post a single **`## 🧪 Verify the whole thing`** comment on the epic *before closing it* — so the owner does **one** QA pass instead of hunting across sub-issues:
+
+- **What landed** — one plain line per merged sub-issue/PR (what's now different).
+- **Where to test** — the **one** link: the deployed preview or production URL, plus any test data (PINs/logins/seed URLs) needed.
+- **Walkthrough** — the per-issue "How to test" steps **stitched into one ordered pass** a human runs end-to-end, with the before/after where it matters.
+
+Close the epic **only after that pass passes** (or the owner confirms). This turns "a bunch of merged PRs" into a single "now go click these and confirm it all works" checklist for a non-technical owner. If a sub-issue couldn't be auto-verified (e.g. needs a device), say so explicitly in the rollup rather than implying it's confirmed.
+
 **Titles are human-first too.** Issue/PR titles read like plain English that anyone grasps at a glance ("Run the whole app on a Raspberry Pi and print directly"), not jargon ("node-server preset + in-process TCP drainer"). Keep the technical specifics in the 🤖 body, never the title.
 
 ## Core rules


### PR DESCRIPTION
## 👤 For humans
Adds a standing rule: when every task under an epic has landed, the epic gets **one** "Verify the whole thing" checklist — what shipped, the single preview/prod link, and the steps to click through in order — so you do a single QA pass before closing it (no hunting across sub-issues). The epic becomes the place you confirm the whole feature works.

## 🤖 For agents
- `.claude/skills/github-tasks/SKILL.md`: new "Epic acceptance rollup" subsection under *How to test*. Epic = verification unit; post a `## 🧪 Verify the whole thing` comment (what landed / one URL + test data / stitched per-issue walkthrough) once all sub-issues merge; close only after the pass; flag anything not auto-verifiable.

## 🧪 How to test
Read the new subsection in `github-tasks/SKILL.md` — it should clearly tell a future session to produce a consolidated, human-runnable acceptance checklist on an epic before closing it. (Docs-only change.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQkAjX9vwBvvhVe2rBnuuQ)_