### PR TITLE
Fix "Invalid origin" login error on custom domains and preview URLs

### DIFF
--- a/apps/fanfare/wrangler.toml
+++ b/apps/fanfare/wrangler.toml
@@ -21,11 +21,12 @@ binding = "KV"
 id = "b3183976e74846ff9913e1b6c641d951"
 
 # Environment variables (set in the Cloudflare dashboard or via wrangler secret).
-# NOTE: do NOT declare BETTER_AUTH_TRUSTED_ORIGINS here — it's already set as a
-# Pages project variable (dashboard), and a duplicate in [vars] makes the deploy
-# fail with "Binding name 'BETTER_AUTH_TRUSTED_ORIGINS' already in use". To let
-# member login work on preview links, add https://*.fanfare.pages.dev to that
-# existing dashboard variable (Pages → fanfare → Settings → Environment variables,
-# Production + Preview) — not here.
+# NOTE: member login no longer depends on BETTER_AUTH_TRUSTED_ORIGINS — crouton-auth
+# trusts the origin each request is served from (kassa.friendlyinter.net, any
+# *.fanfare.pages.dev preview, kassa.local), so same-origin login works with no
+# env var set. Only set BETTER_AUTH_TRUSTED_ORIGINS to trust an *additional*
+# cross-origin caller, and if you do, set it as a Pages project variable
+# (dashboard) — NOT here: a duplicate in [vars] makes the deploy fail with
+# "Binding name 'BETTER_AUTH_TRUSTED_ORIGINS' already in use".
 # [vars]
 # NUXT_PUBLIC_SITE_URL = "https://fanfare.pages.dev"

--- a/packages/crouton-auth/CLAUDE.md
+++ b/packages/crouton-auth/CLAUDE.md
@@ -197,11 +197,13 @@ export default defineNuxtConfig({
 BETTER_AUTH_SECRET=your-secret-key
 BETTER_AUTH_URL=http://localhost:3000
 
-# Optional: extra trusted origins (comma-separated). Works in production —
-# needed when a custom domain fronts a Pages project (e.g.
-# kassa.friendlyinter.net alongside fanfare.pages.dev). Set as a Pages
-# secret/env var on the deployment.
-BETTER_AUTH_TRUSTED_ORIGINS=https://kassa.friendlyinter.net,https://*.fanfare.pages.dev
+# Optional: extra trusted origins (comma-separated). The origin a request is
+# actually served from is ALWAYS trusted automatically (createAuth passes
+# trustedOrigins as a per-request function), so same-origin member login works
+# on any host — custom domain, *.pages.dev preview, kassa.local — with no env
+# var set. Use this only to trust *additional, cross-origin* callers (e.g. a
+# separate front-end host hitting this API). Belt-and-suspenders, not required.
+BETTER_AUTH_TRUSTED_ORIGINS=https://some-other-frontend.example.com
 
 # OAuth (optional)
 GOOGLE_CLIENT_ID=

--- a/packages/crouton-auth/server/lib/auth.ts
+++ b/packages/crouton-auth/server/lib/auth.ts
@@ -146,9 +146,26 @@ export function createAuth(options: CreateAuthOptions) {
       }
     },
 
-    // Trusted origins for CORS/CSRF protection
-    // Allow requests from the baseURL origin and localhost for development
-    trustedOrigins: buildTrustedOrigins(baseURL),
+    // Trusted origins for CORS/CSRF protection.
+    // Passed as a function so the static list (baseURL origin, dev localhost,
+    // BETTER_AUTH_TRUSTED_ORIGINS) is always joined by the origin the request
+    // was actually served from. A browser login is same-origin, so it works on
+    // any host the app runs on — the custom domain (kassa.friendlyinter.net),
+    // *.pages.dev preview URLs, the kassa.local venue host — with no dependency
+    // on BETTER_AUTH_URL / a dashboard env var being set, and without the cached
+    // auth instance locking the list to whichever host initialized it first.
+    // Still CSRF-safe: a cross-site attack carries a foreign Origin header that
+    // won't match the request's own host (same guarantee as Better Auth's own
+    // request-derived baseURL trust).
+    trustedOrigins: (request: Request) => {
+      const origins = buildTrustedOrigins(baseURL)
+      try {
+        origins.push(new URL(request.url).origin)
+      } catch {
+        // Malformed request URL — fall back to the static list.
+      }
+      return origins
+    },
 
     // Plugins - Organization (Teams), Passkey, and 2FA support
     plugins: buildPlugins(config, baseURL, config.debug, db),


### PR DESCRIPTION
## 👤 For humans

Logging in at **kassa.friendlyinter.net** (and on `*.fanfare.pages.dev` preview links) was failing with a red **"Invalid origin"** error whenever the build-time `BETTER_AUTH_URL` or the Cloudflare dashboard variable didn't exactly match the live domain. We'd already patched this twice via deploy config (#94, #98) and it kept coming back.

This makes the auth layer trust **the origin each request is actually served from**, so a normal browser login just works — on the custom domain, on preview URLs, and on the on-site `kassa.local` host — with no env-var dependency. It stays CSRF-safe: a cross-site attack carries a foreign `Origin` header that still won't match the request's own host.

```mermaid
flowchart LR
  A[Browser login POST] --> B{Origin header in trustedOrigins?}
  B -- "before: only baked BETTER_AUTH_URL + dashboard var" --> C[❌ Invalid origin if either is wrong]
  B -- "after: also the request's own host" --> D[✅ same-origin login always trusted]
```

## 🤖 For agents

- `packages/crouton-auth/server/lib/auth.ts`: `trustedOrigins` is now a per-request function `(request) => [...buildTrustedOrigins(baseURL), new URL(request.url).origin]`. Better Auth merges it with the init-time static list per request (`origin-check.mjs:96`), so the served host is always trusted and the cached auth instance no longer locks the list to whichever host initialized it first.
- Docs: `BETTER_AUTH_TRUSTED_ORIGINS` reframed as belt-and-suspenders (only for trusting *additional* cross-origin callers), not load-bearing — `crouton-auth/CLAUDE.md` + `apps/fanfare/wrangler.toml` note.

## 🧪 How to test

1. Go to `https://kassa.friendlyinter.net` → login form ("Welkom terug!").
2. Enter a valid member email + password, press **Inloggen**.
3. *Before:* red **"Invalid origin"** banner, login failed. *After:* signed in, land in the app.
4. Same on a `*.fanfare.pages.dev` preview link.

**Note:** merging does not auto-deploy — the live site updates only when the "Deploy Fanfare" workflow runs.

Closes #101

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7aZRzUpEBQZxuiQEKvPWW)_