### PR TITLE
fix(crouton-sales): rename by-slug param so nested order routes match (#116)

### DIFF
--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -301,7 +301,7 @@ separate `orderInterfaceBlock` was later folded into the `eventWorkspaceBlock`:
 the customer-facing POS is now that block's **anonymous face** — the renderer
 mounts `<SalesPosPanel>` (inline helper PIN login + `<SalesClientOrderInterface>`)
 for visitors without a team session. The underlying public endpoints
-(`events/[teamId]/by-slug/[slug]`, `events/[eventId]/order-data`,
+(`events/[eventId]/by-slug/[slug]`, `events/[eventId]/order-data`,
 `events/[eventId]/orders`) are unchanged and consumed via that panel.
 
 ### Package-shipped Server Endpoints
@@ -317,7 +317,7 @@ All package endpoints live under `/api/crouton-sales/` with an explicit split:
 | `teams/[id]/events/[eventId]/receipt-settings` GET/PUT | team admin | Per-event receipt text customization. Reachability: `staff_order_header` prints only on `isPersonnel` orders (Cart's Staff order switch); `special_instructions_title` heads the remark blocks on kitchen tickets — the per-location remarks from the POS and legacy whole-order notes; `footer_text` only on `type: 'receipt'` printer jobs |
 | `teams/[id]/events/[eventId]/printqueues/retry-failed` POST | team admin | Requeue missed print jobs (status 9, plus jobs stuck at status 1 "printing" for >2 min — fetched by the spooler but never confirmed) back to 0; optional body `{ printerId }` and/or `{ jobId }` (single-line retry). Backs the "Resend failed jobs" button in SettingsTab's printers card and the per-job re-print button in the expanded order |
 | `events/[eventId]/order-data` GET | helper token | All data needed by POS UI (categories are event-scoped — team-wide fetching showed duplicate tabs after event duplication) |
-| `events/[teamId]/by-slug/[slug]` GET | public | Resolve event by slug (team param accepts UUID or slug) |
+| `events/[eventId]/by-slug/[slug]` GET | public | Resolve event by slug (first segment accepts the team's UUID or slug). The param is named `[eventId]` — not `[teamId]` — so it shares one name with its `events/[eventId]/…` siblings: h3 v1/radix3 keeps a single param node per position, and mixing names silently broke the deeper `orders/[orderId]/…` routes (#116) |
 | `events/[eventId]/orders` POST | helper token | Create order + generate print queues (kitchen tickets only — no customer receipt) |
 | `events/[eventId]/orders/[orderId]/print` POST | helper token | Re-queue prints for an existing order, **including the customer receipt** (`withReceipt: true` — the only per-order receipt path) |
 | `events/[eventId]/orders/[orderId]/print-status` GET | helper token | Slim per-order print job status for the POS order button's print watcher (`{ id, status, errorMessage, retryCount, printMode, printerTitle, completedAt }` — printer name joined server-side; order must belong to the event). **Excludes `display` jobs** (they're bumped on a screen, not printed — a display job stays "shown" until the kitchen acts and would hang the checkout button). Empty array = the order generated no tickets, a real answer not an error |
@@ -466,7 +466,7 @@ type and its `eventStorefrontBlock` were removed — the customer POS is the
 `eventWorkspaceBlock`'s anonymous face on a normal CMS page).
 
 All renderers are `clientOnly: true` — helper sessions live in localStorage
-and the public `events/[teamId]/by-slug/[slug]` endpoint is called at mount.
+and the public `events/[eventId]/by-slug/[slug]` endpoint is called at mount.
 
 **All block definitions in `app/app.config.ts` use i18n keys** for `name`,
 `description`, and every schema field `label`/`description` and select-option

--- a/packages/crouton-sales/server/api/crouton-sales/events/[eventId]/by-slug/[slug].get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/events/[eventId]/by-slug/[slug].get.ts
@@ -3,9 +3,14 @@ import { resolveTeamBySlugOrId } from '@fyit/crouton-auth/server/utils/team'
 import { salesEvents } from '~~/layers/sales/collections/events/server/database/schema'
 
 // Public endpoint: resolve event by slug for helper login flow.
-// `teamId` param accepts either the team's UUID or slug.
+// The first segment carries the team's UUID or slug. The folder/param is named
+// `eventId` (not `teamId`) ONLY so it matches its `events/[eventId]/…` siblings:
+// h3 v1's radix3 router keeps a single param node per position, so mixing
+// `[eventId]` and `[teamId]` here silently dropped the deeper two-param routes
+// (`orders/[orderId]/…`) — see issue #116. Revert to `[teamId]` once the server
+// runs on h3 v2 / rou3 (Nitro 3), which handles mixed param names per position.
 export default defineEventHandler(async (event) => {
-  const { team } = await resolveTeamBySlugOrId(event, 'teamId')
+  const { team } = await resolveTeamBySlugOrId(event, 'eventId')
   const slug = getRouterParam(event, 'slug')
 
   if (!slug) {


### PR DESCRIPTION
## 👤 For humans

Two-id sales API routes like `events/:eventId/orders/:orderId/print` silently **404'd** — they fell through to the Nuxt page router instead of running. That left the **manual receipt reprint** and the **POS print-status watcher** effectively dead in production. The cause was a single sibling route using a different URL param name, which confuses Nuxt's server router. Renamed it so they agree. **The public URL is unchanged**, so nothing that calls these endpoints needs updating.

## 🤖 For agents

### Root cause
Server routes match through **Nitro 2.13.1 → h3 1.15.5 → radix3 1.1.2** (verified in the installed code: `nitropack/.../internal/app.mjs` registers every file route via `createRouter`/`router.use` imported from `h3`; `h3/dist/index.mjs` imports `createRouter` from `radix3`). radix3 keeps **one param node + one name per position**. Under `server/api/crouton-sales/events/`, the `by-slug` route used `[teamId]` while every sibling uses `[eventId]`:

```
events/[eventId]/...                  ← clients, orders, order-data, display-jobs, kds-bump
events/[teamId]/by-slug/[slug].get.ts ← the lone conflict
```

Mixing names corrupts the deeper branch and drops the second-level `[orderId]` param, so `orders/[orderId]/print(.post)` and `print-status(.get)` never matched. A repo-wide scan confirmed this was the **only** sibling param-name conflict in the codebase.

Reproduced against the actually-installed `radix3@1.1.2`:

```
/events/E1/clients                => MATCH            (1 param, works)
/events/E1/orders/O1/print        => NO MATCH (404)   (2 params, BROKEN)
/events/E1/orders/O1/print-status => NO MATCH (404)
/events/T1/by-slug/S1             => MATCH            (the "winning" name)
--- control: same param name everywhere ---
/events/E1/orders/O1/print        => MATCH            (fixed)
```

`rou3@0.7.12` (h3 v2 / Nitro 3) matches all of these — the bug is fixed in the newer router, but Nuxt 4.x is pinned to Nitro 2 / radix3. Known upstream limitation: [nuxt#15140](https://github.com/nuxt/nuxt/issues/15140), [nuxt#34235](https://github.com/nuxt/nuxt/issues/34235), [nuxt#21781](https://github.com/nuxt/nuxt/issues/21781), fixed in [rou3#42](https://github.com/h3js/rou3/issues/42). Accepted convention: one consistent param name per path level.

### Change
- `git mv events/[teamId]/by-slug → events/[eventId]/by-slug`
- Handler reads `resolveTeamBySlugOrId(event, 'eventId')` (segment still carries a team UUID/slug; name shared only to satisfy radix3)
- Public URL identical (`/api/crouton-sales/events/<x>/by-slug/<slug>`) → `SalesPosPanel` + `KitchenDisplayRender` callers unchanged
- Handler comment documents the why + revert-to-`[teamId]`-on-Nitro-3 follow-up
- `crouton-sales/CLAUDE.md` endpoint table + refs updated

### Acceptance (from #116)
- [x] A two-param route under `events/[eventId]/.../[param]` matches and runs
- [x] `orders/[orderId]/print` (and `print-status`) reachable — kept, now live

### Verification notes
`pnpm --filter ./apps/fanfare typecheck` has **pre-existing** failures in unrelated packages (crouton-core/editor/pages) and the generated `layers/sales` (Date/string mismatches) — none touch the changed route; the changed file produces zero errors.

Closes #116

https://claude.ai/code/session_01RdUTWgVP9t3f3AbfHtqqA1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdUTWgVP9t3f3AbfHtqqA1)_