### PR TITLE
refactor(crouton-sales): make KDS block theme-driven via Nuxt UI

### DIFF
--- a/packages/crouton-sales/app/components/Blocks/KitchenDisplayRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/KitchenDisplayRender.vue
@@ -147,21 +147,21 @@ function ago(iso: string) {
       {{ t('sales.blocks.kitchenDisplay.ui.eventNotFound') }}
     </div>
 
-    <!-- The board -->
-    <div v-else class="rounded-3xl overflow-hidden bg-slate-950 text-slate-100 p-5">
+    <!-- The board — theme-driven via Nuxt UI semantic tokens (follows dark mode) -->
+    <div v-else class="rounded-3xl overflow-hidden bg-default ring ring-default p-5">
       <header class="flex items-center justify-between mb-5">
         <div class="flex items-center gap-3">
-          <span class="text-2xl">🍳</span>
-          <h1 class="text-xl font-bold tracking-tight">{{ t('sales.blocks.kitchenDisplay.ui.title') }}</h1>
+          <UIcon name="i-lucide-chef-hat" class="size-6 text-primary" />
+          <h2 class="text-xl font-bold tracking-tight text-highlighted">{{ t('sales.blocks.kitchenDisplay.ui.title') }}</h2>
         </div>
-        <div class="flex items-center gap-2 text-sm text-slate-400">
-          <span class="inline-block size-2 rounded-full bg-emerald-400 animate-pulse" />
+        <div class="flex items-center gap-2 text-sm text-muted">
+          <span class="inline-block size-2 rounded-full bg-success animate-pulse" />
           {{ t('sales.blocks.kitchenDisplay.ui.live') }} · {{ t('sales.blocks.kitchenDisplay.ui.active', { count: active.length }) }}
         </div>
       </header>
 
-      <div v-if="active.length === 0" class="flex flex-col items-center justify-center text-center text-slate-500 py-32">
-        <span class="text-5xl mb-3">✅</span>
+      <div v-if="active.length === 0" class="flex flex-col items-center justify-center text-center text-dimmed py-32">
+        <UIcon name="i-lucide-check-check" class="size-12 mb-3 text-success" />
         <p class="text-lg">{{ t('sales.blocks.kitchenDisplay.ui.allCaughtUp') }}</p>
       </div>
 
@@ -173,38 +173,42 @@ function ago(iso: string) {
         <div
           v-for="o in active"
           :key="o.id"
-          class="rounded-2xl bg-slate-900 border border-slate-800 shadow-lg overflow-hidden flex flex-col"
+          class="rounded-2xl bg-muted ring ring-default shadow-sm overflow-hidden flex flex-col"
+          :class="o.isPersonnel ? 'ring-warning/60' : ''"
         >
           <div
-            class="flex items-center justify-between px-4 py-3 border-b border-slate-800"
-            :class="o.isPersonnel ? 'bg-amber-500/15' : 'bg-slate-800/60'"
+            class="flex items-center justify-between px-4 py-3 border-b border-default"
+            :class="o.isPersonnel ? 'bg-warning/10' : 'bg-elevated/60'"
           >
             <div class="flex items-baseline gap-2">
-              <span class="text-2xl font-extrabold">#{{ o.orderNumber }}</span>
-              <span v-if="o.isPersonnel" class="text-[11px] font-bold uppercase text-amber-400">{{ t('sales.blocks.kitchenDisplay.ui.staff') }}</span>
+              <span class="text-2xl font-extrabold text-highlighted">#{{ o.orderNumber }}</span>
+              <UBadge v-if="o.isPersonnel" color="warning" variant="subtle" size="sm" class="font-bold uppercase">{{ t('sales.blocks.kitchenDisplay.ui.staff') }}</UBadge>
             </div>
-            <span class="text-xs text-slate-400 tabular-nums">{{ ago(o.createdAt) }}</span>
+            <span class="text-xs text-muted tabular-nums">{{ ago(o.createdAt) }}</span>
           </div>
 
           <div class="px-4 py-3 flex-1">
-            <p v-if="o.clientName" class="text-sm text-slate-400 mb-2">{{ o.clientName }}</p>
+            <p v-if="o.clientName" class="text-sm text-muted mb-2">{{ o.clientName }}</p>
             <ul class="space-y-1.5">
-              <li v-for="(it, i) in o.items" :key="i" class="flex gap-2 text-[15px]">
-                <span class="font-bold text-emerald-400 tabular-nums min-w-[1.5rem]">{{ it.quantity }}×</span>
+              <li v-for="(it, i) in o.items" :key="i" class="flex gap-2 text-[15px] text-default">
+                <span class="font-bold text-primary tabular-nums min-w-[1.5rem]">{{ it.quantity }}×</span>
                 <span class="flex-1">
                   {{ it.title }}
-                  <span v-if="it.remarks" class="block text-xs text-amber-300/90">↳ {{ it.remarks }}</span>
+                  <span v-if="it.remarks" class="block text-xs text-warning">↳ {{ it.remarks }}</span>
                 </span>
               </li>
             </ul>
           </div>
 
-          <button
-            class="px-4 py-3 text-sm font-bold uppercase tracking-wide bg-emerald-600 hover:bg-emerald-500 active:bg-emerald-700 transition-colors"
+          <UButton
+            color="success"
+            size="lg"
+            block
+            icon="i-lucide-check"
+            :label="t('sales.blocks.kitchenDisplay.ui.bump')"
+            class="rounded-none font-bold uppercase tracking-wide"
             @click="bump(o)"
-          >
-            ✓ {{ t('sales.blocks.kitchenDisplay.ui.bump') }}
-          </button>
+          />
         </div>
       </TransitionGroup>
     </div>

--- a/packages/crouton-sales/app/components/Blocks/KitchenDisplayView.vue
+++ b/packages/crouton-sales/app/components/Blocks/KitchenDisplayView.vue
@@ -106,14 +106,14 @@ function handleOpenPanel() {
           </div>
         </div>
 
-        <!-- Mini KDS preview: a grid of order tiles on a dark board -->
-        <div class="bg-slate-900/80 rounded-lg p-3 border border-slate-700/50">
+        <!-- Mini KDS preview: a grid of order tiles, theme-driven (follows dark mode) -->
+        <div class="bg-muted/50 rounded-lg p-3 ring ring-default">
           <div class="grid grid-cols-3 gap-2">
-            <div v-for="tile in 3" :key="tile" class="rounded-md bg-slate-800/80 p-2 space-y-1.5">
-              <div class="h-3 w-8 rounded bg-emerald-500/40" />
-              <div class="h-2 w-full rounded bg-slate-700/60" />
-              <div class="h-2 w-3/4 rounded bg-slate-700/60" />
-              <div class="h-3 w-full rounded bg-emerald-600/40 mt-1" />
+            <div v-for="tile in 3" :key="tile" class="rounded-md bg-elevated/80 p-2 space-y-1.5">
+              <div class="h-3 w-8 rounded bg-primary/40" />
+              <div class="h-2 w-full rounded bg-accented/60" />
+              <div class="h-2 w-3/4 rounded bg-accented/60" />
+              <div class="h-3 w-full rounded bg-success/40 mt-1" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 👤 For humans
The kitchen-display (KDS) block was the one sales block that ignored Nuxt UI's design system: it hardcoded a fixed dark `slate`/`emerald` palette, so it stayed dark in light mode and never tracked the app's theme colour. It now uses Nuxt UI semantic tokens and components, so it follows light/dark mode and the app's `primary`/`success`/`warning` colours like every other sales block.

## 🤖 For agents
Styling-only; no prop/behaviour/API change.

- `KitchenDisplayRender.vue` (live board): surfaces → `bg-default` / `bg-muted` / `bg-elevated`; borders → `ring-default` / `border-default`; text → `text-highlighted/muted/dimmed`; quantity → `text-primary`, remarks → `text-warning`, live dot → `bg-success`. Raw `<button>` bump → `<UButton color="success" block>`; staff label → `<UBadge color="warning">`; emoji header/empty icons → `UIcon` (`i-lucide-chef-hat` / `check-check` / `check`). Staff tiles use `ring-warning`.
- `KitchenDisplayView.vue` (editor mini-preview): skeleton re-themed to semantic tokens. Shared edit/delete chrome + amber "no event" badge left as-is (identical across sibling block Views).
- Typecheck clean for sales blocks (pre-existing unrelated errors in editor/pages/core remain).

Closes #125

---
_Generated by [Claude Code](https://claude.ai/code/session_01FH7q1y47JXxrmDscntKQXr)_