### PR TITLE
fix(root): grant pull-requests:write on deploy-app.yml callers

### DIFF
--- a/.github/workflows/deploy-fanfare.yml
+++ b/.github/workflows/deploy-fanfare.yml
@@ -50,6 +50,12 @@ on:
 
 jobs:
   deploy:
+    # The reusable workflow's PR-comment step needs pull-requests: write; a caller
+    # must grant it explicitly or the call fails to validate under restrictive
+    # default token permissions ("only allowed pull-requests: none").
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/deploy-app.yml
     with:
       app: fanfare

--- a/.github/workflows/deploy-triage.yml
+++ b/.github/workflows/deploy-triage.yml
@@ -40,6 +40,12 @@ on:
 
 jobs:
   deploy:
+    # The reusable workflow's PR-comment step needs pull-requests: write; a caller
+    # must grant it explicitly or the call fails to validate under restrictive
+    # default token permissions ("only allowed pull-requests: none").
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/deploy-app.yml
     with:
       app: triage

--- a/.github/workflows/deploy-velo.yml
+++ b/.github/workflows/deploy-velo.yml
@@ -41,6 +41,12 @@ on:
 
 jobs:
   deploy:
+    # The reusable workflow's PR-comment step needs pull-requests: write; a caller
+    # must grant it explicitly or the call fails to validate under restrictive
+    # default token permissions ("only allowed pull-requests: none").
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/deploy-app.yml
     with:
       app: velo


### PR DESCRIPTION
Fixes the `Invalid workflow file … only allowed 'pull-requests: none'` error blocking the velo deploy. Adds `permissions: {contents: read, pull-requests: write}` to the `deploy` job of deploy-velo/triage/fanfare callers so the reusable `deploy-app.yml`'s PR-comment permission can be granted under restrictive default token permissions.

Closes #151