### PR TITLE
fix(root): rebuild better-sqlite3 in deploy pipeline for @nuxt/content build

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -99,6 +99,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # --ignore-scripts above also skips native-module build steps. @nuxt/content
+      # (the docs app) needs better-sqlite3's native binding at BUILD time to process
+      # collections into the local DB (the dump that's loaded into D1 at runtime).
+      # Rebuild it so the build doesn't fail with "Could not locate the bindings file".
+      # No-op for apps that don't have it in their graph.
+      - name: Rebuild native build deps skipped by --ignore-scripts
+        run: pnpm rebuild better-sqlite3 2>/dev/null || true
+
       # The dist-consumed framework packages (inputs.layer-packages) must be built
       # before the app build. Pure source layers (crouton-editor/pages/charts) have
       # no build script and are skipped.


### PR DESCRIPTION
Fixes the docs Workers build failure (`Could not locate the bindings file ... better_sqlite3.node`). @nuxt/content needs better-sqlite3's native binding at build time to process collections; `pnpm install --ignore-scripts` skipped it. Adds `pnpm rebuild better-sqlite3` after install in `deploy-app.yml` (no-op for apps without it).

Closes #154. Completes the docs migration (#99/#153) so the Deploy Docs run can go green.