### PR TITLE
fix(docs): bump compatibilityDate to 2024-09-19 (modern cloudflare preset)

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -38,7 +38,10 @@ export default defineNuxtConfig({
     }
   },
 
-  compatibilityDate: '2024-07-11',
+  // Must be >= 2024-09-19 so nitro selects the MODERN cloudflare_module preset
+  // (static assets + deployConfig) instead of cloudflare-module-legacy (Workers
+  // Sites), which doesn't emit a deployable wrangler config → "missing entry-point".
+  compatibilityDate: '2024-09-19',
 
   nitro: {
     prerender: {


### PR DESCRIPTION
Fixes the docs deploy '**missing entry-point**' error. nitro fell back to **cloudflare-module-legacy** (Workers Sites, no deployable config) because the Nuxt `compatibilityDate` was `2024-07-11`. The modern `cloudflare_module` preset (static assets + `deployConfig`) needs **>= 2024-09-19** (per the official @nuxt/content Workers doc). Bumps it → modern preset → `deployConfig` emits the wrangler config → deploy has an entry-point.

After merge: re-run **Deploy Docs** (workflow_dispatch on main). Ref #99/#161.