### PR TITLE
fix(docs): bind docs.pmcp.dev + tighten .gitignore for local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ node-compile-cache/
 dist
 .cache
 
+# Local dev artifacts anywhere in the tree (NuxtHub/wrangler D1+R2+KV+blob state,
+# @nuxt/content DBs). Global patterns so new apps/pocs/fixtures are covered without
+# adding a per-dir line each time (supersedes the apps/<name>/.data list below).
+**/.data/
+**/.wrangler/
+
 # Logs
 *.log
 npm-debug.log*

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -60,6 +60,9 @@ export default defineNuxtConfig({
       wrangler: {
         name: 'docs',
         compatibility_date: '2024-09-19',
+        // Staging-slot domain (#133); → docs.friendlyinter.net at the DNS cutover (#134).
+        // Auto-bound on deploy (pmcp.dev is a CF zone; token has Zone Workers Routes + DNS Edit).
+        routes: [{ pattern: 'docs.pmcp.dev', custom_domain: true }],
         d1_databases: [{ binding: 'DB', database_name: 'docs-db' }]
       }
     }


### PR DESCRIPTION
**(1) docs.pmcp.dev** — the docs worker deployed to `docs.cloudflare-e53.workers.dev` but the custom domain wasn't attached, so `docs.pmcp.dev` 404s. Adds the `docs.pmcp.dev` custom-domain route to `nitro.cloudflare.wrangler` → auto-bound on next deploy. (→ `docs.friendlyinter.net` at the DNS cutover.)

**(2) .gitignore** — replaces the brittle per-app `apps/<name>/.data` list's gap with global `**/.data/` + `**/.wrangler/`, so parked POCs' local D1/R2 state (and future apps/fixtures) stop showing as untracked.

After merge: re-run Deploy Docs → `docs.pmcp.dev` binds. Ref #99/#134.