### PR TITLE
e2e: manifest-driven package surface assertions

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -12,6 +12,7 @@ e2e/                         # the harness (Playwright) — NOT a workspace pack
   helpers.ts                 # shared, non-test module (config, auth flow, manifest loader)
   auth.setup.ts              # 'setup' project: log in / register + create team, save state
   collection.smoke.spec.ts   # generic, manifest-driven list + CRUD checks
+  surface.smoke.spec.ts      # generic, manifest-driven package-surface checks (optional)
   .auth/                     # generated storageState + team slug (gitignored)
 
 fixtures/                    # the apps under test — real crouton apps, one per config
@@ -28,22 +29,34 @@ fixtures/                    # the apps under test — real crouton apps, one pe
 ## Running
 
 ```bash
-pnpm test:e2e                      # default fixture (minimal)
-E2E_FIXTURE=with-pages pnpm test:e2e
+BETTER_AUTH_SECRET=dev BETTER_AUTH_URL=http://localhost:3000 pnpm test:e2e   # default fixture (minimal)
+E2E_FIXTURE=with-pages BETTER_AUTH_SECRET=dev BETTER_AUTH_URL=http://localhost:3000 pnpm test:e2e
 ```
+
+> **`BETTER_AUTH_SECRET` is required** (any value locally; CI sets a placeholder).
+> Without it crouton-auth refuses to mint sessions and `auth.setup.ts` fails with
+> "Could not authenticate test user." Set `BETTER_AUTH_URL` to the server origin too.
 
 The config's `webServer` boots `pnpm --filter e2e-fixture-$E2E_FIXTURE dev` on
 `:3000` (or reuses a server already running there). One fixture per run — they
 all use port 3000. Each fixture has its own local sqlite DB under `.data/`.
+
+> A fresh checkout/worktree must **build the fixture's workspace deps first** (the
+> dist-consumed `@fyit/*` packages), or the dev server can't load `@fyit/crouton`:
+> `pnpm --filter "e2e-fixture-<name>^..." build` (this is what CI does).
 
 ## How it works
 
 1. **setup** (`auth.setup.ts`) runs first: logs the test user in (registering on
    first run), ensures a team exists, saves `storageState` → `.auth/user.json`
    and the team slug → `.auth/team.json`.
-2. **chromium** runs `*.smoke.spec.ts` with that storageState. The generic spec
-   reads the active fixture's `e2e.manifest.json` and, for each collection, checks
-   the list page loads and runs a create → see-in-list → delete cycle.
+2. **chromium** runs `*.smoke.spec.ts` with that storageState, both reading the
+   active fixture's `e2e.manifest.json`:
+   - `collection.smoke.spec.ts` — for each collection, checks the list page loads
+     and runs a create → see-in-list → delete cycle.
+   - `surface.smoke.spec.ts` — for each declared `surface`, visits the route and
+     asserts its element/heading renders. Fixtures with no `surfaces` register no
+     surface tests (the file is a no-op for them).
 
 ### crouton-auth realities the harness depends on
 - Login/register happen in a **RouteModal overlay**, not a form page.
@@ -88,9 +101,25 @@ E2E_FIXTURE=with-i18n pnpm test:e2e
       "heading": "Main Items",      // visible list heading to assert
       "create": { "name": "e2e item" }  // text field label/name -> value; omit to skip CRUD
     }
+  ],
+  // Optional: package-specific UI a generic items CRUD doesn't reach. Omit when a
+  // fixture has nothing extra to assert (e.g. minimal). Proves the *package* mounts,
+  // not just that the app boots — e.g. with-pages asserts the pages workspace.
+  "surfaces": [
+    {
+      "name": "pages workspace renders",         // test title
+      "path": "/admin/{team}/workspace",          // route; {team} -> active team slug
+      "expect": { "visible": "[id$='-panel-pages-sidebar']" }  // CSS selector that must be visible
+      // or: "expect": { "heading": "Workspace" } // a role=heading name (case-insensitive)
+    }
   ]
 }
 ```
+
+> Surface selectors should hook something the *package* owns (here, the
+> `sidebar-id="pages-sidebar"` crouton-pages sets on `CroutonWorkspaceLayout` —
+> Nuxt UI renders the panel DOM id as `<storageKey>-panel-pages-sidebar`, hence
+> the ends-with match), so the assertion fails if that package's UI regresses.
 
 ## Gotchas
 - **Module format:** repo root is CommonJS, and Playwright 1.57 transpiles
@@ -104,6 +133,8 @@ E2E_FIXTURE=with-i18n pnpm test:e2e
   `test-results/` are all gitignored.
 
 ## Scope / follow-ups
-Current: list + CRUD per collection. Not yet: package-specific surfaces (e.g. the
-pages package's own admin UI) — extend the manifest with a `surfaces` field when
-needed. CI wiring is tracked separately (see the harness epic).
+Current: list + CRUD per collection, plus optional package-specific `surfaces`
+(e.g. with-pages asserts the pages workspace mounts). CI wiring runs the matrix
+over `fixtures/*` (see `.github/workflows/e2e.yml`). Next: lean on `surfaces` when
+adding a domain-package fixture (e.g. with-bookings) so it asserts that package's
+UI, not just generic items CRUD.

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -29,8 +29,29 @@ export interface CollectionSpec {
   create?: Record<string, string>
 }
 
+/**
+ * A package-specific surface to smoke beyond generic collection CRUD — e.g. the
+ * pages package's own `/admin/:team/workspace`. Lets a fixture assert that the
+ * package it exercises actually mounts its UI, not just that the app still boots.
+ */
+export interface SurfaceSpec {
+  /** Human label for the test title, e.g. "pages workspace". */
+  name: string
+  /** Route to visit. `{team}` is replaced with the active team slug. */
+  path: string
+  /** What must be visible for the surface to count as working. At least one. */
+  expect: {
+    /** CSS selector that must be visible, e.g. "#pages-sidebar". */
+    visible?: string
+    /** Visible heading (role=heading) name, matched case-insensitively. */
+    heading?: string
+  }
+}
+
 export interface FixtureManifest {
   collections: CollectionSpec[]
+  /** Optional package-specific surfaces; omit for fixtures with nothing extra. */
+  surfaces?: SurfaceSpec[]
 }
 
 /** Read the active fixture's e2e manifest (what to smoke). */
@@ -147,6 +168,11 @@ export async function ensureTeam(page: Page, base: string): Promise<string> {
 /** Build the admin URL for a generated collection (key, e.g. "mainItems"). */
 export function collectionUrl(base: string, teamSlug: string, collectionKey: string): string {
   return `${base}/admin/${teamSlug}/crouton/${collectionKey}`
+}
+
+/** Resolve a surface path against the base URL, substituting `{team}`. */
+export function surfaceUrl(base: string, teamSlug: string, path: string): string {
+  return `${base}${path.replace('{team}', teamSlug)}`
 }
 
 /**

--- a/e2e/surface.smoke.spec.ts
+++ b/e2e/surface.smoke.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Generic package-surface smoke — the "does this package's own UI mount" check.
+ *
+ * Fixture-agnostic, same contract as collection.smoke.spec.ts: it reads the
+ * active fixture's e2e.manifest.json `surfaces[]` (if any) and, for each, visits
+ * the route and asserts the declared element/heading is visible. This is how a
+ * fixture proves the package it exercises actually renders its admin UI — not
+ * just that the app still boots and does generic CRUD.
+ *
+ * Fixtures with nothing package-specific to assert simply omit `surfaces`; this
+ * file then registers no tests for them.
+ *
+ * Uses the saved auth state (see auth.setup.ts).
+ */
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { surfaceUrl, fixtureManifest, TEAM_FILE, FIXTURE } from './helpers'
+
+const manifest = fixtureManifest()
+const surfaces = manifest.surfaces ?? []
+
+test.describe(`fixture "${FIXTURE}" surfaces`, () => {
+  // Nothing to assert for this fixture — keep the file a no-op rather than failing.
+  test.skip(surfaces.length === 0, 'fixture declares no surfaces')
+
+  let slug: string
+  test.beforeAll(() => {
+    slug = JSON.parse(readFileSync(TEAM_FILE, 'utf8')).slug
+  })
+
+  for (const surface of surfaces) {
+    test(surface.name, async ({ page, baseURL }) => {
+      const base = baseURL || 'http://localhost:3000'
+      await page.goto(surfaceUrl(base, slug, surface.path), { waitUntil: 'domcontentloaded' })
+      await page.waitForLoadState('networkidle').catch(() => {})
+
+      const { visible, heading } = surface.expect
+      // Generous timeout: the dev server compiles the route on first hit.
+      if (visible) {
+        await expect(page.locator(visible)).toBeVisible({ timeout: 30000 })
+      }
+      if (heading) {
+        await expect(page.getByRole('heading', { name: new RegExp(heading, 'i') }))
+          .toBeVisible({ timeout: 30000 })
+      }
+    })
+  }
+})

--- a/fixtures/with-pages/e2e.manifest.json
+++ b/fixtures/with-pages/e2e.manifest.json
@@ -5,5 +5,12 @@
       "heading": "Main Items",
       "create": { "name": "e2e item" }
     }
+  ],
+  "surfaces": [
+    {
+      "name": "pages workspace renders",
+      "path": "/admin/{team}/workspace",
+      "expect": { "visible": "[id$='-panel-pages-sidebar']" }
+    }
   ]
 }


### PR DESCRIPTION
## What
Extends the e2e harness so a fixture can assert **package-specific UI**, not just generic items CRUD. Follow-up to the harness epic #157.

- **`e2e/helpers.ts`** — `SurfaceSpec` + optional `FixtureManifest.surfaces[]`; `surfaceUrl()` substitutes `{team}`.
- **`e2e/surface.smoke.spec.ts`** — generic, manifest-driven (same contract as `collection.smoke.spec.ts`): visits each surface, asserts `expect.visible` (CSS) / `expect.heading`. Fixtures with no `surfaces` register no tests.
- **`fixtures/with-pages/e2e.manifest.json`** — asserts `/admin/{team}/workspace` renders the crouton-pages workspace sidebar (`[id$='-panel-pages-sidebar']`), which `minimal` does not have.
- **`e2e/CLAUDE.md`** — documents `surfaces`, the local `BETTER_AUTH_SECRET`/`BETTER_AUTH_URL` requirement (CI sets it; docs omitted it), and the build-deps-first step for fresh worktrees.

## Why
Both fixtures previously shipped byte-identical manifests, so `with-pages` only proved "crouton-pages doesn't break boot + items CRUD." Surfaces give each fixture a real package-specific signal and unlock meaningful future fixtures (e.g. with-bookings).

## Verification
Ran locally against both fixtures:
- `with-pages` — **6 passed** (incl. the new surface test)
- `minimal` — **5 passed** (surface spec skips cleanly; no `surfaces` declared)

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)