### PR TITLE
chore(root): cut production domains over to friendlyinter.net

### DIFF
--- a/apps/fanfare/wrangler.jsonc
+++ b/apps/fanfare/wrangler.jsonc
@@ -7,7 +7,7 @@
   //
   // Migrated in place: PRODUCTION reuses the EXISTING provisioned D1 + KV (same ids
   // the Pages deploy used), so there is NO data migration — the Worker binds the
-  // same fanfare-db. The production domain moves to kassa.pmcp.dev (pmcp.dev is a
+  // same fanfare-db. The production domain moves to kassa.friendlyinter.net (pmcp.dev is a
   // CF zone, so the custom domain + DNS + cert are bound automatically on deploy).
   "name": "fanfare",
   "compatibility_date": "2024-09-02",
@@ -15,7 +15,7 @@
 
   // Custom domain — auto-bound on `wrangler deploy` (pmcp.dev is a CF zone).
   // Cloudflare creates the DNS record + cert; no dashboard step.
-  "routes": [{ "pattern": "kassa.pmcp.dev", "custom_domain": true }],
+  "routes": [{ "pattern": "kassa.friendlyinter.net", "custom_domain": true }],
 
   "d1_databases": [
     {

--- a/apps/triage/wrangler.jsonc
+++ b/apps/triage/wrangler.jsonc
@@ -15,7 +15,7 @@
 
   // Custom domain — auto-bound on `wrangler deploy` (pmcp.dev is a CF zone).
   // Cloudflare creates the DNS record + cert; no dashboard step.
-  "routes": [{ "pattern": "triage.pmcp.dev", "custom_domain": true }],
+  "routes": [{ "pattern": "triage.friendlyinter.net", "custom_domain": true }],
 
   "d1_databases": [
     {
@@ -34,7 +34,7 @@
   // `--env staging` creates a `triage-staging` worker bound to these. The env block
   // is stripped from the generated .output config (nitro#3429), so cf:staging
   // re-injects it via scripts/inject-wrangler-env.mjs. (Route stays on the -preview
-  // hostname until #136 reassigns it to triage.pmcp.dev after the DNS move.)
+  // hostname until #136 reassigns it to triage.friendlyinter.net after the DNS move.)
   "env": {
     "staging": {
       "routes": [{ "pattern": "triage-preview.pmcp.dev", "custom_domain": true }],

--- a/apps/velo/wrangler.jsonc
+++ b/apps/velo/wrangler.jsonc
@@ -14,6 +14,10 @@
   "compatibility_date": "2024-09-02",
   "compatibility_flags": ["nodejs_compat"],
 
+  // Production custom domain (#133/#134): bound on `pnpm cf:deploy` now that
+  // friendlyinter.net is a Cloudflare zone. Staging stays on velo.pmcp.dev (env.staging).
+  "routes": [{ "pattern": "velo.friendlyinter.net", "custom_domain": true }],
+
   "d1_databases": [
     {
       "binding": "DB",

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -62,7 +62,7 @@ export default defineNuxtConfig({
         compatibility_date: '2024-09-19',
         // Staging-slot domain (#133); → docs.friendlyinter.net at the DNS cutover (#134).
         // Auto-bound on deploy (pmcp.dev is a CF zone; token has Zone Workers Routes + DNS Edit).
-        routes: [{ pattern: 'docs.pmcp.dev', custom_domain: true }],
+        routes: [{ pattern: 'docs.friendlyinter.net', custom_domain: true }],
         d1_databases: [{ binding: 'DB', database_name: 'docs-db' }]
       }
     }


### PR DESCRIPTION
## 👤 For humans
friendlyinter.net is now a Cloudflare zone, so this points each live app's **production** worker at its real domain (#133): velo→`velo.friendlyinter.net`, fanfare→`kassa.friendlyinter.net`, triage→`triage.friendlyinter.net`, docs→`docs.friendlyinter.net`. Staging stays on `*.pmcp.dev`.

## 🤖 For agents
- velo: added top-level `velo.friendlyinter.net` route (prod was id-less).
- fanfare/triage: top-level prod route `*.pmcp.dev` → `*.friendlyinter.net` (staging `-preview.pmcp.dev` untouched).
- docs: `nitro.cloudflare.wrangler.routes` → `docs.friendlyinter.net`.

## 🧪 How to deploy (owner, CF-gated — only after the zone is Active)
1. **Confirm Active:** `dig NS friendlyinter.net +short` → `*.ns.cloudflare.com` (switch the nameservers at iwantmyname if not done).
2. Per app: `pnpm --filter <app> cf:deploy` (velo/fanfare/triage) and run **Deploy Docs** (workflow_dispatch) → each binds its `*.friendlyinter.net` custom domain + cert.
3. Verify each prod URL loads + logs in.

Closes #136 (triage); velo/fanfare/docs are the #133 equivalents. Cosmetic follow-up: move fanfare/triage staging to `<app>.pmcp.dev` (prod vacated those).