### PR TITLE
feat(crouton-sales): D1 live-mirror sync pipeline — capture, push, ingest (#176, #177, #178)

### DIFF
--- a/.claude/skills/db-migrations/SKILL.md
+++ b/.claude/skills/db-migrations/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: db-migrations
+description: The migration step and the package-owned-table exception — NOT the normal collection flow. For app collections use the crouton CLI/skill (schema JSON → `crouton config`); reach here when you then need to generate/apply the Drizzle migration and hit the schema.mjs-only-after-build gotcha ("No schema files found"), or when adding a package-owned infra table (the crouton-flow pattern) that does NOT go through `crouton config`.
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+---
+
+# DB migrations & package-owned tables (Drizzle + NuxtHub + D1)
+
+> **Most tables are app collections — use the `crouton` skill/CLI, not this one.**
+> Edit `apps/<app>/schemas/*.json`, ensure it's in `crouton.config.js`, run
+> `crouton config`. That generates the layer + Drizzle schema. This skill is for
+> the **two things the CLI does *not* do**:
+>
+> 1. **The migrate step** — turning a schema change (even a CLI-generated one)
+>    into a committed Drizzle migration, including the gotcha that makes
+>    `pnpm db:generate` fail on a clean tree.
+> 2. **Package-owned infra tables** — non-collection tables shipped by a package
+>    (`flow_configs`, `yjs_collab_states`, `sales_sync_outbox`) that are
+>    hand-defined and never touch `crouton config`.
+>
+> If you're adding a user-facing CRUD collection, stop and use the crouton CLI.
+
+## The pipeline (how a table reaches the DB)
+
+```
+schema.ts (app layer OR package)            ← Drizzle table definitions
+   └─ NuxtHub scans server/db/schema.ts + server/database across all layers
+        └─ writes a bundled schema entry/bundle at BUILD time:
+             .nuxt/hub/db/schema.entry.ts            (after `nuxt prepare`)
+             …/.nuxt/hub/db/schema.mjs               (ONLY after `nuxt build`)
+   └─ drizzle-kit generate  (reads the .mjs bundle)  → server/db/migrations/sqlite/NNNN_*.sql
+                                                       + meta/_journal.json + meta/NNNN_snapshot.json
+   └─ wrangler d1 migrations apply (db:migrate*)     → applies the .sql to D1 (local/remote/staging)
+```
+
+Both runtimes are SQLite (local better-sqlite3/libSQL via `node-server`, D1 on
+Cloudflare), so **one schema + one set of migrations serves both** — never write
+D1-only or node-only SQL in a migration.
+
+Key paths (per app, e.g. `apps/fanfare`):
+- `drizzle.config.ts` — `schema` points at the **bundled** file, trying
+  `.nuxt/hub/db/schema.mjs` then `node_modules/.cache/nuxt/.nuxt/hub/db/schema.mjs`;
+  `out: server/db/migrations/sqlite`.
+- `server/db/migrations/sqlite/` — generated `NNNN_*.sql` + `meta/` (journal +
+  per-migration snapshots). **All committed.** wrangler applies the `.sql`;
+  drizzle-kit needs `meta/` to diff the next migration.
+- `package.json` scripts: `db:generate` (drizzle-kit), `db:migrate` (wrangler,
+  `--local`), `db:migrate:prod` / `db:migrate:staging` (`--remote`),
+  `db:seed*` (crouton-seed). NB: never run `npx nuxt db generate` from repo root.
+
+## Adding an APP collection (the common case)
+
+Use the **crouton** skill / CLI — don't hand-write the table. Edit the schema
+JSON (`apps/<app>/schemas/*.json`), make sure it's in `crouton.config.js`
+(`collections` + `targets`), run `crouton config` to regenerate the layer, then
+generate + apply the migration (see "Generate the migration" below).
+
+## Adding a PACKAGE-OWNED infra table (the crouton-flow pattern)
+
+For a table that ships with a package and should appear in every consuming app
+(an outbox, a config table, a CRDT store) — NOT a user-facing CRUD collection.
+Mirror `packages/crouton-flow` exactly:
+
+1. **`packages/<pkg>/server/database/schema.ts`** — define the table with
+   `sqliteTable(...)` from `drizzle-orm/sqlite-core`. This is the source of truth.
+2. **`packages/<pkg>/server/db/schema.ts`** — one-line re-export:
+   `export { myTable } from '../database/schema'`. **NuxtHub scans `server/db/schema.ts`
+   across extended layers** to build the bundle, so this is what makes consuming
+   apps auto-discover the table (confirm: `.nuxt/hub/db/schema.entry.ts` lists
+   your package after a `nuxt prepare`).
+3. **`packages/<pkg>/server/database/migrations/NNNN_*.sql`** — hand-write the
+   `CREATE TABLE IF NOT EXISTS …` + indexes. This is the package's own copy
+   (for direct apply / docs); the consuming app still generates its own numbered
+   migration in step "Generate the migration".
+4. Editing `packages/` is behind a **hard gate** — get user approval, then
+   `echo '<pkg-name>' >> .claude/.package-edit-approved`, edit, and
+   `rm .claude/.package-edit-approved` when done. (See root CLAUDE.md.)
+5. Document it in `packages/<pkg>/CLAUDE.md` (Key Files + a table/section).
+
+Naming: package tables use the package's prefix (`flow_*`, `sales_*`); column
+names in package tables follow that table's own convention (flow uses snake_case).
+
+## Generate the migration — and the gotcha
+
+`pnpm --filter <app> db:generate` reads `.nuxt/hub/db/schema.mjs`. On a freshly
+cloned / prepared tree **that file does not exist yet** — `nuxt prepare` only
+writes `schema.entry.ts`; the `.mjs` bundle is emitted during **`nuxt build`**.
+Two failure modes you'll hit:
+
+- `Error  No schema files found for path config ['.nuxt/hub/db/schema.mjs']`
+  → the bundle hasn't been built.
+- Pointing drizzle-kit at `schema.entry.ts` directly fails with
+  `ERR_PACKAGE_PATH_NOT_EXPORTED … not defined by "exports"` — drizzle-kit can't
+  resolve the cross-package aliases (e.g. crouton-auth subpaths) that only Nuxt's
+  bundler rewrites. **Don't go down this path.**
+
+**The fix — build once to emit the bundle, then generate:**
+
+```bash
+cd apps/<app>
+# Emit the schema bundle. node-server preset is fine; the bundle is written
+# early (before the slow Nitro stage), so you can stop the build once it exists.
+NITRO_PRESET=node-server nuxt build &
+# wait until the bundle appears, then stop the build:
+until [ -f .nuxt/hub/db/schema.mjs ] \
+   || [ -f node_modules/.cache/nuxt/.nuxt/hub/db/schema.mjs ]; do sleep 2; done
+pkill -f "nuxt build"
+
+# Sanity: confirm your new table is in the bundle
+grep -l "<yourTableName>" node_modules/.cache/nuxt/.nuxt/hub/db/schema.mjs .nuxt/hub/db/schema.mjs 2>/dev/null
+
+pnpm db:generate            # → server/db/migrations/sqlite/NNNN_*.sql (+ meta updates)
+```
+
+Then **inspect the generated `.sql`** — it should contain ONLY your change. If it
+includes unrelated drift, the committed `meta/` snapshots were stale; reconcile
+before committing (don't blindly ship the drift).
+
+Apply locally: `pnpm db:migrate` (wrangler `--local`). Commit the `.sql`, the new
+`meta/NNNN_snapshot.json`, and the updated `meta/_journal.json` together with the
+schema change.
+
+## Validate without booting Nuxt (fast check)
+
+To prove a migration's SQL is valid and a table accepts the rows your code
+writes, run the migration against an in-memory DB with the repo's `better-sqlite3`
+(run the script from inside the repo so `node_modules` resolves):
+
+```bash
+cd /path/to/repo-root   # so imports resolve
+node ./.check.mjs        # import Database from 'better-sqlite3'; db.exec(readFileSync(<migration.sql>)); insert + query
+rm ./.check.mjs
+```
+
+## Gotchas / rules
+
+- **`hub: { db: 'sqlite' }`** in nuxt.config — never `database: true` (breaks the
+  schema entry + local migrations). See root CLAUDE.md.
+- Migrations are **append-only and committed** — never edit an applied `NNNN_*.sql`;
+  add a new one.
+- `meta/` is required for correct future diffs — always commit it with the `.sql`.
+- Drizzle `$default`/`$onUpdate` are **app-level** defaults; they do NOT emit SQL
+  `DEFAULT` clauses. If a column must have a value when written outside your code,
+  set the SQL default in the migration (the package's hand-written `.sql` can; the
+  drizzle-generated app `.sql` won't). Keep your insert code setting the values
+  explicitly so both paths agree.
+- Typecheck after: `pnpm -r --filter './apps/*' typecheck` (or `--filter <app>`).
+```

--- a/.claude/skills/db-migrations/SKILL.md
+++ b/.claude/skills/db-migrations/SKILL.md
@@ -80,6 +80,14 @@ Mirror `packages/crouton-flow` exactly:
 Naming: package tables use the package's prefix (`flow_*`, `sales_*`); column
 names in package tables follow that table's own convention (flow uses snake_case).
 
+**The consuming app needs NO CLI step for a package table.** The crouton CLI
+(`crouton config`) has zero migration logic and is *not* involved here — don't
+add the table to the app's `crouton.config.js`. NuxtHub auto-discovers it from
+the package's `server/db/schema.ts` re-export; the app's only job is the normal
+migrate step below (`db:generate` auto-includes it, then `db:migrate`) — the same
+step any schema change needs. (A package may also ship its own `.sql` for direct
+apply via `wrangler d1 execute --file=node_modules/@fyit/<pkg>/server/database/migrations/<file>.sql`.)
+
 ## Generate the migration — and the gotcha
 
 `pnpm --filter <app> db:generate` reads `.nuxt/hub/db/schema.mjs`. On a freshly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/github-tasks/SKILL.md` | GitHub issue tracking (epics, labels, workflow) |
 | Skill | `.claude/skills/ecosystem-check/SKILL.md` | Check Nuxt/UnJS/Vite/OSS prior art before building |
 | Skill | `.claude/skills/e2e-smoke/SKILL.md` | Run the Playwright fixture smoke harness (boot + auth + CRUD) after a dep bump or `packages/` change |
+| Skill | `.claude/skills/db-migrations/SKILL.md` | The migrate step (`db:generate` schema.mjs-after-build gotcha) + package-owned infra tables. App collections use the `crouton` CLI, not this |
 | Agent | `.claude/agents/sync-checker.md` | Doc sync verification |
 | MCP Server | `packages/nuxt-crouton-mcp-server/` | AI collection generation |
 | Themes | `packages/nuxt-crouton-themes/` | Swappable UI themes |

--- a/apps/fanfare/nuxt.config.ts
+++ b/apps/fanfare/nuxt.config.ts
@@ -65,10 +65,14 @@ export default defineNuxtConfig({
   // Runtime config:
   // - printApiKey: shared key the polling spooler uses
   // - print.enabled: gate that controls whether order POST enqueues print jobs
-  // Override via NUXT_CROUTON_SALES_PRINT_API_KEY / NUXT_CROUTON_SALES_PRINT_ENABLED.
+  // - cloudSyncSecret: shared secret the Pi pusher (#177) presents to the cloud
+  //   D1 ingest (#178). Empty by default = fail-closed (ingest rejects all).
+  // Override via NUXT_CROUTON_SALES_PRINT_API_KEY / NUXT_CROUTON_SALES_PRINT_ENABLED /
+  // NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET.
   runtimeConfig: {
     croutonSales: {
       printApiKey: '1234',
+      cloudSyncSecret: '',
       print: { enabled: true }
     }
   },

--- a/apps/fanfare/server/db/migrations/sqlite/0014_gifted_chronomancer.sql
+++ b/apps/fanfare/server/db/migrations/sqlite/0014_gifted_chronomancer.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `sales_sync_outbox` (
+	`seq` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`id` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`entity_id` text NOT NULL,
+	`operation` text NOT NULL,
+	`order_id` text,
+	`team_id` text,
+	`event_id` text,
+	`payload` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`synced_at` integer
+);
+--> statement-breakpoint
+CREATE INDEX `idx_sales_sync_outbox_pending` ON `sales_sync_outbox` (`synced_at`,`seq`);--> statement-breakpoint
+CREATE INDEX `idx_sales_sync_outbox_entity` ON `sales_sync_outbox` (`entity_type`,`entity_id`);

--- a/apps/fanfare/server/db/migrations/sqlite/meta/0014_snapshot.json
+++ b/apps/fanfare/server/db/migrations/sqlite/meta/0014_snapshot.json
@@ -1,0 +1,3580 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "275f18c2-cbe3-48ac-a681-38057278d74a",
+  "prevId": "b3cf09e0-086b-437c-8869-4be4a1c41327",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "account_provider_idx": {
+          "name": "account_provider_idx",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_email_log": {
+      "name": "auth_email_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailType": {
+          "name": "emailType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_email_log_org_idx": {
+          "name": "auth_email_log_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_type_idx": {
+          "name": "auth_email_log_type_idx",
+          "columns": [
+            "emailType"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_status_idx": {
+          "name": "auth_email_log_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_recipient_idx": {
+          "name": "auth_email_log_recipient_idx",
+          "columns": [
+            "recipientEmail"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_created_idx": {
+          "name": "auth_email_log_created_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crouton_redirects": {
+      "name": "crouton_redirects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fromPath": {
+          "name": "fromPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toPath": {
+          "name": "toPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crouton_redirects_team_from_path_idx": {
+          "name": "crouton_redirects_team_from_path_idx",
+          "columns": [
+            "teamId",
+            "fromPath"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "domain": {
+      "name": "domain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verificationToken": {
+          "name": "verificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "domain_domain_unique": {
+          "name": "domain_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        },
+        "domain_org_idx": {
+          "name": "domain_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "domain_domain_idx": {
+          "name": "domain_domain_idx",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "domain_status_idx": {
+          "name": "domain_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "domain_organizationId_organization_id_fk": {
+          "name": "domain_organizationId_organization_id_fk",
+          "tableFrom": "domain",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviterId_user_id_fk": {
+          "name": "invitation_inviterId_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organizationId_organization_id_fk": {
+          "name": "invitation_organizationId_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "member_org_idx": {
+          "name": "member_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "member_user_org_idx": {
+          "name": "member_user_org_idx",
+          "columns": [
+            "userId",
+            "organizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_userId_user_id_fk": {
+          "name": "member_userId_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organizationId_organization_id_fk": {
+          "name": "member_organizationId_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "personal": {
+          "name": "personal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_idx": {
+          "name": "organization_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organization_owner_idx": {
+          "name": "organization_owner_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "organization_default_idx": {
+          "name": "organization_default_idx",
+          "columns": [
+            "isDefault"
+          ],
+          "isUnique": false
+        },
+        "organization_personal_idx": {
+          "name": "organization_personal_idx",
+          "columns": [
+            "personal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_pages": {
+      "name": "pages_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pageType": {
+          "name": "pageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "showInNavigation": {
+          "name": "showInNavigation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seoTitle": {
+          "name": "seoTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seoDescription": {
+          "name": "seoDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ogImage": {
+          "name": "ogImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "robots": {
+          "name": "robots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_pages_team_slug_idx": {
+          "name": "pages_pages_team_slug_idx",
+          "columns": [
+            "teamId",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_credentialID_unique": {
+          "name": "passkey_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        },
+        "passkey_user_idx": {
+          "name": "passkey_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "passkey_credential_idx": {
+          "name": "passkey_credential_idx",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_categories": {
+      "name": "sales_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayOrder": {
+          "name": "displayOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_clients": {
+      "name": "sales_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isReusable": {
+          "name": "isReusable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_events": {
+      "name": "sales_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isCurrent": {
+          "name": "isCurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiresClient": {
+          "name": "requiresClient",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "helperPin": {
+          "name": "helperPin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sales_events_team_slug_idx": {
+          "name": "sales_events_team_slug_idx",
+          "columns": [
+            "teamId",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_eventsettings": {
+      "name": "sales_eventsettings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settingKey": {
+          "name": "settingKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settingValue": {
+          "name": "settingValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_kdsbumps": {
+      "name": "sales_kdsbumps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_locations": {
+      "name": "sales_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_orderitems": {
+      "name": "sales_orderitems",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unitPrice": {
+          "name": "unitPrice",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selectedOptions": {
+          "name": "selectedOptions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_orders": {
+      "name": "sales_orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventOrderNumber": {
+          "name": "eventOrderNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overallRemarks": {
+          "name": "overallRemarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationRemarks": {
+          "name": "locationRemarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isPersonnel": {
+          "name": "isPersonnel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_printers": {
+      "name": "sales_printers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "driver": {
+          "name": "driver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "showPrices": {
+          "name": "showPrices",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_printqueues": {
+      "name": "sales_printqueues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printerId": {
+          "name": "printerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printData": {
+          "name": "printData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printMode": {
+          "name": "printMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retryCount": {
+          "name": "retryCount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_products": {
+      "name": "sales_products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiresRemark": {
+          "name": "requiresRemark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remarkPrompt": {
+          "name": "remarkPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hasOptions": {
+          "name": "hasOptions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "multipleOptionsAllowed": {
+          "name": "multipleOptionsAllowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_sync_outbox": {
+      "name": "sales_sync_outbox",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sales_sync_outbox_pending": {
+          "name": "idx_sales_sync_outbox_pending",
+          "columns": [
+            "synced_at",
+            "seq"
+          ],
+          "isUnique": false
+        },
+        "idx_sales_sync_outbox_entity": {
+          "name": "idx_sales_sync_outbox_entity",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scopedAccessGrant": {
+      "name": "scopedAccessGrant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "credentialType": {
+          "name": "credentialType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pin'"
+        },
+        "secretHash": {
+          "name": "secretHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "maxUses": {
+          "name": "maxUses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usedCount": {
+          "name": "usedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokenTtl": {
+          "name": "tokenTtl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 28800000
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scoped_grant_resource_idx": {
+          "name": "scoped_grant_resource_idx",
+          "columns": [
+            "resourceType",
+            "resourceId"
+          ],
+          "isUnique": false
+        },
+        "scoped_grant_org_idx": {
+          "name": "scoped_grant_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "scoped_grant_active_idx": {
+          "name": "scoped_grant_active_idx",
+          "columns": [
+            "isActive",
+            "expiresAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scopedAccessGrant_organizationId_organization_id_fk": {
+          "name": "scopedAccessGrant_organizationId_organization_id_fk",
+          "tableFrom": "scopedAccessGrant",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scopedAccessToken": {
+      "name": "scopedAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scopedAccessToken_token_unique": {
+          "name": "scopedAccessToken_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "scoped_access_token_idx": {
+          "name": "scoped_access_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "scoped_access_org_idx": {
+          "name": "scoped_access_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "scoped_access_resource_idx": {
+          "name": "scoped_access_resource_idx",
+          "columns": [
+            "resourceType",
+            "resourceId"
+          ],
+          "isUnique": false
+        },
+        "scoped_access_active_idx": {
+          "name": "scoped_access_active_idx",
+          "columns": [
+            "isActive",
+            "expiresAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scopedAccessToken_organizationId_organization_id_fk": {
+          "name": "scopedAccessToken_organizationId_organization_id_fk",
+          "tableFrom": "scopedAccessToken",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "impersonatingFrom": {
+          "name": "impersonatingFrom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "session_active_org_idx": {
+          "name": "session_active_org_idx",
+          "columns": [
+            "activeOrganizationId"
+          ],
+          "isUnique": false
+        },
+        "session_impersonating_idx": {
+          "name": "session_impersonating_idx",
+          "columns": [
+            "impersonatingFrom"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscription": {
+      "name": "subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'incomplete'"
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trialStart": {
+          "name": "trialStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trialEnd": {
+          "name": "trialEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscription_reference_idx": {
+          "name": "subscription_reference_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "subscription_stripe_idx": {
+          "name": "subscription_stripe_idx",
+          "columns": [
+            "stripeSubscriptionId"
+          ],
+          "isUnique": false
+        },
+        "subscription_status_idx": {
+          "name": "subscription_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_settings": {
+      "name": "team_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_settings": {
+          "name": "ai_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme_settings": {
+          "name": "theme_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_settings": {
+          "name": "site_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_settings": {
+          "name": "email_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notion_settings": {
+          "name": "notion_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_settings_team_id_unique": {
+          "name": "team_settings_team_id_unique",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true
+        },
+        "team_settings_team_idx": {
+          "name": "team_settings_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_settings_team_id_organization_id_fk": {
+          "name": "team_settings_team_id_organization_id_fk",
+          "tableFrom": "team_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translations_ui": {
+      "name": "translations_ui",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ui'"
+        },
+        "key_path": {
+          "name": "key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "values": {
+          "name": "values",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_overrideable": {
+          "name": "is_overrideable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translations_ui_team_id_namespace_key_path_unique": {
+          "name": "translations_ui_team_id_namespace_key_path_unique",
+          "columns": [
+            "team_id",
+            "namespace",
+            "key_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twoFactor": {
+      "name": "twoFactor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_idx": {
+          "name": "two_factor_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "twoFactor_userId_user_id_fk": {
+          "name": "twoFactor_userId_user_id_fk",
+          "tableFrom": "twoFactor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superAdmin": {
+          "name": "superAdmin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bannedUntil": {
+          "name": "bannedUntil",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "user_stripe_customer_idx": {
+          "name": "user_stripe_customer_idx",
+          "columns": [
+            "stripeCustomerId"
+          ],
+          "isUnique": false
+        },
+        "user_super_admin_idx": {
+          "name": "user_super_admin_idx",
+          "columns": [
+            "superAdmin"
+          ],
+          "isUnique": false
+        },
+        "user_banned_idx": {
+          "name": "user_banned_idx",
+          "columns": [
+            "banned"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_userId_unique": {
+          "name": "user_profile_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "user_profile_user_idx": {
+          "name": "user_profile_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_profile_userId_user_id_fk": {
+          "name": "user_profile_userId_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/fanfare/server/db/migrations/sqlite/meta/_journal.json
+++ b/apps/fanfare/server/db/migrations/sqlite/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1781475716173,
       "tag": "0013_black_bug",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1781548812527,
+      "tag": "0014_gifted_chronomancer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -328,6 +328,7 @@ All package endpoints live under `/api/crouton-sales/` with an explicit split:
 | `teams/[id]/events/[eventId]/admin-helper-token` POST | team member | Issue a helper scoped-access token without PIN (displayName = user name) — lets logged-in admins open the POS directly |
 | `teams/[id]/events/[eventId]/active-helpers` GET | team admin | List currently-logged-in helpers for one event |
 | `teams/[id]/active-helpers` GET | team admin | List active helpers across all team events |
+| `sync/ingest` POST | `x-sync-key` secret (fail-closed) | Cloud D1 ingest (#178): idempotent upsert of batched outbox events from the Pi pusher. See "Cloud ingest" above |
 | `teams/[id]/events/[eventId]/receipt-settings` GET/PUT | team admin | Per-event receipt text customization. Reachability: `staff_order_header` prints only on `isPersonnel` orders (Cart's Staff order switch); `special_instructions_title` heads the remark blocks on kitchen tickets — the per-location remarks from the POS and legacy whole-order notes; `footer_text` only on `type: 'receipt'` printer jobs |
 | `teams/[id]/events/[eventId]/printqueues/retry-failed` POST | team admin | Requeue missed print jobs (status 9, plus jobs stuck at status 1 "printing" for >2 min — fetched by the spooler but never confirmed) back to 0; optional body `{ printerId }` and/or `{ jobId }` (single-line retry). Backs the "Resend failed jobs" button in SettingsTab's printers card and the per-job re-print button in the expanded order |
 | `events/[eventId]/order-data` GET | helper token | All data needed by POS UI (categories are event-scoped — team-wide fetching showed duplicate tabs after event duplication) |
@@ -433,6 +434,31 @@ live orders/sales. #176 is the **capture** layer (this package); the push loop
 - **Not captured** (deliberate, for #177+ to revisit): the thermal RUT spooler
   callbacks (`print-server/jobs/[jobId]/{complete,fail}` — the cloud-authoritative
   profile, no Pi outbox) and `printqueues/retry-failed` (admin edge, 9→0).
+
+### Cloud ingest (#178)
+
+The cloud side that **receives** the Pi's changes and writes them into D1.
+
+- **Endpoint `POST /api/crouton-sales/sync/ingest`** (`server/api/crouton-sales/sync/ingest.post.ts`).
+  Body `{ events: IngestEvent[] }` (the outbox rows); reply
+  `{ received, appliedCount, applied: string[], skipped: [{id, reason, permanent}] }`.
+  The pusher (#177) advances its cursor past `applied`, retries non-permanent
+  skips, drops permanent ones.
+- **Auth — fail-closed shared secret** (`server/utils/cloud-sync-auth.ts`,
+  `requireCloudSyncKey`): header `x-sync-key` vs `runtimeConfig.croutonSales.cloudSyncSecret`
+  (env `NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET`). Unlike the print key there is **no
+  default** — unset secret ⇒ 503, wrong key ⇒ 401 (this is the only writer of
+  mirrored data, so it must never default to open).
+- **Apply** (`server/utils/sync-ingest.ts`, `applyOutboxEvents`): per event,
+  **idempotent upsert keyed by the nanoid** into `salesOrders` / `salesOrderitems`
+  / `salesPrintqueues` — UPDATE-by-id, INSERT only when absent (replays converge,
+  no dup rows). A partial *transition* payload updates only its fields; a *create*
+  payload inserts. JSON timestamps are revived to `Date` for timestamp columns
+  (`getTableColumns` dataType check), unknown keys dropped. Per-event try/catch:
+  malformed ⇒ permanent skip; a transition before its create (INSERT NOT-NULL
+  fail) ⇒ non-permanent skip so the pusher retries after the create lands. The
+  batch is **not** atomic — partial application is allowed and acked precisely.
+  No order-number assignment here (Pi-local).
 
 ## Configuration
 

--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -17,6 +17,10 @@ Event-based Point of Sale (POS) system for Nuxt Crouton. Provides products, cate
 | `app/components/Admin/` | Admin sidebar navigation |
 | `app/components/Pos/` | Order management (OrdersList) |
 | `app/components/Settings/` | Print settings modals (opt-in) |
+| `server/utils/sync-outbox.ts` | Pi-side capture for the D1 live mirror (#176) — `recordOutboxEvents()` + `isCloudSyncEnabled()`; gated by `CROUTON_SALES_CLOUD_SYNC` |
+| `server/database/schema.ts` | Package-owned Drizzle schema: `salesSyncOutbox` (`sales_sync_outbox` table) |
+| `server/db/schema.ts` | Re-export NuxtHub scans so consuming apps auto-pick-up `sales_sync_outbox` in `db:generate` |
+| `server/database/migrations/0001_sales_sync_outbox.sql` | Package migration creating `sales_sync_outbox` |
 | `schemas/` | JSON schema files for crouton generate |
 | `seed/index.ts` | Seed provider (`@fyit/crouton-sales/seed`) — event `vlaamsekermis` (PIN `1234`) + categories/products + a scoped kassa demo page |
 
@@ -397,6 +401,38 @@ Auth: shared `x-api-key` header validated against `runtimeConfig.croutonSales.pr
 `printData` returned by `/jobs` is already base64-encoded ESC/POS bytes (built by `formatReceipt` in `server/utils/receipt-formatter.ts`). Spooler decodes and writes raw bytes to printer's TCP port 9100.
 
 The spooler script's expected job-row shape: `{ id, printData, printerIp, printerPort, printMode, locationId, retryCount }`.
+
+## Cloud Sync — Pi-side outbox (D1 live mirror)
+
+Part of epic #175 (keep a live online copy of the venue's data). The venue till
+runs on a Pi as the authoritative writer; when the 5G uplink is up it pushes its
+changes to a Cloudflare D1 **mirror** so an online dashboard (#179) can show
+live orders/sales. #176 is the **capture** layer (this package); the push loop
+(#177) and cloud ingest (#178) build on the rows it records.
+
+- **Table `sales_sync_outbox`** (`server/database/schema.ts`, package-owned like
+  crouton-flow's `flow_configs`). One row **per entity change**, keyed by the
+  entity's existing **nanoid** (`entityId`) so the downstream D1 upsert is
+  idempotent (re-sending after an uncertain push is safe). `seq` is the monotonic
+  cursor the pusher drains oldest-first; `syncedAt` stays NULL until the cloud
+  acks. NuxtHub auto-discovers the table via `server/db/schema.ts` — consuming
+  apps just run `db:generate` + migrate (or apply `0001_sales_sync_outbox.sql`).
+- **Capture** (`recordOutboxEvents()` in `server/utils/sync-outbox.ts`) is wired
+  into the existing mutation paths:
+  - order create + each order-item → `orders/index.post.ts`
+  - print-job create (status `0`) → `generate-print-queues.ts` (the single choke
+    point for order/reprint/end-receipt) — the bulky base64 `printData` is
+    **omitted** from the mirrored payload (the cloud shows status, never prints)
+  - print-status transitions (done `2` / failed `9`) + the order's status flip →
+    `print-job-complete.ts` (the path the in-process ESC/POS drainer and the
+    browser-print drainer both call)
+- **Gated by `CROUTON_SALES_CLOUD_SYNC`** (`'1'`/`'true'`) — OFF by default and
+  on every Cloudflare deploy (the cloud *is* the mirror there; only the venue Pi
+  captures), mirroring the escpos-drainer env-gate. Capture is **best-effort**:
+  failures are logged and swallowed so they can never block the till.
+- **Not captured** (deliberate, for #177+ to revisit): the thermal RUT spooler
+  callbacks (`print-server/jobs/[jobId]/{complete,fail}` — the cloud-authoritative
+  profile, no Pi outbox) and `printqueues/retry-failed` (admin edge, 9→0).
 
 ## Configuration
 

--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -18,6 +18,11 @@ Event-based Point of Sale (POS) system for Nuxt Crouton. Provides products, cate
 | `app/components/Pos/` | Order management (OrdersList) |
 | `app/components/Settings/` | Print settings modals (opt-in) |
 | `server/utils/sync-outbox.ts` | Pi-side capture for the D1 live mirror (#176) — `recordOutboxEvents()` + `isCloudSyncEnabled()`; gated by `CROUTON_SALES_CLOUD_SYNC` |
+| `server/utils/sync-ingest.ts` | Cloud-side apply (#178) — `applyOutboxEvents()` idempotent upsert by nanoid |
+| `server/utils/cloud-sync-auth.ts` | Fail-closed `x-sync-key` auth for the ingest (#178) |
+| `server/utils/cloud-sync-pusher.ts` | Pi-side push loop (#177) — `pushPendingOutbox()` drains outbox → ingest |
+| `server/plugins/cloud-sync-pusher.ts` | Nitro plugin running the push loop (gated, backoff) |
+| `server/api/crouton-sales/sync/ingest.post.ts` | Cloud D1 ingest endpoint (#178) |
 | `server/database/schema.ts` | Package-owned Drizzle schema: `salesSyncOutbox` (`sales_sync_outbox` table) |
 | `server/db/schema.ts` | Re-export NuxtHub scans so consuming apps auto-pick-up `sales_sync_outbox` in `db:generate` |
 | `server/database/migrations/0001_sales_sync_outbox.sql` | Package migration creating `sales_sync_outbox` |
@@ -459,6 +464,26 @@ The cloud side that **receives** the Pi's changes and writes them into D1.
   fail) ⇒ non-permanent skip so the pusher retries after the create lands. The
   batch is **not** atomic — partial application is allowed and acked precisely.
   No order-number assignment here (Pi-local).
+
+### Push loop — Pi side (#177)
+
+The Pi-side background loop that actually sends the outbox up to the cloud.
+
+- **Nitro plugin `server/plugins/cloud-sync-pusher.ts`** — mirrors the
+  escpos-drainer plugin: starts only when `CROUTON_SALES_CLOUD_SYNC` is set AND
+  `CROUTON_SALES_CLOUD_SYNC_URL` is configured (else idle); OFF by default and on
+  Cloudflare. Self-chained `setTimeout` (never overlaps): a full batch reschedules
+  in 50ms so bursts drain in seconds; on push failure it **backs off
+  exponentially** (capped 60s) and resumes on reconnect. Tunables:
+  `CROUTON_SALES_CLOUD_SYNC_POLL_MS` (3000), `CROUTON_SALES_CLOUD_SYNC_BATCH` (100).
+- **`server/utils/cloud-sync-pusher.ts` `pushPendingOutbox()`** — selects pending
+  rows (`syncedAt IS NULL`, `ORDER BY seq`, limited), POSTs `{ events }` to the
+  ingest with `x-sync-key` (secret from `NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET`),
+  then sets `syncedAt` on the cloud's `applied` ids **and** on permanent skips
+  (drop a poison row so it can't wedge the loop); non-permanent skips stay pending
+  for the next tick. Transport errors throw → the plugin backs off. Idempotent by
+  nanoid downstream, so a push that's uncertain (network dropped after apply) is
+  re-sent harmlessly and converges. `fetcher` option is injectable for tests.
 
 ## Configuration
 

--- a/packages/crouton-sales/server/api/crouton-sales/events/[eventId]/orders/index.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/events/[eventId]/orders/index.post.ts
@@ -6,6 +6,7 @@ import { salesEvents } from '~~/layers/sales/collections/events/server/database/
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { generateAndInsertPrintQueues } from '../../../../../utils/generate-print-queues'
+import { recordOutboxEvents } from '../../../../../utils/sync-outbox'
 
 interface OrderItemInput {
   productId: string
@@ -103,6 +104,28 @@ export default defineEventHandler(async (event) => {
       return orderItem
     })
   )
+
+  // Capture for the cloud mirror (#176) — one row for the order + one per item,
+  // keyed by each row's nanoid. No-op unless CROUTON_SALES_CLOUD_SYNC is on
+  // (the venue Pi), best-effort so it never blocks checkout.
+  await recordOutboxEvents(db, [
+    {
+      entityType: 'order',
+      entityId: order.id,
+      orderId: order.id,
+      teamId: salesEvent.teamId,
+      eventId,
+      payload: order as Record<string, unknown>,
+    },
+    ...orderItems.map(item => ({
+      entityType: 'orderitem' as const,
+      entityId: item.id,
+      orderId,
+      teamId: salesEvent.teamId,
+      eventId,
+      payload: item as Record<string, unknown>,
+    })),
+  ])
 
   let printQueueIds: string[] = []
   const { croutonSales } = useRuntimeConfig(event)

--- a/packages/crouton-sales/server/api/crouton-sales/sync/ingest.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/sync/ingest.post.ts
@@ -1,0 +1,36 @@
+/**
+ * Cloud-side ingest for the D1 live mirror (#178, epic #175).
+ *
+ * Receives a batch of outbox events from the Pi pusher (#177) and applies them
+ * as idempotent upserts into the mirrored tables. The only writer of mirrored
+ * venue data on the cloud. Auth is a fail-closed shared secret (`x-sync-key`).
+ *
+ * Body:  { events: IngestEvent[] }
+ * Reply: { applied: string[], skipped: [{ id, reason, permanent }] }
+ *        — the pusher advances its cursor past `applied`, retries non-permanent
+ *          skips, and may drop permanent ones.
+ */
+import { requireCloudSyncKey } from '../../../utils/cloud-sync-auth'
+import { applyOutboxEvents, type IngestEvent } from '../../../utils/sync-ingest'
+
+interface IngestBody {
+  events?: IngestEvent[]
+}
+
+export default defineEventHandler(async (event) => {
+  requireCloudSyncKey(event)
+
+  const body = await readBody<IngestBody>(event)
+  if (!body || !Array.isArray(body.events)) {
+    throw createError({ status: 400, statusText: 'Body must be { events: [...] }' })
+  }
+
+  const db = useDB()
+  const result = await applyOutboxEvents(db, body.events)
+
+  return {
+    received: body.events.length,
+    appliedCount: result.applied.length,
+    ...result,
+  }
+})

--- a/packages/crouton-sales/server/database/migrations/0001_sales_sync_outbox.sql
+++ b/packages/crouton-sales/server/database/migrations/0001_sales_sync_outbox.sql
@@ -1,0 +1,21 @@
+-- Pi-side sync outbox (#176, epic #175 — D1 live mirror).
+-- Records order / order-item / print-status mutations on the venue Pi so the
+-- push loop (#177) can drain them to the cloud ingest endpoint (#178).
+-- Local-only and additive; the till never reads it.
+CREATE TABLE IF NOT EXISTS sales_sync_outbox (
+  seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  operation TEXT NOT NULL DEFAULT 'upsert',
+  order_id TEXT,
+  team_id TEXT,
+  event_id TEXT,
+  payload TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  synced_at INTEGER
+);
+
+-- Drain query: pending rows (synced_at IS NULL), oldest first.
+CREATE INDEX IF NOT EXISTS idx_sales_sync_outbox_pending ON sales_sync_outbox(synced_at, seq);
+CREATE INDEX IF NOT EXISTS idx_sales_sync_outbox_entity ON sales_sync_outbox(entity_type, entity_id);

--- a/packages/crouton-sales/server/database/schema.ts
+++ b/packages/crouton-sales/server/database/schema.ts
@@ -1,0 +1,48 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { nanoid } from 'nanoid'
+
+/**
+ * Pi-side sync outbox (#176, epic #175 — D1 live mirror).
+ *
+ * Records each order / order-item / print-status mutation as it happens on the
+ * venue Pi, so the push loop (#177) can drain it to the cloud ingest endpoint
+ * (#178) and the cloud stays an eventually-consistent, queryable mirror of the
+ * till (#179). The Pi remains the authoritative writer; this table is the only
+ * thing that crosses the 5G uplink for data.
+ *
+ * Local-only and additive — the till never reads it, so capturing has no effect
+ * on ordering or printing. One row per entity change, keyed by the entity's
+ * existing nanoid (`entityId`) so the downstream upsert into D1 is idempotent
+ * (re-sending after an uncertain push is safe). `syncedAt` stays NULL until the
+ * pusher confirms the cloud applied the row; `seq` is the monotonic cursor it
+ * drains oldest-first and advances past acked rows.
+ *
+ * `payload` is the row snapshot to mirror. For a `printstatus` row the bulky
+ * base64 `printData` is deliberately omitted — the cloud shows status, it never
+ * prints, so the events stay kilobytes as the epic requires.
+ */
+export const salesSyncOutbox = sqliteTable('sales_sync_outbox', {
+  // Monotonic cursor: drain oldest-first, advance past acked rows.
+  seq: integer('seq').primaryKey({ autoIncrement: true }),
+  // Stable event id (distinct from the entity it describes) for tracing/acking.
+  id: text('id').notNull().$default(() => nanoid()),
+  // Which mirrored table this change targets: 'order' | 'orderitem' | 'printstatus'.
+  entityType: text('entity_type').notNull(),
+  // The target row's existing nanoid — the idempotency key for the D1 upsert.
+  entityId: text('entity_id').notNull(),
+  // Generic op; create and update both map to an idempotent upsert downstream.
+  operation: text('operation').notNull().$default(() => 'upsert'),
+  // Correlation: the order this change belongs to (null for tab-level receipts).
+  orderId: text('order_id'),
+  teamId: text('team_id'),
+  eventId: text('event_id'),
+  // Full row snapshot to upsert into the cloud mirror (printData omitted).
+  payload: text('payload', { mode: 'json' }).notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$default(() => new Date()),
+  // NULL = pending; set to the push time once the cloud confirms it applied.
+  syncedAt: integer('synced_at', { mode: 'timestamp' }),
+}, table => [
+  // Drain query: pending rows, oldest first.
+  index('idx_sales_sync_outbox_pending').on(table.syncedAt, table.seq),
+  index('idx_sales_sync_outbox_entity').on(table.entityType, table.entityId),
+])

--- a/packages/crouton-sales/server/db/schema.ts
+++ b/packages/crouton-sales/server/db/schema.ts
@@ -1,0 +1,6 @@
+// Database schema exports for crouton-sales.
+// NuxtHub scans `server/db/schema.ts` across extended layers to build the
+// bundled drizzle schema, so re-exporting here makes the consuming app pick up
+// `sales_sync_outbox` in `db:generate` migrations automatically — no manual
+// schema import needed in the app (same pattern as crouton-flow/crouton-collab).
+export { salesSyncOutbox } from '../database/schema'

--- a/packages/crouton-sales/server/plugins/cloud-sync-pusher.ts
+++ b/packages/crouton-sales/server/plugins/cloud-sync-pusher.ts
@@ -1,0 +1,57 @@
+/**
+ * Cloud-sync push loop — Nitro plugin (#177, epic #175).
+ *
+ * On the venue Pi (a Node target), drains the `sales_sync_outbox` (#176) to the
+ * cloud ingest endpoint (#178) on a poll loop. Mirrors the escpos-drainer plugin:
+ * OFF by default and on every Cloudflare deploy, starting only when the Pi opts
+ * in — so existing deploys are unchanged and Workers (no long-lived process,
+ * outbound to itself) never run it.
+ *
+ *   CROUTON_SALES_CLOUD_SYNC           '1' | 'true' to enable (same flag as capture)
+ *   CROUTON_SALES_CLOUD_SYNC_URL       required: the cloud ingest endpoint URL
+ *   NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET  shared secret (x-sync-key)
+ *   CROUTON_SALES_CLOUD_SYNC_POLL_MS   base poll interval (default 3000)
+ *   CROUTON_SALES_CLOUD_SYNC_BATCH     rows per batch (default 100)
+ *
+ * Online-only: when the push fails (offline / endpoint down) it backs off
+ * exponentially (capped) and resumes on reconnect; a full batch drains again
+ * immediately so a burst empties within seconds. Self-chained setTimeout (not
+ * setInterval) means ticks never overlap.
+ */
+import { pushPendingOutbox } from '../utils/cloud-sync-pusher'
+
+const MAX_BACKOFF_MS = 60000
+
+export default defineNitroPlugin(() => {
+  const flag = process.env.CROUTON_SALES_CLOUD_SYNC
+  if (flag !== '1' && flag !== 'true') return
+
+  const url = process.env.CROUTON_SALES_CLOUD_SYNC_URL
+  if (!url) {
+    console.warn('🍞 crouton:sales cloud sync ON but CROUTON_SALES_CLOUD_SYNC_URL unset — pusher idle')
+    return
+  }
+
+  const basePollMs = Number(process.env.CROUTON_SALES_CLOUD_SYNC_POLL_MS) || 3000
+  const batchSize = Number(process.env.CROUTON_SALES_CLOUD_SYNC_BATCH) || 100
+
+  let backoff = 0
+  const schedule = (ms: number) => setTimeout(tick, ms)
+
+  const tick = async () => {
+    try {
+      const res = await pushPendingOutbox(useDB(), { url, batchSize })
+      backoff = 0 // success clears any backoff
+      // Drain bursts fast: a full batch likely means more is pending.
+      schedule(res.claimed >= batchSize ? 50 : basePollMs)
+    }
+    catch (err) {
+      backoff = backoff ? Math.min(backoff * 2, MAX_BACKOFF_MS) : basePollMs
+      console.error(`[crouton-sales] cloud sync push failed (retry in ${backoff}ms):`, (err as { message?: string })?.message || err)
+      schedule(backoff)
+    }
+  }
+
+  console.log(`🍞 crouton:sales cloud sync pusher ON (poll ${basePollMs}ms → ${url})`)
+  schedule(basePollMs)
+})

--- a/packages/crouton-sales/server/utils/cloud-sync-auth.ts
+++ b/packages/crouton-sales/server/utils/cloud-sync-auth.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared-secret auth for the Pi→cloud sync ingest (#178).
+ *
+ * Validates the `x-sync-key` header against runtimeConfig.croutonSales.cloudSyncSecret
+ * (override via env NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET). Unlike the print-server
+ * key, this guards the ONLY writer of mirrored venue data on the cloud, so it is
+ * **fail-closed**: when no secret is configured the endpoint rejects everything
+ * (there is no usable default — an unset secret must never mean "open").
+ */
+import type { H3Event } from 'h3'
+
+export function requireCloudSyncKey(event: H3Event): void {
+  const config = useRuntimeConfig(event)
+  const expected = (config.croutonSales as { cloudSyncSecret?: string } | undefined)?.cloudSyncSecret
+
+  // Fail closed: no secret set ⇒ no access (don't fall back to a default).
+  if (!expected) {
+    throw createError({ status: 503, statusText: 'Cloud sync not configured' })
+  }
+
+  const got = getHeader(event, 'x-sync-key')
+  if (got !== expected) {
+    throw createError({ status: 401, statusText: 'Invalid sync key' })
+  }
+}

--- a/packages/crouton-sales/server/utils/cloud-sync-pusher.ts
+++ b/packages/crouton-sales/server/utils/cloud-sync-pusher.ts
@@ -1,0 +1,108 @@
+/**
+ * @crouton-package crouton-sales
+ * @description Pi-side push loop for the D1 live mirror (#177, epic #175).
+ *
+ * Drains pending `sales_sync_outbox` rows (#176) and POSTs them in batches to the
+ * cloud ingest endpoint (#178). On the cloud's ack it sets `synced_at` on the
+ * applied rows (advancing the cursor); non-permanent skips stay pending and retry
+ * next tick, permanent (malformed) skips are dropped so a poison row can't wedge
+ * the loop. Idempotent by nanoid downstream, so re-sending after an uncertain
+ * push never duplicates — if the network drops after the cloud applied but before
+ * we read the response, the rows stay pending and the next push converges.
+ *
+ * Transport failures throw so the Nitro plugin can back off; the till is never
+ * blocked (this runs entirely outside the order/print path).
+ *
+ * The outbox schema is package-owned (`../database/schema`, imported lazily).
+ */
+import { asc, inArray, isNull } from 'drizzle-orm'
+
+export interface PushOptions {
+  /** Ingest endpoint URL; defaults to env CROUTON_SALES_CLOUD_SYNC_URL. */
+  url?: string
+  /** Shared secret; defaults to env NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET. */
+  secret?: string
+  /** Max rows per batch. Default 100. */
+  batchSize?: number
+  /** Per-request timeout (ms). Default 15000. */
+  timeoutMs?: number
+  /** Injectable HTTP client for tests; defaults to $fetch. */
+  fetcher?: (url: string, init: Record<string, unknown>) => Promise<IngestResponse>
+}
+
+interface IngestResponse {
+  applied?: string[]
+  skipped?: Array<{ id: string, reason?: string, permanent?: boolean }>
+}
+
+export interface PushResult {
+  claimed: number
+  applied: number
+  skippedRetry: number
+  skippedPermanent: number
+}
+
+async function loadOutboxSchema() {
+  const { salesSyncOutbox } = await import('../database/schema')
+  return { salesSyncOutbox }
+}
+
+/**
+ * Push one batch of pending outbox rows. Returns counts; `claimed` reaching
+ * `batchSize` signals more may be pending (the plugin drains again immediately).
+ */
+export async function pushPendingOutbox(db: any, opts: PushOptions = {}): Promise<PushResult> {
+  const url = opts.url || process.env.CROUTON_SALES_CLOUD_SYNC_URL
+  const secret = opts.secret || process.env.NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET
+  if (!url) throw new Error('CROUTON_SALES_CLOUD_SYNC_URL not set')
+  if (!secret) throw new Error('NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET not set')
+
+  const { salesSyncOutbox } = await loadOutboxSchema()
+  const batchSize = opts.batchSize ?? 100
+
+  const rows = await db
+    .select()
+    .from(salesSyncOutbox)
+    .where(isNull(salesSyncOutbox.syncedAt))
+    .orderBy(asc(salesSyncOutbox.seq))
+    .limit(batchSize)
+
+  if (rows.length === 0) return { claimed: 0, applied: 0, skippedRetry: 0, skippedPermanent: 0 }
+
+  const events = rows.map((r: any) => ({
+    id: r.id,
+    entityType: r.entityType,
+    entityId: r.entityId,
+    operation: r.operation,
+    orderId: r.orderId,
+    teamId: r.teamId,
+    eventId: r.eventId,
+    payload: r.payload,
+  }))
+
+  const doFetch = opts.fetcher ?? (globalThis as any).$fetch
+  const res: IngestResponse = await doFetch(url, {
+    method: 'POST',
+    headers: { 'x-sync-key': secret },
+    body: { events },
+    timeout: opts.timeoutMs ?? 15000,
+    retry: 0,
+  })
+
+  const applied = Array.isArray(res?.applied) ? res.applied : []
+  const skipped = Array.isArray(res?.skipped) ? res.skipped : []
+  const permanentIds = skipped.filter(s => s?.permanent).map(s => s.id)
+  const retryCount = skipped.length - permanentIds.length
+
+  // Mark confirmed rows synced: applied + permanently-dropped. Non-permanent
+  // skips (e.g. a transition that arrived before its create) stay pending.
+  const toMark = [...applied, ...permanentIds].filter(Boolean)
+  if (toMark.length > 0) {
+    await db.update(salesSyncOutbox).set({ syncedAt: new Date() }).where(inArray(salesSyncOutbox.id, toMark))
+  }
+  if (permanentIds.length > 0) {
+    console.warn(`[crouton-sales] cloud sync dropped ${permanentIds.length} malformed outbox row(s):`, permanentIds)
+  }
+
+  return { claimed: rows.length, applied: applied.length, skippedRetry: retryCount, skippedPermanent: permanentIds.length }
+}

--- a/packages/crouton-sales/server/utils/generate-print-queues.ts
+++ b/packages/crouton-sales/server/utils/generate-print-queues.ts
@@ -15,6 +15,7 @@ import {
   type PrinterConfig
 } from './print-queue-service'
 import { DEFAULT_RECEIPT_SETTINGS, type ReceiptSettings } from './receipt-formatter'
+import { recordOutboxEvents, type OutboxEvent } from './sync-outbox'
 
 interface GenerateInsertOptions {
   db: any
@@ -148,9 +149,10 @@ export async function generateAndInsertPrintQueues(opts: GenerateInsertOptions):
   )
 
   const queueIds: string[] = []
+  const outboxEvents: OutboxEvent[] = []
   for (const job of jobs) {
     const queueId = nanoid()
-    await db.insert(salesPrintqueues).values({
+    const row = {
       id: queueId,
       teamId,
       owner: helperDisplayName,
@@ -167,9 +169,25 @@ export async function generateAndInsertPrintQueues(opts: GenerateInsertOptions):
       retryCount: '0',
       createdBy: helperId,
       updatedBy: helperId
-    })
+    }
+    await db.insert(salesPrintqueues).values(row)
     queueIds.push(queueId)
+
+    // Mirror the print-status row (#176) without the bulky base64 printData —
+    // the cloud shows status, it never prints, so the event stays kilobytes.
+    const { printData: _printData, ...mirror } = row
+    outboxEvents.push({
+      entityType: 'printstatus',
+      entityId: queueId,
+      orderId,
+      teamId,
+      eventId,
+      payload: mirror
+    })
   }
+
+  // No-op unless CROUTON_SALES_CLOUD_SYNC is on; best-effort, never throws.
+  await recordOutboxEvents(db, outboxEvents)
 
   return queueIds
 }

--- a/packages/crouton-sales/server/utils/print-job-complete.ts
+++ b/packages/crouton-sales/server/utils/print-job-complete.ts
@@ -14,6 +14,7 @@
  * app (same pattern as `generate-print-queues.ts`).
  */
 import { and, count, eq, ne, notInArray, sql } from 'drizzle-orm'
+import { isCloudSyncEnabled, recordOutboxEvents, type OutboxEvent } from './sync-outbox'
 
 // salesPrintqueues.status is text-typed in the generated schema — string literals.
 const STATUS_COMPLETED = '2'
@@ -65,6 +66,25 @@ export async function completePrintJob(
     }
   }
 
+  // Mirror the print-status transition (#176): the job → done, plus the order
+  // row when it auto-completed. No-op unless CROUTON_SALES_CLOUD_SYNC is on
+  // (guard the order re-select too, so disabled processes pay nothing).
+  if (isCloudSyncEnabled() && orderId) {
+    const events: OutboxEvent[] = [{
+      entityType: 'printstatus',
+      entityId: jobId,
+      orderId,
+      payload: { id: jobId, status: STATUS_COMPLETED, completedAt: now.toISOString(), updatedAt: now },
+    }]
+    if (orderCompleted) {
+      const [orderRow] = await db.select().from(salesOrders).where(eq(salesOrders.id, orderId)).limit(1)
+      if (orderRow) {
+        events.push({ entityType: 'order', entityId: orderId, orderId, teamId: orderRow.teamId, eventId: orderRow.eventId, payload: orderRow })
+      }
+    }
+    await recordOutboxEvents(db, events)
+  }
+
   return { found: true, orderCompleted }
 }
 
@@ -102,6 +122,22 @@ export async function failPrintJob(
         eq(salesOrders.id, orderId),
         notInArray(salesOrders.status, ['completed', 'cancelled'])
       ))
+  }
+
+  // Mirror the print-status transition (#176): the job → failed, plus the
+  // current order row (its status may have flipped to print_failed).
+  if (isCloudSyncEnabled() && orderId) {
+    const events: OutboxEvent[] = [{
+      entityType: 'printstatus',
+      entityId: jobId,
+      orderId,
+      payload: { id: jobId, status: STATUS_FAILED, errorMessage, updatedAt: now },
+    }]
+    const [orderRow] = await db.select().from(salesOrders).where(eq(salesOrders.id, orderId)).limit(1)
+    if (orderRow) {
+      events.push({ entityType: 'order', entityId: orderId, orderId, teamId: orderRow.teamId, eventId: orderRow.eventId, payload: orderRow })
+    }
+    await recordOutboxEvents(db, events)
   }
 
   return { found: true }

--- a/packages/crouton-sales/server/utils/sync-ingest.ts
+++ b/packages/crouton-sales/server/utils/sync-ingest.ts
@@ -1,0 +1,137 @@
+/**
+ * @crouton-package crouton-sales
+ * @description Cloud-side apply for the D1 live mirror (#178, epic #175).
+ *
+ * Takes the batched outbox events the Pi pusher (#177) sends and applies each as
+ * an **idempotent upsert keyed by the entity's nanoid** into the mirrored tables
+ * (`salesOrders` / `salesOrderitems` / `salesPrintqueues`). This is the ONLY
+ * writer of mirrored venue data on the cloud; D1 stays otherwise read-mostly.
+ *
+ * Idempotency: UPDATE-by-id, and INSERT only when the row is absent. Replaying
+ * the same batch therefore converges to identical state (no duplicate rows). A
+ * partial *transition* payload (e.g. printstatus → done) updates only the fields
+ * it carries; a full *create* payload inserts the row. If a transition arrives
+ * before its create (row missing → INSERT fails NOT NULL), the event is reported
+ * as a non-permanent skip so the pusher retries it after the create lands.
+ *
+ * Per-event isolation: one bad event never aborts the batch — partial batches
+ * are explicitly allowed, and the caller acks precisely what was applied.
+ *
+ * App-layer schema is imported lazily (the `~~/layers` alias resolves only in
+ * the consuming app — same pattern as generate-print-queues.ts / print-job-complete.ts).
+ */
+import { eq, getTableColumns } from 'drizzle-orm'
+import type { OutboxEntityType } from './sync-outbox'
+
+export interface IngestEvent {
+  /** Stable event id from the outbox (used for the ack); falls back to entityId. */
+  id?: string
+  entityType: OutboxEntityType
+  /** The mirrored row's nanoid — the upsert key. */
+  entityId: string
+  /** Row snapshot: a full row on create, the changed fields on update. */
+  payload: Record<string, unknown>
+  operation?: string
+}
+
+export interface IngestResult {
+  /** Event ids that were upserted — the pusher advances its cursor past these. */
+  applied: string[]
+  /** Events not applied. `permanent` ⇒ malformed (drop it); else retryable. */
+  skipped: Array<{ id: string, reason: string, permanent: boolean }>
+}
+
+const VALID_TYPES: OutboxEntityType[] = ['order', 'orderitem', 'printstatus']
+
+async function loadTables(): Promise<Record<OutboxEntityType, any>> {
+  const { salesOrders } = await import('~~/layers/sales/collections/orders/server/database/schema')
+  const { salesOrderitems } = await import('~~/layers/sales/collections/orderitems/server/database/schema')
+  const { salesPrintqueues } = await import('~~/layers/sales/collections/printqueues/server/database/schema')
+  return { order: salesOrders, orderitem: salesOrderitems, printstatus: salesPrintqueues }
+}
+
+/**
+ * Coerce a JSON payload to the shape drizzle expects for `table`:
+ * - drop keys that aren't real columns (forward-compat / injection-safe)
+ * - revive timestamp-mode columns (dataType 'date') from the ISO string / epoch
+ *   number JSON produced, leaving text columns (e.g. completedAt) as-is.
+ */
+function coerceToColumns(table: any, payload: Record<string, unknown>): Record<string, unknown> {
+  const cols = getTableColumns(table) as Record<string, { dataType: string }>
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(payload)) {
+    const col = cols[key]
+    if (!col) continue // unknown column → drop
+    if (col.dataType === 'date' && value != null && !(value instanceof Date)) {
+      out[key] = new Date(typeof value === 'number' ? value : String(value))
+    }
+    else {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+export async function applyOutboxEvents(
+  db: any,
+  events: IngestEvent[],
+  // Injectable for tests; defaults to the lazily-imported app-layer schema.
+  tablesOverride?: Record<OutboxEntityType, any>
+): Promise<IngestResult> {
+  const result: IngestResult = { applied: [], skipped: [] }
+  if (!Array.isArray(events) || events.length === 0) return result
+
+  const tables = tablesOverride ?? await loadTables()
+
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i]
+    const ackId = e?.id || e?.entityId || `#${i}`
+
+    // Validate shape — malformed events are permanent skips (drop, don't retry).
+    if (!e || !VALID_TYPES.includes(e.entityType)) {
+      result.skipped.push({ id: ackId, reason: `unknown entityType: ${e?.entityType}`, permanent: true })
+      continue
+    }
+    if (!e.entityId || typeof e.entityId !== 'string') {
+      result.skipped.push({ id: ackId, reason: 'missing entityId', permanent: true })
+      continue
+    }
+    if (!e.payload || typeof e.payload !== 'object') {
+      result.skipped.push({ id: ackId, reason: 'missing payload', permanent: true })
+      continue
+    }
+
+    const table = tables[e.entityType]
+    try {
+      // The upsert key always wins over whatever the payload carried.
+      const values = coerceToColumns(table, { ...e.payload, id: e.entityId })
+      const setObj = { ...values }
+      delete setObj.id
+
+      // UPDATE existing row (idempotent: a replay re-sets the same values).
+      let exists = false
+      if (Object.keys(setObj).length > 0) {
+        const updated = await db.update(table).set(setObj).where(eq(table.id, e.entityId)).returning({ id: table.id })
+        exists = updated.length > 0
+      }
+      else {
+        const [row] = await db.select({ id: table.id }).from(table).where(eq(table.id, e.entityId)).limit(1)
+        exists = !!row
+      }
+
+      // INSERT only when absent. A partial transition payload on a missing row
+      // fails NOT NULL here → caught below as a retryable skip.
+      if (!exists) {
+        await db.insert(table).values(values)
+      }
+
+      result.applied.push(ackId)
+    }
+    catch (err: any) {
+      // DB-level failure (e.g. transition before its create) — retryable.
+      result.skipped.push({ id: ackId, reason: err?.message || 'apply failed', permanent: false })
+    }
+  }
+
+  return result
+}

--- a/packages/crouton-sales/server/utils/sync-outbox.ts
+++ b/packages/crouton-sales/server/utils/sync-outbox.ts
@@ -1,0 +1,80 @@
+/**
+ * @crouton-package crouton-sales
+ * @description Pi-side capture for the D1 live-mirror sync (#176, epic #175).
+ *
+ * Records order / order-item / print-status mutations into `sales_sync_outbox`
+ * as they happen, so the push loop (#177) can drain them to the cloud ingest
+ * endpoint (#178) and keep the cloud an eventually-consistent mirror (#179).
+ *
+ * Gated by `CROUTON_SALES_CLOUD_SYNC` — OFF by default and on every Cloudflare
+ * deploy, so existing deploys write no extra rows (the cloud *is* the mirror
+ * there; only the venue Pi captures). Mirrors the escpos-drainer's env-gate.
+ *
+ * Capture is best-effort: a failure here is logged and swallowed so it can never
+ * block the till — the order/print path must succeed regardless of sync state.
+ *
+ * The outbox schema is package-owned (`../database/schema`) and imported
+ * lazily, so loading this module stays cheap and import-safe everywhere.
+ */
+import { nanoid } from 'nanoid'
+
+export type OutboxEntityType = 'order' | 'orderitem' | 'printstatus'
+
+export interface OutboxEvent {
+  entityType: OutboxEntityType
+  /** The target row's existing nanoid — idempotency key for the cloud upsert. */
+  entityId: string
+  /** Row snapshot to mirror (a full row on create; the changed fields on update). */
+  payload: Record<string, unknown>
+  /** Correlation: the order this change belongs to (null for tab-level receipts). */
+  orderId?: string | null
+  teamId?: string | null
+  eventId?: string | null
+  /** Defaults to 'upsert' — create and update both upsert by nanoid downstream. */
+  operation?: string
+}
+
+/**
+ * True when this process should capture to the outbox — i.e. it's the venue Pi
+ * with cloud sync turned on. OFF by default (and always on Cloudflare), so
+ * existing deploys are unchanged and pay no extra writes.
+ */
+export function isCloudSyncEnabled(): boolean {
+  const flag = process.env.CROUTON_SALES_CLOUD_SYNC
+  return flag === '1' || flag === 'true'
+}
+
+async function loadOutboxSchema() {
+  const { salesSyncOutbox } = await import('../database/schema')
+  return { salesSyncOutbox }
+}
+
+/**
+ * Append one pending outbox row per event. No-op when cloud sync is disabled.
+ * Never throws — capture must not break the till.
+ */
+export async function recordOutboxEvents(db: any, events: OutboxEvent[]): Promise<void> {
+  if (!isCloudSyncEnabled() || events.length === 0) return
+
+  try {
+    const { salesSyncOutbox } = await loadOutboxSchema()
+    const now = new Date()
+    await db.insert(salesSyncOutbox).values(
+      events.map(e => ({
+        id: nanoid(),
+        entityType: e.entityType,
+        entityId: e.entityId,
+        operation: e.operation ?? 'upsert',
+        orderId: e.orderId ?? null,
+        teamId: e.teamId ?? null,
+        eventId: e.eventId ?? null,
+        payload: e.payload,
+        createdAt: now,
+        syncedAt: null,
+      })),
+    )
+  }
+  catch (err) {
+    console.error('[crouton-sales] sync outbox capture failed:', err)
+  }
+}


### PR DESCRIPTION
## 👤 For humans

The first three slices of epic #175 (**keep a live online copy of the venue's data**), end to end. The venue till runs on a Pi as the authoritative writer; whenever the 5G uplink is up it quietly pushes its changes to a Cloudflare D1 **mirror** so an online dashboard (#179, not in this PR) can show live orders and sales.

It's built to survive a flaky mobile link: the same change arriving twice is harmless, nothing is lost when offline, and **the till itself is never blocked or slowed** — capture is additive, local-only, and off unless the Pi opts in.

## 🤖 For agents

Three composable pieces, all in `@fyit/crouton-sales`, gated by `CROUTON_SALES_CLOUD_SYNC` (OFF by default and on every Cloudflare deploy):

```mermaid
flowchart LR
  subgraph Pi["Venue Pi (node-server)"]
    T[Till writes:<br/>order / item / print-status] -->|recordOutboxEvents #176| OB[(sales_sync_outbox<br/>pending = synced_at NULL)]
    OB -->|pushPendingOutbox #177<br/>poll + backoff| P{online?}
  end
  P -->|POST /sync/ingest<br/>x-sync-key| IN[applyOutboxEvents #178<br/>idempotent upsert by nanoid]
  IN --> D[(Cloud D1 mirror<br/>orders / items / print-status)]
  IN -->|applied[] / skipped[]| P
  P -->|set synced_at on acked| OB
```

### #176 — capture (`51d1a12`)
- Package-owned `sales_sync_outbox` table (crouton-flow pattern: `server/database/schema.ts` + `server/db/schema.ts` re-export → NuxtHub auto-discovers; package migration `0001_*` + generated fanfare `0014_*`). One row per entity change, keyed by the entity's existing nanoid; `seq` = monotonic cursor, `synced_at NULL` = pending.
- `recordOutboxEvents()` wired into the existing mutation paths: order + items (`orders/index.post.ts`), print-job create (`generate-print-queues.ts`, `printData` omitted to keep events KB), done/failed + order status flip (`print-job-complete.ts`). Best-effort: errors logged & swallowed, never blocks the till.

### #178 — cloud ingest (`b7e6e60`)
- `POST /api/crouton-sales/sync/ingest` → `applyOutboxEvents()`: idempotent upsert by nanoid into `salesOrders`/`salesOrderitems`/`salesPrintqueues` (UPDATE-by-id, INSERT only when absent). Partial transitions update only their fields; JSON timestamps revived to `Date`; per-event isolation (malformed ⇒ permanent skip, transition-before-create ⇒ retryable skip). Returns `{ applied, skipped[{id,reason,permanent}] }`. No order-number assignment (Pi-local).
- `requireCloudSyncKey()`: fail-closed `x-sync-key` vs `croutonSales.cloudSyncSecret` — unset ⇒ 503, wrong ⇒ 401 (the only writer of mirrored data must never default to open).

### #177 — push loop (`2d9307b`)
- Gated Nitro plugin (mirrors the escpos-drainer): self-chained `setTimeout` (no overlap), full batch reschedules in 50ms (bursts drain in seconds), exponential backoff to 60s on failure, resumes on reconnect.
- `pushPendingOutbox()`: drains pending rows by `seq`, POSTs to the ingest, sets `synced_at` on acked + permanent skips (drops poison), leaves non-permanent skips pending. Idempotent downstream, so an uncertain push re-sends harmlessly.

### Also
- `docs(root)`: new `db-migrations` skill (`1152dd5`, `47d474f`) capturing the package-owned-table pattern + the `schema.mjs`-only-after-build `db:generate` gotcha discovered here.

## 🧪 Verification
- `pnpm --filter fanfare typecheck`: clean for all new code (pre-existing charts/core errors untouched).
- Functional tests (real drizzle + better-sqlite3): #176 → one pending row per entity, monotonic cursor, ack drops it; #178 → replay keeps counts at 1/1/1, partial update preserves siblings, malformed doesn't abort the batch; #177 → drains to empty online, stays pending + backs off offline, drops poison, idle when empty.

## Deploy/runtime contract (for the Pi + cloud)
- `CROUTON_SALES_CLOUD_SYNC=1` on the Pi (enables capture + pusher)
- `CROUTON_SALES_CLOUD_SYNC_URL=https://<app>.friendlyinter.net/api/crouton-sales/sync/ingest`
- shared `NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET` on both ends

## Scope
Closes #176
Closes #177
Closes #178

Epic #175 stays open — only #179 (the online dashboard that reads this mirror) remains.

https://claude.ai/code/session_01E2n8D2dhxs93vPfdarL2Rm