### PR TITLE
feat(crouton-sales): online live dashboard over the D1 mirror (#179)

### DIFF
--- a/apps/fanfare/server/db/migrations/sqlite/0015_workable_metal_master.sql
+++ b/apps/fanfare/server/db/migrations/sqlite/0015_workable_metal_master.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `sales_sync_status` (
+	`id` text PRIMARY KEY NOT NULL,
+	`last_contact_at` integer,
+	`last_event_at` integer,
+	`last_batch_applied` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/apps/fanfare/server/db/migrations/sqlite/meta/0015_snapshot.json
+++ b/apps/fanfare/server/db/migrations/sqlite/meta/0015_snapshot.json
@@ -1,0 +1,3625 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f1e85289-017e-4f23-afe5-12bdc598fc93",
+  "prevId": "275f18c2-cbe3-48ac-a681-38057278d74a",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "account_provider_idx": {
+          "name": "account_provider_idx",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_email_log": {
+      "name": "auth_email_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailType": {
+          "name": "emailType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_email_log_org_idx": {
+          "name": "auth_email_log_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_type_idx": {
+          "name": "auth_email_log_type_idx",
+          "columns": [
+            "emailType"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_status_idx": {
+          "name": "auth_email_log_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_recipient_idx": {
+          "name": "auth_email_log_recipient_idx",
+          "columns": [
+            "recipientEmail"
+          ],
+          "isUnique": false
+        },
+        "auth_email_log_created_idx": {
+          "name": "auth_email_log_created_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crouton_redirects": {
+      "name": "crouton_redirects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fromPath": {
+          "name": "fromPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toPath": {
+          "name": "toPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crouton_redirects_team_from_path_idx": {
+          "name": "crouton_redirects_team_from_path_idx",
+          "columns": [
+            "teamId",
+            "fromPath"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "domain": {
+      "name": "domain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verificationToken": {
+          "name": "verificationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "domain_domain_unique": {
+          "name": "domain_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        },
+        "domain_org_idx": {
+          "name": "domain_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "domain_domain_idx": {
+          "name": "domain_domain_idx",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "domain_status_idx": {
+          "name": "domain_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "domain_organizationId_organization_id_fk": {
+          "name": "domain_organizationId_organization_id_fk",
+          "tableFrom": "domain",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_org_idx": {
+          "name": "invitation_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviterId_user_id_fk": {
+          "name": "invitation_inviterId_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organizationId_organization_id_fk": {
+          "name": "invitation_organizationId_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_user_idx": {
+          "name": "member_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "member_org_idx": {
+          "name": "member_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "member_user_org_idx": {
+          "name": "member_user_org_idx",
+          "columns": [
+            "userId",
+            "organizationId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_userId_user_id_fk": {
+          "name": "member_userId_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organizationId_organization_id_fk": {
+          "name": "member_organizationId_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "personal": {
+          "name": "personal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_idx": {
+          "name": "organization_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "organization_owner_idx": {
+          "name": "organization_owner_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "organization_default_idx": {
+          "name": "organization_default_idx",
+          "columns": [
+            "isDefault"
+          ],
+          "isUnique": false
+        },
+        "organization_personal_idx": {
+          "name": "organization_personal_idx",
+          "columns": [
+            "personal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages_pages": {
+      "name": "pages_pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pageType": {
+          "name": "pageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "showInNavigation": {
+          "name": "showInNavigation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seoTitle": {
+          "name": "seoTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seoDescription": {
+          "name": "seoDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ogImage": {
+          "name": "ogImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "robots": {
+          "name": "robots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_pages_team_slug_idx": {
+          "name": "pages_pages_team_slug_idx",
+          "columns": [
+            "teamId",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_credentialID_unique": {
+          "name": "passkey_credentialID_unique",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": true
+        },
+        "passkey_user_idx": {
+          "name": "passkey_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "passkey_credential_idx": {
+          "name": "passkey_credential_idx",
+          "columns": [
+            "credentialID"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_categories": {
+      "name": "sales_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayOrder": {
+          "name": "displayOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_clients": {
+      "name": "sales_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isReusable": {
+          "name": "isReusable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_events": {
+      "name": "sales_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isCurrent": {
+          "name": "isCurrent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiresClient": {
+          "name": "requiresClient",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "helperPin": {
+          "name": "helperPin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sales_events_team_slug_idx": {
+          "name": "sales_events_team_slug_idx",
+          "columns": [
+            "teamId",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_eventsettings": {
+      "name": "sales_eventsettings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settingKey": {
+          "name": "settingKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settingValue": {
+          "name": "settingValue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_kdsbumps": {
+      "name": "sales_kdsbumps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_locations": {
+      "name": "sales_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_orderitems": {
+      "name": "sales_orderitems",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unitPrice": {
+          "name": "unitPrice",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totalPrice": {
+          "name": "totalPrice",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selectedOptions": {
+          "name": "selectedOptions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_orders": {
+      "name": "sales_orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventOrderNumber": {
+          "name": "eventOrderNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "overallRemarks": {
+          "name": "overallRemarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationRemarks": {
+          "name": "locationRemarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isPersonnel": {
+          "name": "isPersonnel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_printers": {
+      "name": "sales_printers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "driver": {
+          "name": "driver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "showPrices": {
+          "name": "showPrices",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_printqueues": {
+      "name": "sales_printqueues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printerId": {
+          "name": "printerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printData": {
+          "name": "printData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printMode": {
+          "name": "printMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retryCount": {
+          "name": "retryCount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_products": {
+      "name": "sales_products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requiresRemark": {
+          "name": "requiresRemark",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remarkPrompt": {
+          "name": "remarkPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hasOptions": {
+          "name": "hasOptions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "multipleOptionsAllowed": {
+          "name": "multipleOptionsAllowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_sync_outbox": {
+      "name": "sales_sync_outbox",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sales_sync_outbox_pending": {
+          "name": "idx_sales_sync_outbox_pending",
+          "columns": [
+            "synced_at",
+            "seq"
+          ],
+          "isUnique": false
+        },
+        "idx_sales_sync_outbox_entity": {
+          "name": "idx_sales_sync_outbox_entity",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sales_sync_status": {
+      "name": "sales_sync_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_contact_at": {
+          "name": "last_contact_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_batch_applied": {
+          "name": "last_batch_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scopedAccessGrant": {
+      "name": "scopedAccessGrant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "credentialType": {
+          "name": "credentialType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pin'"
+        },
+        "secretHash": {
+          "name": "secretHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "maxUses": {
+          "name": "maxUses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usedCount": {
+          "name": "usedCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokenTtl": {
+          "name": "tokenTtl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 28800000
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scoped_grant_resource_idx": {
+          "name": "scoped_grant_resource_idx",
+          "columns": [
+            "resourceType",
+            "resourceId"
+          ],
+          "isUnique": false
+        },
+        "scoped_grant_org_idx": {
+          "name": "scoped_grant_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "scoped_grant_active_idx": {
+          "name": "scoped_grant_active_idx",
+          "columns": [
+            "isActive",
+            "expiresAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scopedAccessGrant_organizationId_organization_id_fk": {
+          "name": "scopedAccessGrant_organizationId_organization_id_fk",
+          "tableFrom": "scopedAccessGrant",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scopedAccessToken": {
+      "name": "scopedAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scopedAccessToken_token_unique": {
+          "name": "scopedAccessToken_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "scoped_access_token_idx": {
+          "name": "scoped_access_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "scoped_access_org_idx": {
+          "name": "scoped_access_org_idx",
+          "columns": [
+            "organizationId"
+          ],
+          "isUnique": false
+        },
+        "scoped_access_resource_idx": {
+          "name": "scoped_access_resource_idx",
+          "columns": [
+            "resourceType",
+            "resourceId"
+          ],
+          "isUnique": false
+        },
+        "scoped_access_active_idx": {
+          "name": "scoped_access_active_idx",
+          "columns": [
+            "isActive",
+            "expiresAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scopedAccessToken_organizationId_organization_id_fk": {
+          "name": "scopedAccessToken_organizationId_organization_id_fk",
+          "tableFrom": "scopedAccessToken",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "impersonatingFrom": {
+          "name": "impersonatingFrom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        },
+        "session_active_org_idx": {
+          "name": "session_active_org_idx",
+          "columns": [
+            "activeOrganizationId"
+          ],
+          "isUnique": false
+        },
+        "session_impersonating_idx": {
+          "name": "session_impersonating_idx",
+          "columns": [
+            "impersonatingFrom"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscription": {
+      "name": "subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'incomplete'"
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trialStart": {
+          "name": "trialStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trialEnd": {
+          "name": "trialEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscription_reference_idx": {
+          "name": "subscription_reference_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "subscription_stripe_idx": {
+          "name": "subscription_stripe_idx",
+          "columns": [
+            "stripeSubscriptionId"
+          ],
+          "isUnique": false
+        },
+        "subscription_status_idx": {
+          "name": "subscription_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_settings": {
+      "name": "team_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "translations": {
+          "name": "translations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_settings": {
+          "name": "ai_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme_settings": {
+          "name": "theme_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_settings": {
+          "name": "site_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_settings": {
+          "name": "email_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notion_settings": {
+          "name": "notion_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_settings_team_id_unique": {
+          "name": "team_settings_team_id_unique",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true
+        },
+        "team_settings_team_idx": {
+          "name": "team_settings_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_settings_team_id_organization_id_fk": {
+          "name": "team_settings_team_id_organization_id_fk",
+          "tableFrom": "team_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translations_ui": {
+      "name": "translations_ui",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ui'"
+        },
+        "key_path": {
+          "name": "key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "values": {
+          "name": "values",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_overrideable": {
+          "name": "is_overrideable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translations_ui_team_id_namespace_key_path_unique": {
+          "name": "translations_ui_team_id_namespace_key_path_unique",
+          "columns": [
+            "team_id",
+            "namespace",
+            "key_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twoFactor": {
+      "name": "twoFactor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_idx": {
+          "name": "two_factor_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "twoFactor_userId_user_id_fk": {
+          "name": "twoFactor_userId_user_id_fk",
+          "tableFrom": "twoFactor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superAdmin": {
+          "name": "superAdmin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bannedUntil": {
+          "name": "bannedUntil",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "user_stripe_customer_idx": {
+          "name": "user_stripe_customer_idx",
+          "columns": [
+            "stripeCustomerId"
+          ],
+          "isUnique": false
+        },
+        "user_super_admin_idx": {
+          "name": "user_super_admin_idx",
+          "columns": [
+            "superAdmin"
+          ],
+          "isUnique": false
+        },
+        "user_banned_idx": {
+          "name": "user_banned_idx",
+          "columns": [
+            "banned"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_profile_userId_unique": {
+          "name": "user_profile_userId_unique",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": true
+        },
+        "user_profile_user_idx": {
+          "name": "user_profile_user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_profile_userId_user_id_fk": {
+          "name": "user_profile_userId_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/fanfare/server/db/migrations/sqlite/meta/_journal.json
+++ b/apps/fanfare/server/db/migrations/sqlite/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1781548812527,
       "tag": "0014_gifted_chronomancer",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1781590867377,
+      "tag": "0015_workable_metal_master",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -20,12 +20,17 @@ Event-based Point of Sale (POS) system for Nuxt Crouton. Provides products, cate
 | `server/utils/sync-outbox.ts` | Pi-side capture for the D1 live mirror (#176) — `recordOutboxEvents()` + `isCloudSyncEnabled()`; gated by `CROUTON_SALES_CLOUD_SYNC` |
 | `server/utils/sync-ingest.ts` | Cloud-side apply (#178) — `applyOutboxEvents()` idempotent upsert by nanoid |
 | `server/utils/cloud-sync-auth.ts` | Fail-closed `x-sync-key` auth for the ingest (#178) |
-| `server/utils/cloud-sync-pusher.ts` | Pi-side push loop (#177) — `pushPendingOutbox()` drains outbox → ingest |
-| `server/plugins/cloud-sync-pusher.ts` | Nitro plugin running the push loop (gated, backoff) |
-| `server/api/crouton-sales/sync/ingest.post.ts` | Cloud D1 ingest endpoint (#178) |
-| `server/database/schema.ts` | Package-owned Drizzle schema: `salesSyncOutbox` (`sales_sync_outbox` table) |
-| `server/db/schema.ts` | Re-export NuxtHub scans so consuming apps auto-pick-up `sales_sync_outbox` in `db:generate` |
+| `server/utils/cloud-sync-pusher.ts` | Pi-side push loop (#177) — `pushPendingOutbox()` drains outbox → ingest; `pingHeartbeat()` idle empty-batch ping (#179) |
+| `server/plugins/cloud-sync-pusher.ts` | Nitro plugin running the push loop (gated, backoff) + idle heartbeat ping (#179) |
+| `server/utils/sync-status.ts` | Cloud-side freshness heartbeat (#179) — `recordSyncHeartbeat()` (best-effort upsert on every ingest) + `readSyncStatus()` |
+| `server/api/crouton-sales/sync/ingest.post.ts` | Cloud D1 ingest endpoint (#178); also stamps the freshness heartbeat (#179) |
+| `server/api/crouton-sales/teams/[id]/sync-status.get.ts` | Live-dashboard freshness read (#179) — `{ lastContactAt, lastEventAt, lastBatchApplied, serverNow }` |
+| `app/components/Sync/Status.vue` | `SalesSyncStatus` — mirror freshness banner (#179): "synced Xs ago" / stale, polls sync-status |
+| `app/components/Dashboard/SalesSummary.vue` | `SalesDashboardSalesSummary` — live revenue/orders/avg + top products (#179), built on the chart endpoints |
+| `server/database/schema.ts` | Package-owned Drizzle schema: `salesSyncOutbox` (`sales_sync_outbox`) + `salesSyncStatus` (`sales_sync_status`, #179 heartbeat) |
+| `server/db/schema.ts` | Re-export NuxtHub scans so consuming apps auto-pick-up `sales_sync_outbox` + `sales_sync_status` in `db:generate` |
 | `server/database/migrations/0001_sales_sync_outbox.sql` | Package migration creating `sales_sync_outbox` |
+| `server/database/migrations/0002_sales_sync_status.sql` | Package migration creating `sales_sync_status` (#179 heartbeat) |
 | `schemas/` | JSON schema files for crouton generate |
 | `seed/index.ts` | Seed provider (`@fyit/crouton-sales/seed`) — event `vlaamsekermis` (PIN `1234`) + categories/products + a scoped kassa demo page |
 
@@ -333,7 +338,8 @@ All package endpoints live under `/api/crouton-sales/` with an explicit split:
 | `teams/[id]/events/[eventId]/admin-helper-token` POST | team member | Issue a helper scoped-access token without PIN (displayName = user name) — lets logged-in admins open the POS directly |
 | `teams/[id]/events/[eventId]/active-helpers` GET | team admin | List currently-logged-in helpers for one event |
 | `teams/[id]/active-helpers` GET | team admin | List active helpers across all team events |
-| `sync/ingest` POST | `x-sync-key` secret (fail-closed) | Cloud D1 ingest (#178): idempotent upsert of batched outbox events from the Pi pusher. See "Cloud ingest" above |
+| `sync/ingest` POST | `x-sync-key` secret (fail-closed) | Cloud D1 ingest (#178): idempotent upsert of batched outbox events from the Pi pusher. See "Cloud ingest" above. Also stamps the freshness heartbeat (#179) on every call (real batch or idle ping) |
+| `teams/[id]/sync-status` GET | team member | Mirror freshness for the live dashboard (#179): `{ lastContactAt, lastEventAt, lastBatchApplied, serverNow }` (epoch ms; `serverNow` lets the client compute age skew-free). Single global heartbeat row; backs `SalesSyncStatus` |
 | `teams/[id]/events/[eventId]/receipt-settings` GET/PUT | team admin | Per-event receipt text customization. Reachability: `staff_order_header` prints only on `isPersonnel` orders (Cart's Staff order switch); `special_instructions_title` heads the remark blocks on kitchen tickets — the per-location remarks from the POS and legacy whole-order notes; `footer_text` only on `type: 'receipt'` printer jobs |
 | `teams/[id]/events/[eventId]/printqueues/retry-failed` POST | team admin | Requeue missed print jobs (status 9, plus jobs stuck at status 1 "printing" for >2 min — fetched by the spooler but never confirmed) back to 0; optional body `{ printerId }` and/or `{ jobId }` (single-line retry). Backs the "Resend failed jobs" button in SettingsTab's printers card and the per-job re-print button in the expanded order |
 | `events/[eventId]/order-data` GET | helper token | All data needed by POS UI (categories are event-scoped — team-wide fetching showed duplicate tabs after event duplication) |
@@ -485,6 +491,37 @@ The Pi-side background loop that actually sends the outbox up to the cloud.
   nanoid downstream, so a push that's uncertain (network dropped after apply) is
   re-sent harmlessly and converges. `fetcher` option is injectable for tests.
 
+### Online dashboard + freshness heartbeat (#179)
+
+The cloud-side read view that closes epic #175: **"see the venue's live data
+online."** A mirror row reveals nothing about *when* it arrived, so the
+dashboard's defining feature is a **freshness signal** — is the Pi connected and
+syncing now, or is this a stale snapshot?
+
+- **Heartbeat table `sales_sync_status`** (`server/database/schema.ts`,
+  package-owned, migration `0002`). A **single global row** (`id = 'live'`): one
+  venue Pi → one cloud deploy, so a per-team key would only complicate the idle
+  ping (which carries no team). Multi-tenant keying is a noted follow-up.
+- **`recordSyncHeartbeat()`** (`server/utils/sync-status.ts`) — the ingest
+  endpoint stamps it on **every** call: `lastContactAt` always advances (data
+  batch OR idle ping → liveness clock), `lastEventAt` + `lastBatchApplied` only
+  when real data landed. **Best-effort** (swallows its own errors): a heartbeat
+  write can never fail an otherwise-successful ingest.
+- **Idle ping** — `pingHeartbeat()` POSTs an empty `{ events: [] }`; the pusher
+  plugin fires it only when nothing is pending **and** `CROUTON_SALES_CLOUD_SYNC_HEARTBEAT_MS`
+  (default 30000) has elapsed since the last contact. Without it, an online-but-
+  quiet till (no orders to push) would look offline. A real push already
+  refreshes the same clock, so the ping is purely a no-traffic keepalive.
+- **Read** — `GET teams/[id]/sync-status` (team member) returns the heartbeat as
+  epoch-ms plus `serverNow` so the client computes age **against the server
+  clock** (skew-proof). Backs `SalesSyncStatus`.
+- **UI** — `salesLiveDashboardBlock` composes `SalesSyncStatus` (green "Live ·
+  synced Xs ago" → amber "Stale · last synced … — the till may be offline" once
+  age ≥ 90s ≈ 3 missed pings), `SalesDashboardSalesSummary` (revenue/orders/avg +
+  top products off the chart endpoints), and the workspace `OrdersTab` live list.
+  All read the same mirrored tables the ingest writes; the orders list's existing
+  2s poll already reflects a successful sync within seconds.
+
 ## Configuration
 
 ```typescript
@@ -556,6 +593,7 @@ the event field's `propertyComponents` editor.
 | `eventWorkspaceBlock` | `SalesBlocksEventWorkspaceView` | `SalesBlocksEventWorkspaceRender` | **The single sales surface for CMS pages — one block, two faces by session.** Anonymous visitors (volunteers) get the kassa only: `<SalesPosPanel>` with inline helper PIN login (this absorbed the removed `orderInterfaceBlock`, incl. its `height` attr — compact/tall/fill, fill grows to the viewport bottom; the height applies to the volunteer kassa only, and **phones (`max-width: 639px`) ignore the attr: the kassa becomes a fixed inset-0 full-screen takeover** with `env(safe-area-inset-top/bottom)` paddings — header under the status bar, cart bar above iOS Safari's floating bottom bar. The layer's `app/plugins/viewport-meta.ts` sets `viewport-fit=cover` (env() insets) + `maximum-scale=1` (suppresses iOS input-focus auto-zoom; pinch still works) via `useHead` — a layer nuxt.config's `app.head` cannot override Nuxt's default viewport meta). Signed-in team members get the full workspace shell (`<SalesEventWorkspaceShell>` — kassa + settings/orders/clients panes; `useAuth().loggedIn` is the discriminator), switcher hidden (event fixed by the editor), header shown for the toggles — **inline only on a wide screen**. On phones/tablets (`max-width: 1023px`, matching Shell's own breakpoint) the inline shell is cramped in the scrolling CMS page, so members instead get the same "Open kassa" launcher → fullscreen modal as volunteers, but the modal hosts the **workspace shell** (with an added close button), not the POS panel (`showInlineShell = loggedIn && !isNarrow`). The shell uses top-level `await`, so the renderer wraps it in its own `<Suspense>` (inline and in the modal). Carries `providesScope: true`: on a `scoped` page the derive-scope hook gates the page behind the event's helper PIN (one login, adopted by the panel) and the page editor hides the access-code field; `EventSlugPicker` warns inline when the picked event has no `helperPin`. category `kassa`. |
 | `salesOrdersBlock` | `SalesBlocksOrdersView` | `SalesBlocksOrdersRender` | **Standalone Orders list** — one event's live orders (the same view as the workspace's "Bestellingen" pane: filters + per-order printer LEDs) on its own CMS page, so an admin can build a dedicated orders / kitchen-status screen without the rest of the register. **Team-members-only**: the renderer gates on `useAuth().loggedIn` (orders come from team-scoped admin endpoints) — non-members get a hint, not an error. The event is resolved member-side via the shared `SalesBlocksEventResolver` (a slot component that `await`s `useCollectionQuery('salesEvents')` and hands the full `SalesEvent` to its slot), which the renderer wraps in `<Suspense>` along with the async-setup `SalesEventWorkspaceOrdersTab`. Editor fixes the event by slug (`EventSlugPicker`). `clientOnly`; category `kassa`. |
 | `salesClientsBlock` | `SalesBlocksClientsView` | `SalesBlocksClientsRender` | **Standalone Clients list** — one event's open client tabs (the same view as the workspace's "Klanten" pane: active clients with the two-step settle / print-receipt action) on its own CMS page. **Team-members-only** (renderer gates on `useAuth().loggedIn`) and only meaningful for **recurring-client events** — a member on a non-`requiresClient` event gets an explanatory note. Resolves the event member-side via the shared `SalesBlocksEventResolver` inside `<Suspense>`, then renders `SalesEventWorkspaceClientsPanel`. Editor fixes the event by slug (`EventSlugPicker`). `clientOnly`; category `kassa`. |
+| `salesLiveDashboardBlock` | `SalesBlocksLiveDashboardView` | `SalesBlocksLiveDashboardRender` | **Live Dashboard (#179, epic #175 — D1 live mirror)** — "see the venue's live data online": one event's mirror-fresh orders + sales on a CMS page, read from the Cloudflare D1 mirror. Deliberately a **composition** of existing pieces: a `SalesSyncStatus` freshness banner (the only new-to-#179 part — "synced Xs ago" / goes stale when the Pi is offline), a `SalesDashboardSalesSummary` (revenue/orders/avg + top products, on the chart endpoints), and the workspace `SalesEventWorkspaceOrdersTab` live orders list. **Team-members-only** (renderer gates on `useAuth().loggedIn` — mirror data is team-scoped); event resolved member-side via `SalesBlocksEventResolver` inside `<Suspense>`. Editor fixes event by slug + optional `title`. `clientOnly`; category `data`. |
 | `salesChartBlock` | `SalesBlocksChartBlockView` | `SalesBlocksChartBlockRender` | Sales analytics chart. Editor picks a chart kind + event scope (one event or All events). Renders via `CroutonChartsWidget` **only when `@fyit/crouton-charts` is installed** (`hasApp('charts')` guard); otherwise shows a "Charts package required" notice. In the admin editor the renderer shows a static placeholder (vue-chrts can't survive the property-panel live preview); the real chart renders on the public page. |
 | `salesProductMatrixBlock` | `SalesBlocksProductMatrixView` | `SalesBlocksProductMatrixRender` | Pivot **table** (Nuxt UI `UTable`): rows = products, columns = days, last column = Total, with an interactive Units/Revenue toggle. No charts dependency. Data from `product-day-matrix`. |
 | `kitchenDisplayBlock` | `SalesBlocksKitchenDisplayView` | `SalesBlocksKitchenDisplayRender` | **Kitchen Display (KDS)** — a drop-on-a-page screen (typically an iPad), **decoupled from printers** (#61/#117). The editor fixes the event by slug (`EventSlugPicker`) and optionally which locations to show (`LocationsPicker`); the renderer resolves the slug to an id via the public `by-slug` endpoint (same as `SalesPosPanel`), then **reads orders directly** off the `display-jobs` GET — one ticket per `(order × location)`, polled every 2s, NOT off `salesPrintqueues`. "Bump" POSTs `kds-bump` (per-`(order, location)` row in `salesKdsbumps`; optimistic local hide). `clientOnly`; category `kassa`. Not a separate `/kds` app route — the block is the only surface. |

--- a/packages/crouton-sales/app/app.config.ts
+++ b/packages/crouton-sales/app/app.config.ts
@@ -207,6 +207,56 @@ const eventWorkspaceBlock: CroutonBlockDefinition = {
   }
 }
 
+// Live Dashboard for crouton-pages (#179, epic #175 — D1 live mirror): one
+// event's mirror-fresh orders + sales, read from the Cloudflare D1 mirror. A
+// composition of existing pieces — a mirror-freshness banner (the only new
+// part), a sales summary on the chart endpoints, and the workspace orders list
+// — so an admin can open a browser anywhere and watch the venue live, with a
+// clear "last synced" indicator that goes stale when the Pi is offline.
+// Team-members-only (the renderer gates on useAuth().loggedIn — mirror data is
+// team-scoped). The editor fixes the event by slug. name/description and field
+// labels are i18n keys (see i18n/locales/*.json).
+const salesLiveDashboardBlock: CroutonBlockDefinition = {
+  type: 'salesLiveDashboardBlock',
+  name: 'sales.blocks.liveDashboard.name',
+  description: 'sales.blocks.liveDashboard.description',
+  icon: 'i-lucide-layout-dashboard',
+  category: 'data',
+  clientOnly: true,
+  defaultAttrs: {
+    eventSlug: '',
+    title: ''
+  },
+  components: {
+    editorView: 'SalesBlocksLiveDashboardView',
+    renderer: 'SalesBlocksLiveDashboardRender'
+  },
+  propertyComponents: {
+    eventSlug: 'SalesBlocksPropertiesEventSlugPicker'
+  },
+  schema: [
+    {
+      name: 'eventSlug',
+      type: 'eventSlug',
+      label: 'sales.blocks.liveDashboard.fields.eventSlug.label',
+      description: 'sales.blocks.liveDashboard.fields.eventSlug.description'
+    },
+    {
+      name: 'title',
+      type: 'text',
+      label: 'sales.blocks.liveDashboard.fields.title.label',
+      description: 'sales.blocks.liveDashboard.fields.title.description'
+    }
+  ],
+  tiptap: {
+    parseHTMLTag: 'div[data-type="sales-live-dashboard-block"]',
+    attributes: {
+      eventSlug: { default: '' },
+      title: { default: '' }
+    }
+  }
+}
+
 // Standalone Orders block for crouton-pages: one event's live orders list
 // (the same view as the workspace "Bestellingen" pane) on its own page, so an
 // admin can build a dedicated orders / kitchen-status screen. Team-members-only
@@ -435,6 +485,7 @@ export default defineAppConfig({
   },
   croutonBlocks: {
     eventWorkspaceBlock,
+    salesLiveDashboardBlock,
     salesOrdersBlock,
     salesClientsBlock,
     kitchenDisplayBlock,

--- a/packages/crouton-sales/app/components/Blocks/LiveDashboardRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/LiveDashboardRender.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+/**
+ * Live Dashboard block — public renderer (#179, epic #175 — D1 live mirror).
+ *
+ * The "see the venue's live data online" surface: one event's mirror-fresh
+ * orders + sales, read from the Cloudflare D1 mirror. It is deliberately a
+ * composition of pieces that already exist — a mirror-freshness banner
+ * (SalesSyncStatus), a sales summary built on the chart endpoints
+ * (SalesDashboardSalesSummary), and the same live orders list as the workspace
+ * "Bestellingen" pane (SalesEventWorkspaceOrdersTab). The only thing new to
+ * #179 is the freshness banner that makes the mirror nature explicit.
+ *
+ * Team-members-only: the orders + chart data come from team-scoped admin
+ * endpoints, so anyone not signed in as a team member gets a hint, not an error
+ * (same posture as salesOrdersBlock). The event is resolved member-side via the
+ * shared SalesBlocksEventResolver inside <Suspense> (it and OrdersTab both
+ * top-level await). clientOnly — BlockContent wraps us in <ClientOnly>.
+ */
+interface LiveDashboardAttrs {
+  eventSlug?: string
+  title?: string
+}
+
+const props = defineProps<{ attrs: LiveDashboardAttrs }>()
+
+const { t } = useT()
+const { loggedIn } = useAuth()
+const route = useRoute()
+
+const eventSlug = computed(() => props.attrs.eventSlug || '')
+const teamParam = computed(() => String(route.params.team || ''))
+</script>
+
+<template>
+  <div class="sales-live-dashboard-block">
+    <!-- Editor didn't pick an event -->
+    <div
+      v-if="!eventSlug"
+      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
+    >
+      <UIcon name="i-lucide-layout-dashboard" class="w-6 h-6 mx-auto mb-2 text-muted" />
+      {{ t('sales.block.noEventPicked') }}
+    </div>
+
+    <!-- Team-members-only: anonymous visitors don't see mirrored data. -->
+    <div
+      v-else-if="!loggedIn"
+      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
+    >
+      <UIcon name="i-lucide-lock" class="w-6 h-6 mx-auto mb-2 text-muted" />
+      {{ t('sales.blocks.liveDashboard.ui.teamOnly') }}
+    </div>
+
+    <!-- Signed-in team member → the live dashboard. -->
+    <div v-else class="rounded-3xl bg-default p-6 space-y-6">
+      <Suspense>
+        <SalesBlocksEventResolver
+          v-slot="{ event }"
+          :event-slug="eventSlug"
+          :not-found-label="t('sales.blocks.liveDashboard.ui.eventNotFound')"
+        >
+          <!-- Header: event title + the mirror-freshness banner -->
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <h2 class="text-lg font-semibold">
+              {{ props.attrs.title || event.title || t('sales.blocks.liveDashboard.ui.defaultTitle') }}
+            </h2>
+            <SalesSyncStatus :team-param="teamParam" />
+          </div>
+
+          <!-- Sales summary (headline numbers + top products) -->
+          <SalesDashboardSalesSummary
+            :team-param="teamParam"
+            :event-id="event.id"
+            :currency="event.currency"
+          />
+
+          <!-- Live orders (same list as the workspace "Bestellingen" pane) -->
+          <div class="rounded-2xl border border-default bg-elevated/40 p-4">
+            <SalesEventWorkspaceOrdersTab :event="event" />
+          </div>
+        </SalesBlocksEventResolver>
+        <template #fallback>
+          <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
+        </template>
+      </Suspense>
+    </div>
+  </div>
+</template>

--- a/packages/crouton-sales/app/components/Blocks/LiveDashboardView.vue
+++ b/packages/crouton-sales/app/components/Blocks/LiveDashboardView.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+/**
+ * Live Dashboard block — editor view (#179, epic #175).
+ *
+ * NodeView component for the page editor: a static preview (freshness pill +
+ * stat tiles + mini orders list) with edit/delete controls; double-click opens
+ * the property panel. Like the other sales block views, uses explicit imports —
+ * VueNodeViewRenderer bypasses Nuxt auto-imports.
+ */
+import { computed, ref } from 'vue'
+import { NodeViewWrapper } from '@tiptap/vue-3'
+import { useI18n } from 'vue-i18n'
+
+interface LiveDashboardAttrs {
+  eventSlug?: string
+  title?: string
+}
+
+const props = defineProps<{
+  node: { attrs: LiveDashboardAttrs }
+  selected: boolean
+  updateAttributes: (attrs: Partial<LiveDashboardAttrs>) => void
+  deleteNode: () => void
+  getPos: () => number
+}>()
+
+const attrs = computed(() => props.node.attrs)
+const { t } = useI18n()
+
+const innerRef = ref<HTMLElement | null>(null)
+
+function findEditorId(): string | undefined {
+  let el: HTMLElement | null = innerRef.value
+  while (el) {
+    if (el.classList?.contains('crouton-editor-blocks') && el.dataset?.editorId) {
+      return el.dataset.editorId
+    }
+    el = el.parentElement
+  }
+  return undefined
+}
+
+function handleOpenPanel() {
+  const editorId = findEditorId()
+  const event = new CustomEvent('block-edit-request', {
+    bubbles: true,
+    detail: { node: props.node, pos: props.getPos(), editorId }
+  })
+  document.dispatchEvent(event)
+}
+</script>
+
+<template>
+  <NodeViewWrapper
+    class="block-wrapper my-1 cursor-pointer"
+    :class="{ 'border-l-2 border-l-primary/50': selected }"
+    data-type="sales-live-dashboard-block"
+    @dblclick="handleOpenPanel"
+  >
+    <div ref="innerRef" class="relative group rounded border border-transparent hover:border-gray-200/50 dark:hover:border-gray-700/50 transition-colors">
+      <div class="p-3">
+        <!-- Header -->
+        <div class="flex items-center justify-between mb-2">
+          <div class="flex items-center gap-2">
+            <span class="inline-flex items-center gap-1 text-[10px] font-medium text-gray-400 uppercase tracking-wider">
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="3" width="7" height="9" rx="1" />
+                <rect x="14" y="3" width="7" height="5" rx="1" />
+                <rect x="14" y="12" width="7" height="9" rx="1" />
+                <rect x="3" y="16" width="7" height="5" rx="1" />
+              </svg>
+              {{ t('sales.blocks.liveDashboard.name') }}
+            </span>
+            <span
+              v-if="attrs.eventSlug"
+              class="inline-flex items-center text-[9px] font-mono font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary"
+            >
+              {{ attrs.eventSlug }}
+            </span>
+            <span
+              v-else
+              class="inline-flex items-center text-[9px] font-medium px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+            >
+              {{ t('sales.block.noEventPicked') }}
+            </span>
+          </div>
+          <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
+            <button
+              type="button"
+              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+              :title="t('sales.block.editBlock')"
+              @click.stop="handleOpenPanel"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+              :title="t('sales.block.deleteBlock')"
+              @click.stop="deleteNode"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Preview: freshness pill + stat tiles + mini orders -->
+        <div class="bg-gray-50/50 dark:bg-gray-800/30 rounded-lg p-4 border border-gray-100 dark:border-gray-700/50 space-y-3">
+          <div class="flex items-center justify-end">
+            <span class="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 px-2 py-0.5 text-[9px] font-medium text-emerald-600 dark:text-emerald-400">
+              <span class="size-1.5 rounded-full bg-emerald-500" />
+              {{ t('sales.sync.live') }}
+            </span>
+          </div>
+          <div class="grid grid-cols-3 gap-2">
+            <div v-for="tile in 3" :key="tile" class="rounded-md bg-gray-200/60 dark:bg-gray-700/40 h-9" />
+          </div>
+          <div class="space-y-1.5">
+            <div v-for="row in 3" :key="row" class="flex items-center gap-2 h-5 rounded bg-gray-200/60 dark:bg-gray-700/40 px-2">
+              <span class="size-2 rounded-full bg-emerald-500/50 shrink-0" />
+              <span class="h-2 flex-1 rounded bg-gray-300/60 dark:bg-gray-600/40" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </NodeViewWrapper>
+</template>

--- a/packages/crouton-sales/app/components/Dashboard/SalesSummary.vue
+++ b/packages/crouton-sales/app/components/Dashboard/SalesSummary.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+/**
+ * Live sales summary for the online dashboard (#179, epic #175).
+ *
+ * The "sales" half of the dashboard: headline numbers + a top-products list for
+ * one event, read from the cloud D1 mirror via the existing team-scoped chart
+ * aggregation endpoints (revenue-by-day, orders-by-status, top-products) — no
+ * new server aggregation, just composition (KISS). Polls on a light cadence so
+ * it tracks freshly-mirrored orders without the 2s churn of the orders list.
+ *
+ * Auto-imported as <SalesDashboardSalesSummary>. Mount inside a clientOnly,
+ * team-members-only surface (the dashboard block) — the chart endpoints require
+ * team membership.
+ */
+interface RevenueRow { date: string, revenue: number }
+interface StatusRow { status: string, count: number }
+interface ProductRow { product: string, quantity: number }
+interface ChartResponse<T> { items: T[] }
+
+const props = withDefaults(defineProps<{
+  teamParam: string
+  eventId: string
+  /** Event currency for money formatting ('EUR' | 'USD'). */
+  currency?: string | null
+  /** Poll cadence for the summary numbers. */
+  pollMs?: number
+}>(), {
+  currency: 'EUR',
+  pollMs: 15000,
+})
+
+const { t } = useT()
+const { format } = useSalesCurrency(() => props.currency)
+
+const revenueRows = ref<RevenueRow[]>([])
+const statusRows = ref<StatusRow[]>([])
+const productRows = ref<ProductRow[]>([])
+const loaded = ref(false)
+
+const base = computed(() => `/api/crouton-sales/teams/${props.teamParam}/charts`)
+const query = computed(() => ({ eventId: props.eventId }))
+
+async function fetchAll() {
+  try {
+    const [rev, status, top] = await Promise.all([
+      $fetch<ChartResponse<RevenueRow>>(`${base.value}/revenue-by-day`, { query: query.value }),
+      $fetch<ChartResponse<StatusRow>>(`${base.value}/orders-by-status`, { query: query.value }),
+      $fetch<ChartResponse<ProductRow>>(`${base.value}/top-products`, { query: query.value }),
+    ])
+    revenueRows.value = rev.items ?? []
+    statusRows.value = status.items ?? []
+    productRows.value = top.items ?? []
+  }
+  catch {
+    // Transient (e.g. brief auth/network blip) — keep the last good numbers.
+  }
+  finally {
+    loaded.value = true
+  }
+}
+
+const totalRevenue = computed(() => revenueRows.value.reduce((s, r) => s + (Number(r.revenue) || 0), 0))
+const totalOrders = computed(() => statusRows.value.reduce((s, r) => s + (Number(r.count) || 0), 0))
+const avgOrder = computed(() => (totalOrders.value > 0 ? totalRevenue.value / totalOrders.value : 0))
+const topProducts = computed(() => productRows.value.slice(0, 5))
+const maxQty = computed(() => Math.max(1, ...topProducts.value.map(p => Number(p.quantity) || 0)))
+
+const stats = computed(() => [
+  { key: 'revenue', label: t('sales.dashboard.revenue'), value: format(totalRevenue.value), icon: 'i-lucide-banknote' },
+  { key: 'orders', label: t('sales.dashboard.orders'), value: String(totalOrders.value), icon: 'i-lucide-receipt' },
+  { key: 'avg', label: t('sales.dashboard.avgOrder'), value: format(avgOrder.value), icon: 'i-lucide-trending-up' },
+])
+
+onMounted(() => {
+  fetchAll()
+  useIntervalFn(fetchAll, props.pollMs)
+})
+</script>
+
+<template>
+  <div class="sales-dashboard-summary space-y-4">
+    <!-- Headline numbers -->
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <div
+        v-for="s in stats"
+        :key="s.key"
+        class="rounded-2xl border border-default bg-elevated/40 p-4"
+      >
+        <div class="flex items-center gap-2 text-muted text-xs font-medium uppercase tracking-wide">
+          <UIcon :name="s.icon" class="size-4" />
+          {{ s.label }}
+        </div>
+        <div class="mt-1.5 text-2xl font-semibold tabular-nums">{{ s.value }}</div>
+      </div>
+    </div>
+
+    <!-- Top products -->
+    <div class="rounded-2xl border border-default bg-elevated/40 p-4">
+      <div class="flex items-center gap-2 text-muted text-xs font-medium uppercase tracking-wide mb-3">
+        <UIcon name="i-lucide-trophy" class="size-4" />
+        {{ t('sales.dashboard.topProducts') }}
+      </div>
+
+      <p v-if="loaded && topProducts.length === 0" class="text-sm text-muted py-2">
+        {{ t('sales.dashboard.noSalesYet') }}
+      </p>
+
+      <ul v-else class="space-y-2">
+        <li v-for="p in topProducts" :key="p.product" class="flex items-center gap-3">
+          <span class="w-32 shrink-0 truncate text-sm">{{ p.product }}</span>
+          <span class="relative h-2 flex-1 overflow-hidden rounded-full bg-muted">
+            <span
+              class="absolute inset-y-0 left-0 rounded-full bg-primary transition-[width] duration-500"
+              :style="{ width: `${Math.round((Number(p.quantity) || 0) / maxQty * 100)}%` }"
+            />
+          </span>
+          <span class="w-8 shrink-0 text-right text-sm font-medium tabular-nums">{{ p.quantity }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/packages/crouton-sales/app/components/Sync/Status.vue
+++ b/packages/crouton-sales/app/components/Sync/Status.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+/**
+ * Mirror freshness banner (#179, epic #175 — D1 live mirror).
+ *
+ * The online dashboard reads a *copy* of the venue till, so it must make the
+ * mirror nature visible: this banner shows when the cloud last heard from the
+ * Pi ("synced 3s ago") and flips to a stale/offline state once that clock stops
+ * advancing. It polls the team-scoped sync-status endpoint, which the cloud
+ * ingest stamps on every push and every idle ping from the Pi.
+ *
+ * Clock skew is neutralised by anchoring age to the server's clock: each fetch
+ * returns `serverNow`, we capture the offset to the local clock once, and a 1s
+ * ticker re-derives the relative label without re-fetching.
+ *
+ * Auto-imported as <SalesSyncStatus>. Mount inside a clientOnly surface (the
+ * dashboard block) — it polls and uses live timers.
+ */
+interface SyncStatusResponse {
+  lastContactAt: number | null
+  lastEventAt: number | null
+  lastBatchApplied: number
+  serverNow: number
+}
+
+const props = withDefaults(defineProps<{
+  teamParam: string
+  /** Poll cadence for the status endpoint. */
+  pollMs?: number
+  /** Age beyond which the mirror is considered stale (Pi likely offline). */
+  staleMs?: number
+}>(), {
+  pollMs: 5000,
+  // The Pi pings at least every 30s when online; 90s = ~3 missed pings.
+  staleMs: 90000,
+})
+
+const { t } = useT()
+
+const data = ref<SyncStatusResponse | null>(null)
+const errored = ref(false)
+/** server clock − local clock, captured each fetch (handles device skew). */
+const clockOffset = ref(0)
+/** ticks every second so the relative label stays live between polls. */
+const nowTick = ref(Date.now())
+
+async function fetchStatus() {
+  try {
+    const res = await $fetch<SyncStatusResponse>(
+      `/api/crouton-sales/teams/${props.teamParam}/sync-status`,
+    )
+    data.value = res
+    clockOffset.value = res.serverNow - Date.now()
+    errored.value = false
+  }
+  catch {
+    errored.value = true
+  }
+}
+
+// Age of the last contact, in ms, against the server clock.
+const ageMs = computed(() => {
+  const last = data.value?.lastContactAt
+  if (!last) return null
+  return (nowTick.value + clockOffset.value) - last
+})
+
+type State = 'never' | 'live' | 'stale' | 'error'
+const state = computed<State>(() => {
+  if (errored.value && !data.value) return 'error'
+  if (!data.value?.lastContactAt) return 'never'
+  return (ageMs.value ?? Infinity) >= props.staleMs ? 'stale' : 'live'
+})
+
+// Compact relative label: "just now" / "12s ago" / "4m ago" / "2h ago".
+function relativeLabel(ms: number | null): string {
+  if (ms == null) return ''
+  const s = Math.max(0, Math.round(ms / 1000))
+  if (s < 5) return t('sales.sync.justNow')
+  if (s < 60) return t('sales.sync.secondsAgo', { n: s })
+  const m = Math.round(s / 60)
+  if (m < 60) return t('sales.sync.minutesAgo', { n: m })
+  const h = Math.round(m / 60)
+  return t('sales.sync.hoursAgo', { n: h })
+}
+
+const ui = computed(() => {
+  switch (state.value) {
+    case 'live':
+      return { dot: 'bg-emerald-500', pulse: true, color: 'text-emerald-600 dark:text-emerald-400',
+        label: t('sales.sync.live'), detail: t('sales.sync.syncedAgo', { ago: relativeLabel(ageMs.value) }) }
+    case 'stale':
+      return { dot: 'bg-amber-500', pulse: false, color: 'text-amber-600 dark:text-amber-400',
+        label: t('sales.sync.stale'), detail: t('sales.sync.staleDetail', { ago: relativeLabel(ageMs.value) }) }
+    case 'never':
+      return { dot: 'bg-gray-400', pulse: false, color: 'text-muted',
+        label: t('sales.sync.waiting'), detail: t('sales.sync.waitingDetail') }
+    default:
+      return { dot: 'bg-red-500', pulse: false, color: 'text-red-600 dark:text-red-400',
+        label: t('sales.sync.unavailable'), detail: t('sales.sync.unavailableDetail') }
+  }
+})
+
+onMounted(() => {
+  fetchStatus()
+  // Poll the endpoint, and tick a local clock every second for the label.
+  useIntervalFn(fetchStatus, props.pollMs)
+  useIntervalFn(() => { nowTick.value = Date.now() }, 1000)
+})
+</script>
+
+<template>
+  <div
+    class="sales-sync-status flex items-center gap-2.5 rounded-full border border-default bg-elevated/60 px-3.5 py-1.5 text-sm"
+    :title="ui.detail"
+  >
+    <span class="relative flex size-2.5 shrink-0">
+      <span
+        v-if="ui.pulse"
+        class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"
+        :class="ui.dot"
+      />
+      <span class="relative inline-flex size-2.5 rounded-full" :class="ui.dot" />
+    </span>
+    <span class="font-medium" :class="ui.color">{{ ui.label }}</span>
+    <span class="text-muted truncate">{{ ui.detail }}</span>
+  </div>
+</template>

--- a/packages/crouton-sales/i18n/locales/en.json
+++ b/packages/crouton-sales/i18n/locales/en.json
@@ -22,6 +22,25 @@
           }
         }
       },
+      "liveDashboard": {
+        "name": "Live Dashboard",
+        "description": "Watch one event's live orders and sales online, read from the cloud mirror — with a 'last synced' indicator that goes stale when the till is offline. For signed-in team members.",
+        "fields": {
+          "eventSlug": {
+            "label": "Event",
+            "description": "Pick which event's live data this dashboard shows."
+          },
+          "title": {
+            "label": "Title",
+            "description": "Optional heading above the dashboard (defaults to the event name)."
+          }
+        },
+        "ui": {
+          "teamOnly": "Sign in as a team member to view the live dashboard.",
+          "eventNotFound": "Event not found",
+          "defaultTitle": "Live dashboard"
+        }
+      },
       "salesChart": {
         "name": "Sales Chart",
         "description": "Embed a sales analytics chart for one event or the whole team",
@@ -164,6 +183,27 @@
     "admin": {
       "sectionTitle": "Point of Sale",
       "overview": "Overview"
+    },
+    "sync": {
+      "live": "Live",
+      "stale": "Stale",
+      "waiting": "Connecting",
+      "unavailable": "Status unavailable",
+      "justNow": "just now",
+      "secondsAgo": "{n}s ago",
+      "minutesAgo": "{n}m ago",
+      "hoursAgo": "{n}h ago",
+      "syncedAgo": "synced {ago}",
+      "staleDetail": "last synced {ago} — the till may be offline",
+      "waitingDetail": "waiting for the first sync from the till",
+      "unavailableDetail": "couldn't reach the sync status"
+    },
+    "dashboard": {
+      "revenue": "Revenue",
+      "orders": "Orders",
+      "avgOrder": "Avg. order",
+      "topProducts": "Top products",
+      "noSalesYet": "No sales yet"
     },
     "common": {
       "save": "Save",

--- a/packages/crouton-sales/i18n/locales/fr.json
+++ b/packages/crouton-sales/i18n/locales/fr.json
@@ -21,6 +21,25 @@
           }
         }
       },
+      "liveDashboard": {
+        "name": "Tableau de bord en direct",
+        "description": "Suivez en ligne les commandes et les ventes en direct d'un événement, lues depuis la copie cloud — avec un indicateur « dernière synchronisation » qui devient obsolète lorsque la caisse est hors ligne. Pour les membres de l'équipe connectés.",
+        "fields": {
+          "eventSlug": {
+            "label": "Événement",
+            "description": "Choisissez l'événement dont ce tableau de bord affiche les données en direct."
+          },
+          "title": {
+            "label": "Titre",
+            "description": "Titre facultatif au-dessus du tableau de bord (par défaut le nom de l'événement)."
+          }
+        },
+        "ui": {
+          "teamOnly": "Connectez-vous en tant que membre de l'équipe pour voir le tableau de bord en direct.",
+          "eventNotFound": "Événement introuvable",
+          "defaultTitle": "Tableau de bord en direct"
+        }
+      },
       "salesChart": {
         "name": "Graphique de ventes",
         "description": "Intégrer un graphique d'analyse des ventes pour un événement ou toute l'équipe",
@@ -163,6 +182,27 @@
     "admin": {
       "sectionTitle": "Point de vente",
       "overview": "Aperçu"
+    },
+    "sync": {
+      "live": "En direct",
+      "stale": "Obsolète",
+      "waiting": "Connexion",
+      "unavailable": "Statut indisponible",
+      "justNow": "à l'instant",
+      "secondsAgo": "il y a {n}s",
+      "minutesAgo": "il y a {n}min",
+      "hoursAgo": "il y a {n}h",
+      "syncedAgo": "synchronisé {ago}",
+      "staleDetail": "dernière synchronisation {ago} — la caisse est peut-être hors ligne",
+      "waitingDetail": "en attente de la première synchronisation depuis la caisse",
+      "unavailableDetail": "impossible d'obtenir le statut de synchronisation"
+    },
+    "dashboard": {
+      "revenue": "Chiffre d'affaires",
+      "orders": "Commandes",
+      "avgOrder": "Commande moy.",
+      "topProducts": "Meilleurs produits",
+      "noSalesYet": "Pas encore de ventes"
     },
     "common": {
       "save": "Enregistrer",

--- a/packages/crouton-sales/i18n/locales/nl.json
+++ b/packages/crouton-sales/i18n/locales/nl.json
@@ -22,6 +22,25 @@
           }
         }
       },
+      "liveDashboard": {
+        "name": "Live dashboard",
+        "description": "Volg de live bestellingen en verkoop van één evenement online, gelezen uit de cloud-kopie — met een 'laatst gesynchroniseerd'-indicator die verouderd wordt als de kassa offline is. Voor ingelogde teamleden.",
+        "fields": {
+          "eventSlug": {
+            "label": "Evenement",
+            "description": "Kies van welk evenement dit dashboard de live data toont."
+          },
+          "title": {
+            "label": "Titel",
+            "description": "Optionele kop boven het dashboard (standaard de naam van het evenement)."
+          }
+        },
+        "ui": {
+          "teamOnly": "Log in als teamlid om het live dashboard te bekijken.",
+          "eventNotFound": "Evenement niet gevonden",
+          "defaultTitle": "Live dashboard"
+        }
+      },
       "salesChart": {
         "name": "Verkoopgrafiek",
         "description": "Sluit een verkoopanalysegrafiek in voor één evenement of het hele team",
@@ -164,6 +183,27 @@
     "admin": {
       "sectionTitle": "Kassa",
       "overview": "Overzicht"
+    },
+    "sync": {
+      "live": "Live",
+      "stale": "Verouderd",
+      "waiting": "Verbinden",
+      "unavailable": "Status onbeschikbaar",
+      "justNow": "zojuist",
+      "secondsAgo": "{n}s geleden",
+      "minutesAgo": "{n}m geleden",
+      "hoursAgo": "{n}u geleden",
+      "syncedAgo": "gesynchroniseerd {ago}",
+      "staleDetail": "laatst gesynchroniseerd {ago} — de kassa is mogelijk offline",
+      "waitingDetail": "wachten op de eerste synchronisatie vanaf de kassa",
+      "unavailableDetail": "kon de synchronisatiestatus niet ophalen"
+    },
+    "dashboard": {
+      "revenue": "Omzet",
+      "orders": "Bestellingen",
+      "avgOrder": "Gem. bestelling",
+      "topProducts": "Topproducten",
+      "noSalesYet": "Nog geen verkoop"
     },
     "common": {
       "save": "Opslaan",

--- a/packages/crouton-sales/server/api/crouton-sales/sync/ingest.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/sync/ingest.post.ts
@@ -12,6 +12,7 @@
  */
 import { requireCloudSyncKey } from '../../../utils/cloud-sync-auth'
 import { applyOutboxEvents, type IngestEvent } from '../../../utils/sync-ingest'
+import { recordSyncHeartbeat } from '../../../utils/sync-status'
 
 interface IngestBody {
   events?: IngestEvent[]
@@ -27,6 +28,12 @@ export default defineEventHandler(async (event) => {
 
   const db = useDB()
   const result = await applyOutboxEvents(db, body.events)
+
+  // Stamp the freshness heartbeat the online dashboard (#179) reads. Advances on
+  // every call — a real batch or the pusher's idle ping (events: []) — so a
+  // quiet-but-online till still reads "connected". Best-effort: never fails the
+  // ingest (the mirrored data already landed; the clock is advisory).
+  await recordSyncHeartbeat(db, result.applied.length)
 
   return {
     received: body.events.length,

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/sync-status.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/sync-status.get.ts
@@ -1,0 +1,28 @@
+/**
+ * Sync status (freshness) endpoint for the online dashboard (#179, epic #175).
+ *
+ * Returns the cloud's D1-mirror heartbeat — when the venue Pi last checked in —
+ * so the live dashboard can render "last synced Xs ago" and flag staleness when
+ * the Pi is offline. Read-only; team-members-only (mirror data is team-scoped).
+ *
+ * `serverNow` is included so the client computes age against the *server's*
+ * clock, immune to device clock skew. The heartbeat is a single global row
+ * (one venue Pi → one cloud deploy), so this is team-gated for access but not
+ * team-keyed in storage — see server/database/schema.ts.
+ */
+import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { readSyncStatus } from '../../../../utils/sync-status'
+
+export default defineEventHandler(async (event) => {
+  await resolveTeamAndCheckMembership(event)
+  const db = useDB()
+
+  const status = await readSyncStatus(db)
+
+  return {
+    lastContactAt: status.lastContactAt ? status.lastContactAt.getTime() : null,
+    lastEventAt: status.lastEventAt ? status.lastEventAt.getTime() : null,
+    lastBatchApplied: status.lastBatchApplied,
+    serverNow: Date.now(),
+  }
+})

--- a/packages/crouton-sales/server/database/migrations/0002_sales_sync_status.sql
+++ b/packages/crouton-sales/server/database/migrations/0002_sales_sync_status.sql
@@ -1,0 +1,12 @@
+-- Cloud-side sync heartbeat (#179, epic #175 — D1 live mirror).
+-- Single global row written by the cloud ingest endpoint (#178) on every call
+-- (real batch OR the pusher's idle ping) so the online dashboard can show
+-- "last synced Xs ago" and detect an offline Pi. Cloud-only; the till never
+-- writes here.
+CREATE TABLE IF NOT EXISTS sales_sync_status (
+  id TEXT PRIMARY KEY,
+  last_contact_at INTEGER,
+  last_event_at INTEGER,
+  last_batch_applied INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);

--- a/packages/crouton-sales/server/database/schema.ts
+++ b/packages/crouton-sales/server/database/schema.ts
@@ -46,3 +46,36 @@ export const salesSyncOutbox = sqliteTable('sales_sync_outbox', {
   index('idx_sales_sync_outbox_pending').on(table.syncedAt, table.seq),
   index('idx_sales_sync_outbox_entity').on(table.entityType, table.entityId),
 ])
+
+/**
+ * Cloud-side sync heartbeat (#179, epic #175 — D1 live mirror).
+ *
+ * The mirror is a copy of the venue till, so a row looks identical whether it
+ * arrived two seconds or two hours ago. The online dashboard (#179) needs to
+ * tell "the Pi is connected and syncing now" from "the Pi went offline, this is
+ * a stale snapshot". This single-row table is that signal: the cloud ingest
+ * endpoint (#178) stamps `lastContactAt` on *every* call — real batches and the
+ * pusher's periodic idle ping alike — so the dashboard can show "last synced
+ * Xs ago" and flag staleness once the clock stops advancing.
+ *
+ * Single global row (`id = 'live'`): one venue Pi pushes to one cloud
+ * deployment, so a per-team key would only complicate the idle ping (which
+ * carries no team). A multi-tenant mirror would key this by team — noted as a
+ * follow-up, out of scope for one venue's live view.
+ *
+ * Cloud-only: written exclusively by the ingest, never by the till. The Pi's
+ * own DB simply never has a row here.
+ */
+export const salesSyncStatus = sqliteTable('sales_sync_status', {
+  // Single global heartbeat row.
+  id: text('id').primaryKey().$default(() => 'live'),
+  // Last time the cloud heard from the Pi at all (data batch OR idle ping) —
+  // the liveness clock the dashboard reads to detect an offline Pi.
+  lastContactAt: integer('last_contact_at', { mode: 'timestamp' }),
+  // Last time the cloud applied actual mirrored data (applied > 0) — distinct
+  // from a bare ping, so the UI can say "last change synced Xs ago" too.
+  lastEventAt: integer('last_event_at', { mode: 'timestamp' }),
+  // Rows applied in the most recent non-empty batch (informational hint).
+  lastBatchApplied: integer('last_batch_applied').notNull().$default(() => 0),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$default(() => new Date()),
+})

--- a/packages/crouton-sales/server/db/schema.ts
+++ b/packages/crouton-sales/server/db/schema.ts
@@ -1,6 +1,7 @@
 // Database schema exports for crouton-sales.
 // NuxtHub scans `server/db/schema.ts` across extended layers to build the
 // bundled drizzle schema, so re-exporting here makes the consuming app pick up
-// `sales_sync_outbox` in `db:generate` migrations automatically — no manual
-// schema import needed in the app (same pattern as crouton-flow/crouton-collab).
-export { salesSyncOutbox } from '../database/schema'
+// `sales_sync_outbox` + `sales_sync_status` in `db:generate` migrations
+// automatically — no manual schema import needed in the app (same pattern as
+// crouton-flow/crouton-collab).
+export { salesSyncOutbox, salesSyncStatus } from '../database/schema'

--- a/packages/crouton-sales/server/plugins/cloud-sync-pusher.ts
+++ b/packages/crouton-sales/server/plugins/cloud-sync-pusher.ts
@@ -12,13 +12,20 @@
  *   NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET  shared secret (x-sync-key)
  *   CROUTON_SALES_CLOUD_SYNC_POLL_MS   base poll interval (default 3000)
  *   CROUTON_SALES_CLOUD_SYNC_BATCH     rows per batch (default 100)
+ *   CROUTON_SALES_CLOUD_SYNC_HEARTBEAT_MS  idle heartbeat interval (default 30000)
  *
  * Online-only: when the push fails (offline / endpoint down) it backs off
  * exponentially (capped) and resumes on reconnect; a full batch drains again
  * immediately so a burst empties within seconds. Self-chained setTimeout (not
  * setInterval) means ticks never overlap.
+ *
+ * Idle heartbeat (#179): when nothing is pending we still ping the ingest with
+ * an empty batch every HEARTBEAT_MS so the cloud's freshness clock keeps
+ * advancing — letting the online dashboard tell "online but quiet" from
+ * "offline". A real push already refreshes that clock, so the ping only fires
+ * after a stretch with no data to send.
  */
-import { pushPendingOutbox } from '../utils/cloud-sync-pusher'
+import { pingHeartbeat, pushPendingOutbox } from '../utils/cloud-sync-pusher'
 
 const MAX_BACKOFF_MS = 60000
 
@@ -34,13 +41,22 @@ export default defineNitroPlugin(() => {
 
   const basePollMs = Number(process.env.CROUTON_SALES_CLOUD_SYNC_POLL_MS) || 3000
   const batchSize = Number(process.env.CROUTON_SALES_CLOUD_SYNC_BATCH) || 100
+  const heartbeatMs = Number(process.env.CROUTON_SALES_CLOUD_SYNC_HEARTBEAT_MS) || 30000
 
   let backoff = 0
+  // Last time we successfully reached the cloud (push or ping). Drives the idle
+  // ping cadence so we don't ping on every quiet tick.
+  let lastContactAt = 0
   const schedule = (ms: number) => setTimeout(tick, ms)
 
   const tick = async () => {
     try {
       const res = await pushPendingOutbox(useDB(), { url, batchSize })
+      // Nothing to send for a while → keep the cloud's freshness clock alive.
+      if (res.claimed === 0 && Date.now() - lastContactAt >= heartbeatMs) {
+        await pingHeartbeat({ url })
+      }
+      lastContactAt = Date.now()
       backoff = 0 // success clears any backoff
       // Drain bursts fast: a full batch likely means more is pending.
       schedule(res.claimed >= batchSize ? 50 : basePollMs)
@@ -52,6 +68,6 @@ export default defineNitroPlugin(() => {
     }
   }
 
-  console.log(`🍞 crouton:sales cloud sync pusher ON (poll ${basePollMs}ms → ${url})`)
+  console.log(`🍞 crouton:sales cloud sync pusher ON (poll ${basePollMs}ms, heartbeat ${heartbeatMs}ms → ${url})`)
   schedule(basePollMs)
 })

--- a/packages/crouton-sales/server/utils/cloud-sync-pusher.ts
+++ b/packages/crouton-sales/server/utils/cloud-sync-pusher.ts
@@ -106,3 +106,29 @@ export async function pushPendingOutbox(db: any, opts: PushOptions = {}): Promis
 
   return { claimed: rows.length, applied: applied.length, skippedRetry: retryCount, skippedPermanent: permanentIds.length }
 }
+
+/**
+ * Idle heartbeat ping (#179, epic #175). POSTs an empty batch to the ingest so
+ * the cloud's freshness clock (`sales_sync_status.lastContactAt`) keeps advancing
+ * even when the till is quiet (no orders to push). Without it, the online
+ * dashboard couldn't tell "Pi online but no sales right now" from "Pi offline".
+ *
+ * The plugin calls this only when there's nothing pending and the ping interval
+ * has elapsed — a real push already refreshes the same clock cloud-side. Throws
+ * on transport failure so the plugin backs off, exactly like a data push.
+ */
+export async function pingHeartbeat(opts: PushOptions = {}): Promise<void> {
+  const url = opts.url || process.env.CROUTON_SALES_CLOUD_SYNC_URL
+  const secret = opts.secret || process.env.NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET
+  if (!url) throw new Error('CROUTON_SALES_CLOUD_SYNC_URL not set')
+  if (!secret) throw new Error('NUXT_CROUTON_SALES_CLOUD_SYNC_SECRET not set')
+
+  const doFetch = opts.fetcher ?? (globalThis as any).$fetch
+  await doFetch(url, {
+    method: 'POST',
+    headers: { 'x-sync-key': secret },
+    body: { events: [] },
+    timeout: opts.timeoutMs ?? 15000,
+    retry: 0,
+  })
+}

--- a/packages/crouton-sales/server/utils/sync-status.ts
+++ b/packages/crouton-sales/server/utils/sync-status.ts
@@ -1,0 +1,89 @@
+/**
+ * @crouton-package crouton-sales
+ * @description Cloud-side sync heartbeat for the D1 live mirror (#179, epic #175).
+ *
+ * The mirror is a copy of the venue till — a row reveals nothing about *when* it
+ * arrived. The online dashboard (#179) needs to distinguish "the Pi is connected
+ * and syncing now" from "the Pi went offline, this is a stale snapshot". This is
+ * that signal: a single-row `sales_sync_status` heartbeat the cloud ingest (#178)
+ * stamps on EVERY call — real data batches and the pusher's periodic idle ping
+ * alike — plus a read used by the dashboard's status endpoint.
+ *
+ * Best-effort: `recordSyncHeartbeat` swallows its own errors so a heartbeat
+ * write can never fail an otherwise-successful ingest (the mirrored data is what
+ * matters; the freshness clock is advisory).
+ *
+ * The heartbeat schema is package-owned (`../database/schema`), imported lazily
+ * to stay import-safe — same pattern as the pusher.
+ */
+import { eq } from 'drizzle-orm'
+
+/** The single global heartbeat row id (one venue Pi → one cloud deploy). */
+export const SYNC_STATUS_ROW_ID = 'live'
+
+export interface SyncStatus {
+  /** Last time the cloud heard from the Pi (data batch OR idle ping); null = never. */
+  lastContactAt: Date | null
+  /** Last time actual mirrored data was applied (applied > 0); null = never. */
+  lastEventAt: Date | null
+  /** Rows applied in the most recent non-empty batch. */
+  lastBatchApplied: number
+}
+
+async function loadStatusSchema() {
+  const { salesSyncStatus } = await import('../database/schema')
+  return { salesSyncStatus }
+}
+
+/**
+ * Stamp the heartbeat after an ingest call. `appliedCount` is how many events
+ * the batch applied (0 for an idle ping). `lastContactAt` always advances;
+ * `lastEventAt` + `lastBatchApplied` advance only when real data landed.
+ *
+ * Idempotent upsert of the single `'live'` row. Best-effort — never throws.
+ */
+export async function recordSyncHeartbeat(db: any, appliedCount: number): Promise<void> {
+  try {
+    const { salesSyncStatus } = await loadStatusSchema()
+    const now = new Date()
+    const applied = Number(appliedCount) || 0
+
+    const base = { lastContactAt: now, updatedAt: now }
+    const dataFields = applied > 0 ? { lastEventAt: now, lastBatchApplied: applied } : {}
+
+    const updated = await db
+      .update(salesSyncStatus)
+      .set({ ...base, ...dataFields })
+      .where(eq(salesSyncStatus.id, SYNC_STATUS_ROW_ID))
+      .returning({ id: salesSyncStatus.id })
+
+    if (updated.length === 0) {
+      await db.insert(salesSyncStatus).values({
+        id: SYNC_STATUS_ROW_ID,
+        lastContactAt: now,
+        lastEventAt: applied > 0 ? now : null,
+        lastBatchApplied: applied,
+        updatedAt: now,
+      })
+    }
+  }
+  catch (err: any) {
+    console.warn('[crouton-sales] sync heartbeat write failed (ignored):', err?.message || err)
+  }
+}
+
+/** Read the heartbeat for the dashboard's status endpoint. Null fields = never synced. */
+export async function readSyncStatus(db: any): Promise<SyncStatus> {
+  const { salesSyncStatus } = await loadStatusSchema()
+  const [row] = await db
+    .select()
+    .from(salesSyncStatus)
+    .where(eq(salesSyncStatus.id, SYNC_STATUS_ROW_ID))
+    .limit(1)
+
+  return {
+    lastContactAt: row?.lastContactAt ?? null,
+    lastEventAt: row?.lastEventAt ?? null,
+    lastBatchApplied: row?.lastBatchApplied ?? 0,
+  }
+}


### PR DESCRIPTION
## 👤 For humans

The last slice of epic #175 (**keep a live online copy of the venue's data**): the **online dashboard**. Open a browser anywhere with a connection and watch one event's **orders and sales in real time**, read from the Cloudflare **D1 mirror** — never touching the Pi.

Because the dashboard shows a *copy* of the till, it makes the mirror nature explicit: a freshness badge reads **"Live · synced 3s ago"** while the Pi is connected and flips to amber **"Stale · last synced … — the till may be offline"** when the uplink drops. So you always know how fresh the numbers are.

It's built mostly by **composing what already exists** — the only genuinely new piece is the freshness signal.

## 🤖 For agents

Two parts, both in `@fyit/crouton-sales`.

### 1. Freshness heartbeat (the new mechanism)

```mermaid
flowchart LR
  subgraph Pi["Venue Pi"]
    P["pusher (#177)"]
  end
  P -->|"POST /sync/ingest — real batch"| IN["ingest (#178)"]
  P -.->|"empty ping every ~30s when idle (pingHeartbeat)"| IN
  IN -->|recordSyncHeartbeat| HB[("sales_sync_status<br/>id='live'<br/>lastContactAt / lastEventAt")]
  HB -->|"GET teams/[id]/sync-status"| BANNER["SalesSyncStatus<br/>'synced Xs ago' / stale"]
```

- **`sales_sync_status`** — package-owned table (`server/database/schema.ts` + `db/schema.ts` re-export; package migration `0002`, fanfare migration `0015`). **Single global row** `id='live'` (one Pi → one cloud deploy; multi-tenant keying is a noted follow-up).
- **`recordSyncHeartbeat()`** (`server/utils/sync-status.ts`) — the ingest stamps it on **every** call: `lastContactAt` always advances (data **or** idle ping → liveness), `lastEventAt`/`lastBatchApplied` only when `applied > 0`. Best-effort: never fails an otherwise-successful ingest.
- **Idle ping** — `pingHeartbeat()` POSTs `{ events: [] }`; the pusher plugin fires it only when nothing is pending **and** `CROUTON_SALES_CLOUD_SYNC_HEARTBEAT_MS` (default 30s) has elapsed. Lets an online-but-quiet till still read "Live" (distinguishes offline from no-sales-right-now).
- **`GET teams/[id]/sync-status`** (team member) — heartbeat as epoch-ms + `serverNow` so the client computes age against the **server** clock (skew-proof).

### 2. `salesLiveDashboardBlock` (the UI surface)

`category: data`, `clientOnly`, **team-members-only** (renderer gates on `useAuth().loggedIn` — mirror data is team-scoped); event resolved member-side via `SalesBlocksEventResolver` inside `<Suspense>`. A **composition**:
- **`SalesSyncStatus`** (`Sync/Status.vue`) — the freshness banner; stale at age ≥ 90s (≈ 3 missed pings).
- **`SalesDashboardSalesSummary`** (`Dashboard/SalesSummary.vue`) — revenue / orders / avg + top products, built on the **existing chart endpoints** (no new aggregation); light 15s poll.
- **`SalesEventWorkspaceOrdersTab`** — the same live orders list as the workspace "Bestellingen" pane (its existing 2s poll reflects a successful sync within seconds).
- `Blocks/LiveDashboard{View,Render}.vue`; i18n `sales.blocks.liveDashboard` + `sales.sync` + `sales.dashboard` across en/nl/fr.

## 🧪 Verification

- `pnpm --filter fanfare typecheck`: clean for all new code (pre-existing crouton-charts/crouton-core errors untouched).
- Migration `0015` generated from the schema bundle (only the new table, no drift) and applied locally via wrangler.
- Acceptance (#179): the orders list + summary read the mirrored tables the ingest writes, reflecting a sync within seconds; the banner goes stale when `lastContactAt` stops advancing (Pi offline) and catches up on reconnect via the next push/ping.

## Scope

Closes #179

Epic #175 is fully addressed once this lands (capture #176 / push #177 / ingest #178 shipped in #183; this is the read view #179).

https://claude.ai/code/session_01REJgq9eMYxR3BJV1JGoxk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01REJgq9eMYxR3BJV1JGoxk7)_