### PR TITLE
Polish the page editor: slim toolbar + settings slideover with visual pickers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Add generator feature | `packages/nuxt-crouton-cli/CLAUDE.md` |
 | Change CLI command | Generator's `CLAUDE.md` + `.claude/skills/crouton.md` |
 | Add new field type | `.claude/skills/crouton.md` (Field Types table) |
+| Add/modify a page type (in a package or via `publishable`) | Always supply `name` + `description` + `icon` (required on `CroutonPageType`; surface in the pages page-type picker). See `packages/crouton-pages/CLAUDE.md` (Page Type Registration / Publishable Collections) |
 | Add new package | Create `packages/{name}/CLAUDE.md` |
 
 ## Claude Code Configuration

--- a/packages/crouton-core/CLAUDE.md
+++ b/packages/crouton-core/CLAUDE.md
@@ -178,7 +178,11 @@ export default defineAppConfig({
       references: { categoryId: 'categories' }, // Auto-refresh on mutation
       dependentFieldComponents: { slots: 'SlotPicker' },
       display: { title: 'name', subtitle: 'category', image: 'coverImage', badge: 'status' },
-      publishable: true // Auto-registers as page type in crouton-pages
+      publishable: true, // Auto-registers as page type in crouton-pages
+      // Optional: describe the derived page type shown in the pages editor's
+      // page-type picker (name/description are i18n keys; icon falls back to
+      // adminNav.icon, then a generic file icon). See crouton-pages CLAUDE.md.
+      pageType: { description: 'shop.products.pageType.description', icon: 'i-lucide-shirt' }
     }
   }
 })

--- a/packages/crouton-core/app/composables/useCollections.ts
+++ b/packages/crouton-core/app/composables/useCollections.ts
@@ -127,6 +127,25 @@ interface CollectionConfig {
    */
   publishable?: boolean
   /**
+   * Describe the page type auto-derived from this publishable collection
+   * (only used when `publishable: true`). Mirrors how packages register
+   * page types — `name`/`description` are i18n keys, `icon` is a Lucide class.
+   * Each field is optional; crouton-pages falls back to a generated name, the
+   * collection's `adminNav.icon`, and a generic description when omitted.
+   *
+   * @example
+   * pageType: {
+   *   description: 'shop.bikes.pageType.description',
+   *   icon: 'i-lucide-bike'
+   * }
+   */
+  pageType?: {
+    name?: string
+    description?: string
+    icon?: string
+    category?: string
+  }
+  /**
    * When true, this collection supports public (unauthenticated) access
    * when bound via a binder page.
    */

--- a/packages/crouton-core/app/types/app.ts
+++ b/packages/crouton-core/app/types/app.ts
@@ -140,16 +140,19 @@ export interface CroutonPageType {
 
   /**
    * Description of what this page type provides.
+   * REQUIRED — shown beneath the name in the page-type picker so authors and
+   * editors can tell types apart. Use an i18n key (translated at render).
    * @example 'Shows an interactive calendar for customers to make bookings'
    */
-  description?: string
+  description: string
 
   /**
    * Icon for the page type.
-   * Uses Lucide icons with 'i-lucide-' prefix.
+   * REQUIRED — shown in the page-type picker. Uses Lucide icons with the
+   * 'i-lucide-' prefix.
    * @example 'i-lucide-calendar', 'i-lucide-list'
    */
-  icon?: string
+  icon: string
 
   /**
    * The Vue component name to render for this page type.

--- a/packages/crouton-pages/CLAUDE.md
+++ b/packages/crouton-pages/CLAUDE.md
@@ -155,11 +155,16 @@ The generated layer should **NOT** have a `Form.vue` or `List.vue` - these are p
 
 ## Page Type Registration
 
-Apps register page types in `app.config.ts`. **`name` and `description` are i18n
-keys** (like `CroutonAppConfig.name`), translated at render via `useT()`'s `t()`.
-The page-type selector shows the `name` as the label and the `description` as a
-one-line explanation beneath it, so each contributing package owns its own copy
-in its locale files (e.g. `bookings.pageTypes.calendar.name` / `.description`).
+Apps register page types in `app.config.ts`. **`name`, `description` and `icon`
+are all REQUIRED** on `CroutonPageType` (enforced by the type — a registration
+missing `description` or `icon` is a TypeScript error). `name`/`description` are
+i18n keys (like `CroutonAppConfig.name`), translated at render via `useT()`'s
+`t()`; `icon` is a Lucide class (`i-lucide-*`). The page-type picker shows the
+`icon` + `name` as the label and the `description` as a one-line explanation
+beneath it, so each contributing package owns its own copy in its locale files
+(e.g. `bookings.pageTypes.calendar.name` / `.description`). **When you add a new
+page type to a package, always supply all three** — they're what make the type
+legible in the picker.
 
 ```typescript
 export default defineAppConfig({

--- a/packages/crouton-pages/CLAUDE.md
+++ b/packages/crouton-pages/CLAUDE.md
@@ -28,6 +28,10 @@ CMS-like page management system for Nuxt Crouton. Provides:
 | `app/components/Footer.vue` | `CroutonPagesFooter` - Self-contained footer for layouts (uses UFooter) |
 | `app/components/FooterRenderer.vue` | `CroutonPagesFooterRenderer` - Footer page renderer (used by Renderer.vue) |
 | `app/components/Editor/BlockEditor.vue` | Block-based page editor |
+| `app/components/Editor/Toolbar.vue` | `CroutonPagesEditorToolbar` - Slim editor action bar: Status + Visibility + a Settings button (emits `show-settings`) on the left, action group (AI/preview/open/delete/save) on the right. All page config moved to SettingsPanel. |
+| `app/components/Editor/SettingsPanel.vue` | `CroutonPagesEditorSettingsPanel` - Roomy page-settings slideover (built on core's `CroutonFormExpandableSlideOver`). Sections: General (page type, parent), Appearance (layout), Navigation (in-menu + chrome toggles), Access (scoped access code). Owns no state — re-emits the same `update:*` events the old toolbar popover did. |
+| `app/components/Editor/LayoutPicker.vue` | `CroutonPagesEditorLayoutPicker` - Visual layout selector: a grid of selectable cards (wireframe thumbnail + icon + label + description) over `layoutOptions`. Emits `update:modelValue` + `layout-change`. |
+| `app/components/Editor/PageTypePicker.vue` | `CroutonPagesEditorPageTypePicker` - Vertically-stacked radio selector for page type (icon + name + description). Options come from `usePageTypes()` (descriptions are package-authored i18n keys in `app.config` pageTypes). |
 | `app/components/Form.vue` | Page creation/editing form |
 | `app/types/blocks.ts` | Block type definitions |
 | `app/utils/block-registry.ts` | Block definitions and schemas |
@@ -335,6 +339,10 @@ Components auto-import with `CroutonPages` prefix:
 - `Footer.vue` → `<CroutonPagesFooter />`
 - `FooterRenderer.vue` → `<CroutonPagesFooterRenderer />`
 - `Editor/BlockEditor.vue` → `<CroutonPagesEditorBlockEditor />`
+- `Editor/Toolbar.vue` → `<CroutonPagesEditorToolbar />`
+- `Editor/SettingsPanel.vue` → `<CroutonPagesEditorSettingsPanel />`
+- `Editor/LayoutPicker.vue` → `<CroutonPagesEditorLayoutPicker />`
+- `Editor/PageTypePicker.vue` → `<CroutonPagesEditorPageTypePicker />`
 - `Blocks/Render/HeroBlock.vue` → `<CroutonPagesBlocksRenderHeroBlock />`
 
 ## URL Structure

--- a/packages/crouton-pages/CLAUDE.md
+++ b/packages/crouton-pages/CLAUDE.md
@@ -207,6 +207,40 @@ Collections with `publishable: true` in their config auto-register as page types
 
 **Example:** A collection `shopBikes` with `publishable: true` creates page type `shop:shopBikes-detail`.
 
+### Describing the derived page type (name / description / icon)
+
+A publishable collection can describe how its derived page type appears in the
+page-type picker — the same `name`/`description`/`icon` a package-registered
+page type carries — via an optional `pageType` block on the collection config
+(typed on `CollectionConfig` in crouton-core). Every field is optional and
+falls back gracefully:
+
+```typescript
+croutonCollections: {
+  shopBikes: {
+    publishable: true,
+    adminNav: { icon: 'i-lucide-bike' },     // reused as the page-type icon
+    pageType: {
+      description: 'shop.bikes.pageType.description', // i18n key (or plain text)
+      icon: 'i-lucide-bike',                  // overrides adminNav.icon if set
+      // name / category optional
+    }
+  }
+}
+```
+
+Resolution in `usePageTypes()`:
+- **name** → `pageType.name` ?? generated `"{Capitalized Name} Page"`
+- **description** → `pageType.description` ?? the generic key
+  `pages.pageTypes.collectionDerived.description` (kept as a **raw key** so the
+  consumer's `t()` resolves it, like package descriptions)
+- **icon** → `pageType.icon` ?? `adminNav.icon` ?? `i-lucide-file-text`
+
+So a publishable collection's page type is never description-less, and picks up
+its admin icon automatically. Names/descriptions are passed through `t(value,
+value)` at render (Workspace/Editor `pageTypeOptions`), so plain-string names
+don't get this app's missing-key `[…]` bracketing.
+
 ## usePageTypes() Composable
 
 ```typescript

--- a/packages/crouton-pages/app/components/Editor/LayoutPicker.vue
+++ b/packages/crouton-pages/app/components/Editor/LayoutPicker.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+/**
+ * LayoutPicker — visual layout/template selector for the page editor.
+ *
+ * Replaces the plain "Default" layout dropdown with a small grid of selectable
+ * cards: each shows a simple wireframe thumbnail + icon + label + one-line
+ * description, so the choice is visual instead of a faceless dropdown value.
+ *
+ * Drop-in for the old `<USelect :items="layoutOptions">`: same `model-value`
+ * (the layout `value` string) and emits both `update:model-value` and the
+ * existing `layout-change` so the live preview re-renders exactly as before.
+ *
+ * @example
+ * <CroutonPagesEditorLayoutPicker
+ *   v-model="state.layout"
+ *   :options="layoutOptions"
+ *   @layout-change="onLayoutChange"
+ * />
+ */
+
+interface LayoutOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+interface Props {
+  /** Currently selected layout value (e.g. 'default'). */
+  modelValue: string
+  /** Layout options — the same `layoutOptions` the toolbar used. */
+  options: LayoutOption[]
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  'layout-change': []
+}>()
+
+const { t } = useT()
+
+/**
+ * Presentation metadata per known layout value: an icon and a tiny wireframe
+ * recipe (which bars to show). Unknown values fall back to the generic entry so
+ * a newly-added layout never breaks the picker — it just renders plainly.
+ */
+interface LayoutVisual {
+  icon: string
+  /** Wireframe regions, top to bottom, suggesting the layout's chrome. */
+  wireframe: {
+    header?: boolean
+    nav?: boolean
+    footer?: boolean
+    /** How much vertical space the body fills: 'normal' | 'tall' | 'full'. */
+    body: 'normal' | 'tall' | 'full'
+  }
+  /** i18n key for the one-line description (falls back to plain text). */
+  descriptionKey: string
+}
+
+const LAYOUT_VISUALS: Record<string, LayoutVisual> = {
+  'default': {
+    icon: 'i-lucide-panels-top-left',
+    wireframe: { header: true, nav: true, footer: true, body: 'normal' },
+    descriptionKey: 'pages.layoutDescriptions.default'
+  },
+  'full-height': {
+    icon: 'i-lucide-rectangle-vertical',
+    wireframe: { header: true, body: 'tall' },
+    descriptionKey: 'pages.layoutDescriptions.fullHeight'
+  },
+  'full-screen': {
+    icon: 'i-lucide-maximize',
+    wireframe: { body: 'full' },
+    descriptionKey: 'pages.layoutDescriptions.fullScreen'
+  }
+}
+
+const FALLBACK_VISUAL: LayoutVisual = {
+  icon: 'i-lucide-layout-template',
+  wireframe: { header: true, body: 'normal' },
+  descriptionKey: ''
+}
+
+function visualFor(value: string): LayoutVisual {
+  return LAYOUT_VISUALS[value] ?? FALLBACK_VISUAL
+}
+
+function descriptionFor(value: string): string {
+  const key = visualFor(value).descriptionKey
+  return key ? t(key) : ''
+}
+
+function select(option: LayoutOption) {
+  if (option.disabled || option.value === props.modelValue) return
+  emit('update:modelValue', option.value)
+  emit('layout-change')
+}
+</script>
+
+<template>
+  <div class="grid grid-cols-3 gap-2">
+    <button
+      v-for="option in options"
+      :key="option.value"
+      type="button"
+      :disabled="option.disabled"
+      :aria-pressed="option.value === modelValue"
+      :class="[
+        'group relative flex flex-col items-center gap-2 rounded-lg border p-2.5 text-center transition-all duration-150',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+        option.disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer hover:border-primary/60 hover:bg-elevated/50',
+        option.value === modelValue
+          ? 'border-primary ring-1 ring-primary bg-primary/5'
+          : 'border-default bg-default'
+      ]"
+      @click="select(option)"
+    >
+      <!-- Selected check badge -->
+      <span
+        v-if="option.value === modelValue"
+        class="absolute right-1.5 top-1.5 flex size-4 items-center justify-center rounded-full bg-primary text-inverted"
+      >
+        <UIcon name="i-lucide-check" class="size-3" />
+      </span>
+
+      <!-- Wireframe thumbnail -->
+      <span
+        class="flex h-14 w-full flex-col gap-1 overflow-hidden rounded-md border border-default bg-muted/40 p-1.5"
+        aria-hidden="true"
+      >
+        <span
+          v-if="visualFor(option.value).wireframe.header"
+          class="h-1.5 w-2/3 rounded-full bg-current opacity-40"
+        />
+        <span
+          v-if="visualFor(option.value).wireframe.nav"
+          class="flex gap-1"
+        >
+          <span class="h-1 w-4 rounded-full bg-current opacity-25" />
+          <span class="h-1 w-4 rounded-full bg-current opacity-25" />
+          <span class="h-1 w-4 rounded-full bg-current opacity-25" />
+        </span>
+        <span
+          :class="[
+            'w-full rounded bg-current opacity-10',
+            visualFor(option.value).wireframe.body === 'full' ? 'flex-1'
+              : visualFor(option.value).wireframe.body === 'tall' ? 'flex-1' : 'h-5'
+          ]"
+        />
+        <span
+          v-if="visualFor(option.value).wireframe.footer"
+          class="mt-auto h-1.5 w-1/2 rounded-full bg-current opacity-30"
+        />
+      </span>
+
+      <!-- Icon + label -->
+      <span class="flex items-center gap-1.5">
+        <UIcon
+          :name="visualFor(option.value).icon"
+          :class="['size-3.5', option.value === modelValue ? 'text-primary' : 'text-muted']"
+        />
+        <span :class="['text-xs font-medium', option.value === modelValue ? 'text-primary' : 'text-default']">
+          {{ option.label }}
+        </span>
+      </span>
+
+      <!-- One-line description -->
+      <span v-if="descriptionFor(option.value)" class="text-[10px] leading-tight text-muted">
+        {{ descriptionFor(option.value) }}
+      </span>
+    </button>
+  </div>
+</template>

--- a/packages/crouton-pages/app/components/Editor/PageTypePicker.vue
+++ b/packages/crouton-pages/app/components/Editor/PageTypePicker.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+/**
+ * PageTypePicker — vertically-stacked radio selector for the page type.
+ *
+ * Replaces the page-type dropdown in the editor's Settings panel with a clearer,
+ * scannable list: each option is a full-width radio "card" showing icon + name +
+ * a one-line description, so it's obvious what each type does at a glance (the
+ * same visual language as the layout picker, stacked instead of in a grid).
+ *
+ * Descriptions come from the package that registers the page type
+ * (`app.config.ts` → `croutonApps.<app>.pageTypes[].description`, an i18n key).
+ * Options without one simply render name-only.
+ *
+ * @example
+ * <CroutonPagesEditorPageTypePicker
+ *   v-model="state.pageType"
+ *   :options="pageTypeOptions"
+ * />
+ */
+
+interface PageTypeOption {
+  /** Full id, e.g. 'pages:regular'. */
+  value: string
+  label: string
+  description?: string
+  icon?: string
+  disabled?: boolean
+}
+
+interface Props {
+  /** Currently selected page-type full id. */
+  modelValue: string
+  options: PageTypeOption[]
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+function select(option: PageTypeOption) {
+  if (option.disabled || option.value === props.modelValue) return
+  emit('update:modelValue', option.value)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2" role="radiogroup">
+    <button
+      v-for="option in options"
+      :key="option.value"
+      type="button"
+      role="radio"
+      :disabled="option.disabled"
+      :aria-checked="option.value === modelValue"
+      :class="[
+        'group flex items-start gap-3 rounded-lg border p-3 text-left transition-all duration-150',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+        option.disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer hover:border-primary/60 hover:bg-elevated/50',
+        option.value === modelValue
+          ? 'border-primary ring-1 ring-primary bg-primary/5'
+          : 'border-default bg-default'
+      ]"
+      @click="select(option)"
+    >
+      <!-- Icon chip -->
+      <span
+        :class="[
+          'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md',
+          option.value === modelValue ? 'bg-primary/10 text-primary' : 'bg-elevated text-muted'
+        ]"
+      >
+        <UIcon :name="option.icon || 'i-lucide-file'" class="size-4" />
+      </span>
+
+      <!-- Name + description -->
+      <span class="min-w-0 flex-1">
+        <span :class="['block text-sm font-medium', option.value === modelValue ? 'text-primary' : 'text-default']">
+          {{ option.label }}
+        </span>
+        <span v-if="option.description" class="mt-0.5 block text-xs leading-snug text-muted">
+          {{ option.description }}
+        </span>
+      </span>
+
+      <!-- Radio indicator -->
+      <span
+        :class="[
+          'mt-1 flex size-4 shrink-0 items-center justify-center rounded-full border transition-colors',
+          option.value === modelValue ? 'border-primary bg-primary text-inverted' : 'border-default'
+        ]"
+      >
+        <span v-if="option.value === modelValue" class="size-1.5 rounded-full bg-current" />
+      </span>
+    </button>
+  </div>
+</template>

--- a/packages/crouton-pages/app/components/Editor/SettingsPanel.vue
+++ b/packages/crouton-pages/app/components/Editor/SettingsPanel.vue
@@ -184,10 +184,10 @@ const showAccessSection = computed(() => props.visibility === 'scoped')
             <UIcon :name="selectedPageType?.icon || 'i-lucide-file'" class="size-4 text-muted" />
             <div class="min-w-0">
               <div class="truncate text-sm font-medium text-default">
-                {{ selectedPageType?.name ? t(selectedPageType.name) : t('pages.editor.regularPage') }}
+                {{ selectedPageType?.name ? t(selectedPageType.name, selectedPageType.name) : t('pages.editor.regularPage') }}
               </div>
               <div v-if="selectedPageType?.description" class="truncate text-xs text-muted">
-                {{ t(selectedPageType.description) }}
+                {{ t(selectedPageType.description, selectedPageType.description) }}
               </div>
             </div>
           </div>

--- a/packages/crouton-pages/app/components/Editor/SettingsPanel.vue
+++ b/packages/crouton-pages/app/components/Editor/SettingsPanel.vue
@@ -1,0 +1,336 @@
+<script setup lang="ts">
+/**
+ * PageEditor SettingsPanel
+ *
+ * The roomy, organized home for everything you configure about a page. Opens as
+ * a right-hand slideover (built on core's CroutonFormExpandableSlideOver — we do
+ * NOT hand-roll a slideover) and groups the controls that used to be crammed
+ * into the toolbar + its tiny popover into clear sections:
+ *
+ *   General     — page type, parent page
+ *   Appearance  — visual layout/template picker (CroutonPagesEditorLayoutPicker)
+ *   Navigation  — show-in-menu, hide nav pill, hide login/account controls
+ *   Access      — scoped-visibility access code (only when visibility = scoped)
+ *
+ * It owns no state: every control re-emits the same `update:*` events the
+ * toolbar popover did, so it's a drop-in re-housing for Workspace/Editor.vue.
+ *
+ * @example
+ * <CroutonPagesEditorSettingsPanel
+ *   v-model:open="settingsOpen"
+ *   :action="action"
+ *   v-model:visibility="state.visibility"
+ *   v-model:show-in-navigation="state.showInNavigation"
+ *   v-model:layout="state.layout"
+ *   v-model:parent-id="state.parentId"
+ *   :page-type="state.pageType"
+ *   :selected-page-type="selectedPageType"
+ *   :page-type-options="pageTypeOptions"
+ *   @update:page-type="state.pageType = $event"
+ *   :layout-options="layoutOptions"
+ *   :parent-options="parentOptions"
+ *   :pages-pending="pagesPending"
+ *   :page-id="state.id"
+ *   :visibility="state.visibility"
+ *   v-model:hide-nav="chromeHideNav"
+ *   v-model:hide-auth-controls="chromeHideAuthControls"
+ *   @layout-change="onLayoutChange"
+ *   @save-access-code="saveAccessCode"
+ *   @remove-access-code="removeAccessCode"
+ * />
+ */
+
+interface PageTypeOption {
+  /** Full id, e.g. 'pages:regular'. */
+  value: string
+  label: string
+  description?: string
+  icon?: string
+  disabled?: boolean
+}
+
+interface PageTypeInfo {
+  icon?: string
+  name?: string
+  description?: string
+  fullId?: string
+}
+
+interface SelectOption {
+  value: string | null
+  label: string
+  disabled?: boolean
+}
+
+interface LayoutOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+interface Props {
+  /** Whether the panel is open (v-model:open). */
+  open: boolean
+  /** 'create' or 'update' — drives page-type editability. */
+  action: 'create' | 'update'
+  /** Current page visibility (gates the Access section). */
+  visibility: string
+  /** Whether page is shown in navigation. */
+  showInNavigation: boolean
+  /** Current page layout value. */
+  layout: string
+  /** Current parent page id. */
+  parentId: string | null
+  /** Current page-type full id (create mode — drives the picker selection). */
+  pageType: string
+  /** Resolved page type object (for the read-only display in edit mode). */
+  selectedPageType?: PageTypeInfo | null
+  /** Page-type options for the create-mode picker (icon + name + description). */
+  pageTypeOptions: PageTypeOption[]
+  /** Layout options for the visual picker. */
+  layoutOptions: LayoutOption[]
+  /** Parent page options. */
+  parentOptions: SelectOption[]
+  /** Whether the parent pages list is loading. */
+  pagesPending: boolean
+  /** Current page id (gates access code on saved pages). */
+  pageId?: string | null
+  /** Whether the page currently has an access-code grant. */
+  hasAccessCode?: boolean
+  /** Whether an access-code save/remove is in flight. */
+  accessCodePending?: boolean
+  /** Whether a scope-providing block makes the page code inert (show hint). */
+  scopeProvidedByBlock?: boolean
+  /** Per-page chrome: hide the nav pill on the public page. */
+  hideNav?: boolean
+  /** Per-page chrome: hide the login/account/admin controls on the public page. */
+  hideAuthControls?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  selectedPageType: null,
+  pageId: null,
+  hasAccessCode: false,
+  accessCodePending: false,
+  scopeProvidedByBlock: false,
+  hideNav: false,
+  hideAuthControls: false
+})
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'update:pageType': [value: string]
+  'update:visibility': [value: string]
+  'update:showInNavigation': [value: boolean]
+  'update:layout': [value: string]
+  'update:parentId': [value: string | null]
+  'update:hideNav': [value: boolean]
+  'update:hideAuthControls': [value: boolean]
+  'layout-change': []
+  'save-access-code': [code: string]
+  'remove-access-code': []
+}>()
+
+const { t } = useT()
+
+const isOpen = computed({
+  get: () => props.open,
+  set: value => emit('update:open', value)
+})
+
+// Local input for the scoped-visibility access code — the stored code is hashed
+// server-side and never round-trips; hasAccessCode only reports existence, so
+// the field always starts empty.
+const accessCodeInput = ref('')
+
+function saveAccessCode() {
+  const code = accessCodeInput.value.trim()
+  if (!code) return
+  emit('save-access-code', code)
+  accessCodeInput.value = ''
+}
+
+const showAccessSection = computed(() => props.visibility === 'scoped')
+</script>
+
+<template>
+  <CroutonFormExpandableSlideOver
+    v-model:open="isOpen"
+    :title="t('pages.editor.pageSettings')"
+    icon="i-lucide-settings"
+    max-width="md"
+  >
+    <div class="space-y-6 p-1">
+      <!-- ───────── General ───────── -->
+      <section class="space-y-3">
+        <p class="text-xs font-semibold uppercase tracking-wide text-muted">
+          {{ t('pages.editor.sectionGeneral') }}
+        </p>
+
+        <!-- Page type — a stacked radio picker in create mode (icon + name +
+             description), a read-only summary once the page exists -->
+        <UFormField :label="t('pages.fields.pageType')" name="pageType">
+          <CroutonPagesEditorPageTypePicker
+            v-if="action === 'create'"
+            :model-value="pageType"
+            :options="pageTypeOptions"
+            @update:model-value="(val: string) => emit('update:pageType', val)"
+          />
+
+          <div
+            v-else
+            class="flex items-center gap-2 rounded-md border border-default bg-elevated/30 px-3 py-2"
+          >
+            <UIcon :name="selectedPageType?.icon || 'i-lucide-file'" class="size-4 text-muted" />
+            <div class="min-w-0">
+              <div class="truncate text-sm font-medium text-default">
+                {{ selectedPageType?.name ? t(selectedPageType.name) : t('pages.editor.regularPage') }}
+              </div>
+              <div v-if="selectedPageType?.description" class="truncate text-xs text-muted">
+                {{ t(selectedPageType.description) }}
+              </div>
+            </div>
+          </div>
+        </UFormField>
+
+        <UFormField :label="t('pages.fields.parent')" name="parentId">
+          <USelect
+            :model-value="parentId"
+            :items="parentOptions"
+            value-key="value"
+            :loading="pagesPending"
+            :placeholder="t('pages.editor.noParent')"
+            size="sm"
+            class="w-full"
+            @update:model-value="(val: string | null) => emit('update:parentId', val)"
+          />
+        </UFormField>
+      </section>
+
+      <USeparator />
+
+      <!-- ───────── Appearance ───────── -->
+      <section class="space-y-3">
+        <p class="text-xs font-semibold uppercase tracking-wide text-muted">
+          {{ t('pages.editor.sectionAppearance') }}
+        </p>
+
+        <UFormField :label="t('pages.fields.layout')" name="layout">
+          <CroutonPagesEditorLayoutPicker
+            :model-value="layout"
+            :options="layoutOptions"
+            @update:model-value="(val: string) => emit('update:layout', val)"
+            @layout-change="emit('layout-change')"
+          />
+        </UFormField>
+      </section>
+
+      <USeparator />
+
+      <!-- ───────── Navigation ───────── -->
+      <section class="space-y-3">
+        <p class="text-xs font-semibold uppercase tracking-wide text-muted">
+          {{ t('pages.editor.sectionNavigation') }}
+        </p>
+
+        <UFormField
+          :label="t('pages.fields.showInNavigation')"
+          name="showInNavigation"
+          class="flex items-center justify-between gap-4"
+        >
+          <USwitch
+            :model-value="showInNavigation"
+            size="sm"
+            @update:model-value="emit('update:showInNavigation', $event)"
+          />
+        </UFormField>
+
+        <UFormField
+          :label="t('pages.editor.chromeHideNav')"
+          :description="t('pages.editor.chromeHideNavDescription')"
+          name="hideNav"
+        >
+          <USwitch
+            :model-value="hideNav ?? false"
+            size="sm"
+            @update:model-value="emit('update:hideNav', $event)"
+          />
+        </UFormField>
+
+        <UFormField
+          :label="t('pages.editor.chromeHideAuth')"
+          :description="t('pages.editor.chromeHideAuthDescription')"
+          name="hideAuthControls"
+        >
+          <USwitch
+            :model-value="hideAuthControls ?? false"
+            size="sm"
+            @update:model-value="emit('update:hideAuthControls', $event)"
+          />
+        </UFormField>
+      </section>
+
+      <!-- ───────── Access (scoped visibility only) ───────── -->
+      <template v-if="showAccessSection">
+        <USeparator />
+        <section class="space-y-3">
+          <p class="text-xs font-semibold uppercase tracking-wide text-muted">
+            {{ t('pages.editor.sectionAccess') }}
+          </p>
+
+          <!-- Scope provided by a content block (e.g. kassa → event helper PIN):
+               the page access code is inert, show the hint instead -->
+          <UAlert
+            v-if="scopeProvidedByBlock"
+            color="info"
+            variant="subtle"
+            icon="i-lucide-key-round"
+            :title="t('pages.editor.scopeFromBlockTitle')"
+            :description="t('pages.editor.scopeFromBlockDescription')"
+          />
+
+          <!-- Access code — only for scoped visibility on a saved page -->
+          <UFormField
+            v-else-if="pageId"
+            :label="t('pages.editor.accessCode')"
+            name="accessCode"
+            :description="hasAccessCode ? t('pages.editor.accessCodeSet') : t('pages.editor.accessCodeUnset')"
+          >
+            <div class="flex gap-2">
+              <UInput
+                v-model="accessCodeInput"
+                :placeholder="hasAccessCode ? '••••••' : t('pages.editor.accessCodePlaceholder')"
+                icon="i-lucide-key-round"
+                size="sm"
+                class="flex-1"
+                autocomplete="off"
+                @keydown.enter.prevent="saveAccessCode"
+              />
+              <UButton
+                size="sm"
+                color="primary"
+                variant="soft"
+                :loading="accessCodePending"
+                :disabled="!accessCodeInput.trim()"
+                @click="saveAccessCode"
+              >
+                {{ t('pages.editor.accessCodeSave') }}
+              </UButton>
+            </div>
+            <UButton
+              v-if="hasAccessCode"
+              size="xs"
+              color="error"
+              variant="link"
+              class="mt-1 px-0"
+              :loading="accessCodePending"
+              @click="emit('remove-access-code')"
+            >
+              {{ t('pages.editor.accessCodeRemove') }}
+            </UButton>
+          </UFormField>
+        </section>
+      </template>
+    </div>
+  </CroutonFormExpandableSlideOver>
+</template>

--- a/packages/crouton-pages/app/components/Editor/Toolbar.vue
+++ b/packages/crouton-pages/app/components/Editor/Toolbar.vue
@@ -2,36 +2,31 @@
 /**
  * PageEditor Toolbar
  *
- * The action bar at the top of the workspace editor. Handles status, page type,
- * visibility, navigation toggle, settings popover (layout + parent), AI generator
- * trigger, preview, external link, delete (two-click confirm) and save.
+ * The action bar at the top of the workspace editor. Deliberately slim: the
+ * left side holds only the two controls you flip often — Status and Visibility
+ * — plus a single Settings button that opens the roomy SettingsPanel slideover
+ * (page type, parent, layout, navigation/chrome toggles and the scoped access
+ * code all live there now, not inline). The right side keeps the action group:
+ * AI generator, preview, open-in-public, delete/cancel and save.
  *
  * @example
  * <CroutonPagesEditorToolbar
  *   v-model:status="state.status"
  *   v-model:visibility="state.visibility"
- *   v-model:show-in-navigation="state.showInNavigation"
- *   v-model:layout="state.layout"
- *   v-model:parent-id="state.parentId"
  *   :action="action"
- *   :selected-page-type="selectedPageType"
- *   :page-type-dropdown-items="pageTypeDropdownItems"
  *   :status-config="statusConfig"
  *   :visibility-config="visibilityConfig"
  *   :status-dropdown-items="statusDropdownItems"
  *   :visibility-dropdown-items="visibilityDropdownItems"
- *   :layout-options="layoutOptions"
- *   :parent-options="parentOptions"
- *   :pages-pending="pagesPending"
  *   :is-regular-page="isRegularPage"
  *   :is-saving="isSaving"
  *   :show-close="showClose"
  *   :page-id="state.id"
  *   :public-url="publicUrl"
  *   :status="state.status"
+ *   @show-settings="showSettings = true"
  *   @show-ai-generator="showAiGenerator = true"
  *   @show-preview="showPreview = true"
- *   @layout-change="onLayoutChange"
  *   @cancel="emit('cancel')"
  *   @delete="handleDelete"
  *   @close="emit('close')"
@@ -45,13 +40,6 @@ interface DropdownItem {
   onSelect?: () => void
 }
 
-interface PageTypeInfo {
-  icon?: string
-  name?: string
-  description?: string
-  fullId?: string
-}
-
 interface StatusConfigEntry {
   color: string
   icon: string
@@ -63,12 +51,6 @@ interface VisibilityConfigEntry {
   label: string
 }
 
-interface SelectOption {
-  value: string | null
-  label: string
-  disabled?: boolean
-}
-
 interface Props {
   /** 'create' or 'update' */
   action: 'create' | 'update'
@@ -76,16 +58,6 @@ interface Props {
   status: string
   /** Current page visibility */
   visibility: string
-  /** Whether page is shown in navigation */
-  showInNavigation: boolean
-  /** Current page layout */
-  layout: string
-  /** Current parent page ID */
-  parentId: string | null
-  /** The resolved page type object */
-  selectedPageType?: PageTypeInfo | null
-  /** Dropdown items for page type selector */
-  pageTypeDropdownItems: DropdownItem[][]
   /** Status config map */
   statusConfig: Record<string, StatusConfigEntry>
   /** Visibility config map */
@@ -94,12 +66,6 @@ interface Props {
   statusDropdownItems: DropdownItem[][]
   /** Dropdown items for visibility selector */
   visibilityDropdownItems: DropdownItem[][]
-  /** Layout options for the settings popover */
-  layoutOptions: SelectOption[]
-  /** Parent page options for the settings popover */
-  parentOptions: SelectOption[]
-  /** Whether parent pages list is loading */
-  pagesPending: boolean
   /** Whether to show the AI generator button (regular pages only) */
   isRegularPage: boolean
   /** Whether AI package is available */
@@ -112,67 +78,32 @@ interface Props {
   pageId?: string | null
   /** Public URL for the open-in-public button */
   publicUrl?: string | null
-  /** Whether the page currently has an access code grant (scoped visibility) */
-  hasAccessCode?: boolean
-  /** Whether an access-code save/remove is in flight */
-  accessCodePending?: boolean
-  /**
-   * Whether the page content contains a scope-providing block (e.g. a kassa
-   * block gated by the event's helper PIN). The server derives the scope from
-   * the block at read time, so the page's own access code is inert — the
-   * field is replaced by an explanatory hint. One trust level per page.
-   */
-  scopeProvidedByBlock?: boolean
-  /** Per-page chrome: hide the page-navigation pill on the public page */
-  hideNav?: boolean
-  /** Per-page chrome: hide the login/account/admin controls on the public page (language + color mode stay) */
-  hideAuthControls?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   showClose: false,
   pageId: null,
   publicUrl: null,
-  selectedPageType: null,
   hasAi: false
 })
 
 const emit = defineEmits<{
   'update:status': [value: string]
   'update:visibility': [value: string]
-  'update:showInNavigation': [value: boolean]
-  'update:layout': [value: string]
-  'update:parentId': [value: string | null]
+  'show-settings': []
   'show-ai-generator': []
   'show-preview': []
-  'layout-change': []
   'cancel': []
   'delete': []
   'close': []
-  'save-access-code': [code: string]
-  'remove-access-code': []
-  'update:hideNav': [value: boolean]
-  'update:hideAuthControls': [value: boolean]
 }>()
 
 const { t } = useT()
-
-// Local input for the scoped-visibility access code — the stored code is
-// hashed server-side and never round-trips; hasAccessCode only reports
-// existence, so the field always starts empty.
-const accessCodeInput = ref('')
-
-function saveAccessCode() {
-  const code = accessCodeInput.value.trim()
-  if (!code) return
-  emit('save-access-code', code)
-  accessCodeInput.value = ''
-}
 </script>
 
 <template>
   <div class="flex flex-wrap items-center gap-3 min-h-12 px-4 py-2 border-b border-default bg-elevated/30">
-    <!-- Left group: Status, Page Type, Visibility, Nav toggle, Settings -->
+    <!-- Left group: Status, Visibility, Settings -->
     <UFieldGroup>
       <!-- Status -->
       <UDropdownMenu
@@ -208,39 +139,6 @@ function saveAccessCode() {
           </span>
         </template>
       </UDropdownMenu>
-
-      <!-- Page Type — items carry icon + label + description, rendered natively
-           by UDropdownMenu (two-line items) so users see what each type does -->
-      <UDropdownMenu
-        v-if="action === 'create'"
-        :items="pageTypeDropdownItems"
-        :content="{ align: 'start' }"
-      >
-        <UButton variant="ghost" color="neutral" size="xs" class="px-2 lg:px-3">
-          <UIcon
-            :name="selectedPageType?.icon || 'i-lucide-file'"
-            class="size-4"
-          />
-          <span class="hidden lg:inline">{{ selectedPageType?.name ? t(selectedPageType.name) : t('pages.editor.defaultPageType') }}</span>
-        </UButton>
-      </UDropdownMenu>
-      <UPopover v-else>
-        <UButton variant="ghost" color="neutral" size="xs" class="px-2 lg:px-3">
-          <UIcon
-            :name="selectedPageType?.icon || 'i-lucide-file'"
-            class="size-4"
-          />
-          <span class="hidden lg:inline">{{ selectedPageType?.name ? t(selectedPageType.name) : t('pages.editor.defaultPageType') }}</span>
-        </UButton>
-        <template #content>
-          <div class="p-3 text-sm">
-            <div class="font-medium">{{ selectedPageType?.name ? t(selectedPageType.name) : t('pages.editor.regularPage') }}</div>
-            <div v-if="selectedPageType?.description" class="text-muted text-xs mt-1">
-              {{ t(selectedPageType.description) }}
-            </div>
-          </div>
-        </template>
-      </UPopover>
 
       <!-- Visibility -->
       <UDropdownMenu
@@ -287,144 +185,18 @@ function saveAccessCode() {
         </template>
       </UDropdownMenu>
 
-      <!-- Show in Navigation -->
-      <UTooltip :text="showInNavigation ? t('pages.editor.shownInMenu') : t('pages.editor.hiddenFromMenu')" :delay-duration="0">
+      <!-- Settings — opens the roomy SettingsPanel slideover -->
+      <UTooltip :text="t('pages.editor.settings')" :delay-duration="0">
         <UButton
           variant="ghost"
           color="neutral"
+          icon="i-lucide-settings"
           size="xs"
-          class="px-2"
-          @click="emit('update:showInNavigation', !showInNavigation)"
+          class="px-2 lg:px-3"
+          @click="emit('show-settings')"
         >
-          <UIcon
-            name="i-lucide-menu"
-            :class="['size-4', showInNavigation ? 'text-muted' : 'opacity-30']"
-          />
-          <span :class="['hidden lg:inline', showInNavigation ? '' : 'opacity-30']">
-            {{ showInNavigation ? t('pages.editor.inMenu') : t('pages.editor.noMenu') }}
-          </span>
+          <span class="hidden lg:inline">{{ t('pages.editor.settings') }}</span>
         </UButton>
-      </UTooltip>
-
-      <!-- Settings -->
-      <UTooltip :text="t('pages.editor.settings')" :delay-duration="0">
-        <UPopover>
-          <UButton
-            variant="ghost"
-            color="neutral"
-            icon="i-lucide-settings"
-            size="xs"
-          >
-            <span class="hidden lg:inline">{{ t('pages.editor.settings') }}</span>
-          </UButton>
-          <template #content>
-            <div class="p-4 w-72 space-y-4">
-              <div class="text-sm font-medium text-default mb-3">{{ t('pages.editor.pageSettings') }}</div>
-
-              <UFormField :label="t('pages.fields.layout')" name="layout">
-                <USelect
-                  :model-value="layout"
-                  :items="layoutOptions"
-                  value-key="value"
-                  size="sm"
-                  class="w-full"
-                  @update:model-value="(val: any) => { emit('update:layout', val); emit('layout-change') }"
-                />
-              </UFormField>
-
-              <UFormField :label="t('pages.fields.parent')" name="parentId">
-                <USelect
-                  :model-value="parentId"
-                  :items="parentOptions"
-                  value-key="value"
-                  :loading="pagesPending"
-                  :placeholder="t('pages.editor.noParent')"
-                  size="sm"
-                  class="w-full"
-                  @update:model-value="(val: string | null) => emit('update:parentId', val)"
-                />
-              </UFormField>
-
-              <!-- Per-page chrome: hide nav pill / login controls on the
-                   public page (language + color mode always stay) -->
-              <UFormField
-                :label="t('pages.editor.chromeHideNav')"
-                :description="t('pages.editor.chromeHideNavDescription')"
-                name="hideNav"
-              >
-                <USwitch
-                  :model-value="hideNav ?? false"
-                  size="sm"
-                  @update:model-value="emit('update:hideNav', $event)"
-                />
-              </UFormField>
-
-              <UFormField
-                :label="t('pages.editor.chromeHideAuth')"
-                :description="t('pages.editor.chromeHideAuthDescription')"
-                name="hideAuthControls"
-              >
-                <USwitch
-                  :model-value="hideAuthControls ?? false"
-                  size="sm"
-                  @update:model-value="emit('update:hideAuthControls', $event)"
-                />
-              </UFormField>
-
-              <!-- Scope provided by a content block (e.g. kassa → event helper
-                   PIN): the page access code is inert, show the hint instead -->
-              <UAlert
-                v-if="visibility === 'scoped' && scopeProvidedByBlock"
-                color="info"
-                variant="subtle"
-                icon="i-lucide-key-round"
-                :title="t('pages.editor.scopeFromBlockTitle')"
-                :description="t('pages.editor.scopeFromBlockDescription')"
-              />
-
-              <!-- Access code — only for scoped visibility on a saved page -->
-              <UFormField
-                v-else-if="visibility === 'scoped' && pageId"
-                :label="t('pages.editor.accessCode')"
-                name="accessCode"
-                :description="hasAccessCode ? t('pages.editor.accessCodeSet') : t('pages.editor.accessCodeUnset')"
-              >
-                <div class="flex gap-2">
-                  <UInput
-                    v-model="accessCodeInput"
-                    :placeholder="hasAccessCode ? '••••••' : t('pages.editor.accessCodePlaceholder')"
-                    icon="i-lucide-key-round"
-                    size="sm"
-                    class="flex-1"
-                    autocomplete="off"
-                    @keydown.enter.prevent="saveAccessCode"
-                  />
-                  <UButton
-                    size="sm"
-                    color="primary"
-                    variant="soft"
-                    :loading="accessCodePending"
-                    :disabled="!accessCodeInput.trim()"
-                    @click="saveAccessCode"
-                  >
-                    {{ t('pages.editor.accessCodeSave') }}
-                  </UButton>
-                </div>
-                <UButton
-                  v-if="hasAccessCode"
-                  size="xs"
-                  color="error"
-                  variant="link"
-                  class="mt-1 px-0"
-                  :loading="accessCodePending"
-                  @click="emit('remove-access-code')"
-                >
-                  {{ t('pages.editor.accessCodeRemove') }}
-                </UButton>
-              </UFormField>
-            </div>
-          </template>
-        </UPopover>
       </UTooltip>
     </UFieldGroup>
 

--- a/packages/crouton-pages/app/components/Workspace/Editor.vue
+++ b/packages/crouton-pages/app/components/Workspace/Editor.vue
@@ -502,14 +502,17 @@ watch(selectedCollectionItem, (item: Record<string, any> | null) => {
 // name/description are i18n keys (see each app's app.config.ts pageTypes).
 // t() returns the key unchanged when missing, so dynamic collection-derived
 // types (plain-string names) stay safe.
-const pageTypeDropdownItems = computed(() => [
+// Page-type options for the Settings panel's stacked radio picker (create mode).
+// Description is an i18n key authored by the package that registers the type
+// (app.config pageTypes); collection-derived types may have none → name only.
+const pageTypeOptions = computed(() =>
   pageTypes.value.map((type: any) => ({
+    value: type.fullId,
     label: t(type.name),
     description: type.description ? t(type.description) : undefined,
-    icon: type.icon,
-    onSelect: () => { state.value.pageType = type.fullId }
+    icon: type.icon
   }))
-])
+)
 
 // Status config
 const statusConfig: Record<string, { color: string; icon: string; label: string }> = {
@@ -860,6 +863,9 @@ const fieldGroups = computed(() => ({
 // Preview drawer state
 const showPreview = ref(false)
 
+// Settings slideover state — opened from the toolbar's Settings button
+const settingsOpen = ref(false)
+
 // Detect optional packages via croutonApps registration
 const { hasApp } = useCroutonApps()
 const hasAssetsPicker = hasApp('assets')
@@ -991,47 +997,60 @@ defineExpose({ state })
       class="flex flex-col h-full"
       @submit="handleSubmit"
     >
-      <!-- Header Bar -->
+      <!-- Header Bar — slim: Status + Visibility + Settings on the left,
+           action group on the right. Page config lives in the SettingsPanel. -->
       <CroutonPagesEditorToolbar
         :action="action"
         :status="state.status"
         :visibility="state.visibility"
-        :show-in-navigation="state.showInNavigation"
-        :layout="state.layout"
-        :parent-id="state.parentId"
-        :selected-page-type="selectedPageType"
-        :page-type-dropdown-items="pageTypeDropdownItems"
         :status-config="statusConfig"
         :visibility-config="visibilityConfig"
         :status-dropdown-items="statusDropdownItems"
         :visibility-dropdown-items="visibilityDropdownItems"
-        :layout-options="layoutOptions"
-        :parent-options="parentOptions"
-        :pages-pending="pagesPending"
         :is-regular-page="isRegularPage"
         :has-ai="hasAI"
         :is-saving="isSaving"
         :show-close="showClose"
         :page-id="state.id"
         :public-url="publicUrl"
+        @update:status="state.status = $event"
+        @update:visibility="state.visibility = $event"
+        @show-settings="settingsOpen = true"
+        @show-ai-generator="showAiGenerator = true"
+        @show-preview="showPreview = true"
+        @cancel="emit('cancel')"
+        @delete="handleDelete"
+        @close="emit('close')"
+      />
+
+      <!-- Settings slideover — the roomy, organized home for all page config
+           (page type, parent, layout, navigation/chrome toggles, access code) -->
+      <CroutonPagesEditorSettingsPanel
+        v-model:open="settingsOpen"
+        :action="action"
+        :visibility="state.visibility"
+        :show-in-navigation="state.showInNavigation"
+        :layout="state.layout"
+        :parent-id="state.parentId"
+        :page-type="state.pageType"
+        :selected-page-type="selectedPageType"
+        :page-type-options="pageTypeOptions"
+        :layout-options="layoutOptions"
+        @update:page-type="state.pageType = $event"
+        :parent-options="parentOptions"
+        :pages-pending="pagesPending"
+        :page-id="state.id"
         :has-access-code="hasAccessCode"
         :access-code-pending="accessCodePending"
         :scope-provided-by-block="scopeProvidedByBlock"
         :hide-nav="chromeHideNav"
         :hide-auth-controls="chromeHideAuthControls"
-        @update:hide-nav="chromeHideNav = $event"
-        @update:hide-auth-controls="chromeHideAuthControls = $event"
-        @update:status="state.status = $event"
-        @update:visibility="state.visibility = $event"
         @update:show-in-navigation="state.showInNavigation = $event"
         @update:layout="state.layout = $event"
         @update:parent-id="state.parentId = $event"
-        @show-ai-generator="showAiGenerator = true"
-        @show-preview="showPreview = true"
+        @update:hide-nav="chromeHideNav = $event"
+        @update:hide-auth-controls="chromeHideAuthControls = $event"
         @layout-change="onLayoutChange"
-        @cancel="emit('cancel')"
-        @delete="handleDelete"
-        @close="emit('close')"
         @save-access-code="saveAccessCode"
         @remove-access-code="removeAccessCode"
       />

--- a/packages/crouton-pages/app/components/Workspace/Editor.vue
+++ b/packages/crouton-pages/app/components/Workspace/Editor.vue
@@ -508,8 +508,11 @@ watch(selectedCollectionItem, (item: Record<string, any> | null) => {
 const pageTypeOptions = computed(() =>
   pageTypes.value.map((type: any) => ({
     value: type.fullId,
-    label: t(type.name),
-    description: type.description ? t(type.description) : undefined,
+    // Pass the raw value as fallback: package types use i18n keys (resolved),
+    // collection-derived types use plain strings — t(value, value) returns them
+    // verbatim instead of this app's missing-key "[value]" bracketing.
+    label: t(type.name, type.name),
+    description: type.description ? t(type.description, type.description) : undefined,
     icon: type.icon
   }))
 )

--- a/packages/crouton-pages/app/composables/usePageTypes.ts
+++ b/packages/crouton-pages/app/composables/usePageTypes.ts
@@ -65,19 +65,35 @@ export function usePageTypes() {
 
       const layer = config.layer || 'app'
       const displayName = config.displayName || config.name || collectionName
-      // Convert camelCase collection name to readable label (e.g., "storeBikes" -> "Bike Page")
-      const singularName = displayName.replace(/([A-Z])/g, ' $1').trim()
+      // Convert camelCase collection name to a readable, capitalized label
+      // (e.g. "shopBikes" -> "Shop Bikes", "mainItems" -> "Main Items").
+      const spaced = displayName.replace(/([A-Z])/g, ' $1').trim()
+      const singularName = spaced.charAt(0).toUpperCase() + spaced.slice(1)
       const fullId = `${layer}:${collectionName}-detail`
 
       // Skip if a manually registered page type already exists with this ID
       if (types.some(t => t.fullId === fullId)) continue
 
+      // A publishable collection may describe its derived page type via a
+      // `pageType` config block (name/description/icon/category) — the same
+      // shape packages register. Each is optional and falls back gracefully:
+      // icon → the collection's admin icon → generic file; description → a
+      // generic i18n key (kept as a RAW key so the consumer's t() resolves it,
+      // matching how package-registered descriptions flow).
+      const pageTypeMeta = (config.pageType ?? {}) as {
+        name?: string
+        description?: string
+        icon?: string
+        category?: string
+      }
+
       types.push({
         id: `${collectionName}-detail`,
-        name: `${singularName} Page`,
+        name: pageTypeMeta.name || `${singularName} Page`,
+        description: pageTypeMeta.description || 'pages.pageTypes.collectionDerived.description',
         component: 'CroutonPagesCollectionPageRenderer',
-        icon: 'i-lucide-file-text',
-        category: 'collections',
+        icon: pageTypeMeta.icon || config.adminNav?.icon || 'i-lucide-file-text',
+        category: pageTypeMeta.category || 'collections',
         collection: collectionName,
         appId: layer,
         appName: layer.charAt(0).toUpperCase() + layer.slice(1),

--- a/packages/crouton-pages/i18n/locales/en.json
+++ b/packages/crouton-pages/i18n/locales/en.json
@@ -63,6 +63,11 @@
       "fullHeight": "Full Height",
       "fullScreen": "Full Screen"
     },
+    "layoutDescriptions": {
+      "default": "Header, footer and page navigation",
+      "fullHeight": "Content fills the viewport height",
+      "fullScreen": "No chrome — content only"
+    },
     "parent": {
       "root": "Root (No Parent)"
     },
@@ -104,6 +109,10 @@
     "editor": {
       "settings": "Settings",
       "pageSettings": "Page Settings",
+      "sectionGeneral": "General",
+      "sectionAppearance": "Appearance",
+      "sectionNavigation": "Navigation",
+      "sectionAccess": "Access",
       "generate": "Generate",
       "preview": "Preview",
       "search": "Search",

--- a/packages/crouton-pages/i18n/locales/en.json
+++ b/packages/crouton-pages/i18n/locales/en.json
@@ -14,6 +14,9 @@
       "footer": {
         "name": "Footer",
         "description": "The site footer, composed from blocks. One per site; shown on every page."
+      },
+      "collectionDerived": {
+        "description": "Publishes items from this collection as standalone pages."
       }
     },
     "workspace": {

--- a/packages/crouton-pages/i18n/locales/fr.json
+++ b/packages/crouton-pages/i18n/locales/fr.json
@@ -2,6 +2,11 @@
   "pages": {
     "title": "Pages",
     "search": "Rechercher des pages...",
+    "pageTypes": {
+      "collectionDerived": {
+        "description": "Publie les éléments de cette collection en tant que pages autonomes."
+      }
+    },
     "workspace": {
       "title": "Espace de travail Pages",
       "emptyTitle": "Sélectionnez une page",

--- a/packages/crouton-pages/i18n/locales/fr.json
+++ b/packages/crouton-pages/i18n/locales/fr.json
@@ -49,6 +49,11 @@
       "fullHeight": "Pleine hauteur",
       "fullScreen": "Plein écran"
     },
+    "layoutDescriptions": {
+      "default": "En-tête, pied de page et navigation",
+      "fullHeight": "Le contenu remplit la hauteur de l'écran",
+      "fullScreen": "Sans habillage — contenu uniquement"
+    },
     "parent": {
       "root": "Racine (pas de parent)"
     },
@@ -90,6 +95,10 @@
     "editor": {
       "settings": "Paramètres",
       "pageSettings": "Paramètres de la page",
+      "sectionGeneral": "Général",
+      "sectionAppearance": "Apparence",
+      "sectionNavigation": "Navigation",
+      "sectionAccess": "Accès",
       "generate": "Générer",
       "preview": "Aperçu",
       "search": "Rechercher",

--- a/packages/crouton-pages/i18n/locales/nl.json
+++ b/packages/crouton-pages/i18n/locales/nl.json
@@ -63,6 +63,11 @@
       "fullHeight": "Volledige hoogte",
       "fullScreen": "Volledig scherm"
     },
+    "layoutDescriptions": {
+      "default": "Koptekst, voettekst en paginanavigatie",
+      "fullHeight": "Inhoud vult de volledige hoogte",
+      "fullScreen": "Geen randelementen — alleen inhoud"
+    },
     "parent": {
       "root": "Root (geen ouder)"
     },
@@ -104,6 +109,10 @@
     "editor": {
       "settings": "Instellingen",
       "pageSettings": "Pagina-instellingen",
+      "sectionGeneral": "Algemeen",
+      "sectionAppearance": "Weergave",
+      "sectionNavigation": "Navigatie",
+      "sectionAccess": "Toegang",
       "generate": "Genereren",
       "preview": "Voorbeeld",
       "search": "Zoeken",

--- a/packages/crouton-pages/i18n/locales/nl.json
+++ b/packages/crouton-pages/i18n/locales/nl.json
@@ -14,6 +14,9 @@
       "footer": {
         "name": "Voettekst",
         "description": "De voettekst van de site, samengesteld uit blokken. Eén per site; verschijnt op elke pagina."
+      },
+      "collectionDerived": {
+        "description": "Publiceert items uit deze collectie als zelfstandige pagina's."
       }
     },
     "workspace": {


### PR DESCRIPTION
Part of epic #199.

## 👤 For humans

The page editor's top toolbar had grown muddy — five different *kinds* of control crammed into one strip. This cleans it up:

- **Slim toolbar** — only **Status · Visibility · Settings** on the left now; everything else moved into a panel.
- **Settings slideover** — a roomy panel slides in from the right (built on core's `CroutonFormExpandableSlideOver`), organized into **General / Appearance / Navigation / Access**.
- **Visual Layout picker** — selectable cards with a wireframe + icon + description, instead of a bare "Default" dropdown.
- **Page Type picker** — a vertically-stacked radio list with icon + name + description.
- **Collection-derived page types** now carry a description + a meaningful icon (configurable via a new `pageType` block on the collection, with graceful fallbacks), instead of looking bare next to package types.
- **Guardrail** — `description` and `icon` are now **required** on every package page type, so a bare type can't ship by accident.

```
toolbar  before:  ● Draft   📄 Regular Page   🌐 Public   ☰ In Menu   ⚙ Settings   |   👁 Preview  ✕ Cancel  💾 Create
         after:   ● Draft   🌐 Public                                  ⚙ Settings   |   👁 Preview  ✕ Cancel  💾 Create
```

Verified on the `with-pages` fixture, desktop + mobile.

## 🤖 For agents

`packages/crouton-pages` (+ additive type changes in `crouton-core`). UI/UX only — no data-model/API/schema changes.

- New `Editor/SettingsPanel.vue` (on `CroutonFormExpandableSlideOver`), `Editor/LayoutPicker.vue`, `Editor/PageTypePicker.vue`.
- `Editor/Toolbar.vue` slimmed to Status + Visibility + a `show-settings` button; `Workspace/Editor.vue` mounts the panel and passes through the moved controls; `pageTypeDropdownItems` → `pageTypeOptions`.
- `usePageTypes()` reads an optional `config.pageType { name, description, icon, category }` for publishable collections, with fallbacks (generated capitalized name, generic description key, `adminNav.icon`). New additive `pageType?` on `CollectionConfig` in crouton-core.
- `CroutonPageType.description` + `.icon` are now **required** (#213) — TS flags any package page type missing them. Safe: all existing registrations already supply both.
- Page-type name/desc rendered via `t(value, value)` to avoid this app's missing-key `[…]` bracketing on plain strings.
- i18n en/nl/fr at parity for all added keys.

**Reuse-first** (owner constraint): slideover = core's `CroutonFormExpandableSlideOver`; everything else Nuxt UI 4 (`USwitch`/`USelect`/`UFormField`/`USeparator`/`UDropdownMenu`/`UAlert`/`UInput`). The two bespoke pickers (visual cards Nuxt UI doesn't provide) are flagged for a possible shared primitive in the audit issue #203.

**Typecheck:** clean for all touched files; remaining `velo` errors are pre-existing (crouton-auth/bookings/admin + crouton-core RedirectsForm + the known `queryRegistry` ones, #188) and untouched here.

Closes #200, #201, #202, #211, #213.
Does **not** close #203 (the reuse/cleanliness audit — intended to run after these land) or the epic #199.

## 🧪 How to test

1. Admin → **Pages** → create or open a page.
2. Top-left shows only **Status**, **Visibility**, **Settings** (Page Type and In-Menu are no longer inline).
3. Click **Settings** → panel slides in with **General / Appearance / Navigation / Access**.
4. **Appearance → Layout**: pick a card (not a dropdown) → it highlights and the preview updates.
5. **General → Page Type** (create mode): a stacked radio list with icon + name + description. Mark any collection `publishable: true` and confirm its type shows a description + icon (its `adminNav.icon`, or a `pageType.icon`).
6. **Navigation**: In-menu + hide-nav + hide-auth toggles. Set Visibility = **Scoped** on a saved page → access-code field appears under **Access**.
7. Save → everything persists as before. Checked desktop + mobile (390px).
