### PR TITLE
Page editor reuse/cleanliness audit (#203): fix French page-type i18n parity

### DIFF
--- a/packages/crouton-pages/i18n/locales/fr.json
+++ b/packages/crouton-pages/i18n/locales/fr.json
@@ -3,6 +3,18 @@
     "title": "Pages",
     "search": "Rechercher des pages...",
     "pageTypes": {
+      "regular": {
+        "name": "Page standard",
+        "description": "Une page de contenu standard que vous construisez avec l'éditeur de blocs — texte, images, sections et plus encore."
+      },
+      "collectionBinder": {
+        "name": "Classeur de collection",
+        "description": "Publie chaque élément d'une collection sous forme de sous-pages liées dans votre navigation."
+      },
+      "footer": {
+        "name": "Pied de page",
+        "description": "Le pied de page du site, composé de blocs. Un seul par site ; affiché sur chaque page."
+      },
       "collectionDerived": {
         "description": "Publie les éléments de cette collection en tant que pages autonomes."
       }


### PR DESCRIPTION
Closes #203

Runs the reuse/cleanliness audit (#203) under epic #199 **for real** — it was closed alongside the #212 merge but never actually executed. The audit came back **almost entirely clean**; the one concrete defect was a French i18n parity gap, fixed in a single additive commit.

## 👤 For humans

I went back over everything the page-editor polish epic touched (Toolbar, SettingsPanel, the two pickers, the Workspace wiring, the locale files) and checked we reused what we already have instead of hand-rolling, and didn't leave any dead code behind. It's in good shape. The only real bug: the French translation was missing the names/descriptions for three page types (Regular, Collection Binder, Footer), so French users saw English/raw text in the type picker. That's now fixed.

## 🤖 For agents — audit findings

### ✅ Nuxt UI 4 first
- Correct v4 component names throughout (`USeparator`, `USwitch`, `UDropdownMenu`, `USelectMenu`, `UFormField`, `UFieldGroup`). No v2/v3 names (`UDropdown`/`UDivider`/`UToggle`/`UNotification`) anywhere in the package.
- **Could the pickers be a `URadioGroup` with a custom item slot?** Considered and rejected. `LayoutPicker` renders per-option **wireframe thumbnails** (header/nav/body/footer bars driven by a `LAYOUT_VISUALS` recipe) and `PageTypePicker` renders an **icon chip + radio indicator**. A `URadioGroup` custom item slot would still require writing all of that markup inside the slot — you'd inherit `URadioGroup`'s value plumbing but the bespoke visual content (the whole point) stays bespoke. Net: no real reduction, added indirection. Both already carry correct a11y (`role="radiogroup"`/`role="radio"`/`aria-checked`, `aria-pressed`). Left as-is.

### ✅ crouton-core reuse
- `SettingsPanel` correctly builds on **`CroutonFormExpandableSlideOver`** (not a hand-rolled slideover) — the epic's hard constraint.
- `FormOptionsSelect` is **not** a fit: it's a DB-collection-backed, creatable select (fetches options from a settings collection via `useCollectionQuery`). The layout/page-type pickers are static option lists, so there's nothing to reuse there — not duplication.
- `DefaultCard` is display-config-driven for data records — also not applicable to these option cards. No core capability is being re-implemented.

### ✅ No one-off cruft
- `Toolbar.vue`: every prop/emit is live (status/visibility configs + dropdown items used in template; all 8 emits fired). No leftovers from the controls that moved into the panel.
- `Workspace/Editor.vue`: checked every state/computed referenced by the new wiring (`settingsOpen`, `selectedPageType`, `parentOptions`, `pagesPending`, `hasAccessCode`, `accessCodePending`, `scopeProvidedByBlock`, `onLayoutChange`, `saveAccessCode`, `removeAccessCode`, chrome flags) — all have live references. The old `pageTypeDropdownItems` is gone (replaced by `pageTypeOptions`). No orphaned popover state.

### ✅ Generalisable — do NOT extract a shared "option card"
The two pickers share only the selected-ring/border utility classes; their interiors are genuinely different layouts (3-col grid + wireframe vs. stacked row + icon chip + radio dot). A shared primitive would have to slot out the entire inner content, trading two readable components for one abstraction over two unrelated shapes. Per the issue's "only if genuinely simpler" — left separate.

### ⚠️ → ✅ i18n parity (the one fix)
`#211` added `pages.pageTypes.{regular,collectionBinder,footer}.{name,description}` to **en** and **nl** but missed **fr** (only `collectionDerived` landed in fr). The new `PageTypePicker` renders these, so French showed raw/English text. Added the three French entries mirroring en/nl. Verified **0 missing keys** across en/nl/fr for the whole `pages` namespace. No bare-`t(key)` bracket renders (descriptions pass through `t(value, value)` fallback).

## 🧪 Verification
- `pnpm --filter fanfare typecheck` (consumes crouton-pages): **0 crouton-pages errors**. Pre-existing failures in `crouton-charts/Widget.vue` and `crouton-core/RedirectsForm.vue` are unrelated to this epic and untouched here.
- Change is a purely additive locale-JSON edit — no runtime/behavioral surface, so the `with-pages` boot/CRUD path is unaffected; JSON validity + tri-locale parity verified programmatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_018mSs64ZAcJ4MbSgrx5P7HN)_