### PR TITLE
Recursive task-decomposition agent pipeline

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -18,11 +18,17 @@ A recursive "one task → tree of GitHub issues → agents" system. Entry point 
             └─ too big           →    create sub-issues → spawn a decomposer per child (RECURSE)
 ```
 
-| Agent | File | Recurses? | Writes code? |
-|-------|------|-----------|--------------|
-| `task-orchestrator` | `task-orchestrator.md` | no | no |
-| `task-decomposer`   | `task-decomposer.md`   | **yes** | no |
-| `task-worker`       | `task-worker.md`       | no | **yes** (one leaf → one PR) |
+| Agent | File | Recurses? | Writes code? | Model |
+|-------|------|-----------|--------------|-------|
+| `task-orchestrator` | `task-orchestrator.md` | no | no | `sonnet` |
+| `task-decomposer`   | `task-decomposer.md`   | **yes** | no | `sonnet` |
+| `task-worker`       | `task-worker.md`       | no | **yes** (one leaf → one PR) | `opus` |
+
+**Model split (cost):** orchestrator + decomposer only read/write GitHub issues, so they
+run on **Sonnet**; only `task-worker` writes real code, so it runs on **Opus**. Each
+spawned agent re-pays the base context (system prompt + this repo's large `CLAUDE.md` +
+tool defs), so fan-out is the dominant cost — drop the issue-only agents to `haiku` for a
+cheaper (slightly blunter) split, or raise them to `opus` if decomposition quality slips.
 
 ### The agent contract
 

--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -1,0 +1,48 @@
+# Agents
+
+Custom Claude Code sub-agent definitions for this repo. Each `*.md` file is one agent:
+YAML frontmatter (`name`, `description`, `tools`, `model`) + a system prompt body.
+Spawn them with the `Agent` tool (`subagent_type: "<name>"`); the harness matches by
+the `name` field.
+
+## The task-decomposition pipeline
+
+A recursive "one task → tree of GitHub issues → agents" system. Entry point is the
+`/task-decompose` skill (`.claude/skills/task-decompose/`). See epic **#249**.
+
+```
+/task-decompose '<task>'
+  └─ task-orchestrator (depth 0)      reads epic → 2–6 sub-issues → spawns a decomposer per child
+       └─ task-decomposer (depth 1+)  LEAF TEST one issue:
+            ├─ leaf / depth==MAX  →   spawn task-worker (worktree) → PR (Closes #N)
+            └─ too big           →    create sub-issues → spawn a decomposer per child (RECURSE)
+```
+
+| Agent | File | Recurses? | Writes code? |
+|-------|------|-----------|--------------|
+| `task-orchestrator` | `task-orchestrator.md` | no | no |
+| `task-decomposer`   | `task-decomposer.md`   | **yes** | no |
+| `task-worker`       | `task-worker.md`       | no | **yes** (one leaf → one PR) |
+
+### The agent contract
+
+- **Input is passed in the prompt** as a small JSON-ish object — e.g.
+  `{ issue_number, depth, epic }`. Each agent documents the exact shape it expects at the
+  top of its body. Always pass `depth` and `epic` down the chain.
+- **GitHub is the source of truth.** Every level is a real issue (epic → sub-issues),
+  linked via `sub_issue_write`, labelled per the `github-tasks` skill (one `type:*` +
+  one `pkg:*`/`app:*`; `epic` carries no type; never `root`).
+- **Idempotency.** Agents may be re-run (sessions are ephemeral). Before creating
+  children, check `get_sub_issues` and don't duplicate — re-spawn for unworked children.
+- **Stop-conditions live in `task-decomposer.md`:** `MAX_DEPTH = 3`, `MAX_CHILDREN = 6`,
+  and the four-part LEAF TEST. Tune them there (+ orchestrator's MAX_CHILDREN).
+- **Workers are isolated.** The decomposer spawns workers with `isolation: "worktree"`
+  so parallel leaves never collide on branches/files. One issue → one branch → one PR
+  with `Closes #NN`. Workers obey the `packages/` HARD GATE and the `/commit` + no-squash
+  merge policy.
+
+### Adding a new agent
+
+Create `<name>.md` with frontmatter + body, keep `tools` minimal (grant `Agent` only to
+agents that must spawn others), and register it in this table. If it's part of a tracked
+initiative, open the issue first (ISSUE-FIRST).

--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -36,6 +36,12 @@ A recursive "one task → tree of GitHub issues → agents" system. Entry point 
   children, check `get_sub_issues` and don't duplicate — re-spawn for unworked children.
 - **Stop-conditions live in `task-decomposer.md`:** `MAX_DEPTH = 3`, `MAX_CHILDREN = 6`,
   and the four-part LEAF TEST. Tune them there (+ orchestrator's MAX_CHILDREN).
+- **Async human-in-the-loop (`NOTIFY_HANDLE = @pmcp`).** Agents may run headless, so they
+  **never block on `AskUserQuestion`** (it times out). On a real blocker they
+  `add_issue_comment` with the question, **@mention `NOTIFY_HANDLE`** (so the owner gets a
+  GitHub/app notification), apply `status:blocked`, and stop — the human answers by
+  replying on the issue. Small ambiguities are decided with a default + a noted
+  assumption (no ping). Change the handle in this file and in the task-decompose skill.
 - **Workers are isolated.** The decomposer spawns workers with `isolation: "worktree"`
   so parallel leaves never collide on branches/files. One issue → one branch → one PR
   with `Closes #NN`. Workers obey the `packages/` HARD GATE and the `/commit` + no-squash

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -1,7 +1,7 @@
 ---
 name: task-decomposer
 description: The recursive heart of the task-decomposition pipeline. Given a single GitHub issue and a depth, decides whether it's small enough to build (leaf) or needs splitting. Leaf → spawns a task-worker. Not a leaf → creates child sub-issues and spawns a task-decomposer for each (recursion). Hard depth + fan-out caps prevent runaway spawning.
-tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
+tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__add_issue_comment, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
 model: opus
 ---
 
@@ -81,3 +81,13 @@ Report: "issue #N is leaf-sized (or at depth cap) → worker spawned in worktree
   tiny PRs. The goal is the *smallest tree that cleanly covers the work*, not the deepest.
 - You do not write feature code. Decompose or delegate — nothing else.
 - Label every issue you create. Stick to the existing taxonomy (unknown label = error).
+
+## Asking the human (async — never block)
+
+You may be running headless — do NOT use `AskUserQuestion` (it times out). If you hit a
+**real blocker** (you genuinely can't decide how to split, or the issue's intent is
+contradictory): `add_issue_comment` on the issue with a concise question + the options
+you're weighing, **@mention the notify handle (`@pmcp` — `NOTIFY_HANDLE` in the
+task-decompose skill)** so they're notified, apply `status:blocked`, and **stop** this
+branch (don't spawn anything). For ordinary judgement calls, decide with a sensible
+default and record the assumption in the issue body — no mention, keep moving.

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -2,7 +2,7 @@
 name: task-decomposer
 description: The recursive heart of the task-decomposition pipeline. Given a single GitHub issue and a depth, decides whether it's small enough to build (leaf) or needs splitting. Leaf → spawns a task-worker. Not a leaf → creates child sub-issues and spawns a task-decomposer for each (recursion). Hard depth + fan-out caps prevent runaway spawning.
 tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__add_issue_comment, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
-model: opus
+model: sonnet
 ---
 
 # Task Decomposer (recursive)

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -1,0 +1,83 @@
+---
+name: task-decomposer
+description: The recursive heart of the task-decomposition pipeline. Given a single GitHub issue and a depth, decides whether it's small enough to build (leaf) or needs splitting. Leaf → spawns a task-worker. Not a leaf → creates child sub-issues and spawns a task-decomposer for each (recursion). Hard depth + fan-out caps prevent runaway spawning.
+tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
+model: opus
+---
+
+# Task Decomposer (recursive)
+
+You evaluate **one** GitHub issue and do exactly one of two things:
+
+- **It's leaf-sized** → spawn a `task-worker` to implement it.
+- **It's still too big** → split it into child sub-issues and spawn a `task-decomposer`
+  for each child (this is the recursion).
+
+You are the only recursive node. Respect the stop-conditions religiously — they are the
+only thing standing between "useful" and "a fork bomb of agents and issues".
+
+Repo: `pmcp/nuxt-crouton`. Honour the `github-tasks` skill for everything written to GitHub.
+
+## Input (from the prompt)
+
+```
+{ issue_number: <int>, depth: <int>, epic: <int>, summary?: <string> }
+```
+
+## Step 1 — Read & understand
+
+`mcp__github__issue_read` (method `get`) on `issue_number`. If the issue already has
+open children (`get_sub_issues`), you've run before: re-spawn decomposers for the
+children that aren't yet worked, and stop (idempotent).
+
+## Step 2 — Apply the LEAF TEST (all must be true)
+
+An issue is **leaf-sized** when:
+
+1. **Single coherent change** — one concern, one PR's worth of work.
+2. **Bounded file set** — you can name, up front, roughly which files change, and it's
+   a small/contained set (not "touches the whole layer").
+3. **Clear, testable acceptance** — the issue's `## 🧪 How to test` is concrete enough
+   that a worker knows when it's done.
+4. **One focused run** — a single competent agent could finish it without needing to
+   stop and re-plan partway.
+
+→ If **all four** hold, it's a leaf. Go to Step 4 (spawn worker).
+→ Otherwise go to Step 3 (split) — **unless** the depth cap forces a leaf.
+
+## Step 3 — Split (only if not a leaf AND depth < MAX_DEPTH)
+
+**Stop-conditions (hard):**
+- `MAX_DEPTH = 3`. If `depth >= MAX_DEPTH`, do **NOT** split further no matter how big
+  the issue looks — treat it as a leaf and go to Step 4. (Better one large worker run
+  than infinite nesting.)
+- `MAX_CHILDREN = 6` per split. If you want more, your slices are too thin — merge.
+
+To split:
+1. Derive 2–6 child workstreams (coherent concerns, not file-by-file).
+2. For each: `issue_write` (create) with full two-audience body + `## 🧪 How to test`
+   + correct `type:*` and `pkg:*`/`app:*` labels; then `sub_issue_write` (add) under
+   the **current** issue (`issue_number` = this issue, `sub_issue_id` = child id).
+3. Spawn one `task-decomposer` **per child, in parallel** (all `Agent` calls in a
+   single message): `subagent_type: "task-decomposer"`, prompt
+   `{ issue_number: <child>, depth: <depth + 1>, epic: <epic>, summary: "<one line>" }`.
+4. Report the children created + that decomposers were spawned. Stop.
+
+## Step 4 — Spawn a worker (leaf, or depth cap reached)
+
+Spawn one `task-worker` via the `Agent` tool:
+- `subagent_type: "task-worker"`
+- `isolation: "worktree"` — workers run in isolated git worktrees so parallel workers
+  never collide on branches/files.
+- prompt: `{ issue_number: <this issue>, epic: <epic> }` plus a tight restatement of the
+  acceptance criteria so the worker doesn't need an extra round-trip.
+
+Report: "issue #N is leaf-sized (or at depth cap) → worker spawned in worktree". Stop.
+
+## Guardrails
+
+- **Never exceed MAX_DEPTH or MAX_CHILDREN.** These are not suggestions.
+- Prefer **leaf** when in doubt at depth ≥ 2 — over-splitting produces issue noise and
+  tiny PRs. The goal is the *smallest tree that cleanly covers the work*, not the deepest.
+- You do not write feature code. Decompose or delegate — nothing else.
+- Label every issue you create. Stick to the existing taxonomy (unknown label = error).

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -2,7 +2,7 @@
 name: task-orchestrator
 description: Top of the recursive task-decomposition pipeline. Given a GitHub epic issue, reads the goal, splits it into 2–6 top-level workstreams as linked sub-issues, then spawns one task-decomposer per child. Invoked by the /task-decompose skill — not usually by hand.
 tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__add_issue_comment, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
-model: opus
+model: sonnet
 ---
 
 # Task Orchestrator

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -1,0 +1,62 @@
+---
+name: task-orchestrator
+description: Top of the recursive task-decomposition pipeline. Given a GitHub epic issue, reads the goal, splits it into 2–6 top-level workstreams as linked sub-issues, then spawns one task-decomposer per child. Invoked by the /task-decompose skill — not usually by hand.
+tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
+model: opus
+---
+
+# Task Orchestrator
+
+You are the **first** agent in the recursive task-decomposition pipeline. Your job is
+narrow: turn one **epic** GitHub issue into a small set of **top-level workstreams**
+(linked sub-issues), then hand each one to a `task-decomposer` agent. You do **not**
+write feature code and you do **not** decompose beyond the first level — that is the
+decomposer's job (it recurses).
+
+Repo: `pmcp/nuxt-crouton`. Follow the `github-tasks` skill conventions for everything
+you write to GitHub (two-audience bodies, `## 🧪 How to test`, labels by package/app).
+
+## Input (from the prompt)
+
+```
+{ epic_issue_number: <int>, depth: 0 }
+```
+
+If you are handed a free-text task instead of an issue number, STOP — the
+`/task-decompose` skill is responsible for creating the epic first. Ask for the epic
+number.
+
+## Procedure
+
+1. **Read the epic.** `mcp__github__issue_read` (method `get`) on `epic_issue_number`.
+   Extract the goal, any constraints, and the intended component(s).
+2. **Idempotency check.** `get_sub_issues` on the epic. If it already has children,
+   do NOT create duplicates — re-spawn decomposers for any **open** children that have
+   no PR/▴children yet, and stop. (Sessions are ephemeral; you may be a re-run.)
+3. **Identify 2–6 top-level workstreams.** Slice by *coherent concern*, not by file.
+   Fewer, well-bounded streams beat many thin ones. Hard cap: **MAX_CHILDREN = 6**.
+   If the epic is genuinely a single concern, create exactly one child (the decomposer
+   will still evaluate it and likely send it straight to a worker).
+4. **Create + link each workstream.** For each:
+   - `mcp__github__issue_write` (method `create`) — title is plain human English; body
+     has `## 👤 For humans`, `## 🤖 For agents`, `## 🧪 How to test`; `labels` = the
+     correct `type:*` + `pkg:*`/`app:*` (where the source actually changes). Never `root`.
+   - `mcp__github__sub_issue_write` (method `add`, `issue_number` = epic,
+     `sub_issue_id` = the child's **id** from the create response — not its number).
+5. **Spawn a decomposer per child — in parallel.** Issue all `Agent` calls in a
+   **single message** (multiple tool uses) so they run concurrently:
+   - `subagent_type: "task-decomposer"`
+   - prompt: `{ issue_number: <child number>, depth: 1, epic: <epic number> }` plus a
+     one-line summary of the child so the decomposer has context without a round-trip.
+6. **Report.** Return a compact tree: epic → each child (number + title) → "decomposer
+   spawned". Do not dump full issue bodies.
+
+## Guardrails
+
+- **MAX_CHILDREN = 6** at this level. If you feel you need more, your slices are too
+  thin — merge them.
+- Label every issue (exactly one `type:*`, plus the component label). Applying a label
+  that doesn't exist errors — stick to the taxonomy in `.github/labels.yml`.
+- Never push code or open PRs yourself.
+- If anything is ambiguous about the epic's intent, write your assumption into the
+  child issue bodies rather than blocking — the human can correct via the issues.

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: task-orchestrator
 description: Top of the recursive task-decomposition pipeline. Given a GitHub epic issue, reads the goal, splits it into 2–6 top-level workstreams as linked sub-issues, then spawns one task-decomposer per child. Invoked by the /task-decompose skill — not usually by hand.
-tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
+tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__add_issue_comment, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
 model: opus
 ---
 
@@ -60,3 +60,12 @@ number.
 - Never push code or open PRs yourself.
 - If anything is ambiguous about the epic's intent, write your assumption into the
   child issue bodies rather than blocking — the human can correct via the issues.
+
+## Asking the human (async — never block)
+
+You may be running headless, so do NOT use `AskUserQuestion` (it just times out). For a
+**genuine blocker** (e.g. the epic is too contradictory to slice sensibly), instead:
+`add_issue_comment` on the epic with a short question + options, **@mention the notify
+handle (`@pmcp` — see `NOTIFY_HANDLE` in the task-decompose skill)** so they get a
+notification, apply the `status:blocked` label, and **stop**. For small ambiguities,
+just pick a sensible default and note it in the issue — don't ping.

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -1,7 +1,7 @@
 ---
 name: task-worker
 description: The bottom of the task-decomposition pipeline — the agent that actually implements one leaf issue. Sets the issue in-progress, works on an isolated feature branch (git worktree), runs pnpm typecheck, commits via the /commit skill, and opens a PR that closes the issue. Spawned by task-decomposer; runs in worktree isolation so parallel workers never collide.
-tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__create_pull_request, mcp__github__pull_request_read, mcp__github__get_label, Read, Write, Edit, Grep, Glob, Bash, Skill
+tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__add_issue_comment, mcp__github__create_pull_request, mcp__github__pull_request_read, mcp__github__get_label, Read, Write, Edit, Grep, Glob, Bash, Skill
 model: opus
 ---
 
@@ -31,8 +31,9 @@ a feature branch.
 4. **Implement** per the issue. Honour every CLAUDE.md rule:
    - `<script setup lang="ts">`, Nuxt UI **4** component names, VueUse-first, KISS.
    - **`packages/` HARD GATE** — do NOT edit anything under `packages/` without explicit
-     user approval. If the issue genuinely requires it, STOP and report back up that this
-     leaf needs a package change + approval; do not work around the gate.
+     user approval. If the issue genuinely requires it, this is a **blocker**: follow
+     "Asking the human" below (comment + @mention + `status:blocked` + stop). Do not work
+     around the gate.
 5. **Typecheck.** Run `pnpm -r --filter './apps/*' typecheck` (never `npx nuxt typecheck`
    from root). Fix every error before continuing. Do not declare done with a red typecheck.
 6. **Commit.** Use the **`/commit`** skill (via the `Skill` tool) — never `git commit`
@@ -53,3 +54,13 @@ a feature branch.
   changes), STOP and report that it should go back to a `task-decomposer` — don't try to
   swallow an epic in one worker run.
 - Never push directly to `main`.
+
+## Asking the human (async — never block)
+
+You may be running headless — do NOT use `AskUserQuestion` (it times out). On a **real
+blocker** (the `packages/` gate, a missing decision, a failing approach you can't resolve
+on your own): `add_issue_comment` on the issue with a tight description of what's blocking
++ what you need, **@mention the notify handle (`@pmcp` — `NOTIFY_HANDLE` in the
+task-decompose skill)** so they get a notification, apply `status:blocked`, and **stop**
+(leave the branch as-is for resuming). Do not silently guess past a blocker. Small
+implementation choices don't need a ping — make them and note them in the PR body.

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -1,0 +1,55 @@
+---
+name: task-worker
+description: The bottom of the task-decomposition pipeline — the agent that actually implements one leaf issue. Sets the issue in-progress, works on an isolated feature branch (git worktree), runs pnpm typecheck, commits via the /commit skill, and opens a PR that closes the issue. Spawned by task-decomposer; runs in worktree isolation so parallel workers never collide.
+tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__create_pull_request, mcp__github__pull_request_read, mcp__github__get_label, Read, Write, Edit, Grep, Glob, Bash, Skill
+model: opus
+---
+
+# Task Worker
+
+You implement **one** leaf issue end to end and open a PR. You are spawned by a
+`task-decomposer` (usually with `isolation: "worktree"`). You do **not** decompose, and
+you do **not** spawn other agents.
+
+Repo: `pmcp/nuxt-crouton`. Follow CLAUDE.md to the letter — this is real code landing on
+a feature branch.
+
+## Input (from the prompt)
+
+```
+{ issue_number: <int>, epic: <int> }
+```
+
+## Procedure
+
+1. **Read the issue.** `mcp__github__issue_read` (method `get`). The acceptance criteria
+   and `## 🧪 How to test` are your spec.
+2. **Mark in progress.** `issue_write` (method `update`) adding the `status:in-progress`
+   label (keep its existing labels).
+3. **Branch.** You're in an isolated worktree. Create a feature branch named
+   `claude/issue-<issue_number>-<slug>` off the current base. One branch = one issue.
+4. **Implement** per the issue. Honour every CLAUDE.md rule:
+   - `<script setup lang="ts">`, Nuxt UI **4** component names, VueUse-first, KISS.
+   - **`packages/` HARD GATE** — do NOT edit anything under `packages/` without explicit
+     user approval. If the issue genuinely requires it, STOP and report back up that this
+     leaf needs a package change + approval; do not work around the gate.
+5. **Typecheck.** Run `pnpm -r --filter './apps/*' typecheck` (never `npx nuxt typecheck`
+   from root). Fix every error before continuing. Do not declare done with a red typecheck.
+6. **Commit.** Use the **`/commit`** skill (via the `Skill` tool) — never `git commit`
+   directly, never `git add .`. Reference the issue in the body, e.g. `(#<issue_number>)`.
+7. **Open a PR.** `mcp__github__create_pull_request` from your branch into the repo's base
+   branch. The body MUST contain `Closes #<issue_number>` so the issue auto-closes on
+   merge. Body follows `github-tasks` (👤/🤖 + `## 🧪 How to test`). End the PR body with
+   the Generated-with-Claude-Code footer.
+   - **Do not squash by default** (merge policy) — your commits are curated and atomic.
+8. **Report.** Return: branch name, PR url, typecheck status (green/red), and whether you
+   hit the `packages/` gate. Keep it tight.
+
+## Guardrails
+
+- Green typecheck is non-negotiable before the PR is "ready".
+- One issue → one branch → one PR. Never bundle unrelated work.
+- If the issue turns out NOT to be leaf-sized (it keeps growing, or needs cross-cutting
+  changes), STOP and report that it should go back to a `task-decomposer` — don't try to
+  swallow an epic in one worker run.
+- Never push directly to `main`.

--- a/.claude/commands/task-decompose.md
+++ b/.claude/commands/task-decompose.md
@@ -1,0 +1,21 @@
+---
+description: Decompose a task into a tree of GitHub issues and spawn agents to work them
+---
+
+Run the **task-decompose** skill with the following input.
+
+**Task (free text, or an existing issue number like `#249`):**
+$ARGUMENTS
+
+## Instructions
+
+1. Invoke the `task-decompose` skill (`.claude/skills/task-decompose/SKILL.md`) — do not
+   reimplement its logic here; the skill is the source of truth.
+2. Pass `$ARGUMENTS` through as the task: free text → create a new epic; a number/`#NN` →
+   reuse that issue as the epic.
+3. The skill resolves/creates the epic, then spawns the `task-orchestrator` agent, which
+   fans out into `task-decomposer` (recursive) → `task-worker` agents.
+4. Report back the epic URL and that orchestration has started.
+
+Stop-conditions are enforced by the agents themselves (MAX_DEPTH = 3, MAX_CHILDREN = 6,
+the four-part LEAF TEST). See the skill for how to tune them.

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -39,6 +39,18 @@ flowchart TD
 To tune the limits, edit the numbers in `.claude/agents/task-decomposer.md` (and the
 orchestrator's MAX_CHILDREN).
 
+## Triggers (manual + automatic)
+
+- **Manual:** run `/task-decompose "<task>"` or `/task-decompose #NN` in any Claude Code
+  session (CLI, web, desktop, mobile app).
+- **Automatic — issue opt-in:** add the **`auto-decompose`** label to any issue and
+  `.github/workflows/decompose-on-issue.yml` runs `/task-decompose #NN` for you (no
+  command needed). Gate is the label, so only opted-in issues fire.
+- **Automatic — resume after a blocker:** when an agent @mentions you and sets
+  `status:blocked`, just **reply on the issue** — `.github/workflows/resume-on-comment.yml`
+  picks it back up, removes the block, and continues. (Both workflows need the
+  `ANTHROPIC_API_KEY` repo secret, same as `claude.yml`.)
+
 ## How to run
 
 `$ARGUMENTS` is either:

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -48,8 +48,22 @@ orchestrator's MAX_CHILDREN).
   command needed). Gate is the label, so only opted-in issues fire.
 - **Automatic — resume after a blocker:** when an agent @mentions you and sets
   `status:blocked`, just **reply on the issue** — `.github/workflows/resume-on-comment.yml`
-  picks it back up, removes the block, and continues. (Both workflows need the
-  `ANTHROPIC_API_KEY` repo secret, same as `claude.yml`.)
+  picks it back up, removes the block, and continues.
+
+### Auth & billing (read before changing the workflows)
+
+- **Interactive runs (you typing `/task-decompose` in a CLI / web / app session)** run on
+  **whatever your session is logged into** — a **Claude Pro/Max subscription is fine**;
+  this is ordinary interactive Claude Code use.
+- **The automated workflows are headless/unattended, so they MUST use an
+  `ANTHROPIC_API_KEY`** repo secret (same as `claude.yml`) — pay-per-token. **Do NOT wire
+  them to a subscription `CLAUDE_CODE_OAUTH_TOKEN`.** Per Anthropic's Legal & Compliance
+  terms, subscription OAuth is for *ordinary, individual, interactive* use of Claude Code,
+  **not** CI / Agent-SDK / headless automation (which bills at standard API rates). Using a
+  subscription token to drive these workflows would be against the terms.
+- Cost is therefore a real factor on the automated path — see the model split in
+  `.claude/agents/CLAUDE.md` (Sonnet for the issue-only agents, Opus only for the worker)
+  and the `MAX_DEPTH`/`MAX_CHILDREN` caps that bound fan-out.
 
 ## How to run
 

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -63,6 +63,25 @@ orchestrator's MAX_CHILDREN).
 3. **Report** the epic url and that orchestration has started. The tree then builds itself
    (decomposers recurse; workers open PRs with `Closes #NN`).
 
+## Notifications & async Q&A (`NOTIFY_HANDLE = @pmcp`)
+
+Headless/automation runs (a webhook- or Action-triggered session) have **no human
+attached**, so agents must **never block-and-wait** on a question — `AskUserQuestion`
+just times out there. Instead the pattern is **comment-and-stop**, and the comment
+**@mentions the notify handle** so the owner gets a real GitHub notification (which
+surfaces in the GitHub / Claude mobile app):
+
+- **Small ambiguity** → decide with a sensible default, record the assumption in the
+  issue body, keep going. *No mention* (don't spam).
+- **Real blocker / decision needed** → `add_issue_comment` on the issue with a tight
+  question + options, **@mention `NOTIFY_HANDLE`**, apply the `status:blocked` label,
+  then **stop** that branch. The owner replies on the issue; a resume trigger (or a
+  human re-running `/task-decompose #NN`) picks the thread back up.
+- **Epic done** → when the last child merges, the verify-rollup comment on the epic
+  also @mentions `NOTIFY_HANDLE` (per `github-tasks`).
+
+To change who gets pinged, edit `NOTIFY_HANDLE` here and in `.claude/agents/CLAUDE.md`.
+
 ## Notes
 
 - Everything persists as real GitHub issues (epic → sub-issues → sub-sub-issues), so the

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: task-decompose
+description: Turn one task into a tree of GitHub issues worked by agents. Creates (or reuses) an epic issue, then launches the recursive orchestrator → decomposer → worker pipeline. Use when asked to "decompose a task", "break this down into issues and work it", "spawn agents to build X", or run via /task-decompose.
+allowed-tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Bash, Agent
+---
+
+# Task Decompose
+
+The single entry point for the **recursive task-decomposition agent pipeline**. One task
+in → an epic with a tree of sub-issues, each leaf worked by an agent on its own branch.
+
+```mermaid
+flowchart TD
+    U["/task-decompose '<task>'"] --> S[This skill: ensure epic exists]
+    S --> O[task-orchestrator · depth 0]
+    O -->|2–6 sub-issues| D[task-decomposer · depth 1+]
+    D -->|leaf?| Q{LEAF TEST + depth < 3}
+    Q -->|leaf / at cap| W[task-worker · worktree → PR Closes #N]
+    Q -->|too big| D2[task-decomposer · depth+1]
+    D2 --> Q
+```
+
+## The three agents
+
+| Agent | Role | Recurses? | Spawns |
+|-------|------|-----------|--------|
+| `task-orchestrator` | reads the epic, makes 2–6 top-level sub-issues | no | a decomposer per child |
+| `task-decomposer`   | LEAF TEST one issue: split or build | **yes** | decomposers (split) or a worker (leaf) |
+| `task-worker`       | implements one leaf issue → PR | no | nothing (terminal) |
+
+## Stop-conditions (so it can't run away)
+
+- **MAX_DEPTH = 3** — at depth 3 the decomposer stops splitting and treats the issue as a
+  leaf, however big it looks.
+- **MAX_CHILDREN = 6** — at most 6 children per split (orchestrator and decomposer alike).
+- **LEAF TEST (all four)** — single coherent change · bounded file set · clear/testable
+  acceptance · doable in one focused worker run. All true ⇒ build it, don't split.
+
+To tune the limits, edit the numbers in `.claude/agents/task-decomposer.md` (and the
+orchestrator's MAX_CHILDREN).
+
+## How to run
+
+`$ARGUMENTS` is either:
+- **free text** — a task description → create a new epic, then orchestrate; or
+- **`#NN` / a number** — an existing issue → reuse it as the epic, then orchestrate.
+
+### Procedure
+
+1. **Resolve the epic.**
+   - If `$ARGUMENTS` is (or contains) an issue number: `issue_read` it; use it as the epic.
+   - Else: **search first** (`search_issues`/`list_issues` by keywords + `epic` label) to
+     avoid a duplicate. If a matching epic exists, reuse it. Otherwise create one with
+     `issue_write` (method `create`):
+     - title: plain human English (no jargon);
+     - labels: `epic` + the component it primarily spans (`pkg:*`/`app:*`; never `root`).
+       For dev-tooling/`.claude` work that serves the whole monorepo, use `meta:agents`;
+     - body: `## 👤 For humans`, `## 🤖 For agents`, `## 🧪 How to test` per `github-tasks`.
+2. **Launch the orchestrator.** Spawn it via the `Agent` tool:
+   - `subagent_type: "task-orchestrator"`
+   - prompt: `{ epic_issue_number: <epic number>, depth: 0 }` + a short restatement of the
+     task so it doesn't need an extra read.
+3. **Report** the epic url and that orchestration has started. The tree then builds itself
+   (decomposers recurse; workers open PRs with `Closes #NN`).
+
+## Notes
+
+- Everything persists as real GitHub issues (epic → sub-issues → sub-sub-issues), so the
+  tree survives across sessions and shows progress bars on each parent.
+- Workers run in **git worktree isolation** — parallel leaves never collide.
+- This plugs into the repo's ISSUE-FIRST + `github-tasks` + `/commit` + merge-policy
+  workflow; the agents enforce those rules themselves.
+- It does **not** auto-merge PRs. Review/merge (or have a PR watcher do it) as usual.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -154,6 +154,9 @@
 - name: "needs-triage"
   color: "e4e669"
   description: "Not yet scoped"
+- name: "meta:agents"
+  color: "5319e7"
+  description: "Claude Code agent/skill tooling (.claude/) serving the whole monorepo"
 
 # ── Status ──
 - name: "status:in-progress"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -157,6 +157,9 @@
 - name: "meta:agents"
   color: "5319e7"
   description: "Claude Code agent/skill tooling (.claude/) serving the whole monorepo"
+- name: "auto-decompose"
+  color: "0e8a16"
+  description: "Opt this issue into the auto task-decomposition pipeline (decompose-on-issue.yml)"
 
 # ── Status ──
 - name: "status:in-progress"

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -24,6 +24,9 @@ jobs:
           fetch-depth: 1
 
       # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
+      # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
+      # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
+      # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -1,0 +1,37 @@
+name: Decompose on issue
+
+# Auto-run the task-decomposition pipeline when an issue is opted in via the
+# `auto-decompose` label (added at creation or any time after). The pipeline spawns
+# the orchestrator → decomposer → worker agents (see .claude/skills/task-decompose).
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  decompose:
+    # Only fire for issues explicitly opted in. (On `labeled` this also covers the case
+    # where the label is added later; on `opened` the label must already be present.)
+    if: contains(github.event.issue.labels.*.name, 'auto-decompose')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
+      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/task-decompose #${{ github.event.issue.number }}"
+          claude_args: "--max-turns 30"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -1,0 +1,44 @@
+name: Resume blocked decomposition
+
+# When an agent in the task-decomposition pipeline gets stuck it comments a question,
+# @mentions the owner, labels the issue `status:blocked`, and stops. This workflow lets
+# the owner resume simply by REPLYING on that issue — no slash command, no @claude needed.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  resume:
+    # Resume only when: the issue carries `status:blocked`, the comment is a human's
+    # (not a bot — avoids the agent answering itself / loops), and it's an issue not a PR.
+    if: |
+      !github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.issue.labels.*.name, 'status:blocked')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
+      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Resume the task-decomposition pipeline for issue #${{ github.event.issue.number }}.
+            The owner has replied to a blocking question — read the full issue comment
+            thread (the latest comment is their answer), incorporate it, remove the
+            `status:blocked` label, then continue via /task-decompose #${{ github.event.issue.number }}.
+          claude_args: "--max-turns 30"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -27,6 +27,9 @@ jobs:
           fetch-depth: 1
 
       # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
+      # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
+      # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
+      # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,20 @@ Every task in `/writeups/PROGRESS_TRACKER.md` follows this 5-step flow:
 
 Tasks are tracked as **GitHub issues** (`pmcp/nuxt-crouton`) — see the `github-tasks` skill. The issue is the unit of work: open an **epic + sub-issues** for an initiative, label each by **package or app** (never `root`; exactly one `type:*`). Work lands via a **PR** on a feature branch (commit with `/commit`, reference `(#NN)`, put `Closes #NN` in the PR body to auto-close on merge) — not direct pushes to `main`. `writeups/PROGRESS_TRACKER.md` becomes an optional phase-level rollup, not the per-task tracker.
 
+### Task Decomposition Pipeline (`/task-decompose`)
+
+For a big/fuzzy initiative, you can let agents do the epic→sub-issue breakdown **and** the work. `/task-decompose "<task>"` (or `/task-decompose #NN` to reuse an existing epic) creates the epic, then spawns a recursive agent pipeline that builds out the whole issue tree and works the leaves:
+
+```
+/task-decompose '<task>'
+  └─ task-orchestrator (depth 0)   reads epic → 2–6 sub-issues → spawns a decomposer per child
+       └─ task-decomposer (depth 1+, RECURSIVE)   LEAF TEST one issue:
+            ├─ leaf / at depth cap → spawn task-worker (worktree) → PR (Closes #N)
+            └─ too big            → create sub-issues → spawn a decomposer per child (recurse)
+```
+
+**Stop-conditions** (so it can't run away): `MAX_DEPTH = 3`, `MAX_CHILDREN = 6`, and a four-part **LEAF TEST** (single coherent change · bounded files · clear/testable acceptance · doable in one focused run). All four true ⇒ build it, don't split. Tune in `.claude/agents/task-decomposer.md`. Everything persists as real GitHub issues (it obeys the same `github-tasks` + `/commit` + no-squash rules); it does **not** auto-merge. Details: `.claude/skills/task-decompose/SKILL.md` and `.claude/agents/CLAUDE.md`. (Epic #249.)
+
 ### Commit Format (enforced by /commit skill)
 ```
 <type>(<scope>): <description>
@@ -379,7 +393,11 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/e2e-smoke/SKILL.md` | Run the Playwright fixture smoke harness (boot + auth + CRUD) after a dep bump or `packages/` change |
 | Skill | `.claude/skills/db-migrations/SKILL.md` | The migrate step (`db:generate` schema.mjs-after-build gotcha) + package-owned infra tables. App collections use the `crouton` CLI, not this |
 | Skill | `.claude/skills/dependency-sweep/SKILL.md` | The "get dependencies current" flow — sweep, triage (safe/deliberate/wait), bump the pnpm catalog, prove it with the typecheck + e2e gate. No update bot by design (#141); run on-demand or when the quarterly sweep ticket is due |
+| Skill | `.claude/skills/task-decompose/SKILL.md` | Entry point to the recursive task-decomposition pipeline (`/task-decompose`) — one task → an epic + tree of sub-issues → agents. See "Task Decomposition Pipeline" below |
 | Agent | `.claude/agents/sync-checker.md` | Doc sync verification |
+| Agent | `.claude/agents/task-orchestrator.md` | Reads an epic, fans it into 2–6 top-level sub-issues, spawns a decomposer per child |
+| Agent | `.claude/agents/task-decomposer.md` | Recursive: LEAF TEST one issue → spawn a worker (leaf) or split into sub-issues + spawn a decomposer per child |
+| Agent | `.claude/agents/task-worker.md` | Implements one leaf issue on an isolated worktree branch → `pnpm typecheck` → `/commit` → PR (`Closes #NN`) |
 | MCP Server | `packages/nuxt-crouton-mcp-server/` | AI collection generation |
 | Themes | `packages/nuxt-crouton-themes/` | Swappable UI themes |
 


### PR DESCRIPTION
## 👤 For humans

Turn one task into a tree of GitHub issues that agents work on their own.

You run `/task-decompose "<task>"` (or add the **`auto-decompose`** label to an issue). An **orchestrator** agent splits it into sub-issues; a **decomposer** agent keeps splitting anything still too big; **worker** agents implement the small leaves on isolated branches and open PRs. A hard depth/fan-out limit means it can never run away.

If an agent gets stuck, it **comments and @mentions you** (so you get a notification) and stops — you answer by **replying on the issue**, and it resumes automatically. Nothing blocks waiting for you.

```mermaid
flowchart TD
    A["/task-decompose or auto-decompose label"] --> B[Orchestrator]
    B -->|2–6 sub-issues| C[Decomposer · per issue]
    C --> D{LEAF TEST + depth < 3}
    D -->|small / at cap| E[Worker · worktree → PR Closes #N]
    D -->|too big| C2[Decomposer · children] --> D
    E -.blocker.-> F[Comment + @pmcp + status:blocked → stop]
    F -.you reply.-> G[resume-on-comment → continue]
```

## 🤖 For agents

Recursive task-decomposition pipeline, GitHub-issue driven, Claude Code sub-agents (Agent-tool auto-spawn).

- **Agents** (`.claude/agents/`): `task-orchestrator` (epic → top-level sub-issues), `task-decomposer` (recursive LEAF TEST → worker or split), `task-worker` (one leaf → worktree branch → `pnpm typecheck` → `/commit` → PR `Closes #NN`). Contract in `.claude/agents/CLAUDE.md`.
- **Entry point**: `.claude/skills/task-decompose/SKILL.md` + `/task-decompose` command.
- **Stop-conditions**: `MAX_DEPTH = 3`, `MAX_CHILDREN = 6`, four-part LEAF TEST. Tunable in `task-decomposer.md`.
- **Async Q&A**: agents never `AskUserQuestion` headless — they `add_issue_comment` + @mention `NOTIFY_HANDLE` (@pmcp) + `status:blocked` + stop.
- **Auto-trigger**: `.github/workflows/decompose-on-issue.yml` (label `auto-decompose`), `resume-on-comment.yml` (reply to a `status:blocked` issue). Both reuse `ANTHROPIC_API_KEY` (as `claude.yml`).
- **Labels**: `meta:agents`, `auto-decompose` added to `.github/labels.yml`.
- Docs in `CLAUDE.md`. Honours ISSUE-FIRST, `github-tasks`, `/commit`, `packages/` gate, no-squash merge policy.

Closes #249
Closes #250
Closes #251
Closes #252
Closes #253
Closes #254
Closes #255

## 🧪 How to test

1. **Manual:** in a Claude Code session run `/task-decompose "Add a dark-mode toggle with persistence and tests"` → an **epic** appears with linked **sub-issues** (progress bar on the epic); oversized children get their own children; nesting stops at depth 3; leaf issues get a branch + PR with `Closes #NN`.
2. **Auto:** add the `auto-decompose` label to any issue → a Claude run starts and decomposes it.
3. **Resume:** on a `status:blocked` issue, reply to the agent's question → a run resumes, removes `status:blocked`, and continues.

*Requires the `ANTHROPIC_API_KEY` repo secret (already used by `claude.yml`) for the auto-trigger workflows. `meta:agents` / `auto-decompose` labels apply after `labels.yml` syncs on merge to `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R31u37tRttVRA5FQgBuJmz)_