### PR TITLE
feat(root): add public blog reader — /blog index + /blog/[slug] (#260)

### DIFF
--- a/apps/blog/app/pages/blog/[slug].vue
+++ b/apps/blog/app/pages/blog/[slug].vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+// Public single-post page — 404s on unknown or draft slugs (API enforces it).
+definePageMeta({ layout: false })
+
+const route = useRoute()
+const slug = computed(() => String(route.params.slug))
+
+const { data: post, error } = await useFetch(() => `/api/blog/posts/${slug.value}`)
+
+if (error.value || !post.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Post not found', fatal: true })
+}
+
+useHead(() => ({ title: post.value?.title ?? 'Post' }))
+
+function formatDate(d: string | number | Date | null | undefined) {
+  if (!d) return ''
+  return new Date(d).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-(--ui-bg)">
+    <div class="max-w-2xl mx-auto px-4 py-10">
+      <ULink
+        to="/blog"
+        class="inline-flex items-center gap-1.5 text-sm text-(--ui-text-muted) hover:text-(--ui-text-highlighted) transition-colors"
+      >
+        <UIcon name="i-lucide-arrow-left" class="size-4" />
+        Back to blog
+      </ULink>
+
+      <article v-if="post" class="mt-6">
+        <div class="flex items-center gap-2 text-sm text-(--ui-text-muted)">
+          <span>{{ formatDate(post.publishedAt) }}</span>
+          <span aria-hidden="true">·</span>
+          <span>{{ post.author }}</span>
+        </div>
+        <h1 class="mt-2 text-3xl font-bold tracking-tight text-(--ui-text-highlighted)">
+          {{ post.title }}
+        </h1>
+        <div v-if="post.tags && post.tags.length" class="mt-3 flex flex-wrap gap-1.5">
+          <UBadge
+            v-for="tag in post.tags"
+            :key="tag"
+            color="neutral"
+            variant="subtle"
+            size="sm"
+          >
+            {{ tag }}
+          </UBadge>
+        </div>
+
+        <USeparator class="my-6" />
+
+        <!-- body is rich-text HTML authored via CroutonEditorSimple in the admin -->
+        <div
+          class="prose prose-neutral dark:prose-invert max-w-none text-(--ui-text)"
+          v-html="post.body"
+        />
+      </article>
+    </div>
+  </div>
+</template>

--- a/apps/blog/app/pages/blog/index.vue
+++ b/apps/blog/app/pages/blog/index.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+// Public blog index — no admin chrome, no auth required.
+definePageMeta({ layout: false })
+
+const { data: posts, pending, error } = await useFetch('/api/blog/posts')
+
+useHead({ title: 'Blog' })
+
+function formatDate(d: string | number | Date | null | undefined) {
+  if (!d) return ''
+  return new Date(d).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-(--ui-bg)">
+    <header class="border-b border-(--ui-border)">
+      <div class="max-w-3xl mx-auto px-4 py-10">
+        <h1 class="text-3xl font-bold tracking-tight text-(--ui-text-highlighted)">
+          Blog
+        </h1>
+        <p class="mt-1 text-(--ui-text-muted)">Latest posts</p>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <div v-if="pending" class="flex justify-center py-16">
+        <UIcon name="i-lucide-loader-2" class="size-6 animate-spin text-(--ui-text-dimmed)" />
+      </div>
+
+      <UAlert
+        v-else-if="error"
+        color="error"
+        variant="subtle"
+        title="Failed to load posts"
+        icon="i-lucide-triangle-alert"
+      />
+
+      <div v-else-if="!posts || posts.length === 0" class="text-center py-16">
+        <UIcon name="i-lucide-newspaper" class="size-10 mx-auto text-(--ui-text-dimmed)" />
+        <p class="mt-3 text-(--ui-text-muted)">No posts published yet.</p>
+      </div>
+
+      <ul v-else class="space-y-4">
+        <li v-for="post in posts" :key="post.id">
+          <ULink :to="`/blog/${post.slug}`" class="block group">
+            <UCard
+              class="transition-all duration-200 hover:shadow-md hover:border-(--ui-border-accented)"
+            >
+              <div class="flex items-center gap-2 text-xs text-(--ui-text-muted)">
+                <span>{{ formatDate(post.publishedAt) }}</span>
+                <span aria-hidden="true">·</span>
+                <span>{{ post.author }}</span>
+              </div>
+              <h2
+                class="mt-1 text-xl font-semibold text-(--ui-text-highlighted) group-hover:text-(--ui-primary) transition-colors"
+              >
+                {{ post.title }}
+              </h2>
+              <p v-if="post.excerpt" class="mt-2 text-(--ui-text-muted) line-clamp-2">
+                {{ post.excerpt }}
+              </p>
+              <div v-if="post.tags && post.tags.length" class="mt-3 flex flex-wrap gap-1.5">
+                <UBadge
+                  v-for="tag in post.tags"
+                  :key="tag"
+                  color="neutral"
+                  variant="subtle"
+                  size="sm"
+                >
+                  {{ tag }}
+                </UBadge>
+              </div>
+            </UCard>
+          </ULink>
+        </li>
+      </ul>
+    </main>
+  </div>
+</template>

--- a/apps/blog/server/api/blog/posts/[slug].get.ts
+++ b/apps/blog/server/api/blog/posts/[slug].get.ts
@@ -1,0 +1,38 @@
+// Public single-post reader — published posts only. 404 for unknown or draft.
+import { eq, and, desc } from 'drizzle-orm'
+import { blogPosts } from '~~/server/db/schema'
+
+export default defineEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'slug')
+  if (!slug) {
+    throw createError({ status: 400, statusText: 'Missing slug' })
+  }
+
+  const db = useDB() as any
+
+  // slug is unique per team, not globally; for the single public blog we take
+  // the most recently published match.
+  const [post] = await db
+    .select({
+      id: blogPosts.id,
+      title: blogPosts.title,
+      slug: blogPosts.slug,
+      author: blogPosts.author,
+      publishedAt: blogPosts.publishedAt,
+      tags: blogPosts.tags,
+      body: blogPosts.body,
+    })
+    .from(blogPosts)
+    .where(and(eq(blogPosts.slug, slug), eq(blogPosts.status, 'published')))
+    .orderBy(desc(blogPosts.publishedAt))
+    .limit(1)
+
+  if (!post) {
+    throw createError({ status: 404, statusText: 'Post not found' })
+  }
+
+  return {
+    ...post,
+    tags: Array.isArray(post.tags) ? post.tags : [],
+  }
+})

--- a/apps/blog/server/api/blog/posts/index.get.ts
+++ b/apps/blog/server/api/blog/posts/index.get.ts
@@ -1,0 +1,40 @@
+// Public blog index — published posts, newest first. No auth, no team scope.
+// The admin CRUD is team-scoped (server/api/teams/[id]/blog-posts), but the
+// public reader is a single shared blog: it reads every published post.
+import { eq, desc } from 'drizzle-orm'
+import { blogPosts } from '~~/server/db/schema'
+
+export default defineEventHandler(async () => {
+  const db = useDB() as any
+
+  const rows = await db
+    .select({
+      id: blogPosts.id,
+      title: blogPosts.title,
+      slug: blogPosts.slug,
+      author: blogPosts.author,
+      publishedAt: blogPosts.publishedAt,
+      tags: blogPosts.tags,
+      body: blogPosts.body,
+    })
+    .from(blogPosts)
+    .where(eq(blogPosts.status, 'published'))
+    .orderBy(desc(blogPosts.publishedAt))
+
+  // Strip the rich-text HTML to a short plain-text excerpt and drop the full body.
+  return rows.map((r: any) => {
+    const text = String(r.body ?? '')
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+    return {
+      id: r.id,
+      title: r.title,
+      slug: r.slug,
+      author: r.author,
+      publishedAt: r.publishedAt,
+      tags: Array.isArray(r.tags) ? r.tags : [],
+      excerpt: text.length > 200 ? `${text.slice(0, 200).trimEnd()}…` : text,
+    }
+  })
+})


### PR DESCRIPTION
Closes #260

## 👤 For humans

Adds the public-facing side of the blog. Two pages, no login required:

- **`/blog`** — lists published posts, newest first, each card showing title, author, date, tags and a short excerpt. Loading / empty / error states included.
- **`/blog/[slug]`** — the full post (title, author, date, tags, body) with a "Back to blog" link.

Draft posts never show publicly, and an unknown or draft slug returns a 404.

> Part of epic #257, stacked on `claude/blog-poc-p70yl4`. Next: end-to-end verification (#261).

## 🤖 For agents

**Public API** (no auth, no team scope — the public reader is a single shared blog; admin CRUD stays team-scoped under `server/api/teams/[id]/blog-posts`):
- `apps/blog/server/api/blog/posts/index.get.ts` — `status='published'`, `orderBy(desc(publishedAt))`, rich-text HTML stripped to a ≤200-char plain-text excerpt.
- `apps/blog/server/api/blog/posts/[slug].get.ts` — single published post by slug; `404` if none. Slug is unique per team (not global), so it returns the most-recently-published match.

**Pages** (Nuxt UI 4, `definePageMeta({ layout: false })`, hover + transition polish):
- `apps/blog/app/pages/blog/index.vue` — `UCard` list, `UBadge` tags, `UAlert` error, loading/empty states.
- `apps/blog/app/pages/blog/[slug].vue` — body via `v-html` (rich text authored by `CroutonEditorSimple`), `USeparator`, fatal `createError(404)`.

**Public reachability:** verified the global `team-context.global.ts` middleware skips `/auth` and, for unauthenticated users, clears team context and returns — **no login redirect**, so `/blog` is anonymous-accessible.

**No `packages/` source changes.**

## 🧪 How to test

- `pnpm --filter blog typecheck` → **green** (verified, exit 0).
- In the admin, create Post A (Published) and Post B (Draft).
- Visit `/blog` (no login) → Post A appears, Post B does not; newest first.
- Click Post A → `/blog/<slug-a>` shows the full body.
- Visit `/blog/<slug-b>` directly → 404.
- Publish B → it appears on `/blog`; set A to Draft → it disappears.

> Note: runtime HTTP smoke is limited in the offline sandbox — the dev server's SSR stalls on `@nuxt/fonts` reaching blocked font CDNs (environment-only, affects velo/fanfare identically). Verification here is typecheck + code review; the live click-through is the #261 / owner QA pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017UaPFaLdM6xjkdZWyDFHh3)_