### PR TITLE
feat(root): public blog reader surface — /blog index + /blog/[slug] permalink (#277)

### DIFF
--- a/pocs/blog/app/pages/blog/[slug].vue
+++ b/pocs/blog/app/pages/blog/[slug].vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+// Public permalink — no auth. Renders one published post; 404 for unknown/draft.
+definePageMeta({ layout: false })
+
+interface BlogPost {
+  id: string
+  title: string
+  slug: string
+  body?: string | null
+  author?: string | null
+  publishedAt?: string | null
+  status: string
+  tags?: string[] | null
+}
+
+const route = useRoute()
+const slug = computed(() => String(route.params.slug))
+
+const { data: post, error } = await useFetch<BlogPost>(
+  () => `/api/blog/${slug.value}`
+)
+
+if (error.value || !post.value) {
+  throw createError({
+    statusCode: 404,
+    statusMessage: 'Post not found',
+    fatal: true
+  })
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+})
+
+function formatDate(value?: string | null): string {
+  if (!value) return ''
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? '' : dateFormatter.format(date)
+}
+
+useHead(() => ({ title: post.value?.title ?? 'Post' }))
+</script>
+
+<template>
+  <div class="min-h-screen bg-(--ui-bg)">
+    <article
+      v-if="post"
+      class="mx-auto max-w-3xl px-6 py-16 motion-safe:animate-[fade-in_0.4s_ease-out]"
+    >
+      <UButton
+        to="/blog"
+        icon="i-lucide-arrow-left"
+        color="neutral"
+        variant="ghost"
+        size="sm"
+        class="mb-8"
+      >
+        Back to blog
+      </UButton>
+
+      <header class="mb-8">
+        <h1 class="text-4xl font-bold tracking-tight text-(--ui-text-highlighted)">
+          {{ post.title }}
+        </h1>
+
+        <div class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-(--ui-text-muted)">
+          <span v-if="post.author">{{ post.author }}</span>
+          <template v-if="post.author && formatDate(post.publishedAt)">
+            <USeparator orientation="vertical" class="h-4" />
+          </template>
+          <time v-if="formatDate(post.publishedAt)" :datetime="post.publishedAt ?? undefined">
+            {{ formatDate(post.publishedAt) }}
+          </time>
+        </div>
+
+        <div v-if="post.tags?.length" class="mt-4 flex flex-wrap gap-2">
+          <UBadge
+            v-for="tag in post.tags"
+            :key="tag"
+            color="neutral"
+            variant="subtle"
+            size="sm"
+          >
+            {{ tag }}
+          </UBadge>
+        </div>
+      </header>
+
+      <USeparator class="mb-8" />
+
+      <div
+        v-if="post.body"
+        class="whitespace-pre-wrap text-base leading-relaxed text-(--ui-text-toned)"
+      >
+        {{ post.body }}
+      </div>
+    </article>
+  </div>
+</template>
+
+<style scoped>
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/pocs/blog/app/pages/blog/index.vue
+++ b/pocs/blog/app/pages/blog/index.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+// Public blog index — no auth. Lists published posts newest-first.
+definePageMeta({ layout: false })
+
+interface BlogPostListItem {
+  id: string
+  title: string
+  slug: string
+  body?: string | null
+  author?: string | null
+  publishedAt?: string | null
+  status: string
+  tags?: string[] | null
+}
+
+const { data: posts, pending } = await useFetch<BlogPostListItem[]>('/api/blog', {
+  default: () => []
+})
+
+const dateFormatter = new Intl.DateTimeFormat('en', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+})
+
+function formatDate(value?: string | null): string {
+  if (!value) return ''
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? '' : dateFormatter.format(date)
+}
+
+function excerpt(body?: string | null): string {
+  if (!body) return ''
+  const text = body.trim()
+  return text.length > 220 ? `${text.slice(0, 220).trimEnd()}…` : text
+}
+
+useHead({ title: 'Blog' })
+</script>
+
+<template>
+  <div class="min-h-screen bg-(--ui-bg)">
+    <div class="mx-auto max-w-3xl px-6 py-16">
+      <header class="mb-12">
+        <h1 class="text-4xl font-bold tracking-tight text-(--ui-text-highlighted)">
+          Blog
+        </h1>
+        <p class="mt-2 text-(--ui-text-muted)">
+          Thoughts, notes, and updates.
+        </p>
+      </header>
+
+      <div v-if="pending" class="space-y-6">
+        <USkeleton v-for="n in 3" :key="n" class="h-40 w-full" />
+      </div>
+
+      <div
+        v-else-if="!posts.length"
+        class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-(--ui-border) py-20 text-center"
+      >
+        <UIcon name="i-lucide-newspaper" class="size-10 text-(--ui-text-dimmed)" />
+        <p class="text-(--ui-text-muted)">
+          No posts published yet. Check back soon.
+        </p>
+      </div>
+
+      <div v-else class="flex flex-col gap-6">
+        <ULink
+          v-for="post in posts"
+          :key="post.id"
+          :to="`/blog/${post.slug}`"
+          class="block"
+        >
+          <UCard
+            class="transition-all duration-200 hover:-translate-y-1 hover:shadow-lg"
+          >
+            <div class="flex flex-col gap-3">
+              <h2 class="text-xl font-semibold text-(--ui-text-highlighted)">
+                {{ post.title }}
+              </h2>
+
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-(--ui-text-muted)">
+                <span v-if="post.author">{{ post.author }}</span>
+                <template v-if="post.author && formatDate(post.publishedAt)">
+                  <USeparator orientation="vertical" class="h-4" />
+                </template>
+                <time v-if="formatDate(post.publishedAt)" :datetime="post.publishedAt ?? undefined">
+                  {{ formatDate(post.publishedAt) }}
+                </time>
+              </div>
+
+              <div v-if="post.tags?.length" class="flex flex-wrap gap-2">
+                <UBadge
+                  v-for="tag in post.tags"
+                  :key="tag"
+                  color="neutral"
+                  variant="subtle"
+                  size="sm"
+                >
+                  {{ tag }}
+                </UBadge>
+              </div>
+
+              <p v-if="excerpt(post.body)" class="text-(--ui-text-muted)">
+                {{ excerpt(post.body) }}
+              </p>
+            </div>
+          </UCard>
+        </ULink>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pocs/blog/server/api/blog/[slug].get.ts
+++ b/pocs/blog/server/api/blog/[slug].get.ts
@@ -1,0 +1,36 @@
+// Public single-post endpoint — no auth. Returns one published post by slug.
+// 404 when the slug is unknown OR the post is not published (drafts stay hidden).
+import { eq, and } from 'drizzle-orm'
+import { useDB } from '@fyit/crouton-auth/server/utils/database'
+import { blogPosts } from '~~/layers/blog/collections/posts/server/database/schema'
+
+export default defineEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'slug')
+
+  if (!slug) {
+    throw createError({ status: 404, statusText: 'Not found' })
+  }
+
+  const db = useDB()
+
+  const [post] = await (db as any)
+    .select({
+      id: blogPosts.id,
+      title: blogPosts.title,
+      slug: blogPosts.slug,
+      body: blogPosts.body,
+      author: blogPosts.author,
+      publishedAt: blogPosts.publishedAt,
+      status: blogPosts.status,
+      tags: blogPosts.tags
+    })
+    .from(blogPosts)
+    .where(and(eq(blogPosts.slug, slug), eq(blogPosts.status, 'published')))
+    .limit(1)
+
+  if (!post) {
+    throw createError({ status: 404, statusText: 'Not found' })
+  }
+
+  return post
+})

--- a/pocs/blog/server/api/blog/index.get.ts
+++ b/pocs/blog/server/api/blog/index.get.ts
@@ -1,0 +1,27 @@
+// Public blog index — no auth. Returns only published posts, newest-first.
+// Single-blog site: read straight across the blog_posts table via the hub db,
+// filtered to status='published' (no team scoping needed for the public surface).
+import { eq, desc } from 'drizzle-orm'
+import { useDB } from '@fyit/crouton-auth/server/utils/database'
+import { blogPosts } from '~~/layers/blog/collections/posts/server/database/schema'
+
+export default defineEventHandler(async () => {
+  const db = useDB()
+
+  const posts = await (db as any)
+    .select({
+      id: blogPosts.id,
+      title: blogPosts.title,
+      slug: blogPosts.slug,
+      body: blogPosts.body,
+      author: blogPosts.author,
+      publishedAt: blogPosts.publishedAt,
+      status: blogPosts.status,
+      tags: blogPosts.tags
+    })
+    .from(blogPosts)
+    .where(eq(blogPosts.status, 'published'))
+    .orderBy(desc(blogPosts.publishedAt))
+
+  return posts
+})


### PR DESCRIPTION
Closes #277

## 👤 For humans

The public reader surface for the blog POC. No login required:

- **`/blog`** — index listing published posts newest-first. Each card shows title, author, formatted publish date, tag pills, and a truncated excerpt, with a hover lift/shadow transition. Shows a friendly empty state when nothing is published yet, and skeletons while loading.
- **`/blog/[slug]`** — permalink showing the full post (title, author, date, tags, body), a back-link to `/blog`, and a subtle fade-in enter transition. Unknown slugs and draft posts return a 404.

## 🤖 For agents

Public (no-auth) routes deliberately live **outside** `teams/[id]/` so they need no session:

- `pocs/blog/server/api/blog/index.get.ts` — queries `blog_posts` via `useDB()`, filtered to `status = 'published'`, ordered by `publishedAt` desc. Single-blog site, so no team scoping at the public layer (KISS).
- `pocs/blog/server/api/blog/[slug].get.ts` — one post by slug; `throw createError({ status: 404, statusText: 'Not found' })` when the slug is unknown **or** `status !== 'published'` (drafts stay hidden).
- `pocs/blog/app/pages/blog/index.vue` — `useFetch('/api/blog')`; `UCard` / `UBadge` / `USeparator` / `USkeleton` (Nuxt UI 4 names only).
- `pocs/blog/app/pages/blog/[slug].vue` — `useFetch('/api/blog/:slug')`; throws a fatal 404 on error/empty result; body rendered as `whitespace-pre-wrap` text.
- Both pages use `definePageMeta({ layout: false })`; **no** auth middleware on any route or page.
- No `packages/` changes.
- `pnpm --filter pocs-blog typecheck` passes (green).

## 🧪 How to test

- `pnpm --filter pocs-blog dev`, then open `/blog` in an incognito window — published posts appear newest-first; a draft post does **not** appear.
- `/blog/<published-slug>` shows the full post body with a back-link.
- `/blog/nonexistent-slug` (and any draft slug) returns a 404 page.
- Both pages load with no authentication.
- Hover a post card — visible lift/shadow transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsWocQvSUrZjCRjBgJAeF)_