### PR TITLE
fix(root): resume-on-comment OIDC — move id-token:write to job level (#284)

### DIFF
--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -7,6 +7,10 @@ on:
   issue_comment:
     types: [created]
 
+# NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
+# OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to
+# be here or the claude-code-action OIDC token request fails
+# ("Could not fetch an OIDC token"). A workflow-level block would be silently shadowed.
 jobs:
   resume:
     # Resume only when: the issue carries `status:blocked`, the comment is a human's
@@ -21,6 +25,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,9 +44,3 @@ jobs:
             thread (the latest comment is their answer), incorporate it, remove the
             `status:blocked` label, then continue via /task-decompose #${{ github.event.issue.number }}.
           claude_args: "--max-turns 30"
-
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write


### PR DESCRIPTION
Closes #284

## 👤 For humans

Fixes the always-failing `Resume blocked decomposition` workflow. It was meant to auto-continue a blocked task-decomposition lane when the owner replies on the issue, but it failed every run with `Could not fetch an OIDC token` — so blocked lanes always had to be re-dispatched by hand (the blog POC epic #274 was hand-driven for exactly this reason).

## 🤖 For agents

**Root cause:** GitHub **job-level `permissions` fully overrides** (does not merge with) the workflow-level block. The job had `contents`/`pull-requests`/`issues` but **no `id-token`**, while a workflow-level block at the bottom carried `id-token: write` — dead code, shadowed for the only job in the file. `anthropics/claude-code-action` needs OIDC to mint its token → failure after 3 attempts.

**Change:** move `id-token: write` into the **job-level** `permissions` block and delete the redundant workflow-level block. Added a comment so it isn't "tidied" back to the wrong level. No behaviour change otherwise (still `issue_comment`-triggered, still API-key auth).

> Note: this only revives the *comment-driven* resume. The proper hands-off fix is the event-driven dependency scheduler in #283 (trigger on blocker-close, fan-in check). This unbreaks the current mechanism cheaply in the meantime.

## 🧪 How to test

- Comment on any `status:blocked` issue → the `resume` job now gets past `setupGitHubToken` instead of failing at OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsWocQvSUrZjCRjBgJAeF)_