### PR TITLE
fix(root): auto-generate BETTER_AUTH_SECRET on deploy — new apps auth-ready, zero per-app setup (#289)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -177,17 +177,24 @@ jobs:
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "Deployed: ${URL:-<url not parsed>}"
 
-      # Push Worker secrets from the (optional) WORKER_SECRETS_JSON bundle. Runs
-      # after the worker exists; secrets persist across deploys, so this is a no-op
-      # re-upload when unchanged. Skipped entirely if the secret isn't provided.
-      # Targets the staging worker with --env staging for non-production deploys.
-      - name: Sync Worker secrets
+      # (Optional) explicit Worker secrets from the WORKER_SECRETS_JSON bundle —
+      # an OVERRIDE for known/shared values (e.g. a deliberate production secret).
+      # The "Ensure BETTER_AUTH_SECRET" step below covers the common case, so this
+      # is only for values you want to pin. Runs first so an explicit BETTER_AUTH_SECRET
+      # wins over the auto-generated one. Secrets persist across deploys (no-op re-upload).
+      #
+      # IMPORTANT — scoping: WORKER_SECRETS_JSON MUST be a *repository-level* Actions
+      # secret, NOT an *Environment* secret. This job is reached via `secrets: inherit`
+      # from a thin caller whose calling job declares no `environment:`, so
+      # Environment-scoped secrets are never in scope to inherit and resolve to EMPTY
+      # (they silently skip). Repository-level secrets inherit correctly.
+      - name: Sync explicit Worker secrets (optional override)
         working-directory: ${{ inputs.workspace }}/${{ inputs.app }}
         env:
           SECRETS_JSON: ${{ secrets.WORKER_SECRETS_JSON }}
         run: |
           if [ -z "$SECRETS_JSON" ]; then
-            echo "No WORKER_SECRETS_JSON provided — skipping secret sync (manage Worker secrets manually)."
+            echo "No WORKER_SECRETS_JSON provided — the Ensure BETTER_AUTH_SECRET step below covers auth."
             exit 0
           fi
           printf '%s' "$SECRETS_JSON" > "$RUNNER_TEMP/worker-secrets.json"
@@ -197,6 +204,34 @@ jobs:
             npx wrangler secret bulk "$RUNNER_TEMP/worker-secrets.json" --env staging
           fi
           rm -f "$RUNNER_TEMP/worker-secrets.json"
+
+      # Guarantee a new app can AUTHENTICATE on first deploy with ZERO per-app setup.
+      # A freshly provisioned Worker has no secrets, so member login 500s with
+      # "[crouton/auth] BETTER_AUTH_SECRET is required". If the Worker lacks one,
+      # generate a strong secret and set it. Worker secrets persist across deploys,
+      # so this runs exactly once per Worker and is a no-op afterwards — it NEVER
+      # rotates an existing secret (which would invalidate live sessions). If the
+      # secret list can't be read (e.g. an app whose wrangler.jsonc has no `name`),
+      # we skip generation rather than risk clobbering. BETTER_AUTH_URL isn't needed:
+      # better-auth infers it from the request for email/password login.
+      - name: Ensure BETTER_AUTH_SECRET (auto-generate if missing)
+        working-directory: ${{ inputs.workspace }}/${{ inputs.app }}
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -o pipefail
+          ENV_FLAG=""
+          if [ "$ENVIRONMENT" != "production" ]; then ENV_FLAG="--env staging"; fi
+          if ! existing=$(npx wrangler secret list $ENV_FLAG 2>/dev/null); then
+            echo "::warning::Could not list Worker secrets for ${{ inputs.app }} ($ENVIRONMENT) — skipping auto-generate to avoid clobbering an existing BETTER_AUTH_SECRET."
+            exit 0
+          fi
+          if echo "$existing" | grep -q 'BETTER_AUTH_SECRET'; then
+            echo "✓ BETTER_AUTH_SECRET already present on the Worker — leaving it untouched."
+          else
+            echo "::notice::No BETTER_AUTH_SECRET on ${{ inputs.app }} ($ENVIRONMENT) — generating one (persists; override anytime via a repo-level WORKER_SECRETS_JSON)."
+            printf '%s' "$(openssl rand -hex 32)" | npx wrangler secret put BETTER_AUTH_SECRET $ENV_FLAG
+          fi
 
       # On PRs, post/update a sticky comment with the isolated staging URL.
       - name: Comment staging URL on PR


### PR DESCRIPTION
Closes #289

## 👤 For humans

Makes a freshly deployed app/POC **auth-ready on first login with zero per-app setup**. Today a brand-new Cloudflare Worker has no secrets, so the first member login 500s with `[crouton/auth] BETTER_AUTH_SECRET is required` (exactly what the blog POC hit, epic #274). After this, the deploy itself ensures the secret exists.

## 🤖 For agents

Reworks the secret-sync in the reusable `deploy-app.yml` into two steps:

1. **`Sync explicit Worker secrets (optional override)`** — the old `WORKER_SECRETS_JSON` bulk push, kept for pinning known/shared values (e.g. a deliberate production secret). Runs **first** so an explicit `BETTER_AUTH_SECRET` wins. Now documents the scoping trap (see below).
2. **`Ensure BETTER_AUTH_SECRET (auto-generate if missing)`** — `wrangler secret list`; if `BETTER_AUTH_SECRET` is absent, `openssl rand -hex 32` → `wrangler secret put`. 
   - **Only when missing** — Worker secrets persist, so it runs once per Worker and **never rotates** an existing secret (no surprise logouts).
   - If the list call **errors** (e.g. an app whose `wrangler.jsonc` has no `name`), it **skips** generation with a `::warning::` rather than risk clobbering.
   - `BETTER_AUTH_URL` not set — better-auth infers it from the request for email/password login (`383bc681`).

### The scoping bug this also documents
`WORKER_SECRETS_JSON` must be a **repository-level** Actions secret, **not** an Environment secret. This job is reached via `secrets: inherit` from a thin caller whose calling job declares no `environment:`, so Environment-scoped secrets are never in scope to inherit → they resolve to empty and the step silently skipped. **Evidence:** blog deploy run `27697256926`, step 12 logged `SECRETS_JSON:` (empty) → `No WORKER_SECRETS_JSON provided — skipping`, despite a `staging`-Environment `WORKER_SECRETS_JSON` being set.

**Blast radius:** shared workflow (velo/fanfare/triage/three-demo/blog). Strictly **additive** — auto-generate fires only when a secret is absent, list-errors degrade to a safe skip, and the explicit-override path is preserved. No app with a manually-set secret is touched.

Related: epic #114, commits `129da744` (added `WORKER_SECRETS_JSON`), `383bc681` (BETTER_AUTH_SECRET on previews).

## 🧪 How to test

1. Deploy a brand-new POC with no secrets → first login works; the run shows a `::notice::` that it generated a secret.
2. Re-deploy the same app → step reports "already present — leaving it untouched" (existing sessions survive).
3. Set a repo-level `WORKER_SECRETS_JSON` containing `BETTER_AUTH_SECRET` → that value is used (override wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsWocQvSUrZjCRjBgJAeF)_