### PR TITLE
fix(crouton-cli,crouton-auth): datetime alias resolution + auth schema export (#285)

### DIFF
--- a/packages/crouton-auth/package.json
+++ b/packages/crouton-auth/package.json
@@ -27,8 +27,9 @@
       "types": "./server/utils/team-auth.ts"
     },
     "./server/database/schema/auth": {
+      "types": "./server/database/schema/auth.ts",
       "import": "./server/database/schema/auth.ts",
-      "types": "./server/database/schema/auth.ts"
+      "default": "./server/database/schema/auth.ts"
     },
     "./server/utils/useServerAuth": {
       "import": "./server/utils/useServerAuth.ts",

--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -410,19 +410,27 @@ Repeater fields can support per-item translations using `translatableProperties`
 
 ### Type Aliases
 
-Some types accept aliases (defined via `aliases` in `crouton-core/crouton.manifest.ts` and
-normalized in `mapType`). A schema can use the alias and it resolves to the canonical type —
-**column type, zod, ts, and seed all follow the canonical type**:
+Some types accept aliases (defined via `aliases` in each package's `crouton.manifest.ts`).
+A schema can use the alias and it resolves to the **canonical** type — so **column type, zod,
+ts, the form control, and seed all follow the canonical type**:
 
-| Alias | Canonical | SQLite column |
-|-------|-----------|---------------|
-| `integer` | `number` | `integer()` |
-| `datetime` | `date` | `integer({ mode: 'timestamp' })` |
+| Alias | Canonical | SQLite column | Form control |
+|-------|-----------|---------------|--------------|
+| `integer` | `number` | `integer()` | `UInputNumber` |
+| `datetime` | `date` | `integer({ mode: 'timestamp' })` | `CroutonCalendar` |
 
-⚠️ Before the alias was normalized in `mapType`, a field declared `"type": "integer"` fell
-through to `text()` (the schema generator only branches on `number`/`decimal`). Use `number`
-for integer columns; `decimal` is the float/`real` type. A value the spooler/endpoints write
-as a **string** (e.g. a status enum `'0'/'1'/'2'`) should be `string`, not `number`.
+**How resolution works (#285):** `getTypeMapping()` (in `lib/utils/manifest-loader.ts`)
+tags every entry — canonical *and* alias keys — with a `canonical` field, and `loadFields`
+resolves `field.type` through it before any generator runs. So a field's `type` is always the
+canonical name and every generator that branches on it (schema column, `form-component`'s
+`type === 'date'` → `CroutonCalendar`, the date-serialization logic) sees the canonical type.
+
+⚠️ Aliases must be resolved *before* the generators, not inside `mapType` (which only
+validates). Earlier, only `integer` was special-cased and `datetime` leaked through unresolved,
+so date fields silently generated a raw `<UInput>` (typecheck error: `Date` vs
+`AcceptableValue`) + a `text` column instead of a timestamp. Use `number` for integer columns;
+`decimal` is the float/`real` type. A value written as a **string** (e.g. a status enum
+`'0'/'1'/'2'`) should be `string`, not `number`.
 
 ## i18n Field Labels
 

--- a/packages/crouton-cli/lib/utils/load-fields.ts
+++ b/packages/crouton-cli/lib/utils/load-fields.ts
@@ -52,7 +52,11 @@ export async function loadFields(p: string, typeMapping: Record<string, any>): P
       fieldMeta.area = 'main'
     }
 
-    const resolvedType = mapType(meta?.type, validTypes)
+    // Resolve aliases (e.g. `datetime` → `date`, `integer` → `number`) to the
+    // canonical type so every downstream generator that branches on `field.type`
+    // sees the canonical name. typeMapping carries `canonical` for both canonical
+    // and alias keys; fall back to mapType for unknown types (#285).
+    const resolvedType = typeMapping[meta?.type]?.canonical ?? mapType(meta?.type, validTypes)
     return {
       name,
       type: resolvedType,

--- a/packages/crouton-cli/lib/utils/manifest-loader.ts
+++ b/packages/crouton-cli/lib/utils/manifest-loader.ts
@@ -294,17 +294,30 @@ export function getModuleRegistryMap(
  */
 export function getTypeMapping(
   manifests: CroutonManifest[],
-): Record<string, { db: string; drizzle: string; zod: string; default: string; tsType: string }> {
-  const registry = getFieldTypeRegistry(manifests)
-  const mapping: Record<string, { db: string; drizzle: string; zod: string; default: string; tsType: string }> = {}
+): Record<string, { db: string; drizzle: string; zod: string; default: string; tsType: string; canonical: string }> {
+  const mapping: Record<string, { db: string; drizzle: string; zod: string; default: string; tsType: string; canonical: string }> = {}
 
-  for (const [name, def] of Object.entries(registry)) {
-    mapping[name] = {
-      db: def.db,
-      drizzle: def.drizzle,
-      zod: def.zod,
-      default: def.defaultValue,
-      tsType: def.tsType,
+  for (const manifest of manifests) {
+    if (!manifest.fieldTypes) continue
+    for (const [name, def] of Object.entries(manifest.fieldTypes)) {
+      // `canonical` lets callers resolve an alias (e.g. `datetime`) back to its
+      // canonical type (`date`). Without it, downstream generators that branch on
+      // `field.type === 'date'` silently miss alias-typed fields — emitting a raw
+      // UInput + text column instead of CroutonCalendar + a timestamp column (#285).
+      const entry = {
+        db: def.db,
+        drizzle: def.drizzle,
+        zod: def.zod,
+        default: def.defaultValue,
+        tsType: def.tsType,
+        canonical: name,
+      }
+      mapping[name] = entry
+      if (def.aliases) {
+        for (const alias of def.aliases) {
+          mapping[alias] = { ...entry, canonical: name }
+        }
+      }
     }
   }
 

--- a/packages/crouton-cli/tests/unit/utils/load-fields.test.ts
+++ b/packages/crouton-cli/tests/unit/utils/load-fields.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadFields } from '../../../lib/utils/load-fields.ts'
+
+// Mirrors the shape getTypeMapping() produces: alias keys carry the canonical
+// type via `canonical`, so loadFields can normalize them (#285).
+const typeMapping = {
+  string: { db: '', drizzle: '', zod: 'z.string()', default: "''", tsType: 'string', canonical: 'string' },
+  number: { db: '', drizzle: '', zod: 'z.number()', default: '0', tsType: 'number', canonical: 'number' },
+  date: { db: '', drizzle: '', zod: 'z.date()', default: 'null', tsType: 'Date | null', canonical: 'date' },
+  // aliases — same def as their canonical, with canonical pointing back
+  integer: { db: '', drizzle: '', zod: 'z.number()', default: '0', tsType: 'number', canonical: 'number' },
+  datetime: { db: '', drizzle: '', zod: 'z.date()', default: 'null', tsType: 'Date | null', canonical: 'date' },
+}
+
+async function loadFromSchema(schema: Record<string, unknown>) {
+  const dir = await mkdtemp(join(tmpdir(), 'crouton-fields-'))
+  const p = join(dir, 'schema.json')
+  await writeFile(p, JSON.stringify(schema))
+  try {
+    const fields = await loadFields(p, typeMapping as any)
+    return Object.fromEntries(fields.map(f => [f.name, f]))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+describe('loadFields alias resolution (#285)', () => {
+  it('resolves the `datetime` alias to the canonical `date` type', async () => {
+    const byName = await loadFromSchema({ publishedAt: { type: 'datetime' } })
+    expect(byName.publishedAt.type).toBe('date')
+    expect(byName.publishedAt.zod).toBe('z.date()')
+    expect(byName.publishedAt.tsType).toBe('Date | null')
+  })
+
+  it('resolves the `integer` alias to the canonical `number` type', async () => {
+    const byName = await loadFromSchema({ count: { type: 'integer' } })
+    expect(byName.count.type).toBe('number')
+    expect(byName.count.zod).toBe('z.number()')
+  })
+
+  it('leaves canonical types and unknown types untouched', async () => {
+    const byName = await loadFromSchema({ title: { type: 'string' }, when: { type: 'date' }, weird: { type: 'nope' } })
+    expect(byName.title.type).toBe('string')
+    expect(byName.when.type).toBe('date')
+    expect(byName.weird.type).toBe('string') // unknown → string fallback
+  })
+})


### PR DESCRIPTION
Closes #285

## 👤 For humans

Fixes two papercuts that bit the blog POC's `posts` collection (epic #274) and would bite **every** new app/collection:

1. **Date fields generate correctly.** A `datetime` field now produces a `<CroutonCalendar>` control + an `integer(…, { mode: 'timestamp' })` column — instead of a raw `<UInput>` (which failed typecheck with `Date` vs `AcceptableValue`) and a `text` column that the worker had to hand-fix.
2. **The first migration just works.** `db:generate` can now resolve the auth schema without the temp-aggregator workaround every new app rediscovered.

## 🤖 For agents

Two atomic commits:

**`fix(crouton-cli)` — alias resolution.** `getTypeMapping()` (`lib/utils/manifest-loader.ts`) now tags every entry — canonical *and* alias keys — with a `canonical` field, and `loadFields` resolves `field.type` through it **before any generator runs**. Root cause: only `integer` was special-cased in `mapType` (which just *validates*); `datetime` leaked through unresolved, so generators branching on `field.type === 'date'` (schema column, `form-component`'s `CroutonCalendar` branch, the date-serialization block) all missed it. Now any aliased field follows its canonical type across schema/zod/ts/form/seed. Data-driven, so future aliases are covered too. Adds `tests/unit/utils/load-fields.test.ts`.

**`fix(crouton-auth)` — export resolvability.** `exports["./server/database/schema/auth"]` declared only `import` + `types`; drizzle-kit resolves under neither, so `@fyit/crouton-auth/server/database/schema/auth` was unresolvable. Added a `default` condition (same module) so it resolves under any condition.

### Verification
- ✅ New regression test + all **255** existing CLI unit/integration tests pass.
- ✅ Real generation of a `datetime` field now emits `<CroutonCalendar v-model:date="state.publishedAt" />` and `integer('publishedAt', { mode: 'timestamp' })` — confirmed, no hand-editing.
- ✅ `pnpm -r --filter './apps/*' typecheck` (velo/fanfare/triage) green — no ripple.
- ✅ Docs synced: `crouton-cli/CLAUDE.md` "Type Aliases" corrected (the old "normalized in `mapType`" claim was false). The `/crouton` skill has no alias refs; `form-component.ts` unchanged so `FormPreview.vue` needs no update.

`packages/` edits were made under the hard-gate approval flow; the approval file has been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsWocQvSUrZjCRjBgJAeF)_