### PR TITLE
feat(crouton-cli): per-collection seed.json fixture so new apps deploy with sample data (#298)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -57,6 +57,16 @@ The contract (`SeedProvider`, `SeedContext`, `createPageWithBlocks`) lives in
 Wire it into an app with `db:seed:local` / `db:seed:remote` scripts (see
 `apps/fanfare/package.json`).
 
+**Plus app-local collection fixtures (#298):** after the package providers, the
+runner also loads every generated collection's `layers/*/collections/*/seed.json`
+— a small, **editable** fixture of auto-derived sample rows the generator emits
+(see `collection-seed-fixture.ts`). For each row it injects a stable
+`seedId(layer, collection, key)` id + the standard system columns (`teamId`,
+`owner`, audit, timestamps) and upserts via `buildUpsert`, so a freshly deployed
+app's public surfaces aren't empty. Idempotent (stable ids) — re-deploys upsert
+in place. Edit `seed.json` to replace the samples with real content, or delete it
+to seed nothing for that collection. Hierarchy collections get no fixture.
+
 ## Add Command (Module Installation)
 
 Add Crouton modules with automatic configuration:
@@ -271,7 +281,8 @@ lib/generators/
 ├── api-endpoints.ts       → GET/POST/PATCH/DELETE
 ├── database-schema.ts     → Drizzle schema
 ├── database-queries.ts    → Query functions
-├── seed-data.ts           → seed.ts (drizzle-seed data)
+├── seed-data.ts           → seed.ts (drizzle-seed data, --seed flag)
+├── collection-seed-fixture.ts → seed.json (editable auto-derived sample rows, #298)
 ├── types.ts               → TypeScript interfaces
 ├── nuxt-config.ts         → Layer config
 ├── field-components.ts    → Dependent field components
@@ -472,6 +483,7 @@ layers/[layer]/collections/[collection]/
 │       ├── schema.ts
 │       ├── queries.ts
 │       └── seed.ts          # Only with --seed flag
+├── seed.json                # Editable auto-derived sample rows (#298)
 ├── types.ts
 └── nuxt.config.ts
 

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -42,6 +42,7 @@ import { generateNuxtConfig } from './generators/nuxt-config.ts'
 import { generateRepeaterItemComponent } from './generators/repeater-item-component.ts'
 import { generateFieldComponents } from './generators/field-components.ts'
 import { generateSeedFile } from './generators/seed-data.ts'
+import { generateSeedFixture } from './generators/collection-seed-fixture.ts'
 import { generateCollectionTypesRegistry } from './generators/collection-types-registry.ts'
 import { generateQueryRegistryFile } from './generators/query-registry.ts'
 
@@ -1019,6 +1020,19 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
       })
     })
     console.log(`  Generating seed.ts (${seedCount} records)`)
+  }
+
+  // Always emit an editable seed.json fixture with a few auto-derived sample
+  // rows, so a freshly deployed app's public surfaces aren't empty (#298). The
+  // app seed runner (crouton-seed) loads it; edit it to replace the samples with
+  // real content. Skipped for hierarchy collections (returns null).
+  const seedFixture = generateSeedFixture(data)
+  if (seedFixture) {
+    files.push({
+      path: path.join(base, 'seed.json'),
+      content: `${JSON.stringify(seedFixture, null, 2)}\n`,
+    })
+    console.log(`  Generating seed.json (${seedFixture.rows.length} sample rows)`)
   }
 
   // Write all files

--- a/packages/crouton-cli/lib/generators/collection-seed-fixture.ts
+++ b/packages/crouton-cli/lib/generators/collection-seed-fixture.ts
@@ -1,0 +1,103 @@
+// Generator for an editable per-collection seed fixture (seed.json).
+//
+// Unlike seed-data.ts (which emits a drizzle-seed `seed.ts` needing a live DB
+// connection), this emits a small, committed, editable JSON fixture that the
+// app-level seed runner (`crouton-seed` / seed-app.ts) loads and turns into
+// idempotent upsert SQL via `@fyit/crouton-core/shared/seed`. So a freshly
+// deployed app comes up with sample rows — its public surfaces aren't empty
+// (#298). Rows are auto-derived from the schema; edit seed.json to replace them
+// with real content.
+import { toSnakeCase } from '../utils/helpers.ts'
+
+// Auto-generated columns the runner injects (id, teamId, audit, timestamps) and
+// hierarchy columns — never authored in the fixture.
+const AUTO_FIELDS = new Set([
+  'id', 'teamId', 'owner',
+  'createdAt', 'updatedAt', 'createdBy', 'updatedBy',
+  'parentId', 'path', 'depth', 'order',
+])
+
+export interface SeedFixture {
+  /** Physical table name (e.g. `blog_posts`). */
+  table: string
+  /** Natural-key field used to derive a stable seed id (e.g. `slug`); else row index. */
+  key: string | null
+  /** Sample rows — user fields only; the runner injects id/teamId/audit/timestamps. */
+  rows: Array<Record<string, unknown>>
+}
+
+/** Derive a plausible literal sample value for a field at row `i`. */
+function deriveValue(field: Record<string, any>, i: number): unknown {
+  const name = String(field.name || '').toLowerCase()
+  const type = field.type
+  const options = field.meta?.options
+
+  // A select/enum → cycle options, biased so the newest row leads with the
+  // "last" option (e.g. `published` for [draft, published]) for a livelier demo.
+  if (Array.isArray(options) && options.length > 0) {
+    return options[(i + 1) % options.length]
+  }
+
+  // Name heuristics (more specific first)
+  if (name === 'slug') return `sample-${i + 1}`
+  if (name.includes('email')) return `user${i + 1}@example.com`
+  if (name === 'title' || name === 'name' || name === 'fullname') return `Sample ${field.name} ${i + 1}`
+  if (name.includes('url') || name.includes('website') || name.includes('link')) return 'https://example.com'
+
+  // Type fallbacks
+  switch (type) {
+    case 'number':
+    case 'decimal':
+      return i + 1
+    case 'boolean':
+      return i % 2 === 0
+    case 'date':
+      // unix seconds, staggered one day apart so "newest first" ordering shows
+      return Math.floor(Date.now() / 1000) - i * 86_400
+    case 'json':
+      return {}
+    case 'array':
+      return ['sample']
+    case 'image':
+    case 'file':
+      return ''
+    case 'text':
+      return `Sample ${field.name} content for row ${i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing elit.`
+    default:
+      return `Sample ${field.name} ${i + 1}`
+  }
+}
+
+/**
+ * Build a seed fixture for a collection. Returns `null` when no fixture should
+ * be written (hierarchy collections — their parentId/path/depth/order seeding is
+ * out of scope; edit by hand if needed).
+ */
+export function generateSeedFixture(data: Record<string, any>, count = 3): SeedFixture | null {
+  const { layer, plural, fields, hierarchy } = data
+  if (hierarchy?.enabled) return null
+
+  const table = toSnakeCase(`${layer}_${plural}`)
+
+  // User fields only. FK refs (refTarget) are skipped — they'd need real target
+  // ids; leaving them out makes the column nullable-or-absent and avoids dangling
+  // references in the sample data.
+  const userFields = (fields as Array<Record<string, any>>).filter(
+    f => !AUTO_FIELDS.has(f.name) && !f.refTarget,
+  )
+
+  if (userFields.length === 0) return null
+
+  const key
+    = userFields.find(f => f.name === 'slug')?.name
+    ?? userFields.find(f => /name|title/i.test(f.name))?.name
+    ?? null
+
+  const rows = Array.from({ length: count }, (_, i) => {
+    const row: Record<string, unknown> = {}
+    for (const f of userFields) row[f.name] = deriveValue(f, i)
+    return row
+  })
+
+  return { table, key, rows }
+}

--- a/packages/crouton-cli/lib/seed-app.ts
+++ b/packages/crouton-cli/lib/seed-app.ts
@@ -12,7 +12,7 @@
 import { createJiti } from 'jiti'
 import consola from 'consola'
 import { execFileSync } from 'node:child_process'
-import { readFileSync, existsSync } from 'node:fs'
+import { readFileSync, existsSync, readdirSync } from 'node:fs'
 import { join, resolve, dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -137,6 +137,61 @@ async function discoverProviders(
 }
 
 /**
+ * Turn the app's generated collection fixtures (`layers/*​/collections/*​/seed.json`,
+ * emitted by the CLI) into idempotent upsert SQL (#298). Each row gets a stable,
+ * namespace-derived id and the standard crouton system columns (teamId, owner,
+ * audit, timestamps) injected — the fixture itself only carries user fields, so
+ * re-runs upsert in place. `core` is `@fyit/crouton-core/shared/seed`.
+ */
+function collectCollectionFixtureSql(appDir: string, core: any, teamId: string): string {
+  const layersDir = join(appDir, 'layers')
+  if (!existsSync(layersDir)) return ''
+
+  const now = Math.floor(Date.now() / 1000)
+  const stmts: string[] = []
+
+  for (const layer of readdirSync(layersDir)) {
+    const collectionsDir = join(layersDir, layer, 'collections')
+    if (!existsSync(collectionsDir)) continue
+
+    for (const collection of readdirSync(collectionsDir)) {
+      const fixturePath = join(collectionsDir, collection, 'seed.json')
+      if (!existsSync(fixturePath)) continue
+
+      let fixture: any
+      try {
+        fixture = JSON.parse(readFileSync(fixturePath, 'utf8'))
+      } catch {
+        consola.warn(`Skipping unparseable fixture: ${layer}/${collection}/seed.json`)
+        continue
+      }
+
+      const { table, key, rows } = fixture ?? {}
+      if (!table || !Array.isArray(rows) || rows.length === 0) continue
+
+      rows.forEach((row: Record<string, unknown>, i: number) => {
+        const keyVal = key && row[key] != null ? row[key] : i
+        const id = core.seedId(layer, collection, String(keyVal))
+        const values = {
+          teamId,
+          owner: 'seed',
+          createdBy: 'seed',
+          updatedBy: 'seed',
+          createdAt: now,
+          updatedAt: now,
+          ...row,
+        }
+        stmts.push(core.buildUpsert(table, { id }, values, { immutable: ['createdAt'] }))
+      })
+
+      consola.info(`Discovered collection fixture: ${layer}/${collection} (${rows.length} rows → ${table})`)
+    }
+  }
+
+  return stmts.join('\n')
+}
+
+/**
  * Run the seed: discover → order → collect SQL → execute via wrangler.
  * Returns the generated SQL (handy for tests / dry runs).
  */
@@ -156,25 +211,28 @@ export async function seedApp(options: SeedAppOptions): Promise<string> {
   const croutonDeps = discoverCroutonPackageNames(appDir)
   const { providers, createPageWithBlocks } = await discoverProviders(jiti, croutonDeps)
 
-  if (providers.length === 0) {
-    consola.warn('No seed providers found among the app\'s @fyit/crouton-* packages — nothing to seed.')
-    return ''
-  }
-
   const core: any = await tsImport(jiti, '@fyit/crouton-core/shared/seed')
   const teamId = core.seedOrgId(teamSlug)
 
-  const sql: string = await core.collectSeedSql({
-    providers,
-    teamSlug,
-    teamId,
-    locale,
-    withStaff: options.withStaff,
-    createPageWithBlocks
-  })
+  // 1) Package providers — auth org + demo content shipped by extended packages.
+  const providerSql: string = providers.length > 0
+    ? await core.collectSeedSql({
+        providers,
+        teamSlug,
+        teamId,
+        locale,
+        withStaff: options.withStaff,
+        createPageWithBlocks
+      })
+    : ''
+
+  // 2) App-local generated collections' editable seed.json fixtures (#298).
+  const fixtureSql = collectCollectionFixtureSql(appDir, core, teamId)
+
+  const sql = [providerSql, fixtureSql].filter(s => s.trim()).join('\n')
 
   if (!sql.trim()) {
-    consola.warn('Providers produced no statements — nothing to seed.')
+    consola.warn('No seed providers or collection fixtures found — nothing to seed.')
     return sql
   }
 

--- a/packages/crouton-cli/tests/unit/generators/collection-seed-fixture.test.ts
+++ b/packages/crouton-cli/tests/unit/generators/collection-seed-fixture.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { generateSeedFixture } from '../../../lib/generators/collection-seed-fixture.ts'
+
+const blogFields = [
+  { name: 'title', type: 'string', meta: { required: true } },
+  { name: 'slug', type: 'string', meta: { required: true } },
+  { name: 'body', type: 'text', meta: {} },
+  { name: 'author', type: 'string', meta: {} },
+  { name: 'publishedAt', type: 'date', meta: {} },
+  { name: 'status', type: 'string', meta: { options: ['draft', 'published'] } },
+  { name: 'tags', type: 'array', meta: {} },
+  // injected system + FK fields that must be excluded
+  { name: 'id', type: 'string', meta: {} },
+  { name: 'teamId', type: 'string', meta: {} },
+  { name: 'createdAt', type: 'date', meta: {} },
+  { name: 'categoryId', type: 'string', meta: {}, refTarget: 'categories' },
+]
+
+describe('generateSeedFixture (#298)', () => {
+  const fixture = generateSeedFixture({ layer: 'blog', plural: 'posts', fields: blogFields })!
+
+  it('derives the snake_case table name and picks slug as the key', () => {
+    expect(fixture.table).toBe('blog_posts')
+    expect(fixture.key).toBe('slug')
+    expect(fixture.rows).toHaveLength(3)
+  })
+
+  it('excludes auto/system and FK fields from rows', () => {
+    const cols = Object.keys(fixture.rows[0])
+    expect(cols).toContain('title')
+    expect(cols).toContain('status')
+    expect(cols).not.toContain('id')
+    expect(cols).not.toContain('teamId')
+    expect(cols).not.toContain('createdAt')
+    expect(cols).not.toContain('categoryId') // FK ref skipped
+  })
+
+  it('produces sensible per-type values', () => {
+    const r0 = fixture.rows[0] as any
+    expect(r0.slug).toBe('sample-1')
+    expect(typeof r0.publishedAt).toBe('number') // unix seconds, not an ISO string
+    expect(Array.isArray(r0.tags)).toBe(true)
+    // select cycles, biased so the newest row leads with the last option
+    expect(r0.status).toBe('published')
+    expect((fixture.rows[1] as any).status).toBe('draft')
+  })
+
+  it('stages dates newest-first', () => {
+    const t0 = (fixture.rows[0] as any).publishedAt
+    const t1 = (fixture.rows[1] as any).publishedAt
+    expect(t0).toBeGreaterThan(t1) // row 0 newer than row 1
+  })
+
+  it('returns null for hierarchy collections', () => {
+    expect(generateSeedFixture({ layer: 'blog', plural: 'posts', fields: blogFields, hierarchy: { enabled: true } })).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #298

## 👤 For humans

A freshly deployed app/POC now comes up with **sample collection data**, so its public surfaces (e.g. `/blog`) aren't empty on first load. The data is **auto-derived but editable** — replace it with real content anytime, or delete the file to seed nothing.

## 🤖 For agents

Two parts, both in `crouton-cli`:

1. **Generator** (`lib/generators/collection-seed-fixture.ts`, wired into `generate-collection.ts`): emits `layers/<layer>/collections/<collection>/seed.json` — `{ table, key, rows }` with a few auto-derived sample rows. Heuristics: `slug`→`sample-N`, `title`/`name`→sample text, `text`→lorem, `email`/`url` specials, select/enum fields **cycle their options** (biased so the newest row leads with the last option, e.g. `published`), `date`→unix seconds **staggered newest-first**, `array`→`["sample"]`. User fields only — auto/system + FK-ref fields are excluded. Hierarchy collections get no fixture.
2. **Runner** (`lib/seed-app.ts`): after the package providers, discovers each collection's `seed.json`, injects a stable `seedId(layer, collection, key)` id + the standard system columns (`teamId`, `owner`, audit, timestamps), and upserts via `buildUpsert(..., { immutable: ['createdAt'] })`. Team-scoped + idempotent → re-deploys upsert in place. Reuses `@fyit/crouton-core/shared/seed` (no core change).

### Verification
- ✅ New unit test + all **263** CLI tests pass.
- ✅ **End-to-end**: generated the blog `posts` collection, ran the real `seedApp` (dry-run), and applied its SQL to an in-memory SQLite matching the generated schema → **3 rows insert, idempotent on re-apply (stays 3), 2 published / 1 draft, JSON tags stored, newest = published**. So `/blog` would show the published posts and hide the draft.
- ✅ `pnpm -r --filter './apps/*' typecheck` green (change is CLI-internal; apps unaffected).
- ✅ Docs synced (`crouton-cli/CLAUDE.md`: App Seeding section, Generators list, Generated Output tree).

`packages/` edit under the hard-gate approval flow; approval file removed.

> Sample of the generated SQL (one row):
> ```sql
> INSERT INTO "blog_posts" ("teamId","owner","createdBy","updatedBy","createdAt","updatedAt","title","slug","body","author","publishedAt","status","tags","id")
> VALUES ('seed:org:test1','seed','seed','seed',…,'Sample title 1','sample-1',…,'published','["sample"]','seed:blog:posts:sample-1')
> ON CONFLICT("id") DO UPDATE SET …;
> ```

## 🧪 How to test

Scaffold an app, generate a collection (e.g. with a `datetime` + `select` field), deploy → the public surface shows seeded sample rows (incl. a hidden draft); re-deploy doesn't duplicate. Edit `seed.json` to swap in real content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsWocQvSUrZjCRjBgJAeF)_