### PR TITLE
fix(playground): seed blog sample posts on deploy, not just the admin (#298)

### DIFF
--- a/pocs/blog/scripts/seed.ts
+++ b/pocs/blog/scripts/seed.ts
@@ -27,10 +27,11 @@
  *   tsx scripts/seed.ts --db blog-db --dry-run   # print SQL, don't execute
  */
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync, readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { hashPassword } from 'better-auth/crypto'
+import { buildUpsert, seedId } from '@fyit/crouton-core/shared/seed'
 
 // ── Args ─────────────────────────────────────────────────────────────────────
 const argv = process.argv.slice(2)
@@ -97,7 +98,60 @@ ON CONFLICT(id) DO UPDATE SET role = excluded.role;`
   return [organization, user, account, member].join('\n\n')
 }
 
-const sql = await buildSql()
+/**
+ * Seed the app's generated collections from their editable seed.json fixtures
+ * (#298). The standard `crouton-seed` runner does this, but the blog uses this
+ * bespoke admin seeder instead — and `crouton-seed` over-discovers seed
+ * providers (pages/sales) the blog doesn't have. So we load this app's own
+ * collection fixtures directly, scoped to its `blog` team so the rows show in
+ * both /blog and the admin list. Idempotent (stable seed ids).
+ */
+function buildCollectionsSql(): string {
+  const layersDir = 'layers'
+  if (!existsSync(layersDir)) return ''
+
+  const nowSec = Math.floor(Date.now() / 1000)
+  const stmts: string[] = []
+
+  for (const layer of readdirSync(layersDir)) {
+    const collectionsDir = join(layersDir, layer, 'collections')
+    if (!existsSync(collectionsDir)) continue
+
+    for (const collection of readdirSync(collectionsDir)) {
+      const fixturePath = join(collectionsDir, collection, 'seed.json')
+      if (!existsSync(fixturePath)) continue
+
+      let fixture: any
+      try {
+        fixture = JSON.parse(readFileSync(fixturePath, 'utf8'))
+      } catch {
+        continue
+      }
+
+      const { table, key, rows } = fixture ?? {}
+      if (!table || !Array.isArray(rows)) continue
+
+      rows.forEach((row: Record<string, unknown>, i: number) => {
+        const keyVal = key && row[key] != null ? row[key] : i
+        const id = seedId(layer, collection, String(keyVal))
+        const values = {
+          teamId, // the seeded `blog` org
+          owner: 'seed',
+          createdBy: 'seed',
+          updatedBy: 'seed',
+          createdAt: nowSec,
+          updatedAt: nowSec,
+          ...row,
+        }
+        stmts.push(buildUpsert(table, { id }, values, { immutable: ['createdAt'] }))
+      })
+    }
+  }
+
+  return stmts.join('\n')
+}
+
+const sql = [await buildSql(), buildCollectionsSql()].filter(s => s.trim()).join('\n\n')
 
 if (dryRun) {
   console.log(sql)
@@ -120,4 +174,4 @@ if (res.status !== 0) {
   console.error('✗ seed failed')
   process.exit(res.status ?? 1)
 }
-console.log(`✓ admin seeded — log in at the preview with ${ADMIN.email} / ${ADMIN.password}`)
+console.log(`✓ seeded admin + sample posts — log in at the preview with ${ADMIN.email} / ${ADMIN.password}`)


### PR DESCRIPTION
## 👤 For humans

The blog deploy seeded the admin but **not the sample posts**, so login worked but `/blog` was empty. Now the deploy seeds both — `/blog` shows the sample posts (and hides the draft).

## 🤖 For agents

Root cause: `pocs/blog`'s `db:seed:*` runs only the bespoke `scripts/seed.ts` (admin user/org/account/member) and never invokes `crouton-seed` — so the `seed.json` collection fixture from #298/#301 was never loaded.

`crouton-seed` can't simply be dropped in here: discovered against the blog it **over-discovers** seed providers — it pulled in `pages` + `sales` (reachable via the `crouton-cli` *devDependency*) and would `INSERT INTO pages_pages` / `sales_events`, tables the blog doesn't have → the seed would fail.

Fix: `scripts/seed.ts` now loads the app's **own** collection fixtures directly — scans `layers/*/collections/*/seed.json`, injects a stable `seedId` + the standard system columns, and upserts via `@fyit/crouton-core/shared/seed`'s `buildUpsert`, scoped to the seeded **`blog`** team (`teamId = seed:org:blog`, matching the admin's org). So the rows appear on the public `/blog` **and** in the team-scoped admin Posts list. Idempotent.

**Dry-run verified:** admin (org/user/account/member) + **3 `blog_posts`** (2 published, 1 draft), all `teamId = seed:org:blog`, JSON tags, unix-second timestamps. `pnpm --filter pocs-blog typecheck` green.

> Follow-ups (filing separately): (1) `crouton-seed` should only discover seed providers from **runtime** deps, not devDependencies (the over-discovery above); (2) the POC scaffold's seed template should align with `crouton-seed` so collection fixtures seed automatically. Tracked under epic #291.

## 🧪 How to test

Re-deploy the blog (Actions → **Deploy Blog (POC preview)** → Run workflow). After the seed step:
1. `/blog` (no login) → **Sample title 1 & 3** (published), **Sample title 2** hidden (draft), newest first.
2. Admin Posts list (logged in) → all 3 posts, with the calendar Published-At field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsWocQvSUrZjCRjBgJAeF)_