### PR TITLE
Add ui-proposal skill: before/after UI mockup → PNG for design sign-off

### DIFF
--- a/.claude/skills/ui-proposal/SKILL.md
+++ b/.claude/skills/ui-proposal/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ui-proposal
+description: Generate a before/after UI mockup (pure HTML/CSS/SVG, offline) for a proposed UI change, render it to a PNG, and commit the source — so a human can sign off on the look-and-feel BEFORE the real component is built. Use when a task adds or changes UI (a .vue component, a layout, a screen), or when asked to "mock this up", "show me a proposal", "what would this look like".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# UI Proposal — mock it before you build it
+
+Turns "I'm about to add/change this screen" into a **visual artifact a human can approve**: a self-contained before/after HTML mockup (pure CSS + inline SVG — **no JS, no CDN**, so it renders anywhere, including a phone file-preview), plus a rendered **PNG** that can be posted in a PR comment.
+
+This is the foundation of the UI sign-off loop (epic #307): produce the mockup → it gets posted on the PR → iterate on feedback → only then build the real thing.
+
+> **Why a PNG?** GitHub comments can't render raw HTML/CSS. The committed `.html` is the editable source; the `.png` is what gets posted.
+
+## When to use
+- A task's diff adds or changes a **visual surface**: a `.vue` component, a layout, a page, a theme.
+- The user asks to "mock up", "propose", "show what it'd look like", or wants design sign-off.
+- **Skip** for pure logic/types/server changes with no visible result.
+
+## What it produces
+| Artifact | Path | Committed? |
+|----------|------|-----------|
+| Mockup source | `writeups/ui-proposals/<slug>.html` | ✅ yes (editable source of truth) |
+| Rendered image | `screenshots/ui-proposal-<slug>.png` | ❌ no — `screenshots/` is gitignored; it's posted to the PR, not committed |
+
+`<slug>` = kebab of the surface, e.g. `mobile-collection-viewer`.
+
+## Step 1 — Understand the surface
+Read the component(s) you're about to change (and any real data/screenshots the user gave). The mockup must reflect the **actual** current UI for "before" and your **intended** design for "after". Use real labels/data where you have them — it makes the proposal trustworthy.
+
+## Step 2 — Build the mockup from the template
+Copy `template.html` (next to this skill) to `writeups/ui-proposals/<slug>.html` and fill the slots:
+- **Frame**: use the **phone** frame for mobile surfaces, the **desktop** frame for wide ones (both are in the template).
+- **Before**: mirror today's UI honestly (including the rough edges the change fixes).
+- **After**: your proposed design.
+- **"What changes"** list: 3–5 plain-language bullets.
+
+Rules (keep it portable):
+- **No JavaScript, no external/CDN assets.** Inline SVG icons only (the template ships a set). This is non-negotiable — the artifact must render offline.
+- Match the app's look: dark Nuxt-UI palette, emerald primary, the variables already in the template.
+- One file, self-contained.
+
+`example.html` (next to this skill) is a complete worked reference — the mobile collection viewer before/after.
+
+## Step 3 — Render to PNG
+```bash
+node .claude/skills/ui-proposal/render.mjs writeups/ui-proposals/<slug>.html screenshots/ui-proposal-<slug>.png
+# optional: --width 1100   (default 1000)   --selector ".stage"   (crop to an element)
+```
+Uses the repo's Playwright (`@playwright/test`) headless Chromium — no network. Renders at 2× for a crisp image.
+
+## Step 4 — Hand off
+- **Commit** the `.html` (via `/commit`, scope `docs`).
+- The **PNG** is the thing to post in the PR comment (handled by the worker gate / revision-loop sub-issues #309/#310). When running this skill by hand, attach/post the PNG yourself.
+
+## Conventions
+- Before **and** after side-by-side for a *change*; **after-only** for net-new UI (no "before" exists).
+- Keep the mockup focused on the surface under discussion — don't redraw the whole app.
+- Re-render after every edit so the PNG never drifts from the HTML.

--- a/.claude/skills/ui-proposal/example.html
+++ b/.claude/skills/ui-proposal/example.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<!-- ui-proposal WORKED EXAMPLE — mobile collection viewer (epic #307 / PR #305). -->
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>UI Proposal — Mobile collection viewer</title>
+<style>
+  :root{
+    --page:#0a0e17; --ink:#e8edf6; --muted:#8b97ad;
+    --app-bg:#0b0f1a; --card:#151b27; --card-2:#11161f; --line:#222b3a; --line-soft:#1b2230;
+    --green:#34d399; --green-d:#0e3a2a;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0; background:radial-gradient(1100px 500px at 75% -10%, #16213c 0%, var(--page) 55%);
+    color:var(--ink); line-height:1.55; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif; -webkit-font-smoothing:antialiased;}
+  .wrap{max-width:880px; margin:0 auto; padding:40px 20px 80px;}
+  .eyebrow{text-transform:uppercase; letter-spacing:.18em; font-size:12px; color:var(--green); font-weight:700;}
+  h1{font-size:clamp(26px,4vw,38px); margin:6px 0 6px; line-height:1.1;}
+  .lede{color:var(--muted); font-size:16px; max-width:64ch; margin:0 0 28px;}
+  .stage{display:flex; flex-wrap:wrap; gap:32px; justify-content:center; align-items:flex-start;}
+  .col{display:flex; flex-direction:column; align-items:center; gap:12px;}
+  .col h2{font-size:15px; margin:0; display:flex; align-items:center; gap:8px;}
+  .tag{font-size:11px; padding:2px 9px; border-radius:999px; border:1px solid var(--line); color:var(--muted);}
+  .tag.bad{color:#f6a; border-color:#5b2740;} .tag.good{color:var(--green); border-color:#1f5e47;}
+  .note{font-size:12.5px; color:var(--muted); max-width:300px; text-align:center;}
+  .phone{width:320px; border-radius:40px; padding:10px; background:linear-gradient(#1c2433,#11161f); border:1px solid #2b3852; box-shadow:0 24px 60px rgba(0,0,0,.5);}
+  .screen{background:var(--app-bg); border-radius:31px; overflow:hidden; height:640px; display:flex; flex-direction:column; position:relative;}
+  .statusbar{display:flex; justify-content:space-between; align-items:center; padding:10px 18px 4px; font-size:12px;}
+  .ic{width:17px; height:17px; stroke:currentColor; fill:none; stroke-width:1.8; stroke-linecap:round; stroke-linejoin:round; flex:none;}
+  .ic.sm{width:15px;height:15px;}
+  .btn{display:inline-flex; align-items:center; gap:6px; border-radius:9px; border:1px solid var(--line); background:var(--card-2); color:var(--ink); font-size:13px; padding:7px 10px;}
+  .btn.icon{padding:7px;} .btn.green{background:var(--green); border-color:var(--green); color:#04231a; font-weight:700;} .btn.ghost{background:transparent; border-color:transparent; color:var(--muted);}
+  .appbar{display:flex; align-items:center; gap:10px; padding:10px 14px;}
+  .appbar .title{font-size:18px; font-weight:700; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
+  .spacer{flex:1;}
+  .searchrow{display:flex; gap:8px; padding:4px 14px 12px; align-items:center;}
+  .search{flex:1; min-width:0; display:flex; align-items:center; gap:8px; background:var(--card-2); border:1px solid var(--line); border-radius:10px; padding:8px 11px; color:var(--muted); font-size:13px;}
+  .b-subbar{display:flex; align-items:center; gap:8px; padding:8px 14px; border-top:1px solid var(--line-soft);}
+  .b-subbar .ttl{font-size:14px; font-weight:600; color:var(--muted);}
+  .switch{display:flex; gap:2px; background:var(--card-2); border:1px solid var(--line); border-radius:9px; padding:3px;}
+  .switch .s{width:26px; height:24px; display:grid; place-items:center; border-radius:6px; color:var(--muted);}
+  .switch .s.on{background:var(--green); color:#04231a;}
+  .tablewrap{margin:0 14px; border:1px solid var(--line); border-radius:12px; overflow:hidden; position:relative;}
+  table{border-collapse:collapse; width:460px;}
+  th,td{text-align:left; padding:10px 12px; font-size:12.5px; white-space:nowrap; border-bottom:1px solid var(--line-soft);}
+  th{color:var(--muted); font-weight:600; background:var(--card-2);}
+  .pillrow{display:inline-flex; align-items:center; gap:6px;}
+  .badge{font-size:10px; font-weight:700; padding:2px 7px; border-radius:999px; background:var(--green-d); color:var(--green); border:1px solid #1f5e47;}
+  .cut{position:absolute; top:0; right:0; bottom:0; width:46px; pointer-events:none; background:linear-gradient(90deg, rgba(11,15,26,0), var(--app-bg));}
+  .scrollhint{position:absolute; top:50%; right:8px; transform:translateY(-50%); color:var(--muted); font-size:18px;}
+  .act{display:inline-flex; gap:6px;}
+  .act .a{width:24px;height:24px;display:grid;place-items:center;border-radius:6px;border:1px solid var(--line);}
+  .act .a.del{color:#f87171;border-color:#5b2740;} .act .a.ed{color:var(--green);}
+  .list{padding:4px 12px; display:flex; flex-direction:column; gap:10px; overflow:auto;}
+  .ccard{display:flex; align-items:center; gap:12px; background:var(--card); border:1px solid var(--line); border-radius:14px; padding:13px 14px;}
+  .ccard-main{min-width:0; flex:1;}
+  .ccard-title{font-size:15px; font-weight:650;}
+  .ccard-sub{display:flex; align-items:center; gap:6px; color:var(--muted); font-size:12.5px; margin-top:3px;}
+  .ccard-side{display:flex; align-items:center; gap:10px; flex:none;}
+  .kebab{color:var(--muted);}
+  .footer{margin-top:auto; padding:10px 14px; border-top:1px solid var(--line-soft); display:flex; align-items:center; gap:10px; font-size:12px; color:var(--muted);}
+  .mini{background:var(--card-2); border:1px solid var(--line); border-radius:7px; padding:3px 7px; color:var(--ink); font-size:12px;}
+  .pg{margin-left:auto; display:flex; gap:4px; align-items:center;}
+  .pg .p{width:24px;height:24px;display:grid;place-items:center;border:1px solid var(--line);border-radius:7px;}
+  .pg .p.on{background:var(--green); color:#04231a; border-color:var(--green); font-weight:700;}
+  .changes{margin-top:40px; background:#101725; border:1px solid var(--line); border-radius:16px; padding:20px 22px;}
+  .changes h3{margin:0 0 12px; font-size:16px;}
+  .changes ul{margin:0; padding-left:0; list-style:none; display:grid; gap:10px;}
+  .changes li{display:flex; gap:10px; align-items:flex-start; font-size:14px; color:#cdd6e6;}
+  .changes li b{color:#fff;} .check{color:var(--green); flex:none; margin-top:2px;}
+  .changes code{font-family:ui-monospace,Menlo,Consolas,monospace; font-size:.9em; background:rgba(52,211,153,.12); color:#a9f0d2; padding:1px 6px; border-radius:6px;}
+  footer.fin{margin-top:30px; color:var(--muted); font-size:12.5px; text-align:center;}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <span class="eyebrow">nuxt-crouton · proposal</span>
+  <h1>Mobile collection viewer — before / after</h1>
+  <p class="lede">On phones, render <strong>cards instead of a sideways-scrolling table</strong> and collapse the <strong>duplicated header</strong> into one bar. Desktop is untouched.</p>
+
+  <div class="stage">
+    <!-- BEFORE -->
+    <div class="col">
+      <h2>Before <span class="tag bad">today</span></h2>
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>23:45</span><span>···· 32</span></div>
+        <div class="appbar">
+          <div class="title">Sales Categories</div>
+          <div class="switch">
+            <div class="s on"><svg class="ic sm" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18"/></svg></div>
+            <div class="s"><svg class="ic sm" viewBox="0 0 24 24"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg></div>
+            <div class="s"><svg class="ic sm" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg></div>
+          </div>
+        </div>
+        <div class="b-subbar">
+          <svg class="ic" viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          <span class="ttl">SalesCategories</span>
+          <div class="spacer"></div>
+          <span class="btn ghost" style="color:var(--green)">Importeren</span>
+          <span class="btn green">Aanmaken</span>
+        </div>
+        <div class="searchrow">
+          <div class="search"><svg class="ic sm" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg> Zoeken</div>
+          <span class="btn icon"><svg class="ic" viewBox="0 0 24 24"><path d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6"/></svg></span>
+        </div>
+        <div class="tablewrap">
+          <table>
+            <thead><tr><th>Acties</th><th>EventId</th><th>Title</th><th>Body</th></tr></thead>
+            <tbody>
+              <tr><td><span class="act"><span class="a del"><svg class="ic sm" viewBox="0 0 24 24"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg></span><span class="a ed"><svg class="ic sm" viewBox="0 0 24 24"><path d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg></span></span></td><td><span class="pillrow">Vlaamse Kermis <span class="badge">ACTIVE</span></span></td><td>Dranken</td><td>Sample…</td></tr>
+              <tr><td><span class="act"><span class="a del"><svg class="ic sm" viewBox="0 0 24 24"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14"/></svg></span><span class="a ed"><svg class="ic sm" viewBox="0 0 24 24"><path d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg></span></span></td><td><span class="pillrow">Vlaamse Kermis <span class="badge">ACTIVE</span></span></td><td>Eten</td><td>Sample…</td></tr>
+            </tbody>
+          </table>
+          <div class="cut"></div><div class="scrollhint">›</div>
+        </div>
+        <div class="footer"><span>Rijen: <span class="mini">10</span></span><span>1–2 / 2</span><div class="pg"><span class="p">‹</span><span class="p on">1</span><span class="p">›</span></div></div>
+      </div></div>
+      <p class="note">Name shown twice · table clips “Dranken / Eten” · crowded switcher.</p>
+    </div>
+
+    <!-- AFTER -->
+    <div class="col">
+      <h2>After <span class="tag good">proposed</span></h2>
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>23:45</span><span>···· 32</span></div>
+        <div class="appbar">
+          <svg class="ic" viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h18"/></svg>
+          <div class="title">Sales Categories</div>
+          <div class="spacer"></div>
+          <span class="btn icon"><svg class="ic" viewBox="0 0 24 24"><path d="M12 15V3M7 8l5-5 5 5M5 21h14"/></svg></span>
+          <span class="btn green icon"><svg class="ic" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></span>
+        </div>
+        <div class="searchrow">
+          <div class="search"><svg class="ic sm" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg> Zoeken</div>
+          <span class="btn icon"><svg class="ic" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></span>
+          <span class="btn icon"><svg class="ic" viewBox="0 0 24 24"><path d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6"/></svg></span>
+        </div>
+        <div class="list">
+          <div class="ccard">
+            <div class="ccard-main"><div class="ccard-title">Dranken</div><div class="ccard-sub"><svg class="ic sm" viewBox="0 0 24 24"><path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0L3 13V3h10l7.6 7.6a2 2 0 0 1 0 2.8Z"/><circle cx="7.5" cy="7.5" r="1.2"/></svg> Vlaamse Kermis</div></div>
+            <div class="ccard-side"><span class="badge">Actief</span><span class="kebab"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="5" r="1.4"/><circle cx="12" cy="12" r="1.4"/><circle cx="12" cy="19" r="1.4"/></svg></span></div>
+          </div>
+          <div class="ccard">
+            <div class="ccard-main"><div class="ccard-title">Eten</div><div class="ccard-sub"><svg class="ic sm" viewBox="0 0 24 24"><path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0L3 13V3h10l7.6 7.6a2 2 0 0 1 0 2.8Z"/><circle cx="7.5" cy="7.5" r="1.2"/></svg> Vlaamse Kermis</div></div>
+            <div class="ccard-side"><span class="badge">Actief</span><span class="kebab"><svg class="ic" viewBox="0 0 24 24"><circle cx="12" cy="5" r="1.4"/><circle cx="12" cy="12" r="1.4"/><circle cx="12" cy="19" r="1.4"/></svg></span></div>
+          </div>
+        </div>
+        <div class="footer"><span>1–2 / 2</span><div class="pg"><span class="p">‹</span><span class="p on">1</span><span class="p">›</span></div></div>
+      </div></div>
+      <p class="note">One header (name once) · tidy cards, no horizontal scroll · icon actions · switcher in a menu.</p>
+    </div>
+  </div>
+
+  <div class="changes">
+    <h3>What changes (and what doesn't)</h3>
+    <ul>
+      <li><svg class="ic check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg><span><b>Cards on phones.</b> Under <code>sm</code>, render the list/card layout instead of the table — title + reference + status badge per row, no sideways scroll.</span></li>
+      <li><svg class="ic check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg><span><b>One header.</b> Collapse the two stacked bars into a single row: name once, Import + Aanmaken as icon buttons.</span></li>
+      <li><svg class="ic check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg><span><b>Leaner footer.</b> Drop the “Rijen per pagina” selector on phones — count + pager only.</span></li>
+      <li><svg class="ic check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg><span><b>Desktop untouched.</b> All changes are <code>sm:</code>-gated.</span></li>
+    </ul>
+  </div>
+  <footer class="fin">Mockup only · pure HTML/CSS/SVG, no JS · data mirrors the live Sales Categories collection</footer>
+</div>
+</body>
+</html>

--- a/.claude/skills/ui-proposal/render.mjs
+++ b/.claude/skills/ui-proposal/render.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Render a self-contained HTML mockup to a PNG via Playwright (headless Chromium).
+ * Offline — no network needed (the mockups must be JS/CDN-free anyway).
+ *
+ *   node render.mjs <input.html> <output.png> [--width N] [--selector "CSS"]
+ *
+ *   --width N        viewport width in px (default 1000)
+ *   --selector CSS   crop to the first matching element instead of full page
+ *
+ * Uses the repo's existing Playwright dep (@playwright/test ships the `playwright` runtime).
+ */
+import { chromium } from 'playwright'
+import { pathToFileURL } from 'node:url'
+import { resolve, dirname, join } from 'node:path'
+import { existsSync, mkdirSync, readdirSync } from 'node:fs'
+
+/**
+ * Find an already-installed Chromium so we don't need network to download one.
+ * Honours PLAYWRIGHT_CHROMIUM (explicit path), then PLAYWRIGHT_BROWSERS_PATH /
+ * the usual cache dirs, picking the newest chromium-* build present.
+ */
+function findChromium() {
+  if (process.env.PLAYWRIGHT_CHROMIUM && existsSync(process.env.PLAYWRIGHT_CHROMIUM)) {
+    return process.env.PLAYWRIGHT_CHROMIUM
+  }
+  const roots = [
+    process.env.PLAYWRIGHT_BROWSERS_PATH,
+    '/opt/pw-browsers',
+    join(process.env.HOME || '', '.cache', 'ms-playwright')
+  ].filter(Boolean)
+  for (const root of roots) {
+    if (!existsSync(root)) continue
+    const builds = readdirSync(root).filter(d => d.startsWith('chromium-')).sort().reverse()
+    for (const b of builds) {
+      for (const rel of ['chrome-linux/chrome', 'chrome-mac/Chromium.app/Contents/MacOS/Chromium', 'chrome-win/chrome.exe']) {
+        const p = join(root, b, rel)
+        if (existsSync(p)) return p
+      }
+    }
+  }
+  return null
+}
+
+const args = process.argv.slice(2)
+const [input, output] = args.filter(a => !a.startsWith('--'))
+if (!input || !output) {
+  console.error('Usage: render.mjs <input.html> <output.png> [--width N] [--selector "CSS"]')
+  process.exit(1)
+}
+const widthIdx = args.indexOf('--width')
+const width = widthIdx !== -1 ? parseInt(args[widthIdx + 1], 10) : 1000
+const selIdx = args.indexOf('--selector')
+const selector = selIdx !== -1 ? args[selIdx + 1] : null
+
+if (!existsSync(input)) {
+  console.error(`Input not found: ${input}`)
+  process.exit(1)
+}
+mkdirSync(dirname(resolve(output)), { recursive: true })
+
+const executablePath = findChromium()
+let browser
+try {
+  browser = await chromium.launch({ executablePath: executablePath || undefined, args: ['--no-sandbox'] })
+} catch (err) {
+  console.error('Could not launch Chromium.', executablePath ? `Tried: ${executablePath}` : 'No installed browser found.')
+  console.error('Install one with:  npx playwright install chromium   (or set PLAYWRIGHT_CHROMIUM=/path/to/chrome)')
+  throw err
+}
+try {
+  const page = await browser.newPage({
+    viewport: { width, height: 900 },
+    deviceScaleFactor: 2 // crisp 2× output
+  })
+  await page.goto(pathToFileURL(resolve(input)).href, { waitUntil: 'networkidle' })
+  if (selector) {
+    await page.locator(selector).first().screenshot({ path: output })
+  } else {
+    await page.screenshot({ path: output, fullPage: true })
+  }
+  console.log(`✓ Rendered ${input} → ${output} (${width}px @2x${selector ? `, crop ${selector}` : ''})`)
+} finally {
+  await browser.close()
+}

--- a/.claude/skills/ui-proposal/template.html
+++ b/.claude/skills/ui-proposal/template.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<!--
+  ui-proposal TEMPLATE — copy to writeups/ui-proposals/<slug>.html and fill the slots.
+  RULES: no JavaScript, no external/CDN assets. Inline SVG icons only. Self-contained.
+  Frames provided: .phone (mobile surfaces) and .deviceframe (desktop surfaces) — keep
+  the one you need, delete the other. Replace BEFORE/AFTER content with the real UI.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>UI Proposal — {{TITLE}}</title>
+<style>
+  :root{
+    --page:#0a0e17; --ink:#e8edf6; --muted:#8b97ad;
+    --app-bg:#0b0f1a; --card:#151b27; --card-2:#11161f; --line:#222b3a; --line-soft:#1b2230;
+    --green:#34d399; --green-d:#0e3a2a; --radius:16px;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0; background:radial-gradient(1100px 500px at 75% -10%, #16213c 0%, var(--page) 55%);
+    color:var(--ink); line-height:1.55; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif; -webkit-font-smoothing:antialiased;}
+  .wrap{max-width:980px; margin:0 auto; padding:40px 20px 80px;}
+  .eyebrow{text-transform:uppercase; letter-spacing:.18em; font-size:12px; color:var(--green); font-weight:700;}
+  h1{font-size:clamp(26px,4vw,38px); margin:6px 0 6px; line-height:1.1;}
+  .lede{color:var(--muted); font-size:16px; max-width:64ch; margin:0 0 28px;}
+
+  .stage{display:flex; flex-wrap:wrap; gap:32px; justify-content:center; align-items:flex-start;}
+  .col{display:flex; flex-direction:column; align-items:center; gap:12px;}
+  .col h2{font-size:15px; margin:0; display:flex; align-items:center; gap:8px;}
+  .tag{font-size:11px; padding:2px 9px; border-radius:999px; border:1px solid var(--line); color:var(--muted);}
+  .tag.bad{color:#f6a; border-color:#5b2740;} .tag.good{color:var(--green); border-color:#1f5e47;}
+  .note{font-size:12.5px; color:var(--muted); max-width:320px; text-align:center;}
+
+  /* ---- phone frame (mobile surfaces) ---- */
+  .phone{width:320px; border-radius:40px; padding:10px; background:linear-gradient(#1c2433,#11161f); border:1px solid #2b3852; box-shadow:0 24px 60px rgba(0,0,0,.5);}
+  .phone .screen{background:var(--app-bg); border-radius:31px; overflow:hidden; height:640px; display:flex; flex-direction:column; position:relative;}
+  .statusbar{display:flex; justify-content:space-between; align-items:center; padding:10px 18px 4px; font-size:12px;}
+
+  /* ---- desktop frame (wide surfaces) ---- */
+  .deviceframe{width:640px; max-width:100%; border-radius:14px; overflow:hidden; border:1px solid #2b3852; box-shadow:0 24px 60px rgba(0,0,0,.5); background:var(--app-bg);}
+  .deviceframe .bar{display:flex; gap:6px; padding:10px 14px; background:#11161f; border-bottom:1px solid var(--line);}
+  .deviceframe .bar i{width:11px; height:11px; border-radius:50%; background:#33405a; display:inline-block;}
+  .deviceframe .body{padding:0;}
+
+  /* ---- shared UI atoms (reuse in BEFORE/AFTER) ---- */
+  .ic{width:17px; height:17px; stroke:currentColor; fill:none; stroke-width:1.8; stroke-linecap:round; stroke-linejoin:round; flex:none;}
+  .ic.sm{width:15px;height:15px;}
+  .btn{display:inline-flex; align-items:center; gap:6px; border-radius:9px; border:1px solid var(--line); background:var(--card-2); color:var(--ink); font-size:13px; padding:7px 10px;}
+  .btn.icon{padding:7px;} .btn.green{background:var(--green); border-color:var(--green); color:#04231a; font-weight:700;} .btn.ghost{background:transparent; border-color:transparent; color:var(--muted);}
+  .appbar{display:flex; align-items:center; gap:10px; padding:10px 14px;}
+  .appbar .title{font-size:18px; font-weight:700; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
+  .spacer{flex:1;}
+  .badge{font-size:10px; font-weight:700; padding:2px 7px; border-radius:999px; background:var(--green-d); color:var(--green); border:1px solid #1f5e47;}
+  .card-row{display:flex; align-items:center; gap:12px; background:var(--card); border:1px solid var(--line); border-radius:14px; padding:13px 14px; margin:0 12px 10px;}
+
+  .changes{margin-top:40px; background:#101725; border:1px solid var(--line); border-radius:16px; padding:20px 22px;}
+  .changes h3{margin:0 0 12px; font-size:16px;}
+  .changes ul{margin:0; padding-left:0; list-style:none; display:grid; gap:10px;}
+  .changes li{display:flex; gap:10px; align-items:flex-start; font-size:14px; color:#cdd6e6;}
+  .changes li b{color:#fff;} .check{color:var(--green); flex:none; margin-top:2px;}
+  .changes code{font-family:ui-monospace,Menlo,Consolas,monospace; font-size:.9em; background:rgba(52,211,153,.12); color:#a9f0d2; padding:1px 6px; border-radius:6px;}
+  footer.fin{margin-top:30px; color:var(--muted); font-size:12.5px; text-align:center;}
+
+  /* Icon reference (copy into BEFORE/AFTER as needed):
+     search:  <circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>
+     plus:    <path d="M12 5v14M5 12h14"/>
+     upload:  <path d="M12 15V3M7 8l5-5 5 5M5 21h14"/>
+     menu:    <path d="M3 6h18M3 12h18M3 18h18"/>
+     kebab:   <circle cx="12" cy="5" r="1.4"/><circle cx="12" cy="12" r="1.4"/><circle cx="12" cy="19" r="1.4"/>
+     check:   <path d="M20 6 9 17l-5-5"/>
+     grid:    <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>
+     tag:     <path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0L3 13V3h10l7.6 7.6a2 2 0 0 1 0 2.8Z"/><circle cx="7.5" cy="7.5" r="1.2"/>
+  */
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <span class="eyebrow">nuxt-crouton · proposal</span>
+  <h1>{{TITLE}}</h1>
+  <p class="lede">{{ONE_LINE_SUMMARY of the proposed change}}</p>
+
+  <div class="stage">
+
+    <!-- ============ BEFORE (delete this column for net-new UI) ============ -->
+    <div class="col">
+      <h2>Before <span class="tag bad">today</span></h2>
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>23:45</span><span>···· 32</span></div>
+        <!-- TODO: mirror the CURRENT UI honestly -->
+      </div></div>
+      <p class="note">{{what's wrong today}}</p>
+    </div>
+
+    <!-- ============ AFTER ============ -->
+    <div class="col">
+      <h2>After <span class="tag good">proposed</span></h2>
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>23:45</span><span>···· 32</span></div>
+        <!-- TODO: the PROPOSED UI -->
+      </div></div>
+      <p class="note">{{what's better}}</p>
+    </div>
+
+  </div>
+
+  <div class="changes">
+    <h3>What changes (and what doesn't)</h3>
+    <ul>
+      <li><svg class="ic check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg><span><b>{{Change 1.}}</b> {{detail}}</span></li>
+      <li><svg class="ic check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg><span><b>{{Change 2.}}</b> {{detail}}</span></li>
+      <li><svg class="ic check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg><span><b>Scope.</b> {{what stays the same / what's untouched}}</span></li>
+    </ul>
+  </div>
+
+  <footer class="fin">Mockup only · pure HTML/CSS/SVG, no JS · {{data source note}}</footer>
+
+</div>
+</body>
+</html>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/db-migrations/SKILL.md` | The migrate step (`db:generate` schema.mjs-after-build gotcha) + package-owned infra tables. App collections use the `crouton` CLI, not this |
 | Skill | `.claude/skills/dependency-sweep/SKILL.md` | The "get dependencies current" flow — sweep, triage (safe/deliberate/wait), bump the pnpm catalog, prove it with the typecheck + e2e gate. No update bot by design (#141); run on-demand or when the quarterly sweep ticket is due |
 | Skill | `.claude/skills/task-decompose/SKILL.md` | Entry point to the recursive task-decomposition pipeline (`/task-decompose`) — one task → an epic + tree of sub-issues → agents. See "Task Decomposition Pipeline" below |
+| Skill | `.claude/skills/ui-proposal/SKILL.md` | Generate a before/after UI mockup (offline HTML/CSS/SVG) + render it to PNG for design sign-off before building UI. Part of the UI sign-off loop (#307) |
 | Agent | `.claude/agents/sync-checker.md` | Doc sync verification |
 | Agent | `.claude/agents/task-orchestrator.md` | Reads an epic, fans it into 2–6 top-level sub-issues, spawns a decomposer per child |
 | Agent | `.claude/agents/task-decomposer.md` | Recursive: LEAF TEST one issue → spawn a worker (leaf) or split into sub-issues + spawn a decomposer per child |


### PR DESCRIPTION
## 👤 For humans

First piece of the UI sign-off loop (epic #307): a skill that turns a planned UI change into a **before/after HTML mockup** (pure CSS/SVG, renders offline — even in a phone file-preview) and a rendered **PNG** you can drop into a PR comment. The point: a human approves the look-and-feel **before** the real component is built.

Here's the rendered output of the skill run against its own worked example (the mobile collection viewer):

_(see the screenshot comment below — dogfooded)_

## 🤖 For agents

New skill `.claude/skills/ui-proposal/`:
- **SKILL.md** — when to use (UI diffs / "mock this up"), what it produces (committed `.html` under `writeups/ui-proposals/`, rendered `screenshots/ui-proposal-<slug>.png`), and the 4-step flow.
- **template.html** — reusable phone + desktop frame skeleton, dark Nuxt-UI palette, inline SVG icon set, before/after + "what changes" slots. **No JS, no CDN.**
- **example.html** — worked reference (mobile collection viewer before/after).
- **render.mjs** — HTML→PNG via the repo's Playwright. Auto-detects an installed Chromium (`PLAYWRIGHT_CHROMIUM` / `PLAYWRIGHT_BROWSERS_PATH`) so it runs **offline**, `--no-sandbox`, 2× scale. Verified end-to-end.
- **CLAUDE.md** — artifacts-table row.

Deliberately scoped to *producing* the artifact. Posting it to PRs, the UI-change detection gate, the revision loop, and the post-build screenshot are the sibling sub-issues (#309/#310/#311).

## 🧪 How to test

```bash
node .claude/skills/ui-proposal/render.mjs \
  .claude/skills/ui-proposal/example.html \
  screenshots/ui-proposal-example.png --selector .stage
```
Produces a crisp before/after PNG. Open `example.html` in any browser (offline) to confirm it renders with no network.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQPxXd1HwWPgJ9VZAA8QA8)_