### PR TITLE
docs: skills-and-triggers overview (HTML)

### DIFF
--- a/writeups/architecture/skills-and-triggers.html
+++ b/writeups/architecture/skills-and-triggers.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Crouton Skills — what fires when</title>
+<style>
+  :root{
+    --page:#0a0e17; --ink:#e8edf6; --muted:#8b97ad;
+    --panel:#121a2e; --panel-2:#0f1626; --line:#243049;
+    --auto:#34d399; --ask:#60a5fa; --flow:#a78bfa; --radius:14px;
+    --shadow:0 10px 30px rgba(0,0,0,.35);
+  }
+  *{box-sizing:border-box;}
+  body{margin:0; background:radial-gradient(1200px 600px at 75% -10%, #16213c 0%, var(--page) 55%);
+    color:var(--ink); line-height:1.55; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif; -webkit-font-smoothing:antialiased;}
+  .wrap{max-width:1080px; margin:0 auto; padding:44px 22px 90px;}
+  .eyebrow{text-transform:uppercase; letter-spacing:.18em; font-size:12px; color:var(--auto); font-weight:700;}
+  h1{font-size:clamp(27px,4vw,40px); margin:6px 0 8px; line-height:1.1;}
+  .lede{color:var(--muted); font-size:16px; max-width:70ch; margin:0 0 22px;}
+
+  .legend{display:flex; flex-wrap:wrap; gap:10px; margin-bottom:8px;}
+  .chip{display:inline-flex; align-items:center; gap:8px; background:var(--panel); border:1px solid var(--line); padding:6px 12px; border-radius:999px; font-size:13px; color:var(--muted);}
+  .dot{width:10px;height:10px;border-radius:50%;}
+  .dot.auto{background:var(--auto);} .dot.ask{background:var(--ask);} .dot.flow{background:var(--flow);}
+
+  /* lifecycle strip */
+  .strip{margin:26px 0 8px; background:linear-gradient(180deg,var(--panel),var(--panel-2)); border:1px solid var(--line); border-radius:var(--radius); box-shadow:var(--shadow); padding:14px; overflow-x:auto;}
+  .strip svg{width:100%; height:auto; min-width:760px; display:block;}
+  .strip text{fill:var(--ink); font-family:inherit;}
+  .s-t{font-size:13px; font-weight:700;} .s-s{font-size:10.5px; fill:var(--muted);}
+  .edge{stroke:#52628a; stroke-width:1.7; fill:none;}
+
+  h2{font-size:18px; margin:34px 0 4px; display:flex; align-items:center; gap:10px;}
+  h2 .num{display:inline-grid;place-items:center;width:26px;height:26px;border-radius:8px;background:#1e2a47;border:1px solid var(--line);font-size:13px;color:var(--muted);}
+  .grp-sub{color:var(--muted); font-size:13px; margin:0 0 14px;}
+
+  .grid{display:grid; grid-template-columns:1fr; gap:12px;}
+  @media(min-width:720px){.grid{grid-template-columns:1fr 1fr;}}
+  .skill{background:var(--panel); border:1px solid var(--line); border-radius:var(--radius); padding:15px 16px;}
+  .skill-head{display:flex; align-items:center; justify-content:space-between; gap:8px; margin-bottom:7px;}
+  .name{font-family:ui-monospace,Menlo,Consolas,monospace; font-size:14px; font-weight:700; color:#cfe3ff;}
+  .badges{display:flex; gap:5px; flex-wrap:wrap; justify-content:flex-end;}
+  .b{font-size:10.5px; font-weight:700; padding:2px 8px; border-radius:999px; white-space:nowrap;}
+  .b.auto{background:rgba(52,211,153,.14); color:var(--auto); border:1px solid #1f5e47;}
+  .b.ask{background:rgba(96,165,250,.14); color:var(--ask); border:1px solid #29456f;}
+  .b.flow{background:rgba(167,139,250,.14); color:var(--flow); border:1px solid #443a6b;}
+  .trig{font-size:13px; margin:0 0 6px;}
+  .trig b{color:#fff;}
+  .what{font-size:12.5px; color:var(--muted); margin:0;}
+  .skill code{font-family:ui-monospace,Menlo,Consolas,monospace; font-size:.9em; background:rgba(96,165,250,.12); color:#cfe3ff; padding:1px 5px; border-radius:5px;}
+
+  footer{margin-top:46px; padding-top:18px; border-top:1px solid var(--line); color:var(--muted); font-size:12.5px;}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <span class="eyebrow">nuxt-crouton · agent flow</span>
+  <h1>Skills — what fires when</h1>
+  <p class="lede">Every skill in <code>.claude/skills/</code>, grouped by job, with the <strong>trigger</strong> that fires it. Three kinds of trigger:</p>
+  <div class="legend">
+    <span class="chip"><span class="dot auto"></span> <b style="color:var(--auto)">Automatic</b> — a hook / pre-commit step runs it for you</span>
+    <span class="chip"><span class="dot ask"></span> <b style="color:var(--ask)">On ask</b> — you invoke it (<code>/name</code>) or request the work</span>
+    <span class="chip"><span class="dot flow"></span> <b style="color:var(--flow)">In flow</b> — fires inside the agent task pipeline</span>
+  </div>
+
+  <!-- lifecycle strip -->
+  <div class="strip">
+    <svg viewBox="0 0 880 150" role="img" aria-label="Where skills fire across a task lifecycle">
+      <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#52628a"/></marker></defs>
+      <line class="edge" x1="118" y1="58" x2="158" y2="58" marker-end="url(#a)"/>
+      <line class="edge" x1="276" y1="58" x2="316" y2="58" marker-end="url(#a)"/>
+      <line class="edge" x1="434" y1="58" x2="474" y2="58" marker-end="url(#a)"/>
+      <line class="edge" x1="592" y1="58" x2="632" y2="58" marker-end="url(#a)"/>
+      <line class="edge" x1="750" y1="58" x2="790" y2="58" marker-end="url(#a)"/>
+
+      <g><rect x="20" y="34" width="98" height="48" rx="9" fill="#13213c" stroke="#2f4068"/><text class="s-t" x="69" y="55" text-anchor="middle">Plan</text><text class="s-s" x="69" y="71" text-anchor="middle">github-tasks</text></g>
+      <g><rect x="158" y="34" width="118" height="48" rx="9" fill="#13213c" stroke="#2f4068"/><text class="s-t" x="217" y="55" text-anchor="middle">Build</text><text class="s-s" x="217" y="71" text-anchor="middle">crouton · ui-proposal</text></g>
+      <g><rect x="316" y="34" width="118" height="48" rx="9" fill="#102a22" stroke="#1f5e47"/><text class="s-t" x="375" y="55" text-anchor="middle">Pre-commit</text><text class="s-s" x="375" y="71" text-anchor="middle">sync-docs · i18n-check</text></g>
+      <g><rect x="474" y="34" width="118" height="48" rx="9" fill="#102a22" stroke="#1f5e47"/><text class="s-t" x="533" y="55" text-anchor="middle">Commit</text><text class="s-s" x="533" y="71" text-anchor="middle">/commit</text></g>
+      <g><rect x="632" y="34" width="118" height="48" rx="9" fill="#13213c" stroke="#2f4068"/><text class="s-t" x="691" y="55" text-anchor="middle">Review</text><text class="s-s" x="691" y="71" text-anchor="middle">review · audit</text></g>
+      <g><rect x="790" y="34" width="90" height="48" rx="9" fill="#13213c" stroke="#2f4068"/><text class="s-t" x="835" y="55" text-anchor="middle">Ship</text><text class="s-s" x="835" y="71" text-anchor="middle">deploy · e2e</text></g>
+
+      <text class="s-s" x="375" y="104" text-anchor="middle">↑ green stages run automatically before the commit lands</text>
+    </svg>
+  </div>
+
+  <!-- 1. Build & generate -->
+  <h2><span class="num">1</span> Build &amp; generate</h2>
+  <p class="grp-sub">Turn intent into code (or into issues that become code).</p>
+  <div class="grid">
+    <div class="skill">
+      <div class="skill-head"><span class="name">/crouton</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> you generate a CRUD collection — schema JSON → Form/List/API/composable/schema.</p>
+      <p class="what">The collection generator workflow (CLI <code>crouton config</code>). The backbone of building an app's data surfaces.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/ui-proposal</span><span class="badges"><span class="b flow">in flow</span><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> a task adds/changes UI (a <code>.vue</code>, a layout, a screen), or you ask to “mock this up”.</p>
+      <p class="what">Builds a before/after HTML mockup (offline) + renders a PNG for design sign-off <em>before</em> the real component is built. (Epic #307.)</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/task-decompose</span><span class="badges"><span class="b ask">on ask</span><span class="b flow">in flow</span></span></div>
+      <p class="trig"><b>Fires when:</b> “break this down into issues and work it” / “spawn agents to build X”.</p>
+      <p class="what">One task → an epic + recursive tree of sub-issues → orchestrator → decomposer → worker agents.</p>
+    </div>
+  </div>
+
+  <!-- 2. Plan & track -->
+  <h2><span class="num">2</span> Plan &amp; track</h2>
+  <p class="grp-sub">Before code exists — the ISSUE-FIRST gate and prior-art checks.</p>
+  <div class="grid">
+    <div class="skill">
+      <div class="skill-head"><span class="name">/github-tasks</span><span class="badges"><span class="b ask">on ask</span><span class="b flow">in flow</span></span></div>
+      <p class="trig"><b>Fires when:</b> planning a feature, “make issues”, “track this in GitHub” — and the <b>ISSUE-FIRST</b> hard gate before any new initiative.</p>
+      <p class="what">Creates epics + labelled sub-issues (<code>pkg:</code>/<code>app:</code>/<code>meta:</code>), tied to the commit/PR workflow.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/ecosystem-check</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> weighing build-vs-adopt or starting new infra/tooling.</p>
+      <p class="what">Checks Nuxt / UnJS / Vite / OSS prior art first (it’s often already solved) within the project’s constraints.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/mcp-idea</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> a task reveals repetitive work an MCP tool could automate.</p>
+      <p class="what">Drops the idea onto the MCP backlog (<code>.claude/mcp-ideas.md</code>).</p>
+    </div>
+  </div>
+
+  <!-- 3. Commit gates -->
+  <h2><span class="num">3</span> Commit gates</h2>
+  <p class="grp-sub">These run <strong>automatically</strong> as part of landing a change — you rarely call them by hand.</p>
+  <div class="grid">
+    <div class="skill">
+      <div class="skill-head"><span class="name">/sync-docs</span><span class="badges"><span class="b auto">auto · pre-commit</span></span></div>
+      <p class="trig"><b>Fires when:</b> automatically <em>before</em> every <code>/commit</code>.</p>
+      <p class="what">Updates only the docs the change touches (package CLAUDE.md, docs pages, skills). Assumes docs are stale; never over-reaches.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/i18n-check</span><span class="badges"><span class="b auto">auto · pre-commit</span></span></div>
+      <p class="trig"><b>Fires when:</b> committing and the diff includes <code>.vue</code> files in an i18n app (or as a review add-on).</p>
+      <p class="what">Catches hardcoded labels, missing locale keys, locale-sync issues — fast, only what changed.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/commit</span><span class="badges"><span class="b ask">on ask</span><span class="b auto">required</span></span></div>
+      <p class="trig"><b>Fires when:</b> <em>every</em> commit — mandated for all commits (never <code>git commit</code> directly).</p>
+      <p class="what">Granular, conventional commits; filters to session-relevant files, groups by intent, runs sync-docs/i18n-check first.</p>
+    </div>
+  </div>
+
+  <!-- 4. Review & audit -->
+  <h2><span class="num">4</span> Review &amp; audit</h2>
+  <p class="grp-sub">Quality checks on demand.</p>
+  <div class="grid">
+    <div class="skill">
+      <div class="skill-head"><span class="name">/review</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> reviewing uncommitted changes or recent commits, before or after committing.</p>
+      <p class="what">Pattern violations, security issues, bugs — tuned for a solo dev moving fast.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/audit</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> checking package docs / documentation health across the monorepo.</p>
+      <p class="what">Detects drift between code and docs; reports completeness.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/sync-check</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> verifying field-type sync across generator ↔ MCP ↔ skill ↔ docs.</p>
+      <p class="what">Reports mismatches with fix instructions (the CLI’s mandatory sync workflow).</p>
+    </div>
+  </div>
+
+  <!-- 5. Deploy -->
+  <h2><span class="num">5</span> Deploy</h2>
+  <p class="grp-sub">Code → a live Cloudflare Workers URL.</p>
+  <div class="grid">
+    <div class="skill">
+      <div class="skill-head"><span class="name">/deploy</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> deploying a launched app in <code>apps/</code> (first bootstrap, CI wiring, or routine deploy; or migrating a Pages app).</p>
+      <p class="what">Auto-provisions D1+KV, syncs ids, migrates, two-domain staging/prod.</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/poc-deploy</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> giving a <code>pocs/</code> app a staging preview URL (or “build X as a poc” needs a clickable link).</p>
+      <p class="what">The lighter, staging-only POC path — every PR deploys an isolated preview.</p>
+    </div>
+  </div>
+
+  <!-- 6. Verify & maintain -->
+  <h2><span class="num">6</span> Verify &amp; maintain</h2>
+  <p class="grp-sub">Prove nothing broke; keep the repo current.</p>
+  <div class="grid">
+    <div class="skill">
+      <div class="skill-head"><span class="name">/e2e-smoke</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> after a <code>packages/</code> change or a dependency bump — “smoke test”, “run e2e”.</p>
+      <p class="what">Boots a real generated fixture app → login → CRUD → package surfaces (Playwright).</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/dependency-sweep</span><span class="badges"><span class="b ask">on ask</span><span class="b auto">scheduled</span></span></div>
+      <p class="trig"><b>Fires when:</b> “update dependencies” / “are we on the latest”, or the recurring quarterly sweep ticket comes due.</p>
+      <p class="what">Sweep → triage (safe/deliberate/wait) → bump the pnpm catalog → typecheck + e2e gate. (No update bot by design.)</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/db-migrations</span><span class="badges"><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> a schema change needs a Drizzle migration generated/applied (the schema.mjs-after-build gotcha), or adding a package-owned infra table.</p>
+      <p class="what">The migration step — <em>not</em> the normal collection flow (that’s <code>/crouton</code>).</p>
+    </div>
+    <div class="skill">
+      <div class="skill-head"><span class="name">/session-start-hook</span><span class="badges"><span class="b auto">auto · session start</span><span class="b ask">on ask</span></span></div>
+      <p class="trig"><b>Fires when:</b> setting up a repo for Claude Code on the web — the <code>SessionStart</code> hook that boots the env each session.</p>
+      <p class="what">Ensures the project can install / run tests / lint inside web sessions.</p>
+    </div>
+  </div>
+
+  <footer>
+    Triggers reflect the skill descriptions + <code>CLAUDE.md</code> rules (ISSUE-FIRST, “always <code>/commit</code>”, sync-docs runs before commit). Agents (<code>task-orchestrator</code> → <code>task-decomposer</code> → <code>task-worker</code>) drive the “in flow” skills. Inline SVG · no JS · renders offline.
+  </footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 👤 For humans

A visual catalogue of every `.claude/` skill, grouped by job (build · plan · commit gates · review · deploy · verify), each tagged with **how it triggers** — automatic (pre-commit hooks), on-ask (`/command`), or in-flow (agent pipeline) — plus a task-lifecycle strip showing where each fires.

Handy reference for "wait, which skill runs when?". Pure HTML/SVG, renders offline.

## 🤖 For agents

- `writeups/architecture/skills-and-triggers.html` — self-contained, inline SVG, no JS. Informational; mirrors the skill descriptions + `CLAUDE.md` trigger rules (ISSUE-FIRST, always-`/commit`, sync-docs-before-commit).

Split out of PR #312 to keep that one focused on the `ui-proposal` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQPxXd1HwWPgJ9VZAA8QA8)_