### PR TITLE
Staging-only by default; production gets its own /deploy-production skill

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: deploy-production
+description: Deploy a crouton app to Cloudflare Workers PRODUCTION (<app>.friendlyinter.net). A deliberate, human-initiated action — separate from the default staging /deploy skill. Use ONLY when explicitly asked to ship/release to production. Never run as part of routine work or an automated flow.
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
+---
+
+# Deploy to Production — Cloudflare Workers (deliberate)
+
+The **only** place a crouton app ships to **production**. Everything routine goes to
+**staging** via the **`/deploy`** skill; production is split out here so it can never
+happen by accident or as a side effect of an agent flow.
+
+> **🛑 Gate — run this skill ONLY on an explicit human request to deploy to production**
+> ("ship X to prod", "release to production", "promote to prod"). If the ask is just
+> "deploy", that means **staging** → use `/deploy`. Before running anything, confirm:
+> (1) which app, and (2) that production is genuinely intended. When in doubt, ask.
+
+## Target
+
+| Env | wrangler env | Worker | Domain | Script |
+|-----|--------------|--------|--------|--------|
+| **production** | top-level | `<app>` | `<app>.friendlyinter.net` | `cf:deploy` |
+
+(Staging — `env.staging` / `<app>.pmcp.dev` / `cf:staging` — is **not** here; that's `/deploy`.)
+
+## Pre-flight (confirm before deploying)
+
+1. **The change is already on staging and verified there.** Deploy to production only
+   what staging has proven — never straight to prod.
+2. **App is Workers-ready** — same checks as `/deploy` Step 2 (the shared mechanics live
+   in that skill; don't duplicate them).
+3. **Production Worker secrets are set** — `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL` = the
+   **production** domain (`https://<app>.friendlyinter.net`), `NUXT_*`. Worker secrets
+   persist across deploys, so this is a one-time bootstrap per worker:
+   `npx wrangler secret bulk secrets.json` (no `--env` = production).
+4. **Credentials** — `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` present (see `/deploy` → Credentials).
+
+## Deploy (both paths are explicit, human-initiated)
+
+- **CI (preferred, canonical):** GitHub → the app's deploy workflow → **Run workflow**
+  (`workflow_dispatch`) with **`environment = production`**. Push/PR never deploys prod —
+  only this manual dispatch does.
+- **Local:** from the app dir:
+  ```bash
+  cd apps/{app}
+  pnpm cf:deploy   # build → wrangler deploy (auto-provision) → sync:ids → d1 migrations apply --remote
+  # first bootstrap only — commit the written-back ids:
+  git add apps/{app}/wrangler.jsonc && git commit -m "chore({app}): commit provisioned prod D1/KV ids"
+  ```
+
+> **Sandbox / no Cloudflare egress:** you CANNOT run a production deploy. Prepare and verify
+> the config, then hand the `workflow_dispatch` (or `cf:deploy`) to the user to run, and
+> confirm the result with them.
+
+## After
+
+- Verify `<app>.friendlyinter.net` is live and the remote migration applied.
+- Production is **never demo-seeded** — the seed's known admin (`--with-staff`) is a
+  staging/local-only login and must never run against the prod DB.
+
+## Shared mechanics
+
+Pipeline scripts, auto-provisioning, Pages→Workers migration, credentials, and
+troubleshooting are documented once in the **`/deploy`** skill. This skill only adds the
+**production trigger** and its **human gate**.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy
-description: Deploy a crouton app to Cloudflare Workers (auto-provisioning). Handles the first bootstrap deploy (auto-creates D1+KV, syncs ids, migrates), wiring CI, and routine deploys. Also migrates an older Pages app to Workers. Use when deploying any app in apps/.
+description: Deploy a crouton app to Cloudflare Workers STAGING (auto-provisioning) — the DEFAULT deploy, staging only, never production. Handles the staging bootstrap (auto-creates D1+KV, syncs ids, migrates), wiring CI, routine staging deploys, and Pages→Workers migration. For production use the separate /deploy-production skill. Use when deploying any app in apps/.
 allowed-tools: Bash, Read, Grep, Glob, Edit, Agent, AskUserQuestion
 ---
 
@@ -9,6 +9,10 @@ allowed-tools: Bash, Read, Grep, Glob, Edit, Agent, AskUserQuestion
 Deploys a crouton app to **Cloudflare Workers (static assets)** — the crouton
 deploy standard (#108). Wrangler **auto-provisions** the app's D1 + KV on the
 first deploy, so there's no manual resource/project creation, no id-juggling.
+
+> **🟦 STAGING ONLY — this skill never deploys to production.** "Deploy" defaults to
+> **staging** here. Shipping to production is a deliberate, human-initiated action handled
+> by the separate **`/deploy-production`** skill. Never deploy production as part of routine work.
 
 > **Not Cloudflare Pages.** We do NOT use `wrangler pages …`, `pages_build_output_dir`,
 > or the Pages "strip env" step anymore. If you find those, the app is on the old
@@ -32,14 +36,14 @@ monorepo's convention, applied per app at its production cutover — #136 for tr
 ## Usage
 
 ```
-/deploy              # Deploy current app (auto-detected from cwd)
-/deploy three-demo   # Deploy a specific app (staging)
-/deploy velo prod    # Deploy to production
+/deploy              # Deploy current app to STAGING (auto-detected from cwd)
+/deploy three-demo   # Deploy a specific app to STAGING
+# production → use the separate /deploy-production skill
 ```
 
 ## Rules
 
-1. **NEVER deploy without confirming the target app and environment.**
+1. **STAGING ONLY.** This skill deploys to **staging**, never production (that's the separate `/deploy-production` skill). Always confirm the target app first.
 2. **Workers, not Pages** — `NITRO_PRESET=cloudflare_module`, output in `.output/`, deploy with `wrangler deploy` (never `wrangler pages deploy`).
 3. **NEVER manually create D1/KV** — they auto-provision from the **id-less** `wrangler.jsonc` on first deploy. After provisioning, run `sync:ids` and **commit** the written-back ids (remote `d1 migrations apply` needs them — workers-sdk#13632).
 4. **NEVER skip `nuxt prepare` before build** in CI — rolldown tsconfig bug. (Locally, the `cf:*` scripts assume `node_modules`/`.nuxt` are prepared from `pnpm install`.)
@@ -51,7 +55,7 @@ monorepo's convention, applied per app at its production cutover — #136 for tr
 The deploy logic lives in the app's **`package.json` scripts** — the same commands
 you run locally and that CI runs. Don't reinvent them step-by-step:
 
-- **`cf:deploy`** (production): `build → wrangler deploy (auto-provision) → sync:ids → d1 migrations apply --remote`
+- **`cf:deploy`** (production — run **only** via the `/deploy-production` skill): `build → wrangler deploy (auto-provision) → sync:ids → d1 migrations apply --remote`
 - **`cf:staging`** (isolated staging env): `build → inject-wrangler-env → wrangler deploy --env staging → sync:ids → inject-wrangler-env → d1 migrations apply --env staging --remote`
 - **`sync:ids`** — queries wrangler, writes provisioned ids back into `wrangler.jsonc`
 - **`db:migrate` / `db:migrate:prod` / `db:migrate:staging`** — D1 migrations (local / remote / staging-remote)
@@ -78,24 +82,22 @@ Confirm the app is Workers-ready:
 
 If anything is missing and the app is on the old Pages setup → **Migrating a Pages app → Workers**. If it's just missing files, copy them from `apps/three-demo` (the reference) or re-run the scaffolder.
 
-### Step 3: First (bootstrap) deploy
-The id-less bindings auto-provision here. Confirm with the user, then:
+### Step 3: First (bootstrap) staging deploy
+The id-less bindings auto-provision here. Confirm with the user, then deploy the
+isolated **staging** environment (its own auto-provisioned D1+KV):
 
 ```bash
 cd apps/{app}
-pnpm cf:deploy      # prod: builds, AUTO-PROVISIONS D1+KV, syncs ids, migrates
+pnpm cf:staging     # provisions + deploys the *-staging worker, migrates --env staging
 ```
 
 Then **commit the written-back ids** (bootstrap → committed):
 ```bash
-git add apps/{app}/wrangler.jsonc && git commit -m "chore({app}): commit provisioned D1/KV ids"
+git add apps/{app}/wrangler.jsonc && git commit -m "chore({app}): commit provisioned staging D1/KV ids"
 ```
 
-For the isolated staging environment (its own auto-provisioned D1+KV):
-```bash
-pnpm cf:staging     # provisions + deploys the *-staging worker
-git add apps/{app}/wrangler.jsonc   # commit the staging ids too
-```
+> The **production** bootstrap (`cf:deploy`, prod D1+KV, `<app>.friendlyinter.net`) is a
+> deliberate, separate step — see the **`/deploy-production`** skill. This skill stops at staging.
 
 > If you're an agent **without Cloudflare egress** (sandbox), you can't run these —
 > verify what's verifiable (config, `pnpm sync:ids --dry-run` logic) and have the
@@ -128,9 +130,10 @@ Two ways:
   deploy (`--env staging` for non-prod). Omit it to manage secrets manually.
   Automation can't invent values — they must live in that secret once.
 
-### Step 5: Routine deploys
-- **CI (preferred):** push to `staging` (or open a PR) → the caller runs the pipeline.
-- **Local:** `pnpm cf:deploy` (prod) / `pnpm cf:staging` (staging) from the app dir.
+### Step 5: Routine deploys (staging)
+- **CI (preferred):** push to `staging` (or open a PR) → the caller runs the staging pipeline.
+- **Local:** `pnpm cf:staging` from the app dir.
+- **Production is never routine** — ship it deliberately via the **`/deploy-production`** skill.
 
 ## Migrating a Pages app → Workers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,8 @@ After each task: announce completion, say the code word, STOP. User runs `/clear
 
 **Two-domain topology (#133):** production → **`<app>.friendlyinter.net`**, staging → **`<app>.pmcp.dev`** (separate registrable domains = bulletproof session/cookie isolation). The deploy env is named **`staging`** (not `preview`).
 
+**🟦 STANDING RULE — deploy to STAGING, never production (#318).** The default deploy target is **always staging**: agents, skills, and routine work deploy to staging only (`/deploy` skill / `cf:staging` / push to `staging`). **NEVER deploy to production** except via the dedicated **`/deploy-production`** skill, invoked on an **explicit human request** to ship to prod. Production stays a deliberate, manual `workflow_dispatch` (env=production) — never a side effect of an agent flow.
+
 The pattern, end to end:
 - **`wrangler.jsonc`** (Workers): **no** `pages_build_output_dir`; `compatibility_flags: ["nodejs_compat"]`; bindings `DB` (D1), `KV`/`BLOB` (R2) as needed — **id-less** so the first deploy auto-provisions them; plus an **`env.staging`** block with **separate** staging ids + a `<app>.pmcp.dev` custom-domain `route` (bindings do NOT inherit across envs). `name`/`main`/`assets` are injected by the preset at build.
 - **Build preset**: `NITRO_PRESET=cloudflare_module nuxt build` → output in `.output/`.


### PR DESCRIPTION
## 👤 For humans

New standing rule: **deploy to staging, never production** by default. Routine work and agents only ever touch staging. Production is split into its own deliberate **`/deploy-production`** skill that you invoke explicitly — so a casual "deploy this" can never accidentally ship to prod.

## 🤖 For agents

- **`.claude/skills/deploy/SKILL.md`** → staging-only: a `🟦 STAGING ONLY` banner, rule #1 rewritten, usage drops the `prod` arg, Step 3 bootstraps **staging**, Step 5 routes production to the new skill, and `cf:deploy` is tagged "production — only via `/deploy-production`".
- **`.claude/skills/deploy-production/SKILL.md`** (new) — the only place production ships: manual `workflow_dispatch` env=production / `cf:deploy` → `<app>.friendlyinter.net`, behind a 🛑 human-gate, with pre-flight (must be verified on staging first, prod secrets, no demo seed). References `/deploy` for shared mechanics rather than duplicating them.
- **`CLAUDE.md`** — standing rule in the deployment section: staging is always the default; production only via `/deploy-production` on explicit request; never a side effect of an agent flow.

No workflow changes — CI is already split (push/PR → staging, manual dispatch → prod). This governs **skill/agent behaviour**. `poc-deploy` was already staging-only.

## 🧪 How to test

Ask an agent to "deploy app X" → it uses the **staging** path only and never production. Production requires explicitly invoking `/deploy-production`. The `CLAUDE.md` deployment section states the staging-default / prod-is-separate rule.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQPxXd1HwWPgJ9VZAA8QA8)_