### PR TITLE
fix(root): align fanfare staging to kassa.pmcp.dev convention

### DIFF
--- a/.github/workflows/deploy-fanfare.yml
+++ b/.github/workflows/deploy-fanfare.yml
@@ -2,8 +2,8 @@ name: Deploy Fanfare
 
 # Thin caller for the reusable Workers deploy pipeline (#121, on #114's deploy-app.yml).
 # Push to `staging` (or open a PR) → isolated, demo-seeded staging deploy
-# (auto-provisioned fanfare-staging-db + KV, bound to kassa-preview.pmcp.dev). Manual
-# dispatch with environment=production → production (reuses fanfare-db, kassa.pmcp.dev).
+# (auto-provisioned fanfare-staging-db + KV, bound to kassa.pmcp.dev). Manual
+# dispatch with environment=production → production (reuses fanfare-db, kassa.friendlyinter.net).
 #
 # Replaces the old Pages workflows (deploy-fanfare.yml production + the separate
 # deploy-fanfare-preview.yml that seeded the SHARED prod DB). The staging env now binds
@@ -60,8 +60,8 @@ jobs:
     with:
       app: fanfare
       environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.environment == 'production') && 'production' || 'staging' }}
-      production-url: https://kassa.pmcp.dev
-      staging-url: https://kassa-preview.pmcp.dev
+      production-url: https://kassa.friendlyinter.net
+      staging-url: https://kassa.pmcp.dev
       # Only the dist-consumed packages with a build script. crouton-i18n/charts/
       # pages/sales are pure source layers — the reusable workflow skips those.
       layer-packages: '@fyit/crouton-core @fyit/crouton-auth @fyit/crouton'

--- a/apps/fanfare/wrangler.jsonc
+++ b/apps/fanfare/wrangler.jsonc
@@ -39,7 +39,7 @@
   // cf:staging re-injects it via scripts/inject-wrangler-env.mjs.
   "env": {
     "staging": {
-      "routes": [{ "pattern": "kassa-preview.pmcp.dev", "custom_domain": true }],
+      "routes": [{ "pattern": "kassa.pmcp.dev", "custom_domain": true }],
       "d1_databases": [
         {
           "binding": "DB",


### PR DESCRIPTION
## Why

`https://kassa.pmcp.dev` didn't resolve — nothing was deployed there. The kassa app is **fanfare**, and it was the one app not following the two-domain convention (#133):

- staging lived at the off-convention `kassa-preview.pmcp.dev` (every other app uses bare `<app>.pmcp.dev` — see velo, triage)
- the deploy workflow also **mislabeled `kassa.pmcp.dev` as the *production* URL**, but prod actually runs at `kassa.friendlyinter.net`

So the URL people reached for (`kassa.pmcp.dev`) was the *correct* convention name that fanfare simply never used.

## What changed

| File | Change |
|------|--------|
| `apps/fanfare/wrangler.jsonc` | `env.staging` route `kassa-preview.pmcp.dev` → `kassa.pmcp.dev` (prod route `kassa.friendlyinter.net` unchanged) |
| `.github/workflows/deploy-fanfare.yml` | `production-url` → `https://kassa.friendlyinter.net`; `staging-url` → `https://kassa.pmcp.dev`; header comment corrected |

## Takes effect on next deploy

This is config only — Cloudflare provisions the new `kassa.pmcp.dev` custom domain + DNS on the **next `cf:staging` deploy** (push to `staging` / `/deploy`). That deploy must also **re-set the `BETTER_AUTH_URL` worker secret to `https://kassa.pmcp.dev`** or member login 400s with "Invalid origin" (#101).

## Follow-up

Renaming the worker/app `fanfare` → `kassa` is tracked separately in #322 (it touches the prod worker holding `fanfare-db`). Not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)