### PR TITLE
docs(root): correct fanfare domains in deployment topology

### DIFF
--- a/writeups/architecture/deployment-topology.html
+++ b/writeups/architecture/deployment-topology.html
@@ -382,7 +382,7 @@
         <tbody>
           <tr><td><strong>velo</strong></td><td><span class="mono">velo.friendlyinter.net</span></td><td><span class="mono">velo.pmcp.dev</span></td><td><span class="tag">apps/velo/** only</span></td></tr>
           <tr><td><strong>triage</strong></td><td><span class="mono">triage.friendlyinter.net</span></td><td><span class="mono">triage.pmcp.dev</span></td><td><span class="tag">apps/triage/**</span></td></tr>
-          <tr><td><strong>fanfare</strong></td><td><span class="mono">kassa.pmcp.dev</span> <span class="tag">legacy naming</span></td><td><span class="mono">kassa-preview.pmcp.dev</span></td><td><span class="tag">apps/** + packages/**</span></td></tr>
+          <tr><td><strong>fanfare</strong> <span class="tag">app→domain rename: #322</span></td><td><span class="mono">kassa.friendlyinter.net</span></td><td><span class="mono">kassa.pmcp.dev</span></td><td><span class="tag">apps/fanfare/** + packages/**</span></td></tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## What
Updates the per-app domain table in `deployment-topology.html` so the **fanfare** row matches reality after the staging-alignment change merged earlier today:

| | Production | Staging/Preview |
|---|---|---|
| before | `kassa.pmcp.dev` (legacy) | `kassa-preview.pmcp.dev` |
| **after** | **`kassa.friendlyinter.net`** | **`kassa.pmcp.dev`** |

Also points the app/domain name-mismatch note at the rename issue (#322) instead of a vague "legacy naming" tag, and makes the path-filter note app-specific.

## Why
Doc-sync of an already-merged change — the diagram was the only place still describing the old topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTnQN9E8okSLYCNre8W1Sa)_