### PR TITLE
chore(e2e): capture visual-QA artifacts (video + trace) on fixtures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,10 +83,13 @@ jobs:
       - name: Run e2e smoke
         run: pnpm test:e2e
 
-      - name: Upload report on failure
-        if: failure()
+      # Visual-QA artifact (#356): upload the self-contained HTML report on EVERY
+      # run (not just failures) so each PR carries reviewable visual proof — open
+      # index.html to see each test's video, trace timeline, and screenshots.
+      - name: Upload visual-QA report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.fixture }}
+          name: visual-qa-${{ matrix.fixture }}
           path: playwright-report/
-          retention-days: 7
+          retention-days: 14

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -180,6 +180,32 @@ E2E_FIXTURE=with-i18n pnpm test:e2e
 > asserted string is crouton's own `home.*` label, so a broken switcher or stuck
 > locale fails it.
 
+## Visual-QA artifacts (#356)
+
+The smoke doesn't just gate green/red — it records what it does, so any PR (a dep
+bump, a `packages/` change, a UI tweak) yields **reviewable visual proof**. This is
+Playwright-native capture, no custom infra (`use` in `playwright.config.ts`):
+
+- `trace: 'on'` — an interactive step-by-step timeline with a before/after
+  **screenshot of every action**, DOM snapshots, network, and **console logs**
+  (the console matters most for a component-library bump — silent Vue warnings show
+  here). Open with `npx playwright show-trace <trace.zip>` or drag onto
+  [trace.playwright.dev](https://trace.playwright.dev).
+- `video: 'on'` — a `.webm` clip of the full boot → login → CRUD → surface run,
+  watchable like a Loom.
+- `screenshot: 'on'` — a final screenshot per test.
+
+In CI the **HTML reporter** bundles all three into one self-contained
+`playwright-report/`, uploaded as artifact **`visual-qa-<fixture>` on every run**
+(`if: always()`, 14-day retention — see `.github/workflows/e2e.yml`). To review:
+PR → Actions run → **Artifacts** → download `visual-qa-<fixture>` → open
+`index.html`. (Artifacts download as a zip; they don't render inline in the PR.)
+
+Locally, `pnpm test:e2e` writes the same HTML report to `playwright-report/`
+(`npx playwright show-report` to open). Out of scope for now: `toHaveScreenshot()`
+pixel-diff baselines (flake-prone, separate follow-up) and screenshotting the live
+staging deploys.
+
 ## Gotchas
 - **Module format:** repo root is CommonJS, and Playwright 1.57 transpiles
   config/specs to CJS — use `__dirname`/`join`, **not** `import.meta.url`

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: process.env.CI ? 'list' : 'html',
+  // CI emits the self-contained HTML report (bundles video + trace + screenshots)
+  // alongside the line reporter, so each run uploads one reviewable artifact (#356).
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'html',
   // Generous per-test budget: a fixture's first hit on a route/modal compiles it
   // on demand (nuxt dev), which is markedly slower on CI runners than locally.
   // Generous per-test budget. `nuxt dev` compiles each route on first hit, and CI
@@ -39,8 +41,14 @@ export default defineConfig({
     ...(process.env.PW_EXECUTABLE_PATH
       ? { launchOptions: { executablePath: process.env.PW_EXECUTABLE_PATH } }
       : {}),
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
+    // Visual-QA capture (#356): record on every run so each PR yields reviewable
+    // proof, not just a green check. trace = a step-by-step timeline with a
+    // before/after screenshot of every action plus DOM snapshots and console logs
+    // (the part that matters most for a UI-library bump); video = a watchable clip;
+    // screenshot = a final shot per test. The CI HTML report bundles all three.
+    trace: 'on',
+    video: 'on',
+    screenshot: 'on',
     actionTimeout: 20000,
     navigationTimeout: 120000
   },


### PR DESCRIPTION
Turns the e2e smoke from a green/red gate into something you can **watch**, so a UI-touching PR (like the @nuxt/ui 4.9 bump #235) no longer needs a manual human click-through — the harness records what it does and attaches the proof to every run.

Closes #356.

## 👤 For humans
Every e2e run now records, per fixture:
- a **video** of the full boot → login → CRUD → surface flow (watchable like a Loom), and
- a **trace**: a step-by-step timeline with a before/after screenshot of every action, DOM snapshots, and the **console** (silent Vue warnings show up here — exactly what you want to catch on a component-library bump).

Both are bundled into the HTML report and uploaded as a PR artifact. **To review:** PR → Actions run → **Artifacts** → download `visual-qa-<fixture>` → open `index.html`. (Heads-up: artifacts download as a zip — they don't render inline in the PR thread.)

## 🤖 For agents
- `e2e/playwright.config.ts`: `trace` / `video` / `screenshot` → `'on'` (were `on-first-retry` / `only-on-failure`); CI reporter → `[['list'], ['html', { open: 'never' }]]` so the self-contained report is produced.
- `.github/workflows/e2e.yml`: upload step now `if: always()` (was `failure()`), artifact renamed `visual-qa-<fixture>`, retention 7 → 14 days. One reviewable bundle per fixture on **every** run.
- Playwright-native capture only — no custom infra.
- Target: the 4 fixtures already in CI (`minimal`, `with-pages`, `with-bookings`, `with-assets`).

## Scope
- **In:** video + trace + screenshots, bundled + uploaded per fixture.
- **Out (separate follow-up if wanted):** `toHaveScreenshot()` pixel-diff baselines (flake-prone, needs baseline management); screenshotting the live staging deploys.

## Verification
- ✅ `playwright test --list` — config parses, 8 tests discovered.
- ⏳ The artifacts themselves are produced by **this PR's** E2E run — once it's green, download `visual-qa-with-bookings` and confirm the report opens with video + trace. (The dev sandbox can't download the browser / cold-boot a fixture, so the real proof is CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQiEVeYcRb9s5egGHAVnK5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQiEVeYcRb9s5egGHAVnK5)_