### PR TITLE
Daily epic digest + write issues as bets

### DIFF
--- a/.claude/skills/epic-digest/SKILL.md
+++ b/.claude/skills/epic-digest/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: epic-digest
+description: Generate a daily "where are we?" digest from this repo's GitHub epics — a render-only HTML + plain-text email summarising the last 24h of activity plus a progress snapshot of every open epic. Use when asked for a "daily digest", "epic report", "status rapport", "what moved this week", or "where are we on the epics".
+allowed-tools: mcp__github__search_issues, mcp__github__list_issues, mcp__github__issue_read, Read, Write, Bash
+---
+
+# Epic Digest — the daily "where are we?" email
+
+Turns the GitHub issue tree (`pmcp/nuxt-crouton`) into a **skimmable digest**: a short
+"since yesterday" activity band, then one card per open **epic** with a progress
+bar and a one-line status — the sub-issue breakdown tucked into a collapsible
+section so the overview stays clean. Built to be **read at a glance, drilled into
+if needed**.
+
+**This is render-only.** It *makes* the digest (HTML + plain text under
+`writeups/reports/`) and shows you where it landed — it does **not** send email
+yet. Forwarding/sending and scheduling are follow-up sub-issues of epic #357.
+
+## When to use
+- A daily/weekly "where are we?" check, a status rapport, or "what moved".
+- Before a planning session, to see which epics are close to done or blocked.
+- **Skip** if you just need one issue's detail — open the issue directly.
+
+## What it produces
+| Artifact | Path |
+|----------|------|
+| HTML digest (forward / view in browser) | `writeups/reports/epic-digest-<YYYYMMDD>.html` |
+| Plain-text digest (terminal / paste into email) | `writeups/reports/epic-digest-<YYYYMMDD>.txt` |
+
+These are **generated artifacts** — render them on demand; don't commit them.
+
+## Step 1 — Pick the window
+Default is the **last 24h**. For a Monday digest covering the weekend, or a weekly,
+widen it: compute the cutoff date (e.g. `2026-06-17`) and use it in the searches
+below. Set `windowHours` in the data accordingly (24 / 72 / 168).
+
+## Step 2 — Gather the data (GitHub MCP, read-only)
+Build the JSON object described in **Step 3** using these calls (all `owner: pmcp`,
+`repo: nuxt-crouton`):
+
+1. **Open epics** — `search_issues`, query `repo:pmcp/nuxt-crouton is:issue is:open label:epic`.
+2. **Each epic's children** — `issue_read` with `method: get_sub_issues`. Count
+   `done` = children with `state: "closed"`, `total` = all children. Read each
+   child's labels (or the `get_sub_issues` state) to set its `status`
+   (`in-progress` / `blocked` from the `status:*` label) and `state`.
+   Mark the epic `blocked` if it carries `status:blocked` or any child is blocked.
+3. **Activity in the window** (the "since yesterday" band) — use date-filtered search,
+   substituting `<cutoff>` (YYYY-MM-DD):
+   - Closed: `search_issues` → `repo:pmcp/nuxt-crouton is:issue is:closed closed:>=<cutoff>`
+   - Opened: `search_issues` → `repo:pmcp/nuxt-crouton is:issue created:>=<cutoff>`
+   - Merged PRs: `search_issues` → `repo:pmcp/nuxt-crouton is:pr is:merged merged:>=<cutoff>`
+     (note: `search_issues` is scoped to issues; for PRs use `mcp__github__search_pull_requests`
+     if available, else `list_pull_requests` filtered client-side.)
+4. Set `recentActivity` per epic to a **one-line, human** summary of what moved in
+   the window (a closed child, a merged PR, "no movement", "blocked on X"). This is
+   the line a busy person reads — keep it plain, no file paths.
+
+Keep it lean: titles, numbers, URLs, states. Don't fetch comment bodies.
+
+## Step 3 — Write the data file
+Write the gathered object to a temp path (e.g. `writeups/reports/.epic-digest.data.json`).
+Shape (`example.data.json` next to this skill is a complete, renderable sample):
+
+```jsonc
+{
+  "generatedAt": "<ISO now>",
+  "windowHours": 24,
+  "repo": "pmcp/nuxt-crouton",
+  "activity": {
+    "opened":    [{ "number": 358, "title": "...", "url": "https://github.com/...", "kind": "issue" }],
+    "closed":    [{ "number": 351, "title": "...", "url": "...", "kind": "issue" }],
+    "mergedPRs": [{ "number": 352, "title": "...", "url": "...", "kind": "pr" }]
+  },
+  "epics": [
+    {
+      "number": 249, "title": "...", "url": "https://github.com/...",
+      "status": "in-progress",          // in-progress | blocked | open | done
+      "blocked": false,
+      "total": 5, "done": 4,            // sub-issue counts → drives the progress bar
+      "recentActivity": "One plain line about what moved.",
+      "children": [
+        { "number": 254, "title": "...", "url": "...", "state": "open", "status": "in-progress" },
+        { "number": 253, "title": "...", "url": "...", "state": "closed" }
+      ]
+    }
+  ]
+}
+```
+
+## Step 4 — Render
+```bash
+node .claude/skills/epic-digest/render.mjs writeups/reports/.epic-digest.data.json
+# options: --out-dir writeups/reports   --date 20260618   (default: out-dir=writeups/reports, date=today)
+```
+Dependency-free (no npm deps, no network). Writes the `.html` + `.txt` and prints
+their paths.
+
+## Step 5 — Hand off
+- Show the user where the files landed and a short text summary of the headline
+  numbers (epics, closed, PRs merged).
+- HTML is for forwarding / browser viewing; text is for pasting into an email or
+  reading in a terminal. (Optional: render the HTML to a PNG with
+  `.claude/skills/ui-proposal/render.mjs <html> screenshots/epic-digest.png` to
+  preview it inline.)
+
+## Conventions & gotchas
+- **Epics are the unit.** Lead with epics + progress, not a flat issue list — that's
+  the whole point ("focus on epics").
+- **Render-only.** Don't try to send mail; that's a separate follow-up (#357).
+- **`<details>` in email:** the collapsible sub-issue section renders expanded in
+  mail clients that strip `<details>` — that's fine, it degrades gracefully.
+- The renderer sorts **blocked epics first**, then by % complete, so attention
+  lands where it's needed.

--- a/.claude/skills/epic-digest/SKILL.md
+++ b/.claude/skills/epic-digest/SKILL.md
@@ -51,9 +51,15 @@ Build the JSON object described in **Step 3** using these calls (all `owner: pmc
    - Merged PRs: `search_issues` → `repo:pmcp/nuxt-crouton is:pr is:merged merged:>=<cutoff>`
      (note: `search_issues` is scoped to issues; for PRs use `mcp__github__search_pull_requests`
      if available, else `list_pull_requests` filtered client-side.)
-4. Set `recentActivity` per epic to a **one-line, human** summary of what moved in
-   the window (a closed child, a merged PR, "no movement", "blocked on X"). This is
-   the line a busy person reads — keep it plain, no file paths.
+4. Write the **two human lines** per epic — these are the heart of the digest, the
+   part a busy person actually reads. Keep them plain English, no file paths, no jargon:
+   - `whatItIs` — one or two sentences on **what this epic is for** and why it matters.
+     Derive it from the epic's "👤 For humans" section / title — don't just restate the title.
+   - `whereWeAre` — the **current status in plain words**: what's done, what's next, and
+     any blocker (e.g. "Almost done — only X left", "Stuck waiting on Y"). This is where
+     the last-24h movement gets folded in.
+   - `recentActivity` (optional) — kept for back-compat; if `whereWeAre` is absent the
+     renderer falls back to it. Prefer writing `whereWeAre`.
 
 Keep it lean: titles, numbers, URLs, states. Don't fetch comment bodies.
 
@@ -77,7 +83,9 @@ Shape (`example.data.json` next to this skill is a complete, renderable sample):
       "status": "in-progress",          // in-progress | blocked | open | done
       "blocked": false,
       "total": 5, "done": 4,            // sub-issue counts → drives the progress bar
-      "recentActivity": "One plain line about what moved.",
+      "whatItIs": "One or two plain sentences: what this epic is for and why it matters.",
+      "whereWeAre": "Plain status: what's done, what's next, any blocker.",
+      "recentActivity": "(optional, back-compat) one line about what moved.",
       "children": [
         { "number": 254, "title": "...", "url": "...", "state": "open", "status": "in-progress" },
         { "number": 253, "title": "...", "url": "...", "state": "closed" }

--- a/.claude/skills/epic-digest/SKILL.md
+++ b/.claude/skills/epic-digest/SKILL.md
@@ -51,15 +51,19 @@ Build the JSON object described in **Step 3** using these calls (all `owner: pmc
    - Merged PRs: `search_issues` → `repo:pmcp/nuxt-crouton is:pr is:merged merged:>=<cutoff>`
      (note: `search_issues` is scoped to issues; for PRs use `mcp__github__search_pull_requests`
      if available, else `list_pull_requests` filtered client-side.)
-4. Write the **two human lines** per epic — these are the heart of the digest, the
-   part a busy person actually reads. Keep them plain English, no file paths, no jargon:
-   - `whatItIs` — one or two sentences on **what this epic is for** and why it matters.
-     Derive it from the epic's "👤 For humans" section / title — don't just restate the title.
-   - `whereWeAre` — the **current status in plain words**: what's done, what's next, and
-     any blocker (e.g. "Almost done — only X left", "Stuck waiting on Y"). This is where
-     the last-24h movement gets folded in.
-   - `recentActivity` (optional) — kept for back-compat; if `whereWeAre` is absent the
-     renderer falls back to it. Prefer writing `whereWeAre`.
+4. Write the **human lines** per epic — these are the heart of the digest, the part a
+   busy person actually reads. We write issues as **bets** (see the `github-tasks` skill),
+   so the digest surfaces the bet and its signal. Keep them plain English, no file paths,
+   no jargon:
+   - `theBet` — the epic's bet, pulled from its "## 🎯 The bet" / "We think that…" line:
+     *if we do X, then Y will happen — and Y is what we want*. This is the lead line.
+   - `weWillKnowBy` — the bet's signal, from the epic's "We'll know by…": how we'll know
+     the assumption paid off (a measurable/checkable outcome).
+   - `whereWeAre` — the **current status in plain words**: what's done, what's next, any
+     blocker. This is where the last-24h movement gets folded in.
+   - `whatItIs` (optional) / `recentActivity` (optional) — back-compat fallbacks: `theBet`
+     falls back to `whatItIs`, `whereWeAre` falls back to `recentActivity`. Prefer the
+     bet-framed fields.
 
 Keep it lean: titles, numbers, URLs, states. Don't fetch comment bodies.
 
@@ -83,9 +87,11 @@ Shape (`example.data.json` next to this skill is a complete, renderable sample):
       "status": "in-progress",          // in-progress | blocked | open | done
       "blocked": false,
       "total": 5, "done": 4,            // sub-issue counts → drives the progress bar
-      "whatItIs": "One or two plain sentences: what this epic is for and why it matters.",
+      "theBet": "We think that if we do X, then Y will happen — and Y is what we want.",
+      "weWillKnowBy": "The signal that tells us the bet paid off.",
       "whereWeAre": "Plain status: what's done, what's next, any blocker.",
-      "recentActivity": "(optional, back-compat) one line about what moved.",
+      "whatItIs": "(optional, back-compat) → theBet falls back to this.",
+      "recentActivity": "(optional, back-compat) → whereWeAre falls back to this.",
       "children": [
         { "number": 254, "title": "...", "url": "...", "state": "open", "status": "in-progress" },
         { "number": 253, "title": "...", "url": "...", "state": "closed" }

--- a/.claude/skills/epic-digest/example.data.json
+++ b/.claude/skills/epic-digest/example.data.json
@@ -1,0 +1,65 @@
+{
+  "generatedAt": "2026-06-18T09:00:00Z",
+  "windowHours": 24,
+  "repo": "pmcp/nuxt-crouton",
+  "activity": {
+    "opened": [
+      { "number": 357, "title": "Daily epic-progress digest: an at-a-glance email of what moved and what's left", "url": "https://github.com/pmcp/nuxt-crouton/issues/357", "kind": "issue" },
+      { "number": 358, "title": "Build the /epic-digest skill — render a daily epic-progress digest (HTML + text)", "url": "https://github.com/pmcp/nuxt-crouton/issues/358", "kind": "issue" }
+    ],
+    "closed": [
+      { "number": 351, "title": "Fix stale staging cookie on logout", "url": "https://github.com/pmcp/nuxt-crouton/issues/351", "kind": "issue" }
+    ],
+    "mergedPRs": [
+      { "number": 352, "title": "fix(crouton-auth): clear session cookie on the staging domain", "url": "https://github.com/pmcp/nuxt-crouton/pull/352", "kind": "pr" }
+    ]
+  },
+  "epics": [
+    {
+      "number": 318,
+      "title": "Standing rule: deploy to staging, never production by default",
+      "url": "https://github.com/pmcp/nuxt-crouton/issues/318",
+      "status": "blocked",
+      "blocked": true,
+      "total": 4,
+      "done": 1,
+      "recentActivity": "Blocked on the production token scope — waiting on account access.",
+      "children": [
+        { "number": 319, "title": "Add cf:staging as the default deploy script", "url": "https://github.com/pmcp/nuxt-crouton/issues/319", "state": "closed" },
+        { "number": 320, "title": "Gate /deploy-production behind an explicit human request", "url": "https://github.com/pmcp/nuxt-crouton/issues/320", "state": "open", "status": "blocked" },
+        { "number": 321, "title": "Document the two-domain topology", "url": "https://github.com/pmcp/nuxt-crouton/issues/321", "state": "open", "status": "in-progress" },
+        { "number": 322, "title": "Add a CI guard that refuses prod from a non-dispatch trigger", "url": "https://github.com/pmcp/nuxt-crouton/issues/322", "state": "open" }
+      ]
+    },
+    {
+      "number": 249,
+      "title": "Recursive task-decomposition pipeline (epic → sub-issues → workers)",
+      "url": "https://github.com/pmcp/nuxt-crouton/issues/249",
+      "status": "in-progress",
+      "blocked": false,
+      "total": 5,
+      "done": 4,
+      "recentActivity": "Worker isolation via git worktrees merged yesterday; only the depth-cap tuning is left.",
+      "children": [
+        { "number": 250, "title": "task-orchestrator agent", "url": "https://github.com/pmcp/nuxt-crouton/issues/250", "state": "closed" },
+        { "number": 251, "title": "task-decomposer recursive agent", "url": "https://github.com/pmcp/nuxt-crouton/issues/251", "state": "closed" },
+        { "number": 252, "title": "task-worker on worktree isolation", "url": "https://github.com/pmcp/nuxt-crouton/issues/252", "state": "closed" },
+        { "number": 253, "title": "LEAF TEST + stop-conditions", "url": "https://github.com/pmcp/nuxt-crouton/issues/253", "state": "closed" },
+        { "number": 254, "title": "Tune MAX_DEPTH / MAX_CHILDREN defaults", "url": "https://github.com/pmcp/nuxt-crouton/issues/254", "state": "open", "status": "in-progress" }
+      ]
+    },
+    {
+      "number": 357,
+      "title": "Daily epic-progress digest: an at-a-glance email of what moved and what's left",
+      "url": "https://github.com/pmcp/nuxt-crouton/issues/357",
+      "status": "in-progress",
+      "blocked": false,
+      "total": 1,
+      "done": 0,
+      "recentActivity": "Epic opened today; the render-only skill is the first sub-issue, in progress now.",
+      "children": [
+        { "number": 358, "title": "Build the /epic-digest skill — render a daily epic-progress digest (HTML + text)", "url": "https://github.com/pmcp/nuxt-crouton/issues/358", "state": "open", "status": "in-progress" }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/epic-digest/example.data.json
+++ b/.claude/skills/epic-digest/example.data.json
@@ -23,7 +23,8 @@
       "blocked": true,
       "total": 4,
       "done": 1,
-      "whatItIs": "Make staging the default deploy target everywhere, so an agent or a routine push can never ship to production by accident — production stays a deliberate, manual action.",
+      "theBet": "We think that if staging is the default everywhere, then no agent or routine push can ship to production by accident — which is what we want.",
+      "weWillKnowBy": "No unintended production deploys appear in the deploy logs, and shipping to prod only ever happens via the explicit /deploy-production path.",
       "whereWeAre": "The default staging script is in. The production gate and the CI guard are still open, and the whole thing is stuck waiting on a production API token with the right scope.",
       "recentActivity": "Blocked on the production token scope — waiting on account access.",
       "children": [
@@ -41,7 +42,8 @@
       "blocked": false,
       "total": 5,
       "done": 4,
-      "whatItIs": "Let one fuzzy task be broken into a tree of GitHub issues automatically and worked by agents end-to-end — orchestrator splits the epic, decomposers recurse, workers build the leaves on isolated branches.",
+      "theBet": "We think that if one fuzzy task can be auto-split into a tree of issues and worked by agents end-to-end, then we ship bigger initiatives without hand-managing every sub-task — which is what we want.",
+      "weWillKnowBy": "A single /task-decompose call produces a sensible epic→sub-issue tree and lands working PRs, without runaway spawning.",
       "whereWeAre": "Almost done — the orchestrator, recursive decomposer, worktree-isolated worker, and the leaf-test stop conditions all merged. Only tuning the depth and fan-out defaults is left.",
       "recentActivity": "Worker isolation via git worktrees merged yesterday; only the depth-cap tuning is left.",
       "children": [
@@ -60,7 +62,8 @@
       "blocked": false,
       "total": 1,
       "done": 0,
-      "whatItIs": "This very digest — a daily at-a-glance email of where every epic stands and what moved in the last 24h, so you don't have to piece it together from the issues board.",
+      "theBet": "We think that if a daily digest rolls up every epic and the last 24h, then you'll grasp project status in one read instead of trawling the board — which is what we want.",
+      "weWillKnowBy": "You forward/use the digest and ask fewer 'where are we on X?' questions because the answer's already in your inbox.",
       "whereWeAre": "Just kicked off. The render-only skill (HTML + text) is the first sub-issue and is in progress now; email sending and scheduling come after.",
       "recentActivity": "Epic opened today; the render-only skill is the first sub-issue, in progress now.",
       "children": [

--- a/.claude/skills/epic-digest/example.data.json
+++ b/.claude/skills/epic-digest/example.data.json
@@ -23,6 +23,8 @@
       "blocked": true,
       "total": 4,
       "done": 1,
+      "whatItIs": "Make staging the default deploy target everywhere, so an agent or a routine push can never ship to production by accident — production stays a deliberate, manual action.",
+      "whereWeAre": "The default staging script is in. The production gate and the CI guard are still open, and the whole thing is stuck waiting on a production API token with the right scope.",
       "recentActivity": "Blocked on the production token scope — waiting on account access.",
       "children": [
         { "number": 319, "title": "Add cf:staging as the default deploy script", "url": "https://github.com/pmcp/nuxt-crouton/issues/319", "state": "closed" },
@@ -39,6 +41,8 @@
       "blocked": false,
       "total": 5,
       "done": 4,
+      "whatItIs": "Let one fuzzy task be broken into a tree of GitHub issues automatically and worked by agents end-to-end — orchestrator splits the epic, decomposers recurse, workers build the leaves on isolated branches.",
+      "whereWeAre": "Almost done — the orchestrator, recursive decomposer, worktree-isolated worker, and the leaf-test stop conditions all merged. Only tuning the depth and fan-out defaults is left.",
       "recentActivity": "Worker isolation via git worktrees merged yesterday; only the depth-cap tuning is left.",
       "children": [
         { "number": 250, "title": "task-orchestrator agent", "url": "https://github.com/pmcp/nuxt-crouton/issues/250", "state": "closed" },
@@ -56,6 +60,8 @@
       "blocked": false,
       "total": 1,
       "done": 0,
+      "whatItIs": "This very digest — a daily at-a-glance email of where every epic stands and what moved in the last 24h, so you don't have to piece it together from the issues board.",
+      "whereWeAre": "Just kicked off. The render-only skill (HTML + text) is the first sub-issue and is in progress now; email sending and scheduling come after.",
       "recentActivity": "Epic opened today; the render-only skill is the first sub-issue, in progress now.",
       "children": [
         { "number": 358, "title": "Build the /epic-digest skill — render a daily epic-progress digest (HTML + text)", "url": "https://github.com/pmcp/nuxt-crouton/issues/358", "state": "open", "status": "in-progress" }

--- a/.claude/skills/epic-digest/render.mjs
+++ b/.claude/skills/epic-digest/render.mjs
@@ -150,7 +150,8 @@ function epicCard(e) {
           <td style="white-space:nowrap;${muted}font-size:12px;font-weight:600">${e.done}/${e.total} · ${p}%</td>
         </tr></table>
 
-        ${labeledLine('What it is', e.whatItIs)}
+        ${labeledLine('The bet', e.theBet || e.whatItIs)}
+        ${labeledLine("We'll know by", e.weWillKnowBy)}
         ${labeledLine('Where we are', e.whereWeAre || e.recentActivity)}
 
         ${
@@ -236,11 +237,13 @@ const txt =
           const kids = (e.children || [])
             .map((c) => `      ${c.state === 'closed' ? '[x]' : '[ ]'} #${c.number} ${c.title}`)
             .join('\n')
+          const theBet = e.theBet || e.whatItIs
           const whereWeAre = e.whereWeAre || e.recentActivity
           return (
             `${head}\n  ${bar(e)}\n` +
-            (e.whatItIs ? `  What it is:   ${e.whatItIs}\n` : '') +
-            (whereWeAre ? `  Where we are: ${whereWeAre}\n` : '') +
+            (theBet ? `  The bet:       ${theBet}\n` : '') +
+            (e.weWillKnowBy ? `  We'll know by: ${e.weWillKnowBy}\n` : '') +
+            (whereWeAre ? `  Where we are:  ${whereWeAre}\n` : '') +
             (kids ? `${kids}\n` : '')
           )
         })

--- a/.claude/skills/epic-digest/render.mjs
+++ b/.claude/skills/epic-digest/render.mjs
@@ -96,6 +96,15 @@ function statBox(n, label, color) {
   )
 }
 
+function labeledLine(label, text) {
+  if (!text) return ''
+  return (
+    `<div style="margin-top:10px;font-size:13px;line-height:1.55">` +
+    `<span style="display:inline-block;min-width:88px;${muted}font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;vertical-align:top">${label}</span>` +
+    `<span style="color:#334155">${esc(text)}</span></div>`
+  )
+}
+
 function epicCard(e) {
   const s = statusOf(e)
   const p = pct(e)
@@ -141,7 +150,8 @@ function epicCard(e) {
           <td style="white-space:nowrap;${muted}font-size:12px;font-weight:600">${e.done}/${e.total} · ${p}%</td>
         </tr></table>
 
-        ${e.recentActivity ? `<div style="${muted}font-size:13px;margin-top:10px">${esc(e.recentActivity)}</div>` : ''}
+        ${labeledLine('What it is', e.whatItIs)}
+        ${labeledLine('Where we are', e.whereWeAre || e.recentActivity)}
 
         ${
           children.length
@@ -226,9 +236,11 @@ const txt =
           const kids = (e.children || [])
             .map((c) => `      ${c.state === 'closed' ? '[x]' : '[ ]'} #${c.number} ${c.title}`)
             .join('\n')
+          const whereWeAre = e.whereWeAre || e.recentActivity
           return (
             `${head}\n  ${bar(e)}\n` +
-            (e.recentActivity ? `  ${e.recentActivity}\n` : '') +
+            (e.whatItIs ? `  What it is:   ${e.whatItIs}\n` : '') +
+            (whereWeAre ? `  Where we are: ${whereWeAre}\n` : '') +
             (kids ? `${kids}\n` : '')
           )
         })

--- a/.claude/skills/epic-digest/render.mjs
+++ b/.claude/skills/epic-digest/render.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * Render a daily epic-progress digest to HTML + plain text.
+ *
+ *   node render.mjs <data.json> [--out-dir writeups/reports] [--date YYYYMMDD]
+ *
+ * Dependency-free (no npm deps, no network). Reads a JSON data file produced by
+ * the /epic-digest gather step (see SKILL.md for the schema) and writes:
+ *
+ *   <out-dir>/epic-digest-<YYYYMMDD>.html   email-safe HTML (inline styles, table layout)
+ *   <out-dir>/epic-digest-<YYYYMMDD>.txt    plain-text mirror
+ *
+ * The HTML is built for forwarding: inline styles, a light theme with emerald
+ * accents, progress bars as nested elements, and a <details> per epic for the
+ * sub-issue breakdown (collapsed by default — "at a glance, drill in if needed").
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve, join, dirname } from 'node:path'
+
+// ── args ──────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2)
+const positional = args.filter((a) => !a.startsWith('--'))
+const input = positional[0]
+if (!input) {
+  console.error('Usage: render.mjs <data.json> [--out-dir DIR] [--date YYYYMMDD]')
+  process.exit(1)
+}
+const flag = (name, dflt) => {
+  const i = args.indexOf(`--${name}`)
+  return i !== -1 ? args[i + 1] : dflt
+}
+
+const data = JSON.parse(readFileSync(resolve(input), 'utf8'))
+const generated = data.generatedAt ? new Date(data.generatedAt) : new Date()
+const stamp = flag('date', generated.toISOString().slice(0, 10).replace(/-/g, ''))
+const outDir = flag('out-dir', 'writeups/reports')
+const repo = data.repo || 'repo'
+const windowHours = data.windowHours ?? 24
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+const esc = (s) =>
+  String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+const prettyDate = generated.toLocaleDateString('en-US', {
+  weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
+})
+
+const STATUS = {
+  blocked: { label: 'Blocked', bg: '#fef2f2', fg: '#b91c1c', bar: '#ef4444' },
+  'in-progress': { label: 'In progress', bg: '#fffbeb', fg: '#b45309', bar: '#f59e0b' },
+  done: { label: 'Done', bg: '#ecfdf5', fg: '#047857', bar: '#10b981' },
+  open: { label: 'Open', bg: '#f1f5f9', fg: '#475569', bar: '#10b981' }
+}
+const statusOf = (epic) => {
+  if (epic.blocked || epic.status === 'blocked') return STATUS.blocked
+  if (epic.total > 0 && epic.done >= epic.total) return STATUS.done
+  if (epic.status === 'in-progress') return STATUS['in-progress']
+  return STATUS[epic.status] || STATUS.open
+}
+const pct = (e) => (e.total > 0 ? Math.round((e.done / e.total) * 100) : 0)
+
+const activity = data.activity || {}
+const epics = (data.epics || []).slice().sort((a, b) => {
+  // blocked first, then most-active (highest %) so the eye lands on what matters
+  const ba = a.blocked ? 1 : 0, bb = b.blocked ? 1 : 0
+  if (ba !== bb) return bb - ba
+  return pct(b) - pct(a)
+})
+
+// ── HTML ─────────────────────────────────────────────────────────────────────
+const card = 'background:#ffffff;border:1px solid #e2e8f0;border-radius:10px;'
+const muted = 'color:#64748b;'
+
+function activityList(items, emptyText) {
+  if (!items || !items.length) return `<div style="${muted}font-size:13px;margin:2px 0 0">${emptyText}</div>`
+  return items
+    .map(
+      (it) =>
+        `<div style="font-size:13px;line-height:1.6;margin:1px 0">` +
+        `<a href="${esc(it.url)}" style="color:#0f766e;text-decoration:none">#${esc(it.number)}</a> ` +
+        `<span style="color:#334155">${esc(it.title)}</span></div>`
+    )
+    .join('')
+}
+
+function statBox(n, label, color) {
+  return (
+    `<td align="center" style="padding:10px 4px;${card}">` +
+    `<div style="font-size:26px;font-weight:700;color:${color};line-height:1">${n}</div>` +
+    `<div style="${muted}font-size:11px;text-transform:uppercase;letter-spacing:.04em;margin-top:4px">${label}</div>` +
+    `</td>`
+  )
+}
+
+function epicCard(e) {
+  const s = statusOf(e)
+  const p = pct(e)
+  const children = e.children || []
+  const childRows = children
+    .map((c) => {
+      const closed = c.state === 'closed'
+      const mark = closed ? '✓' : '○'
+      const markColor = closed ? '#10b981' : '#94a3b8'
+      const titleStyle = closed ? 'color:#94a3b8;text-decoration:line-through' : 'color:#334155'
+      const cs = c.status && STATUS[c.status]
+      const tag = cs && !closed
+        ? ` <span style="font-size:10px;padding:1px 6px;border-radius:8px;background:${cs.bg};color:${cs.fg}">${cs.label}</span>`
+        : ''
+      return (
+        `<div style="font-size:13px;line-height:1.7;padding:2px 0">` +
+        `<span style="color:${markColor};font-weight:700">${mark}</span> ` +
+        `<a href="${esc(c.url)}" style="color:#0f766e;text-decoration:none">#${esc(c.number)}</a> ` +
+        `<span style="${titleStyle}">${esc(c.title)}</span>${tag}</div>`
+      )
+    })
+    .join('')
+
+  return `
+  <tr><td style="padding:0 0 14px">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="${card}">
+      <tr><td style="padding:16px 18px">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>
+          <td style="font-size:15px;font-weight:600">
+            <a href="${esc(e.url)}" style="color:#0f172a;text-decoration:none">#${esc(e.number)} · ${esc(e.title)}</a>
+          </td>
+          <td align="right" style="white-space:nowrap">
+            <span style="font-size:11px;font-weight:600;padding:3px 10px;border-radius:20px;background:${s.bg};color:${s.fg}">${s.label}</span>
+          </td>
+        </tr></table>
+
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:12px"><tr>
+          <td style="width:100%;padding-right:12px">
+            <div style="background:#e2e8f0;border-radius:6px;height:8px;width:100%">
+              <div style="background:${s.bar};border-radius:6px;height:8px;width:${p}%"></div>
+            </div>
+          </td>
+          <td style="white-space:nowrap;${muted}font-size:12px;font-weight:600">${e.done}/${e.total} · ${p}%</td>
+        </tr></table>
+
+        ${e.recentActivity ? `<div style="${muted}font-size:13px;margin-top:10px">${esc(e.recentActivity)}</div>` : ''}
+
+        ${
+          children.length
+            ? `<details style="margin-top:10px">
+                 <summary style="cursor:pointer;color:#0f766e;font-size:12px;font-weight:600;outline:none">Sub-issues (${children.length})</summary>
+                 <div style="margin-top:8px;padding-top:8px;border-top:1px solid #f1f5f9">${childRows}</div>
+               </details>`
+            : ''
+        }
+      </td></tr>
+    </table>
+  </td></tr>`
+}
+
+const html = `<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Epic digest · ${esc(prettyDate)}</title></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#0f172a">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc"><tr><td align="center" style="padding:28px 16px">
+  <table role="presentation" width="640" cellpadding="0" cellspacing="0" style="max-width:640px;width:100%">
+
+    <tr><td style="padding:0 0 20px">
+      <div style="font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#0f766e">Daily Epic Digest</div>
+      <div style="font-size:22px;font-weight:700;margin-top:4px">${esc(prettyDate)}</div>
+      <div style="${muted}font-size:13px;margin-top:2px">${esc(repo)} · last ${windowHours}h · ${epics.length} open epic${epics.length === 1 ? '' : 's'}</div>
+    </td></tr>
+
+    <tr><td style="padding:0 0 22px">
+      <div style="font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;${muted}margin:0 0 10px">Since yesterday</div>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="8" style="margin:-8px"><tr>
+        ${statBox((activity.opened || []).length, 'Opened', '#0f172a')}
+        ${statBox((activity.closed || []).length, 'Closed', '#047857')}
+        ${statBox((activity.mergedPRs || []).length, 'PRs merged', '#7c3aed')}
+      </tr></table>
+
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:14px;${card}"><tr><td style="padding:14px 18px">
+        <div style="font-size:12px;font-weight:600;color:#047857;margin-bottom:2px">Closed</div>
+        ${activityList(activity.closed, 'Nothing closed.')}
+        <div style="font-size:12px;font-weight:600;color:#7c3aed;margin:12px 0 2px">PRs merged</div>
+        ${activityList(activity.mergedPRs, 'No PRs merged.')}
+        <div style="font-size:12px;font-weight:600;color:#0f172a;margin:12px 0 2px">Opened</div>
+        ${activityList(activity.opened, 'Nothing new opened.')}
+      </td></tr></table>
+    </td></tr>
+
+    <tr><td style="padding:0 0 10px">
+      <div style="font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;${muted}">Open epics</div>
+    </td></tr>
+    ${epics.length ? epics.map(epicCard).join('') : `<tr><td style="${muted}font-size:14px;padding:0 0 14px">No open epics. 🎉</td></tr>`}
+
+    <tr><td style="padding:10px 0 0;border-top:1px solid #e2e8f0;${muted}font-size:12px">
+      Generated ${esc(generated.toISOString())} by the <code>/epic-digest</code> skill.
+    </td></tr>
+
+  </table>
+</td></tr></table>
+</body></html>`
+
+// ── plain text ────────────────────────────────────────────────────────────
+const line = (it) => `  #${it.number}  ${it.title}\n      ${it.url}`
+const txtList = (items, empty) => (items && items.length ? items.map(line).join('\n') : `  (${empty})`)
+const bar = (e) => {
+  const p = pct(e)
+  const filled = Math.round(p / 5)
+  return `[${'#'.repeat(filled)}${'.'.repeat(20 - filled)}] ${e.done}/${e.total}  ${p}%`
+}
+
+const txt =
+  `DAILY EPIC DIGEST — ${prettyDate}\n` +
+  `${repo} · last ${windowHours}h · ${epics.length} open epic(s)\n` +
+  `${'='.repeat(64)}\n\n` +
+  `SINCE YESTERDAY\n` +
+  `  ${(activity.opened || []).length} opened · ${(activity.closed || []).length} closed · ${(activity.mergedPRs || []).length} PRs merged\n\n` +
+  `Closed:\n${txtList(activity.closed, 'nothing closed')}\n\n` +
+  `PRs merged:\n${txtList(activity.mergedPRs, 'none')}\n\n` +
+  `Opened:\n${txtList(activity.opened, 'nothing new')}\n\n` +
+  `${'='.repeat(64)}\n\nOPEN EPICS\n\n` +
+  (epics.length
+    ? epics
+        .map((e) => {
+          const head = `#${e.number}  ${e.title}  [${statusOf(e).label}]`
+          const kids = (e.children || [])
+            .map((c) => `      ${c.state === 'closed' ? '[x]' : '[ ]'} #${c.number} ${c.title}`)
+            .join('\n')
+          return (
+            `${head}\n  ${bar(e)}\n` +
+            (e.recentActivity ? `  ${e.recentActivity}\n` : '') +
+            (kids ? `${kids}\n` : '')
+          )
+        })
+        .join('\n')
+    : '  No open epics.\n') +
+  `\n${'='.repeat(64)}\nGenerated ${generated.toISOString()} by /epic-digest\n`
+
+// ── write ────────────────────────────────────────────────────────────────────
+mkdirSync(resolve(outDir), { recursive: true })
+const htmlPath = join(outDir, `epic-digest-${stamp}.html`)
+const txtPath = join(outDir, `epic-digest-${stamp}.txt`)
+writeFileSync(resolve(htmlPath), html)
+writeFileSync(resolve(txtPath), txt)
+console.log(`✓ HTML  → ${htmlPath}`)
+console.log(`✓ Text  → ${txtPath}`)
+console.log(`  ${epics.length} epic(s), ${(activity.closed || []).length} closed / ${(activity.mergedPRs || []).length} PRs merged in last ${windowHours}h`)

--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -8,6 +8,27 @@ allowed-tools: mcp__github__issue_write, mcp__github__sub_issue_write, mcp__gith
 
 The canonical task tracker for this repo is **GitHub Issues** (`pmcp/nuxt-crouton`). This skill defines how to create and label them consistently so every task maps to a real part of the monorepo.
 
+## Write it as a bet (assumption-first — the default for every epic & issue)
+
+**Frame work as an assumption, not a task list.** A task says "do X". A bet says "we think *if* we do X, *then* Y will happen — and Y is what we want", so later we can look back and honestly say whether we were right. It's more human, it forces the *why* and the *how-we'll-know* up front, and it's what the daily digest surfaces. Use it for **every epic and issue as much as possible**; only trivial chores (a typo, a dep bump) may fall back to a plain task description.
+
+The bet has **4 parts**:
+
+1. **We think that** — *if* we [do/change X], *then* [outcome Y] will happen — and Y is what we want. *(the bet)*
+2. **We'll do that by** — [this, this, and that]. *(the work)*
+3. **We'll be right if** — [these things turn out to be true]. *(success conditions)*
+4. **We'll know by** — [measuring / checking these signals]. *(measurement)*
+
+**It's a lens over the sections below, not a new competing heading.** Don't bolt a 5th section on — map the bet onto what's already required:
+
+| Bet part | Lives in |
+|----------|----------|
+| 1–2 · the bet + the work (plain) | the **👤 For humans** lead (open the body with "We think that…") |
+| 2 · the work (precise) | the **🤖 For agents** block |
+| 3–4 · we'll be right if / we'll know by | the **🧪 How to test** section (retitle it `## 🧪 We'll be right if / We'll know by` when it reads more naturally as the bet's check) |
+
+A good epic body therefore *opens* with a `## 🎯 The bet` block, then the 👤/🤖 sections expand it, then the check closes it. See epic #359 and #357 / issues #358, #360, #361 for worked examples.
+
 ## Writing for two audiences (REQUIRED — applies to issues, PRs, and commits)
 
 Everything that lands in GitHub is written for **two readers**, in this order:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/sync-docs/SKILL.md` | Doc sync before commits |
 | Skill | `.claude/skills/i18n-audit.md` | Translation audit + fix |
 | Skill | `.claude/skills/github-tasks/SKILL.md` | GitHub issue tracking (epics, labels, workflow) |
+| Skill | `.claude/skills/epic-digest/SKILL.md` | Daily "where are we?" digest — render-only HTML+text email of last-24h activity + a progress snapshot of every open epic (gathers via GitHub MCP, renders dependency-free). For a status rapport / "what moved this week". Sending + scheduling are follow-ups (#357) |
 | Skill | `.claude/skills/ecosystem-check/SKILL.md` | Check Nuxt/UnJS/Vite/OSS prior art before building |
 | Skill | `.claude/skills/e2e-smoke/SKILL.md` | Run the Playwright fixture smoke harness (boot + auth + CRUD) after a dep bump or `packages/` change |
 | Skill | `.claude/skills/db-migrations/SKILL.md` | The migrate step (`db:generate` schema.mjs-after-build gotcha) + package-owned infra tables. App collections use the `crouton` CLI, not this |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Every task in `/writeups/PROGRESS_TRACKER.md` follows this 5-step flow:
 
 Tasks are tracked as **GitHub issues** (`pmcp/nuxt-crouton`) — see the `github-tasks` skill. The issue is the unit of work: open an **epic + sub-issues** for an initiative, label each by **package or app** (never `root`; exactly one `type:*`). Work lands via a **PR** on a feature branch (commit with `/commit`, reference `(#NN)`, put `Closes #NN` in the PR body to auto-close on merge) — not direct pushes to `main`. `writeups/PROGRESS_TRACKER.md` becomes an optional phase-level rollup, not the per-task tracker.
 
+**Write issues & epics as bets, not task lists (default).** Frame work as an assumption — *We think that* if we do X, then Y will happen (and Y is what we want) · *We'll do that by* … · *We'll be right if* … · *We'll know by* … — so we can later check whether we were right. It's a lens over the existing 👤/🤖/🧪 sections (open with `## 🎯 The bet`), not a new heading. Use it for every epic/issue as much as possible; trivial chores may opt out. Full template + worked examples in the `github-tasks` skill (epic #359).
+
 ### Task Decomposition Pipeline (`/task-decompose`)
 
 For a big/fuzzy initiative, you can let agents do the epic→sub-issue breakdown **and** the work. `/task-decompose "<task>"` (or `/task-decompose #NN` to reuse an existing epic) creates the epic, then spawns a recursive agent pipeline that builds out the whole issue tree and works the leaves:

--- a/scripts/gen-skills-doc.mjs
+++ b/scripts/gen-skills-doc.mjs
@@ -25,6 +25,7 @@ const META = {
   'ui-proposal': { group: 'build', triggers: ['flow', 'ask'] },
   'task-decompose': { group: 'build', triggers: ['ask', 'flow'] },
   'github-tasks': { group: 'plan', triggers: ['ask', 'flow'] },
+  'epic-digest': { group: 'plan', triggers: ['ask'] },
   'ecosystem-check': { group: 'plan', triggers: ['ask'] },
   'sync-docs': { group: 'commit', triggers: ['auto'] },
   'i18n-check': { group: 'commit', triggers: ['auto'] },

--- a/writeups/architecture/skills-and-triggers.html
+++ b/writeups/architecture/skills-and-triggers.html
@@ -111,6 +111,10 @@
         <p class="what">Before building new infrastructure or a non-trivial capability, check whether the Nuxt ecosystem, UnJS, Vite, or other OSS already solves it — within our constraints (Nuxt, OSS, self-hostable, no mandatory SaaS). Use when weighing build-vs-adopt or starting new infra/tooling.</p>
       </div>
       <div class="skill">
+        <div class="skill-head"><span class="name">/epic-digest</span><span class="badges"><span class="b ask">on ask</span></span></div>
+        <p class="what">Generate a daily "where are we?" digest from this repo's GitHub epics — a render-only HTML + plain-text email summarising the last 24h of activity plus a progress snapshot of every open epic. Use when asked for a "daily digest", "epic report", "status rapport", "what moved this week", or "where are we on the epics".</p>
+      </div>
+      <div class="skill">
         <div class="skill-head"><span class="name">/github-tasks</span><span class="badges"><span class="b ask">on ask</span><span class="b flow">in flow</span></span></div>
         <p class="what">Track work as GitHub issues in this monorepo — create epics + child/sub-issues, label them consistently by package/app, and tie them into the commit workflow. Use when planning a feature, breaking work into tasks, or asked to "track this in GitHub", "make issues", "set up tracking".</p>
       </div>


### PR DESCRIPTION
Closes #358
Closes #360
Closes #361

## 🎯 The bet

**We think that** if we add a daily epic digest *and* start writing issues as bets — and pull the bet through the digest — **then** you'll grasp project status in one read, framed as "what we're betting on and how we'll know", instead of trawling the issues board. That's what we want.

**We'll be right if** you reach for the digest instead of the board, and new issues start leading with "We think that…".

**We'll know by** running `/epic-digest` and seeing a bet-framed status briefing; and new issues using the format.

## 👤 For humans

Two connected things land here:

1. **A `/epic-digest` skill** — a daily "where are we?" digest from this repo's GitHub epics: a short "since yesterday" band (opened / closed / merged PRs), then one card per open epic with a progress bar. Render-only for now (HTML + plain text under `writeups/reports/`); you read or forward it.
2. **Writing issues & epics as bets** — the default is now "we think *if* we do X, *then* Y will happen — and Y is what we want", plus how we'll know it paid off. The digest surfaces each epic's **The bet** + **We'll know by** alongside **Where we are**.

![digest preview](https://github.com/pmcp/nuxt-crouton/issues/358)

## 🤖 For agents

- **`.claude/skills/epic-digest/`** — `SKILL.md` (gather via GitHub MCP), dependency-free `render.mjs` (JSON → email-safe HTML + text), `example.data.json`.
- **`.claude/skills/github-tasks/SKILL.md`** — "Write it as a bet" section: the 4 parts as a lens over the existing 👤/🤖/🧪 sections, not a 5th heading.
- **`CLAUDE.md`** — registers the skill (skills table) and the bet default (issue-tracking guidance).
- **`scripts/gen-skills-doc.mjs`** + regenerated `skills-and-triggers.html` — `/epic-digest` placed in "Plan & track".
- #357 / #358 retrofitted as worked examples on GitHub.

Part of epics #357 (digest) and #359 (assumption format) — both stay open for their follow-ups (email delivery, scheduling, CRM).

## Merge policy
Preserve the curated commits — **do not squash** (each is atomic, green, single-concern).

## 🧪 We'll be right if / We'll know by
- `node .claude/skills/epic-digest/render.mjs .claude/skills/epic-digest/example.data.json` → writes `.html` + `.txt`, each showing the activity band and one card per epic with **The bet** / **We'll know by** / **Where we are** + a progress bar.
- Open a fresh issue → it leads with "We think that…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqrbLZqfd4LDzkx5FUGLE2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqrbLZqfd4LDzkx5FUGLE2)_