### PR TITLE
Subtractive minimal-theme buttons via Nuxt UI 4.9 slot-class replacer

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -405,6 +405,53 @@ export default defineAppConfig({
 })
 ```
 
+### Two theming modes: additive (variants) vs subtractive (replacers)
+
+The pattern above is **additive** — a named `variant` + `compoundVariants` *add*
+CSS classes on top of Nuxt UI's defaults, which still get merged in via
+`tailwind-merge`. You can override conflicting utilities, but you **cannot remove**
+a default (rounded/shadow/ring), which is why the older theme CSS leans on
+`!important` to win the specificity war.
+
+**Nuxt UI ≥ 4.9 ([PR #6562](https://github.com/nuxt/ui/pull/6562)) adds the missing
+"subtract" lever:** a slot value can be a `(defaults) => classes` **function** that
+**replaces** the slot's resolved defaults instead of merging onto them (a string
+still merges). It works in `app.config.ui`, the per-instance `:ui` prop, and
+`<UTheme>`. Because the function receives the *fully resolved* default string, you
+can transform rather than blank it (keep layout, drop only decorative utilities):
+
+```ts
+// minimal/app.config.ts — strip rounded/shadow/ring, keep layout, no !important
+const stripDecorative = (defaults: string) =>
+  defaults.split(/\s+/).filter(c => !/^-?(rounded|shadow|ring)(-|$)/.test(c.split(':').pop()!))
+    .concat('minimal-flat').join(' ')
+
+export default defineAppConfig({
+  ui: { button: { slots: { base: stripDecorative } } }
+})
+```
+
+**Hard constraints (verified against `@nuxt/ui` `dist/runtime/utils/tv.ts`):**
+
+| | Additive (variant) | Subtractive (replacer) |
+|---|---|---|
+| Where read | `variants` / `compoundVariants` | top-level `base`/`slots`, per-instance `:ui`, `<UTheme>` |
+| Scope | per **named variant** (opt-in: `variant="minimal"`) | **global** to every instance / a `<UTheme>` subtree / one component |
+| Can subtract defaults | ❌ merge-only | ✅ replaces |
+| Runtime theme switching (`ThemeSwitcher`) | ✅ per-component `:variant` | ⚠️ a global `app.config` replacer can't be switched off per-component; use `<UTheme>` for a switchable subtree |
+
+- **Replacers are NOT variant-scoped.** `extractDirectives` only reads top-level
+  `base`/`slots` — a function inside `variants.variant.minimal.base` is ignored. So
+  subtractive theming is a *global/subtree/per-instance* tool, orthogonal to the
+  variant system; the two modes coexist (the `minimal` button uses both).
+- **Keep replacers pure & deterministic** so SSR and client compute the same string
+  (no hydration mismatch) — the original reason this package avoided base overrides.
+- **Multi-theme caveat:** a global `app.config` base replacer applies to *all*
+  buttons, so an app that `extends` several themes + flips them at runtime should
+  prefer `<UTheme>` (subtree) over a global replacer. Single-theme apps are clean.
+
+Spike: #364.
+
 ## Dependencies
 
 - **Peer deps**: `@nuxt/ui ^4.0.0`, `nuxt ^4.0.0`

--- a/packages/crouton-themes/minimal/app.config.ts
+++ b/packages/crouton-themes/minimal/app.config.ts
@@ -1,6 +1,25 @@
 // Minimal Theme Configuration
 // Super clean, black lines, white background, minimal aesthetic
 
+// Subtractive-theming helper (Nuxt UI >= 4.9, PR #6562).
+// A slot value that is a `(defaults) => classes` function REPLACES the resolved
+// default classes instead of merging onto them. We keep Nuxt UI's layout/sizing
+// and remove only the decorative utilities (rounded-* / shadow-* / ring-*, incl.
+// variant-prefixed ones like `focus-visible:ring-2`), then tag the element with
+// `minimal-flat`. Pure + deterministic, so SSR and client compute the identical
+// class string -> no hydration mismatch.
+const isDecorative = (cls: string): boolean => {
+  const util = cls.split(':').pop() ?? cls // drop variant prefixes (hover:, focus-visible:, dark:)
+  return /^-?(rounded|shadow|ring)(-|$)/.test(util)
+}
+
+const stripDecorative = (defaults: string): string =>
+  defaults
+    .split(/\s+/)
+    .filter(c => c && !isDecorative(c))
+    .concat('minimal-flat')
+    .join(' ')
+
 export default defineAppConfig({
   ui: {
     colors: {
@@ -9,7 +28,15 @@ export default defineAppConfig({
     },
 
     button: {
-      // Note: No slots.base override - let Nuxt UI handle base classes to avoid hydration mismatches
+      // Subtractive base via a slot-class replacer (see stripDecorative above).
+      // NOTE: this is GLOBAL to every <UButton> in an app that extends this
+      // theme -- it is NOT scoped to `variant="minimal"`. Replacers are only read
+      // at the top-level base/slots or the per-instance :ui prop, never inside
+      // variants/compoundVariants, so a theme that wants to *subtract* defaults
+      // does it here, while the named `minimal*` variants below stay additive.
+      slots: {
+        base: stripDecorative
+      },
       variants: {
         variant: {
           minimal: '',

--- a/packages/crouton-themes/minimal/assets/css/main.css
+++ b/packages/crouton-themes/minimal/assets/css/main.css
@@ -54,6 +54,14 @@
    BUTTON STYLES
    ============================================ */
 
+/* Applied by the slot-class replacer in app.config.ts, which has already
+   stripped Nuxt UI's rounded-*/shadow-*/ring-* defaults from the base slot.
+   Because those defaults are gone (not merged), this flattens corners with
+   NO !important -- the proof that subtractive theming ends the specificity war. */
+.minimal-flat {
+  border-radius: var(--minimal-radius);
+}
+
 .minimal-btn {
   font-family: var(--minimal-font) !important;
   font-weight: 500 !important;


### PR DESCRIPTION
Closes #364.

## 👤 For humans

The `minimal` theme's buttons can finally be **truly flat**. Until now a theme could only *add* classes on top of Nuxt UI's defaults, so `minimal` had to fight the built-in rounded corners / shadow / focus-ring with a wall of `!important`. Nuxt UI **4.9** ([PR #6562](https://github.com/nuxt/ui/pull/6562)) added the missing lever — a slot class can now be a **function that replaces** the defaults instead of merging onto them. This spike wires that into the `minimal` theme so its buttons drop those decorative defaults (while keeping layout/padding) with **no `!important`**.

It also pins down a real architectural finding for the package: replacers are a **global / `<UTheme>`-subtree / per-instance** tool — they **cannot** be scoped to a named `variant`. So this is a *second, subtractive* theming mode that sits alongside the existing additive variant system, not a replacement for it.

```mermaid
flowchart LR
  A["UButton base slot"] --> B{slot value type?}
  B -->|"string (today)"| C["MERGE with defaults<br/>(rounded/shadow/ring stay → needs !important)"]
  B -->|"(defaults) =>  (4.9)"| D["REPLACE defaults<br/>strip rounded/shadow/ring, keep layout<br/>+ minimal-flat → no !important"]
```

> ⚠️ **Needs a human click-through.** I can't render UI in the sandbox, so please eyeball a `minimal`-themed button on a preview: square corners, no shadow/ring, and **no hydration flicker** on refresh.

## 🤖 For agents

Dependency already satisfied by #353 / #235 (`@nuxt/ui ^4.9.0` is on `main`); branch is rebased onto it.

- **`minimal/app.config.ts`** — adds `button.slots.base` replacer `stripDecorative`: `(defaults) => defaults` minus `rounded-*`/`shadow-*`/`ring-*` (incl. variant-prefixed like `focus-visible:ring-2`, matched after the last `:`), appending `minimal-flat`. Pure + deterministic → identical SSR/client string (no hydration mismatch — the reason the old config avoided base overrides).
- **`minimal/assets/css/main.css`** — `.minimal-flat { border-radius: var(--minimal-radius) }`, **no `!important`** — the proof the defaults are gone, not merged.
- **`CLAUDE.md`** — documents additive-vs-subtractive modes + constraints **verified against `dist/runtime/utils/tv.ts`**: `extractDirectives` reads replacers only at top-level `base`/`slots` (and call-time `:ui`/`<UTheme>`), never inside `variants`/`compoundVariants` ⇒ not variant-scoped; a global `app.config` replacer can't be toggled per-component, so runtime multi-theme switching should use `<UTheme>` (subtree) instead.

**Scope/risk:** the replacer is GLOBAL to every `<UButton>` in a theme-extending app — but **no app currently extends any crouton theme**, so blast radius is zero. The named `minimal*` variants and `ThemeSwitcher` are untouched.

**Decision captured (spike output):** keep replacers as an opt-in *subtractive/global* mode (theme `app.config` for single-theme apps, `<UTheme>` for switchable subtrees); the existing additive variant mode stays for runtime per-component switching. Rolling this out to `ko`/`kr11`/`blackandwhite` is a follow-up, intentionally out of scope.

## 🧪 How to test

**What changed:** `minimal`-theme buttons render flat (no Nuxt UI rounded corners / shadow / focus ring) via a replacer, not an `!important` override.

**Where you'll see it:** any app that `extends: '@fyit/crouton-themes/minimal'` — render `<UButton variant="minimal" color="primary">Save</UButton>` (or a plain `<UButton>`, since the base replacer is global).

**Steps:**
1. In a minimal-themed app, place `<UButton variant="minimal" color="primary">Save</UButton>`.
2. Load it. **Before:** corners stayed rounded / a subtle shadow/ring showed through under the minimal styling. **After:** square corners, no shadow, no ring.
3. Inspect the element — it carries `minimal-flat` and the default `rounded-*`/`shadow-*`/`ring-*` utilities are absent from the base slot.
4. Hard-refresh a few times, watch the console — **no hydration mismatch warning**.
5. (If using multiple themes) flip via `<ThemeSwitcher />` — note the documented caveat: a global `app.config` replacer isn't per-component switchable; `<UTheme>` is the switchable path.

**Test data:** none beyond an app extending `@fyit/crouton-themes/minimal` (e.g. a local playground; no fixture extends a theme today).

**Typecheck note:** `pnpm -r --filter './apps/*' typecheck` surfaces pre-existing `Cannot find module 'nanoid'` errors in `velo`/`fanfare` (a sandbox install artifact — reproduces on clean `main` with this change stashed); this PR introduces no new type errors and touches no app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frb6RNQyBC7mxPBTakMomL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Frb6RNQyBC7mxPBTakMomL)_