### PR TITLE
Harden the task-decomposition pipeline (epic branch, one-time approval, review steps, block-don't-improvise)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -53,6 +53,24 @@ cheaper (slightly blunter) split, or raise them to `opus` if decomposition quali
   with `Closes #NN`. Workers obey the `packages/` HARD GATE and the `/commit` + no-squash
   merge policy.
 
+### Integration-branch flow & safety (#348)
+
+Hardening from the #325 post-mortem (parallel workers off `main` re-created the same
+package). Threaded through `epic_branch` in the agent contract:
+
+- **Epic integration branch (#349).** The orchestrator creates `epic/<NN>-<slug>` off
+  `main` and passes `epic_branch` down to every decomposer/worker. Workers branch off it
+  and target their PRs **at it**, not `main` — so later sub-issues see earlier ones' merged
+  work. One **epic→`main`** PR at the end is the single human review; the epic isn't "done"
+  until that lands. Dependency-ordered children are **wave-gated** (foundation first).
+- **Epic-scoped approval (#350).** The `packages/` gate also honours the
+  `CROUTON_PACKAGE_EDIT_APPROVED` env var (inherited by spawned workers) — approve a
+  package-touching epic once, not per worker. The `.package-edit-approved` file must never
+  be committed (`guard-package-approval.yml` enforces it).
+- **Block, don't improvise (#352).** A worker missing a prerequisite a sibling owns
+  **stops** (blocker) — it never scaffolds the missing thing or silently diverges from the
+  epic's stated design invariants (which the decomposer passes into the worker prompt).
+
 ### Adding a new agent
 
 Create `<name>.md` with frontmatter + body, keep `tools` minimal (grant `Agent` only to

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -21,8 +21,12 @@ Repo: `pmcp/nuxt-crouton`. Honour the `github-tasks` skill for everything writte
 ## Input (from the prompt)
 
 ```
-{ issue_number: <int>, depth: <int>, epic: <int>, summary?: <string> }
+{ issue_number: <int>, depth: <int>, epic: <int>, summary?: <string>, epic_branch?: <string> }
 ```
+
+`epic_branch` (when present, e.g. `epic/325-printing`) is the integration branch the
+pipeline is building on — pass it straight through to any child decomposer **and** to the
+worker you spawn, so everything branches off it (not `main`). See the task-decompose skill.
 
 ## Step 1 — Read & understand
 
@@ -60,8 +64,15 @@ To split:
    the **current** issue (`issue_number` = this issue, `sub_issue_id` = child id).
 3. Spawn one `task-decomposer` **per child, in parallel** (all `Agent` calls in a
    single message): `subagent_type: "task-decomposer"`, prompt
-   `{ issue_number: <child>, depth: <depth + 1>, epic: <epic>, summary: "<one line>" }`.
+   `{ issue_number: <child>, depth: <depth + 1>, epic: <epic>, summary: "<one line>", epic_branch: <epic_branch> }`.
 4. Report the children created + that decomposers were spawned. Stop.
+
+**Dependency order (when children depend on each other).** If one child must land before a
+sibling (e.g. "scaffold the package" before "move code into it"), do **not** fan them all
+out at once — that's how the #325 run produced duplicate scaffolds. Spawn the foundation
+child first; note the dependent children in a comment and spawn them only once the
+foundation has merged into the epic branch (a re-run of this decomposer, idempotent, picks
+them up). Independent children still go out in parallel.
 
 ## Step 4 — Spawn a worker (leaf, or depth cap reached)
 
@@ -69,8 +80,10 @@ Spawn one `task-worker` via the `Agent` tool:
 - `subagent_type: "task-worker"`
 - `isolation: "worktree"` — workers run in isolated git worktrees so parallel workers
   never collide on branches/files.
-- prompt: `{ issue_number: <this issue>, epic: <epic> }` plus a tight restatement of the
-  acceptance criteria so the worker doesn't need an extra round-trip.
+- prompt: `{ issue_number: <this issue>, epic: <epic>, epic_branch: <epic_branch> }` plus a
+  tight restatement of the acceptance criteria **and the epic's design invariants** (e.g.
+  "use the generic `print_jobs` table") so the worker neither needs a round-trip nor
+  silently diverges. The worker branches off `epic_branch` and targets its PR there.
 
 Report: "issue #N is leaf-sized (or at depth cap) → worker spawned in worktree". Stop.
 

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: task-orchestrator
 description: Top of the recursive task-decomposition pipeline. Given a GitHub epic issue, reads the goal, splits it into 2–6 top-level workstreams as linked sub-issues, then spawns one task-decomposer per child. Invoked by the /task-decompose skill — not usually by hand.
-tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__add_issue_comment, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, Read, Grep, Glob, Bash, Agent
+tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__add_issue_comment, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, mcp__github__create_pull_request, mcp__github__pull_request_read, Read, Grep, Glob, Bash, Agent
 model: sonnet
 ---
 
@@ -29,11 +29,24 @@ number.
 ## Procedure
 
 1. **Read the epic.** `mcp__github__issue_read` (method `get`) on `epic_issue_number`.
-   Extract the goal, any constraints, and the intended component(s).
+   Extract the goal, any constraints, the intended component(s), and the epic's stated
+   **design invariants** (the rules every sub-issue must honour — you'll pass these down).
 2. **Idempotency check.** `get_sub_issues` on the epic. If it already has children,
    do NOT create duplicates — re-spawn decomposers for any **open** children that have
-   no PR/▴children yet, and stop. (Sessions are ephemeral; you may be a re-run.)
-3. **Identify 2–6 top-level workstreams.** Slice by *coherent concern*, not by file.
+   no PR/▴children yet (passing `epic_branch`, below), and stop. (Sessions are ephemeral;
+   you may be a re-run.)
+3. **Create the epic integration branch (#349).** All sub-issue work lands here first,
+   not on `main` — so a later sub-issue sees what an earlier one built (no duplicate
+   scaffolds), and the whole feature gets **one** human review at the end. From the main
+   checkout:
+   ```bash
+   git fetch origin main
+   git push origin origin/main:refs/heads/epic/<epic_number>-<slug>   # idempotent; ok if it exists
+   ```
+   Call this `epic_branch = epic/<epic_number>-<slug>`. Pass it to **every** decomposer/
+   worker you (or they) spawn. (If branch creation isn't possible in this environment,
+   note it on the epic and fall back to `main` as the base — but prefer the epic branch.)
+4. **Identify 2–6 top-level workstreams.** Slice by *coherent concern*, not by file.
    Fewer, well-bounded streams beat many thin ones. Hard cap: **MAX_CHILDREN = 6**.
    If the epic is genuinely a single concern, create exactly one child (the decomposer
    will still evaluate it and likely send it straight to a worker).
@@ -45,19 +58,48 @@ number.
      PR so CI deploys a staging Worker and posts the `https://<name>.pmcp.dev` URL. The
      epic's acceptance is that live, auth-working preview URL — not just merged code.
      (See the `poc-deploy` skill.)
-4. **Create + link each workstream.** For each:
+5. **Create + link each workstream.** For each:
    - `mcp__github__issue_write` (method `create`) — title is plain human English; body
      has `## 👤 For humans`, `## 🤖 For agents`, `## 🧪 How to test`; `labels` = the
      correct `type:*` + `pkg:*`/`app:*` (where the source actually changes). Never `root`.
    - `mcp__github__sub_issue_write` (method `add`, `issue_number` = epic,
      `sub_issue_id` = the child's **id** from the create response — not its number).
-5. **Spawn a decomposer per child — in parallel.** Issue all `Agent` calls in a
-   **single message** (multiple tool uses) so they run concurrently:
+   - **Note dependency order** in the body when one workstream must land before another
+     (the decomposer/skill uses this to wave-gate, not fan everything out at once).
+6. **Plan-review gate (#351) — for risky epics, pause before spawning.** If the epic
+   **creates a package, changes a DB schema, or is a dependency chain** (or carries a
+   `review:plan` label), this is high-risk: do **not** spawn workers yet. Post the
+   proposed tree (each child + dependency order) as a comment on the epic, **@mention
+   `@pmcp`**, apply `status:blocked`, and **stop**. A human approves by replying (a re-run
+   then proceeds). For low-risk epics (or `review:auto`), skip the gate and continue.
+7. **Spawn a decomposer per child.** Issue the `Agent` calls so independent children run
+   concurrently (single message); **wave-gate** dependency-ordered children (spawn the
+   foundation first; spawn dependents on a re-run once it has merged into `epic_branch`):
    - `subagent_type: "task-decomposer"`
-   - prompt: `{ issue_number: <child number>, depth: 1, epic: <epic number> }` plus a
-     one-line summary of the child so the decomposer has context without a round-trip.
-6. **Report.** Return a compact tree: epic → each child (number + title) → "decomposer
-   spawned". Do not dump full issue bodies.
+   - prompt: `{ issue_number: <child number>, depth: 1, epic: <epic number>, epic_branch: <epic_branch> }`
+     plus a one-line summary **and the epic's design invariants** so the child has context
+     without a round-trip and can't silently diverge.
+8. **The final epic→`main` PR (the review gate).** The epic is NOT done when its children
+   merge into `epic_branch` — it's done when `epic_branch` merges to `main` behind one
+   human review. On an idempotent re-run, once **all** children are closed/merged into the
+   epic branch, open that single PR (base `main`, head `epic_branch`) with a rollup body
+   (`github-tasks` 👤/🤖 + `## 🧪 How to test`, `Closes` the epic) — or hand back to the
+   human to open/merge it. Never merge it yourself.
+9. **Report.** Return a compact tree: epic → epic_branch → each child (number + title) →
+   "decomposer spawned" / "blocked for plan review" / "waiting on <dep>". Don't dump full
+   issue bodies.
+
+## Epic-scoped package approval (#350)
+
+If the epic legitimately edits/creates a `packages/*` package, approval is granted **once
+for the whole epic**, not per worker. The `packages/` HARD GATE
+(`.claude/hooks/gate-package-edits.sh`) honours the **`$CROUTON_PACKAGE_EDIT_APPROVED`**
+env var (a space/comma list of approved package names) in addition to the local
+`.package-edit-approved` file; because env is inherited by the agents you spawn, setting it
+once covers every worker in the run. Record the epic's approved packages in the epic body
+so a re-run knows them. **Never** commit a `.package-edit-approved` file — a CI guard fails
+any PR to `main` that contains one. You don't write code or edit packages yourself; this is
+just what you tell workers and how the approval propagates.
 
 ## Guardrails
 

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -23,38 +23,87 @@ a feature branch.
 ## Procedure
 
 1. **Read the issue.** `mcp__github__issue_read` (method `get`). The acceptance criteria
-   and `## 🧪 How to test` are your spec.
+   and `## 🧪 How to test` are your spec. Also read the **epic** (the `epic` number in
+   your prompt) so you know the epic's stated design/invariants.
 2. **Mark in progress.** `issue_write` (method `update`) adding the `status:in-progress`
    label (keep its existing labels).
-3. **Branch.** You're in an isolated worktree. Create a feature branch named
-   `claude/issue-<issue_number>-<slug>` off the current base. One branch = one issue.
-4. **Implement** per the issue. Honour every CLAUDE.md rule:
+3. **Prerequisite & invariant check — BLOCK, don't improvise (HARD RULE).** Before you
+   write anything, confirm the ground you're building on exists and matches the plan:
+   - **Missing prerequisite ⇒ STOP.** If the issue depends on something a *sibling* issue
+     was supposed to create — a package, a module, a table, an exported symbol — and it
+     **isn't there yet** (the sibling hasn't merged into your base), do **NOT** scaffold,
+     stub, or re-create it yourself. That is exactly how parallel workers produce
+     conflicting duplicates. Treat it as a blocker: comment + `@mention` + `status:blocked`
+     + **stop** (see "Asking the human"). The pipeline (epic branch + dependency order)
+     is supposed to give you the prerequisite; if it's absent, the right move is to wait,
+     not to invent it.
+   - **Don't silently diverge from the epic's design.** If implementing the issue as
+     written would contradict the epic's stated model/invariant (e.g. the epic says "use
+     the generic `print_jobs` table" but the path of least resistance is to extend the old
+     one), do **not** quietly pick the other design. Either follow the stated invariant, or
+     — if you believe it's wrong — block and raise it. Never ship a second, divergent
+     approach without a human deciding.
+4. **Branch.** You're in an isolated worktree. Create a feature branch named
+   `claude/issue-<issue_number>-<slug>` off the current base (the **epic branch** when one
+   was passed — see "Epic integration branch" below; otherwise the repo base). One branch
+   = one issue.
+5. **Implement** per the issue. Honour every CLAUDE.md rule:
    - `<script setup lang="ts">`, Nuxt UI **4** component names, VueUse-first, KISS.
-   - **`packages/` HARD GATE** — do NOT edit anything under `packages/` without explicit
-     user approval. If the issue genuinely requires it, this is a **blocker**: follow
-     "Asking the human" below (comment + @mention + `status:blocked` + stop). Do not work
-     around the gate.
-5. **Typecheck.** Run `pnpm -r --filter './apps/*' typecheck` (never `npx nuxt typecheck`
+   - **`packages/` HARD GATE** — do NOT edit anything under `packages/` unless this epic
+     was approved to (epic-scoped approval — see "Epic-scoped package approval" below; the
+     gate honours `$CROUTON_PACKAGE_EDIT_APPROVED`). If the edit isn't covered by the
+     epic's approval, it's a **blocker**: comment + @mention + `status:blocked` + stop.
+     Do not work around the gate.
+6. **Typecheck.** Run `pnpm -r --filter './apps/*' typecheck` (never `npx nuxt typecheck`
    from root). Fix every error before continuing. Do not declare done with a red typecheck.
-6. **Commit + push immediately (CHECKPOINT).** Use the **`/commit`** skill (via the
+7. **Commit + push immediately (CHECKPOINT).** Use the **`/commit`** skill (via the
    `Skill` tool) — never `git commit` directly, never `git add .`. Reference the issue in
    the body, e.g. `(#<issue_number>)`. **Then push the branch right away**
    (`git push -u origin <branch>`), the moment the work is written and typecheck is green —
    **before any long step** (dev boot, deploy, extended verification). Sessions can be
    suspended mid-run: an unpushed worktree is lost work, a pushed branch is recoverable.
    Never sit on uncommitted changes across a long-running command.
-7. **Open a PR.** `mcp__github__create_pull_request` from your branch into the repo's base
-   branch. The body MUST contain `Closes #<issue_number>` so the issue auto-closes on
-   merge. Body follows `github-tasks` (👤/🤖 + `## 🧪 How to test`). End the PR body with
-   the Generated-with-Claude-Code footer.
+8. **Open a PR.** `mcp__github__create_pull_request` **into the epic branch** when one was
+   passed (else the repo base). The body MUST contain `Closes #<issue_number>` so the issue
+   auto-closes on merge. Body follows `github-tasks` (👤/🤖 + `## 🧪 How to test`). End the
+   PR body with the Generated-with-Claude-Code footer.
    - **Do not squash by default** (merge policy) — your commits are curated and atomic.
-8. **Report.** Return: branch name, PR url, typecheck status (green/red), and whether you
-   hit the `packages/` gate. Keep it tight.
+9. **Report.** Return: branch name, PR url, **PR base (epic branch or main)**, typecheck
+   status (green/red), and whether you hit the `packages/` gate. Keep it tight.
+
+## Epic integration branch
+
+When the prompt includes `epic_branch` (e.g. `epic/325-printing`), the pipeline is running
+in **integration-branch mode** (see the task-decompose skill):
+- **Branch off `origin/<epic_branch>`**, not `main`. Fetch it first
+  (`git fetch origin <epic_branch>`). The epic branch already contains earlier sub-issues'
+  merged work, so your prerequisites are present — this is what prevents the duplicate-
+  scaffold problem.
+- **Target your PR at `<epic_branch>`** (`create_pull_request` `base: <epic_branch>`), not
+  `main`. Sub-PRs merge into the epic branch; one final epic→`main` PR (opened per the
+  skill) is where the whole feature gets its human review.
+- If no `epic_branch` is passed, fall back to the repo base (`main`) as before.
+
+## Epic-scoped package approval
+
+The `packages/` HARD GATE (`.claude/hooks/gate-package-edits.sh`) blocks edits under
+`packages/` unless the package is approved. An epic that legitimately edits/creates a
+package is approved **once, at the epic level** — surfaced to you as the
+**`$CROUTON_PACKAGE_EDIT_APPROVED`** env var (a space/comma list of package names the gate
+also honours, inherited by this worker). You do **not** create or edit the
+`.claude/.package-edit-approved` file yourself — the gate denies that on purpose, and that
+file must never be committed (a CI guard fails any PR to `main` that contains it). If your
+package edit isn't covered by the epic's approval, that's a blocker — comment + @mention +
+`status:blocked` + stop.
 
 ## Guardrails
 
 - Green typecheck is non-negotiable before the PR is "ready".
 - One issue → one branch → one PR. Never bundle unrelated work.
+- **Block, don't improvise** — a missing prerequisite (a package/module/table/symbol a
+  sibling issue owns) is a STOP, never a "I'll just scaffold it". Inventing it is how the
+  pipeline produced three conflicting copies of one package (the #325 post-mortem that
+  motivated #348). Wait for it; don't recreate it.
 - If the issue turns out NOT to be leaf-sized (it keeps growing, or needs cross-cutting
   changes), STOP and report that it should go back to a `task-decomposer` — don't try to
   swallow an epic in one worker run.

--- a/.claude/hooks/gate-package-edits.sh
+++ b/.claude/hooks/gate-package-edits.sh
@@ -3,9 +3,14 @@
 # Blocks Edit/Write calls targeting files in packages/
 # Exit 2 = block the action (Claude Code PreToolUse convention)
 #
-# Override: after getting user approval, the agent writes the package name
-# to .claude/.package-edit-approved (one per line). The hook allows edits
-# to approved packages.
+# Two approval channels (either one un-gates a given package):
+#  1. Interactive: after user approval, write the package name to
+#     .claude/.package-edit-approved (one per line). Session-scoped, gitignored.
+#  2. Epic-scoped (#350): the CROUTON_PACKAGE_EDIT_APPROVED env var — a
+#     space/comma-separated list of approved package names. Set once when a
+#     package-touching epic is approved; inherited by every spawned agent/worktree,
+#     so the whole task-decomposition run is covered by one approval. Env is never
+#     committed, so (unlike a file) it cannot leak the gate-off state into main.
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -26,14 +31,25 @@ fi
 PKG=$(echo "$REL_PATH" | cut -d'/' -f2)
 APPROVAL_FILE="$PROJECT_DIR/.claude/.package-edit-approved"
 
-# Check if this package has been approved
+# Channel 1 — interactive approval file (one package name per line).
 if [ -f "$APPROVAL_FILE" ] && grep -qx "$PKG" "$APPROVAL_FILE" 2>/dev/null; then
   exit 0
+fi
+
+# Channel 2 — epic-scoped env approval. Normalise separators (comma/space) to
+# whitespace and match the package as a whole word.
+if [ -n "$CROUTON_PACKAGE_EDIT_APPROVED" ]; then
+  for approved in ${CROUTON_PACKAGE_EDIT_APPROVED//,/ }; do
+    if [ "$approved" = "$PKG" ]; then
+      exit 0
+    fi
+  done
 fi
 
 echo "BLOCKED: This edit targets shared package '$PKG' (packages/$PKG)." >&2
 echo "Shared packages affect all consuming apps." >&2
 echo "" >&2
-echo "To proceed after user approval, run:" >&2
-echo "  echo '$PKG' >> $APPROVAL_FILE" >&2
+echo "To proceed after user approval, either:" >&2
+echo "  • interactive:  echo '$PKG' >> $APPROVAL_FILE" >&2
+echo "  • epic-scoped:  export CROUTON_PACKAGE_EDIT_APPROVED=\"\$CROUTON_PACKAGE_EDIT_APPROVED $PKG\"" >&2
 exit 2

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -39,6 +39,36 @@ flowchart TD
 To tune the limits, edit the numbers in `.claude/agents/task-decomposer.md` (and the
 orchestrator's MAX_CHILDREN).
 
+## Integration-branch flow & safety (#348 hardening)
+
+Learned from the #325 run, where parallel workers — branching off `main`, unable to see
+each other's unmerged work — each re-created the same new package and a couple silently
+chose a different design. Four rules now prevent that:
+
+1. **Epic integration branch (#349).** The orchestrator creates `epic/<NN>-<slug>` off
+   `main`. Every sub-issue branches off **that** branch and targets its PR **at** it (not
+   `main`), so a later sub-issue sees what an earlier one built — no duplicate scaffolds.
+   The whole feature gets **one** human review when `epic/<NN>` is PR'd into `main` at the
+   end (the epic is "done" only then, not when its children merge into the epic branch).
+   Dependency-ordered children are **wave-gated** (foundation merges first, then dependents
+   on an idempotent re-run); independent ones still run in parallel.
+
+2. **Epic-scoped package approval (#350).** A package-touching epic is approved **once**:
+   the `packages/` gate honours the **`CROUTON_PACKAGE_EDIT_APPROVED`** env var (inherited
+   by every spawned worker), so you don't unlock per-worker. **Never** commit the
+   `.claude/.package-edit-approved` file — `guard-package-approval.yml` fails any PR to
+   `main` that contains it (env can't leak; a committed file would disable the gate for all).
+
+3. **Review dial (#351).** Risky epics (create a package / change schema / dependency
+   chain, or labelled `review:plan`) **pause for human plan-approval before any worker
+   runs** — the orchestrator posts the proposed tree, @mentions `@pmcp`, blocks. Plus the
+   epic→`main` PR is the integration review. Low-risk epics (`review:auto`) skip the gate.
+
+4. **Block, don't improvise (#352).** A worker that finds a prerequisite missing (a
+   package/table/symbol a sibling owns, not yet merged) **stops and waits** — it never
+   scaffolds the missing thing itself, and never silently diverges from the epic's stated
+   design invariants. Missing prerequisite = blocker, not a DIY.
+
 ## Triggers (manual + automatic)
 
 - **Manual:** run `/task-decompose "<task>"` or `/task-decompose #NN` in any Claude Code
@@ -86,8 +116,10 @@ orchestrator's MAX_CHILDREN).
    - `subagent_type: "task-orchestrator"`
    - prompt: `{ epic_issue_number: <epic number>, depth: 0 }` + a short restatement of the
      task so it doesn't need an extra read.
-3. **Report** the epic url and that orchestration has started. The tree then builds itself
-   (decomposers recurse; workers open PRs with `Closes #NN`).
+3. **Report** the epic url and that orchestration has started. The orchestrator creates the
+   `epic/<NN>-<slug>` integration branch; the tree then builds itself onto it (decomposers
+   recurse; workers open PRs into the epic branch with `Closes #NN`); a single epic→`main`
+   PR lands the lot behind one review.
 
 ## Building an app? It's a POC by default — end at a preview URL
 
@@ -122,7 +154,9 @@ To change who gets pinged, edit `NOTIFY_HANDLE` here and in `.claude/agents/CLAU
 
 - Everything persists as real GitHub issues (epic → sub-issues → sub-sub-issues), so the
   tree survives across sessions and shows progress bars on each parent.
-- Workers run in **git worktree isolation** — parallel leaves never collide.
+- Workers run in **git worktree isolation** — parallel leaves never collide; they branch
+  off and PR into the **epic branch**, not `main` (see "Integration-branch flow").
 - This plugs into the repo's ISSUE-FIRST + `github-tasks` + `/commit` + merge-policy
   workflow; the agents enforce those rules themselves.
-- It does **not** auto-merge PRs. Review/merge (or have a PR watcher do it) as usual.
+- Sub-PRs may auto-merge into the **epic branch** (a staging area). The final
+  **epic→`main`** PR is **not** auto-merged — that's the human review/merge gate.

--- a/.github/workflows/guard-package-approval.yml
+++ b/.github/workflows/guard-package-approval.yml
@@ -1,0 +1,27 @@
+name: Guard package-edit approval
+
+# Safety net for the packages/ HARD GATE (#350). The override file
+# `.claude/.package-edit-approved` is session-scoped + gitignored and must NEVER
+# reach main — committing it would silently disable the gate for everyone. This
+# fails any PR to main that contains it (e.g. via `git add -f`). Epic-scoped
+# approval rides the CROUTON_PACKAGE_EDIT_APPROVED env var instead, which can't
+# be committed.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  no-approval-file:
+    name: No committed approval file
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fail if .claude/.package-edit-approved is committed
+        run: |
+          if git ls-files --error-unmatch .claude/.package-edit-approved >/dev/null 2>&1; then
+            echo "::error file=.claude/.package-edit-approved::This file disables the packages/ HARD GATE and must never be committed. Remove it from the PR; use the CROUTON_PACKAGE_EDIT_APPROVED env var for epic-scoped approval instead."
+            exit 1
+          fi
+          echo "OK — no committed package-edit approval file."


### PR DESCRIPTION
Closes #348
Closes #349
Closes #350
Closes #351
Closes #352

## 👤 For humans

When we ran the agent pipeline (`/task-decompose`) on the printing epic, it tripped over itself: several helper agents — each in its own private copy branched off `main`, unable to see each other's unfinished work — **independently rebuilt the same new package three ways**, and a couple quietly picked a different design than the plan. We threw away the duplicates and rebuilt by hand.

This PR fixes the process so that can't happen again. Four changes:

1. **Each epic gets its own branch.** Helpers branch off the *epic* branch (which already has earlier steps' work), not `main` — so a later task sees what an earlier one built. One final review PR (epic → `main`) instead of a scattering.
2. **Approve package edits once per epic, not per helper.** You hit the per-helper unlock friction yourself; now one approval covers the whole run — and a committed "gate-off" file can never reach `main`.
3. **Review checkpoints, on a dial.** Risky epics (new package / schema change / dependency chain) pause for a plan review before any helper runs; the epic→`main` PR is the integration review.
4. **"Block, don't improvise."** A helper missing a prerequisite (a package a sibling hasn't built yet) now **stops and waits** instead of inventing its own copy — the actual root cause of the collision.

```mermaid
flowchart TD
    M[main] --> E["epic/NN branch (approval seeded once)"]
    E --> F[foundation sub-PR → merges into epic]
    F --> A[dependent sub-PR branches off epic · sees foundation]
    A --> P[ONE epic→main PR · human review]
    P --> M
```

## 🤖 For agents

Pure `.claude/` + `.github/` change (no product code). Threaded through a new `epic_branch` field in the agent contract.

- **#349 epic integration branch** — `task-orchestrator.md`: creates `epic/<NN>-<slug>` off `main`, passes `epic_branch` to every decomposer/worker, opens the final epic→`main` PR (gains `create_pull_request`/`pull_request_read`); `task-decomposer.md`: threads `epic_branch`, wave-gates dependency-ordered children; `task-worker.md`: branches off `epic_branch`, targets PRs at it.
- **#350 epic-scoped approval** — `gate-package-edits.sh` also honours `CROUTON_PACKAGE_EDIT_APPROVED` (env, inherited by workers); new `guard-package-approval.yml` fails any PR to `main` containing `.claude/.package-edit-approved`.
- **#351 review dial** — orchestrator plan-review gate (blocks for `@pmcp` on package/schema/dependency-chain epics or `review:plan`; `review:auto` skips); epic→`main` PR as integration review.
- **#352 block-don't-improvise** — `task-worker.md` hard rule: missing prerequisite a sibling owns ⇒ blocker, never scaffold/diverge; decomposer passes the epic's design invariants into the worker prompt.
- Docs: `SKILL.md` + `agents/CLAUDE.md` describe the integration-branch flow + the four rules.

## 🧪 How to test

- **Gate hook (verified locally):** `printf '{"tool_input":{"file_path":"'$PWD'/packages/crouton-printing/x.ts"}}' | CROUTON_PACKAGE_EDIT_APPROVED="crouton-printing" CLAUDE_PROJECT_DIR="$PWD" bash .claude/hooks/gate-package-edits.sh` → exit 0 (allowed); a package not in the list → exit 2 (blocked). `bash -n` clean.
- **CI guard:** add `.claude/.package-edit-approved` to a throwaway PR against `main` → `guard-package-approval.yml` fails it.
- **Pipeline (the real proof):** the next `/task-decompose` on a dependency-chain epic should create an `epic/<NN>-…` branch, branch sub-issues off it, wave-gate the foundation, pause for plan review, and a missing-prerequisite worker should block rather than scaffold. (No fixture for this — it's the next live run; that's the honest verification.)
- `node scripts/gen-skills-doc.mjs` regenerates the skills overview identically (no diff) → `skills-doc.yml` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01479Uxfnv2DMtBMyChDirzg

---
_Generated by [Claude Code](https://claude.ai/code/session_01479Uxfnv2DMtBMyChDirzg)_