### PR TITLE
docs(root): prune stale references from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,14 +41,14 @@ Each todo requires:
 
 ## Task Execution Workflow (MANDATORY)
 
-Every task in `/writeups/PROGRESS_TRACKER.md` follows this 5-step flow:
+Every task is a **GitHub issue** (see `### GitHub Issue Tracking` below) and follows this 5-step flow:
 
 ```
-1. Mark Task In Progress → Edit PROGRESS_TRACKER.md ([ ] → 🔄), use TodoWrite
-2. Do The Work          → Follow CLAUDE.md patterns, KISS principle
-3. Run Type Checking    → pnpm typecheck (runs per-app), fix errors immediately
-4. Update Progress      → PROGRESS_TRACKER.md (🔄 → [x] ✅), update stats & Daily Log
-5. Git Commit           → ALWAYS use /commit skill — NEVER git commit directly
+1. Claim the issue   → set it in-progress, use TodoWrite for the local breakdown
+2. Do The Work       → Follow CLAUDE.md patterns, KISS principle
+3. Run Type Checking → pnpm typecheck (runs per-app), fix errors immediately
+4. Update the issue  → comment progress / tick acceptance criteria
+5. Git Commit        → ALWAYS use /commit skill, reference (#NN) — NEVER git commit directly
 ```
 
 ### GitHub Issue Tracking
@@ -79,7 +79,7 @@ For a big/fuzzy initiative, you can let agents do the epic→sub-issue breakdown
 ```
 Types: `feat` | `fix` | `refactor` | `docs` | `test` | `chore`
 
-Scopes: `crouton` | `crouton-core` | `crouton-cli` | `crouton-i18n` | `crouton-editor` | `crouton-flow` | `crouton-three` | `crouton-assets` | `crouton-devtools` | `crouton-auth` | `docs` | `playground` | `test` | `root`
+Scopes (canonical list lives in the `/commit` skill): `crouton` | `crouton-core` | `crouton-cli` | `crouton-i18n` | `crouton-editor` | `crouton-flow` | `crouton-assets` | `crouton-devtools` | `crouton-auth` | `crouton-triage` | `crouton-pages` | `crouton-bookings` | `docs` | `playground` | `rakim` | `root`
 
 ### Merge Policy (preserve curated commits — don't squash by default)
 
@@ -90,19 +90,17 @@ Scopes: `crouton` | `crouton-core` | `crouton-cli` | `crouton-i18n` | `crouton-e
 - **The real requirement** (not the merge button): every commit landing on `main` is atomic, **green/buildable**, single-concern, and carries a real "why". Keep that true and granular history is strictly more useful than squashed.
 - **Corollary:** don't bundle many unrelated concerns into one PR and then squash — that's how you get an unblameable megacommit. One PR = one coherent change set (an epic + its sub-issues is fine; the commits stay separate).
 
-### Progress Tracker Updates
-- Task Status: `[ ]` → `🔄` → `[x] ✅`
-- Update Quick Stats table (tasks completed, hours logged)
-- Update phase progress percentage
-- Add Daily Log entry
+### Issue Status Updates
+- Move the issue through its states: open → in-progress → closed (via the PR's `Closes #NN` on merge)
+- `writeups/PROGRESS_TRACKER.md` is an **optional** phase-level rollup, not the per-task tracker — update it only when keeping a phase summary current.
 
 ### Multi-Agent Continuity
-When starting or resuming: read `/writeups/PROGRESS_TRACKER.md` first. Check git status for uncommitted work.
+When starting or resuming: read the relevant GitHub issue/epic first (plus `writeups/PROGRESS_TRACKER.md` if a phase rollup exists). Check git status for uncommitted work.
 
 ### Critical Reminders
 - ✅ ALWAYS use `/commit` skill for ALL commits
 - ✅ ALWAYS run `pnpm typecheck` after code changes
-- ✅ ALWAYS update PROGRESS_TRACKER.md before committing
+- ✅ ALWAYS keep the GitHub issue updated (in-progress → closed via `Closes #NN`)
 - ✅ ALWAYS use TodoWrite for 3+ step tasks
 - ❌ NEVER batch multiple tasks in one commit
 - ❌ NEVER use `git add .`
@@ -126,7 +124,7 @@ The approval file is gitignored and session-scoped. Always clean it up after fin
 This applies to all agents, including Pi worker and sub-agents.
 
 ### Context Clearing Between Tasks
-After each task: announce completion, say the code word, STOP. User runs `/clear`. Fresh agent reads PROGRESS_TRACKER.md and continues.
+After each task: announce completion, say the code word, STOP. User runs `/clear`. Fresh agent reads the relevant GitHub issue/epic (and PROGRESS_TRACKER.md if a phase rollup exists) and continues.
 
 ## Technology Stack
 
@@ -359,7 +357,7 @@ import { useDrizzle } from '#server/utils/drizzle'
 ## Sub-Agent Usage
 
 When delegating: template scout first → parallel tasks → clear boundaries → smell check after.
-Agent personalities are defined in `.claude/agents/*.md`. Include personality in the Task prompt when invoking agents with custom personas (e.g., code-smell-detector is "Sal the Brooklyn Code Plumber").
+Agent definitions live in `.claude/agents/*.md` (the recursive `task-orchestrator` / `task-decomposer` / `task-worker` pipeline). When an agent defines a custom persona, include it in the Task prompt when invoking.
 
 ## Documentation Organization
 
@@ -387,8 +385,8 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Add/modify composable | Package's `CLAUDE.md` (Key Files, Common Tasks) |
 | Add/modify component | Package's `CLAUDE.md` (Key Files, Component Naming) |
 | Add/change API endpoint | Package's `CLAUDE.md` (API Patterns) |
-| Add generator feature | `packages/nuxt-crouton-cli/CLAUDE.md` |
-| Change CLI command | Generator's `CLAUDE.md` + `.claude/skills/crouton.md` |
+| Add generator feature | `packages/crouton-cli/CLAUDE.md` |
+| Change CLI command | `packages/crouton-cli/CLAUDE.md` + `.claude/skills/crouton.md` |
 | Add new field type | `.claude/skills/crouton.md` (Field Types table) |
 | Add/modify a page type (in a package or via `publishable`) | Always supply `name` + `description` + `icon` (required on `CroutonPageType`; surface in the pages page-type picker). See `packages/crouton-pages/CLAUDE.md` (Page Type Registration / Publishable Collections) |
 | Add new package | Create `packages/{name}/CLAUDE.md` |
@@ -412,12 +410,11 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/dependency-sweep/SKILL.md` | The "get dependencies current" flow — sweep, triage (safe/deliberate/wait), bump the pnpm catalog, prove it with the typecheck + e2e gate. No update bot by design (#141); run on-demand or when the quarterly sweep ticket is due |
 | Skill | `.claude/skills/task-decompose/SKILL.md` | Entry point to the recursive task-decomposition pipeline (`/task-decompose`) — one task → an epic + tree of sub-issues → agents. See "Task Decomposition Pipeline" below |
 | Skill | `.claude/skills/ui-proposal/SKILL.md` | Generate a before/after UI mockup (offline HTML/CSS/SVG) + render it to PNG for design sign-off before building UI. Part of the UI sign-off loop (#307) |
-| Agent | `.claude/agents/sync-checker.md` | Doc sync verification |
 | Agent | `.claude/agents/task-orchestrator.md` | Reads an epic, fans it into 2–6 top-level sub-issues, spawns a decomposer per child |
 | Agent | `.claude/agents/task-decomposer.md` | Recursive: LEAF TEST one issue → spawn a worker (leaf) or split into sub-issues + spawn a decomposer per child |
 | Agent | `.claude/agents/task-worker.md` | Implements one leaf issue on an isolated worktree branch → `pnpm typecheck` → `/commit` → PR (`Closes #NN`) |
-| MCP Server | `packages/nuxt-crouton-mcp-server/` | AI collection generation |
-| Themes | `packages/nuxt-crouton-themes/` | Swappable UI themes |
+| MCP Server | `packages/crouton-mcp/` | AI collection generation |
+| Themes | `packages/crouton-themes/` | Swappable UI themes |
 
 ### MCP Server Tools
 `design_schema` → `validate_schema` → `generate_collection` | also: `list_collections`, `list_layers`
@@ -431,7 +428,7 @@ Available: `KO` theme (hardware-inspired). Usage: `extends: ['@fyit/crouton-them
 
 When any task reveals repetitive work an MCP tool/resource/prompt could automate, capture with `/mcp-idea <description>` or add to `.claude/mcp-ideas.md`.
 
-MCP Servers: CLI MCP (`packages/nuxt-crouton-mcp-server/`), Docs MCP (`docs/server/mcp/`)
+MCP Servers: CLI MCP (`packages/crouton-mcp/`), Docs MCP (`docs/server/mcp/`)
 
 ## Key Reminders
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-The code word is a random song of the beatles.
-
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Your Role
@@ -121,10 +119,10 @@ If a feature genuinely requires a package change:
 
 The approval file is gitignored and session-scoped. Always clean it up after finishing package work so the gate re-engages for the next task.
 
-This applies to all agents, including Pi worker and sub-agents.
+This applies to all agents and sub-agents.
 
 ### Context Clearing Between Tasks
-After each task: announce completion, say the code word, STOP. User runs `/clear`. Fresh agent reads the relevant GitHub issue/epic (and PROGRESS_TRACKER.md if a phase rollup exists) and continues.
+After each task: announce completion, STOP. User runs `/clear`. Fresh agent reads the relevant GitHub issue/epic (and PROGRESS_TRACKER.md if a phase rollup exists) and continues.
 
 ## Technology Stack
 


### PR DESCRIPTION
Prunes the root `CLAUDE.md` of stale and contradictory content.

## What changed
- **Fixed broken references** — stale package paths (`nuxt-crouton-{mcp-server,themes,cli}` → `crouton-{mcp,themes,cli}`), removed the deleted `sync-checker` agent row and the non-existent `code-smell-detector` persona, and realigned the inline commit-scope list with the `/commit` skill's canonical list.
- **Resolved the PROGRESS_TRACKER contradiction** — reframed the task workflow (Task Execution Workflow, Issue Status Updates, Multi-Agent Continuity, Context Clearing, Critical Reminders) around GitHub issues as the unit of work; `PROGRESS_TRACKER.md` is now consistently described as the optional phase rollup.
- **Removed vestigial bits** — the Beatles "code word" ritual (definition + the "say the code word" step) and the ThinkGraph/Pi worker example (not in active use).

## Left for a later pass (pending owner call)
Nuxt MCP/Context7 rules, the "Key Reminders" tail recap, generic filler lines, and the "Your Role" blurb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uSxGm668PQnyVVPMfh5N4

---
_Generated by [Claude Code](https://claude.ai/code/session_019uSxGm668PQnyVVPMfh5N4)_