### PR TITLE
feat(root): UI visual sign-off loop — gate, revision loop, screenshot (#307)

### DIFF
--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -127,6 +127,34 @@ skips the gate entirely: no mockup, no comment, no hold.
 - **Conservative by design.** False-negative (treat a borderline diff as non-UI) is cheaper
   than false-positive (gating a pure-logic PR). When unsure, don't gate.
 
+### Revision & approval loop (#310)
+
+Posting the mockup is not the end. The ephemeral worker has already stopped, so an **attended
+session owns the loop** via `subscribe_pr_activity` on the draft PR (the orchestrator or the
+human's session subscribes and drives it per the harness's "Handling PR Activity Events"
+rules). Fully-headless, workflow-driven watching of the autonomous pipeline is tracked
+separately under #336 — don't build it here.
+
+While the PR is held (`status:blocked` + a `<!-- ui-proposal:<slug> -->` comment), each human
+(non-bot) reply is one of two things:
+
+- **Change request** (anything asking for a different look): revise
+  `writeups/ui-proposals/<slug>.html`, re-render the PNG (`render.mjs`), and **edit the same
+  sticky comment in place** — never post a new one. Append a one-line revision-history entry to
+  that comment (`- rN: <what changed>`) so the thread shows each round. The hold stays. Commit
+  the revised `.html` (`/commit`, scope `docs`) and push.
+- **Approval signal** — **any one of**:
+  - a human PR comment whose body contains **`approve`** or **`lgtm`** (case-insensitive), or
+  - a **👍 reaction** on the sticky mockup comment, or
+  - the **`ui-approved`** label on the PR.
+
+  On approval: remove `status:blocked`, drop a short "approved → building" note on the sticky
+  comment, and **resume the build** (step 6 onward). The post-build before/after screenshot
+  (#311) closes the loop and the draft PR is marked ready.
+
+**Ignore bot and self-authored comments** to avoid loops — same `user.type != 'Bot'` filter as
+`resume-on-comment.yml`.
+
 ## Epic-scoped package approval
 
 The `packages/` HARD GATE (`.claude/hooks/gate-package-edits.sh`) blocks edits under

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -57,13 +57,16 @@ a feature branch.
    - **Not UI → skip cleanly.** No mockup, no comment, no hold — go straight to implementation.
    - **UI → gate (HOLD, do not build yet):**
      1. Run the **`ui-proposal`** skill (`Skill` tool) to produce the mockup
-        `writeups/ui-proposals/<slug>.html` and render `screenshots/ui-proposal-<slug>.png`
-        (before/after for a change; after-only for net-new UI).
-     2. Commit the `.html` via **`/commit`** (scope `docs`) and **push** the branch.
+        `writeups/ui-proposals/<slug>.html`, a committed **`<slug>.md`** ("what changes" list,
+        one item per line — the commentable surface), and render
+        `screenshots/ui-proposal-<slug>.png` (before/after for a change; after-only for net-new).
+     2. Commit the `.html` + `.md` via **`/commit`** (scope `docs`) and **push** the branch —
+        the `.md` lands in the PR diff so it can be reviewed line-by-line.
      3. **Open the PR early as a draft** (`create_pull_request` with `draft: true`, same base
-        rules as the "Open a PR" step) so there's a surface to review on, then post the rendered
-        PNG as a **sticky** comment marked `<!-- ui-proposal:<slug> -->` — one comment, edited
-        in place on later rounds, never a flood.
+        rules as the "Open a PR" step). Post the rendered PNG as a **sticky** comment marked
+        `<!-- ui-proposal:<slug> -->` (the at-a-glance visual; one comment, edited in place,
+        never a flood) — but **steer feedback to inline comments on the committed `<slug>.md`
+        in the diff**, where each note pins to a specific change.
      4. Apply `status:blocked`, @mention the notify handle (`@pmcp`) noting it's **awaiting UI
         sign-off**, and **STOP** — do not implement. The revision/approval loop (#310) iterates
         the mockup on feedback and resumes the build on an approval signal; the real before/after
@@ -116,14 +119,19 @@ you **mock it before you build it**: generate a before/after (or after-only) moc
 waits for human sign-off. A non-visual diff (logic/types/`server/**`/config/tests/docs)
 skips the gate entirely: no mockup, no comment, no hold.
 
+- **Review happens on the diff, not the image.** A PNG can't be commented on. The committed
+  `<slug>.md` ("what changes", one item per line) is the **actionable** surface — the reviewer
+  inline-comments a specific change in "Files changed", no copying. The PNG is just the glance.
 - **One sticky comment.** The mockup PNG goes in a single comment carrying the marker
   `<!-- ui-proposal:<slug> -->`. On later rounds, **edit that comment in place** — never post
   a new one per revision.
 - **The hold is `status:blocked`** (the existing human-hold label), with an @mention of the
   notify handle so the owner is pinged. You stop after posting; you do not implement.
 - **Where the loop continues:** the revision/approval loop (#310) watches the PR, revises the
-  mockup on change-requests (re-rendering the PNG into the same sticky comment), and resumes
-  the build on an approval signal; the post-build before/after screenshot (#311) closes it.
+  mockup on change-requests — reading **inline review comments on the committed `<slug>.md`** in
+  the diff (plus top-level comments), re-rendering the PNG into the same sticky comment, and
+  replying to/resolving each thread — then resumes the build on an approval signal; the
+  post-build before/after screenshot (#311) closes it.
 - **Conservative by design.** False-negative (treat a borderline diff as non-UI) is cheaper
   than false-positive (gating a pure-logic PR). When unsure, don't gate.
 
@@ -138,11 +146,14 @@ separately under #336 — don't build it here.
 While the PR is held (`status:blocked` + a `<!-- ui-proposal:<slug> -->` comment), each human
 (non-bot) reply is one of two things:
 
-- **Change request** (anything asking for a different look): revise
-  `writeups/ui-proposals/<slug>.html`, re-render the PNG (`render.mjs`), and **edit the same
-  sticky comment in place** — never post a new one. Append a one-line revision-history entry to
-  that comment (`- rN: <what changed>`) so the thread shows each round. The hold stays. Commit
-  the revised `.html` (`/commit`, scope `docs`) and push.
+- **Change request.** Feedback arrives two ways — **inline review comments on the committed
+  `<slug>.md`/`.html` in the diff** (the primary, low-friction channel: each note is pinned to a
+  specific change) and top-level PR comments. Read **both** via `pull_request_read` (review
+  comments + threads). For each: revise the mockup (`<slug>.html` **and** the `<slug>.md` list),
+  re-render the PNG (`render.mjs`), **edit the sticky comment in place** (append
+  `- rN: <what changed>`), and **reply to / resolve each inline thread** you addressed so it's
+  clear what's done. Commit (`/commit`, scope `docs`) and push — the diff updates in place. The
+  hold stays.
 - **Approval signal** — **any one of**:
   - a human PR comment whose body contains **`approve`** or **`lgtm`** (case-insensitive), or
   - a **👍 reaction** on the sticky mockup comment, or

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -155,6 +155,26 @@ While the PR is held (`status:blocked` + a `<!-- ui-proposal:<slug> -->` comment
 **Ignore bot and self-authored comments** to avoid loops — same `user.type != 'Bot'` filter as
 `resume-on-comment.yml`.
 
+### Post-build screenshot (#311)
+
+After the approved UI is actually built (step 6) and typecheck is green, **prove the mockup
+became reality**: capture a real before/after of the changed surface and post it as a *separate*
+sticky comment marked `<!-- ui-screenshot:<slug> -->` (distinct from the mockup's
+`<!-- ui-proposal:<slug> -->` comment) so the mockup → real comparison is visible on the PR.
+
+- **Use the existing harness — don't hand-roll.** Boot the surface (a `fixtures/` app or the
+  relevant `apps/` app) and capture with **`scripts/app-shots.mjs`**:
+  `node scripts/app-shots.mjs <baseUrl> <route>:<slug>-after --out screenshots`. For the
+  **before**, capture the same route from the base branch (check out base / use the deployed
+  base) → `<slug>-before.png`. Both land in `screenshots/` (the gitignored hard-gate) — they're
+  posted to the PR, not committed.
+- **Be honest about reachability.** If the changed surface **isn't reachable** in a fixture or a
+  running app (no route, needs unavailable data/auth), **say so explicitly** in the comment
+  rather than implying verification — post the after-only shot or a plain note, never a fake
+  "before".
+- This is the closing step: once the screenshot comment is posted, mark the draft PR **ready
+  for review**.
+
 ## Epic-scoped package approval
 
 The `packages/` HARD GATE (`.claude/hooks/gate-package-edits.sh`) blocks edits under

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -47,28 +47,52 @@ a feature branch.
    `claude/issue-<issue_number>-<slug>` off the current base (the **epic branch** when one
    was passed — see "Epic integration branch" below; otherwise the repo base). One branch
    = one issue.
-5. **Implement** per the issue. Honour every CLAUDE.md rule:
+5. **UI sign-off gate — mock before you build (visual changes only).** Before implementing,
+   decide whether this issue changes a **visual surface**. Treat it as UI-touching if the work
+   will add or change any of: `**/*.vue`, `**/app/components/**`, `**/app/layouts/**`,
+   `**/app/pages/**`, a theme (`packages/crouton-themes/**`, a `ui:` block in `app.config.ts`),
+   or app CSS / Tailwind theme tokens. It is **not** UI (skip the gate) for pure
+   `<script>`/composables/types, `server/**`, config, tests, or docs — anything with no visible
+   result. Keep the test **conservative**: visual surfaces only; when unsure, it's not UI.
+   - **Not UI → skip cleanly.** No mockup, no comment, no hold — go straight to implementation.
+   - **UI → gate (HOLD, do not build yet):**
+     1. Run the **`ui-proposal`** skill (`Skill` tool) to produce the mockup
+        `writeups/ui-proposals/<slug>.html` and render `screenshots/ui-proposal-<slug>.png`
+        (before/after for a change; after-only for net-new UI).
+     2. Commit the `.html` via **`/commit`** (scope `docs`) and **push** the branch.
+     3. **Open the PR early as a draft** (`create_pull_request` with `draft: true`, same base
+        rules as the "Open a PR" step) so there's a surface to review on, then post the rendered
+        PNG as a **sticky** comment marked `<!-- ui-proposal:<slug> -->` — one comment, edited
+        in place on later rounds, never a flood.
+     4. Apply `status:blocked`, @mention the notify handle (`@pmcp`) noting it's **awaiting UI
+        sign-off**, and **STOP** — do not implement. The revision/approval loop (#310) iterates
+        the mockup on feedback and resumes the build on an approval signal; the real before/after
+        screenshot (#311) closes the loop after the build.
+6. **Implement** per the issue. Honour every CLAUDE.md rule:
    - `<script setup lang="ts">`, Nuxt UI **4** component names, VueUse-first, KISS.
    - **`packages/` HARD GATE** — do NOT edit anything under `packages/` unless this epic
      was approved to (epic-scoped approval — see "Epic-scoped package approval" below; the
      gate honours `$CROUTON_PACKAGE_EDIT_APPROVED`). If the edit isn't covered by the
      epic's approval, it's a **blocker**: comment + @mention + `status:blocked` + stop.
      Do not work around the gate.
-6. **Typecheck.** Run `pnpm -r --filter './apps/*' typecheck` (never `npx nuxt typecheck`
+7. **Typecheck.** Run `pnpm -r --filter './apps/*' typecheck` (never `npx nuxt typecheck`
    from root). Fix every error before continuing. Do not declare done with a red typecheck.
-7. **Commit + push immediately (CHECKPOINT).** Use the **`/commit`** skill (via the
+8. **Commit + push immediately (CHECKPOINT).** Use the **`/commit`** skill (via the
    `Skill` tool) — never `git commit` directly, never `git add .`. Reference the issue in
    the body, e.g. `(#<issue_number>)`. **Then push the branch right away**
    (`git push -u origin <branch>`), the moment the work is written and typecheck is green —
    **before any long step** (dev boot, deploy, extended verification). Sessions can be
    suspended mid-run: an unpushed worktree is lost work, a pushed branch is recoverable.
    Never sit on uncommitted changes across a long-running command.
-8. **Open a PR.** `mcp__github__create_pull_request` **into the epic branch** when one was
+9. **Open a PR.** `mcp__github__create_pull_request` **into the epic branch** when one was
    passed (else the repo base). The body MUST contain `Closes #<issue_number>` so the issue
    auto-closes on merge. Body follows `github-tasks` (👤/🤖 + `## 🧪 How to test`). End the
    PR body with the Generated-with-Claude-Code footer.
    - **Do not squash by default** (merge policy) — your commits are curated and atomic.
-9. **Report.** Return: branch name, PR url, **PR base (epic branch or main)**, typecheck
+   - **If the UI gate already opened a draft PR** (step 5), don't open a second one — reuse it:
+     push the implementation, then mark it ready for review (and let #311 post the real
+     screenshot). One issue still = one PR.
+10. **Report.** Return: branch name, PR url, **PR base (epic branch or main)**, typecheck
    status (green/red), and whether you hit the `packages/` gate. Keep it tight.
 
 ## Epic integration branch
@@ -83,6 +107,25 @@ in **integration-branch mode** (see the task-decompose skill):
   `main`. Sub-PRs merge into the epic branch; one final epic→`main` PR (opened per the
   skill) is where the whole feature gets its human review.
 - If no `epic_branch` is passed, fall back to the repo base (`main`) as before.
+
+## UI sign-off gate (#307)
+
+No UI lands unseen. When the work changes a **visual surface** (the heuristic in step 5),
+you **mock it before you build it**: generate a before/after (or after-only) mockup with the
+`ui-proposal` skill, post the rendered PNG on a **draft** PR, and **hold** — implementation
+waits for human sign-off. A non-visual diff (logic/types/`server/**`/config/tests/docs)
+skips the gate entirely: no mockup, no comment, no hold.
+
+- **One sticky comment.** The mockup PNG goes in a single comment carrying the marker
+  `<!-- ui-proposal:<slug> -->`. On later rounds, **edit that comment in place** — never post
+  a new one per revision.
+- **The hold is `status:blocked`** (the existing human-hold label), with an @mention of the
+  notify handle so the owner is pinged. You stop after posting; you do not implement.
+- **Where the loop continues:** the revision/approval loop (#310) watches the PR, revises the
+  mockup on change-requests (re-rendering the PNG into the same sticky comment), and resumes
+  the build on an approval signal; the post-build before/after screenshot (#311) closes it.
+- **Conservative by design.** False-negative (treat a borderline diff as non-UI) is cheaper
+  than false-positive (gating a pure-logic PR). When unsure, don't gate.
 
 ## Epic-scoped package approval
 

--- a/.claude/skills/ui-proposal/SKILL.md
+++ b/.claude/skills/ui-proposal/SKILL.md
@@ -49,9 +49,16 @@ node .claude/skills/ui-proposal/render.mjs writeups/ui-proposals/<slug>.html scr
 ```
 Uses the repo's Playwright (`@playwright/test`) headless Chromium — no network. Renders at 2× for a crisp image.
 
-## Step 4 — Hand off
-- **Commit** the `.html` (via `/commit`, scope `docs`).
-- The **PNG** is the thing to post in the PR comment (handled by the worker gate / revision-loop sub-issues #309/#310). When running this skill by hand, attach/post the PNG yourself.
+## Step 4 — Hand off (review happens on the DIFF)
+**Commit a text artifact so feedback can be inline.** Alongside the `.html`, write a
+`writeups/ui-proposals/<slug>.md` — the **"what changes"** list, one item per line. Committed,
+it lands in the PR's "Files changed", so the reviewer can click any line and comment on that
+specific change ("make this a switch", "drop this one") with no copying.
+
+- **Commit** the `.html` + `.md` (via `/commit`, scope `docs`).
+- The **PNG** is the at-a-glance visual to post as a PR comment (handled by the worker gate /
+  revision-loop #309/#310); steer feedback to **inline comments on the committed `.md`**. When
+  running this skill by hand, post the PNG and point the reviewer at the `.md` in the diff.
 
 ## Conventions
 - Before **and** after side-by-side for a *change*; **after-only** for net-new UI (no "before" exists).

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -191,3 +191,6 @@
 - name: "status:blocked"
   color: "d93f0b"
   description: "Blocked / waiting on something"
+- name: "ui-approved"
+  color: "0e8a16"
+  description: "UI sign-off given — the mockup is approved, build may proceed (#307/#310)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,6 +357,20 @@ import { useDrizzle } from '#server/utils/drizzle'
 When delegating: template scout first → parallel tasks → clear boundaries → smell check after.
 Agent definitions live in `.claude/agents/*.md` (the recursive `task-orchestrator` / `task-decomposer` / `task-worker` pipeline). When an agent defines a custom persona, include it in the Task prompt when invoking.
 
+## UI Sign-Off (mock before you build) — epic #307
+
+**When a task changes a visual surface, mock it before you build it.** Treat work as
+UI-touching if it adds/changes a `.vue` component, `app/components|layouts|pages/**`, a theme
+(`crouton-themes`, a `ui:` block in `app.config.ts`), or app CSS/theme tokens. Pure
+`<script>`/composables/types, `server/**`, config, tests, and docs are **not** UI — skip this.
+
+For a UI change: run the **`ui-proposal`** skill to produce a before/after (or after-only)
+mockup + PNG, get a human to sign off on the look-and-feel **first**, and only then build the
+real component. In the agent pipeline this is automated as a gate in `.claude/agents/task-worker.md`
+(post the mockup on a draft PR → hold on `status:blocked` → revise on feedback (#310) → build →
+real screenshot (#311)). In an interactive session, do the same by hand: propose, get a yes,
+then build. Be conservative — when unsure whether a diff is "visual", don't gate.
+
 ## Documentation Organization
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,10 @@ real component. In the agent pipeline this is automated as a gate in `.claude/ag
 real screenshot (#311)). In an interactive session, do the same by hand: propose, get a yes,
 then build. Be conservative — when unsure whether a diff is "visual", don't gate.
 
+**What counts as approval** (the sign-off signal): a reply containing `approve`/`lgtm`, a 👍 on
+the mockup comment, or the `ui-approved` label. Anything else is a change request — revise the
+mockup in place (edit the same sticky comment, re-render the PNG) and iterate until approved (#310).
+
 ## Documentation Organization
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,11 @@ real component. In the agent pipeline this is automated as a gate in `.claude/ag
 real screenshot (#311)). In an interactive session, do the same by hand: propose, get a yes,
 then build. Be conservative — when unsure whether a diff is "visual", don't gate.
 
+**Give feedback on the diff, not the image.** The proposed change is committed as a text
+artifact (the UI "what changes" list `<slug>.md`, or a schema's `.md` field table), so it shows
+up in the PR's "Files changed" — inline-comment the exact line, no copying. The agent reads
+those inline review comments and revises that specific item.
+
 **What counts as approval** (the sign-off signal): a reply containing `approve`/`lgtm`, a 👍 on
 the mockup comment, or the `ui-approved` label. Anything else is a change request — revise the
 mockup in place (edit the same sticky comment, re-render the PNG) and iterate until approved (#310).


### PR DESCRIPTION
Completes epic **#307** — every UI change now ships with an approve-before-build visual sign-off loop. Builds on #308 (the `ui-proposal` skill, already merged); this PR wires the remaining three sub-issues into the agent flow.

## 👤 For humans

No UI lands unseen. When an agent's task changes a visual surface, it now:
1. **mocks it first** (before/after) and posts the mockup on a draft PR,
2. **holds** the build and lets you **iterate** — reply with changes and the mockup is revised in place until you approve,
3. once approved, **builds** the real UI and posts a **real before/after screenshot** as proof.

Pure logic/server/config/docs changes are unaffected.

```mermaid
flowchart TD
    A["UI diff detected"] --> B["Mockup on draft PR · hold (status:blocked)"]
    B --> C{"Happy?"}
    C -- "change request" --> D["Revise mockup in place"]
    D --> B
    C -- "approve / lgtm / 👍 / ui-approved" --> E["Build the real UI"]
    E --> F["Real before/after screenshot ✅ · PR ready"]
```

## 🤖 For agents

All `.claude/`-scoped prose + one label — no app/package code.

- **#309** — `task-worker.md` step 5 "UI sign-off gate": conservative visual-surface heuristic; on UI → run `ui-proposal`, commit the `.html`, open a **draft** PR, post the PNG as a sticky `<!-- ui-proposal:<slug> -->` comment, `status:blocked` + `@pmcp`, **hold**. Non-UI skips cleanly. `CLAUDE.md` mock-first rule for interactive sessions.
- **#310** — "Revision & approval loop": attended `subscribe_pr_activity` (headless workflow watching is #336); change request → revise `.html` + re-render + edit the same sticky comment in place (`- rN:` history); **approval signal = `approve`/`lgtm` comment OR 👍 OR `ui-approved` label** → unblock → resume build. Added the `ui-approved` label to `.github/labels.yml`.
- **#311** — "Post-build screenshot": capture via `scripts/app-shots.mjs` into `screenshots/` (gitignored), post as a separate sticky `<!-- ui-screenshot:<slug> -->` comment; before = same route on base; honest-reachability clause; mark PR ready.

## 🧪 How to test

- Markdown/YAML only (agent prose + `CLAUDE.md` + `labels.yml`) — no TS, `pnpm typecheck` N/A.
- Read `.claude/agents/task-worker.md` steps 5–10 + the "UI sign-off gate (#307)" section: the flow is coherent (gate → revise → approve → build → screenshot), the approval signal is unambiguous, and non-UI diffs skip.
- `ui-approved` syncs to GitHub when `labels.yml` lands on `main`.

Closes #309
Closes #310
Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VL6iKWWi3MA4m8BLi3k9j

---
_Generated by [Claude Code](https://claude.ai/code/session_013VL6iKWWi3MA4m8BLi3k9j)_