### PR TITLE
feat(root): schema-review skill — render a collection schema for sign-off (#315)

### DIFF
--- a/.claude/skills/schema-review/SKILL.md
+++ b/.claude/skills/schema-review/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: schema-review
+description: Render a crouton collection schema (the field-definition JSON) into a human-readable field table + relationships sketch (HTML + PNG + a terse Markdown table), so a human can sign off on the DATA MODEL before any code is generated. Use when an agent drafts or changes a collection schema (before `crouton config` / `generate_collection`), or when asked to "review a schema", "show the data model", "check these fields".
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Schema Review — check the data model before you generate it
+
+Turns a raw collection schema (field-definition JSON) into a **reviewable artifact**: a
+skimmable field table (name · type · required · translatable · default · references) plus a
+small relationships sketch — so the data model can be approved *before* `crouton config`
+generates the Form / List / API / migration from it.
+
+This is the schema analog of the `ui-proposal` skill, and the foundation of the schema
+sign-off loop (epic #314): produce the review → it gets posted on the PR → iterate on
+feedback → only then generate the collection. The schema is the foundation; a wrong field
+type or missing relationship means regenerating the whole collection, so approving it first
+is cheap and fixing it after is not.
+
+> **Why a PNG?** GitHub comments can't render raw HTML/CSS. The committed `.html` is the
+> editable source; the `.png` is what gets posted (plus the inline Markdown table).
+
+## When to use
+- An agent has drafted/changed a **collection schema** (the `fieldsFile` JSON, or MCP
+  `design_schema` output) and is about to run `crouton config` / `generate_collection`.
+- The user asks to "review the schema", "show the data model", "check these fields".
+- **Skip** for non-schema work (no collection / field defs involved).
+
+It sits **after** the machine `validate_schema` step (which checks the JSON is well-formed)
+— this is the **human** gate on top of it.
+
+## What it produces
+| Artifact | Path | Committed? |
+|----------|------|-----------|
+| Review source (HTML) | `writeups/schema-reviews/<collection>.html` | ✅ yes (editable source of truth) |
+| Markdown table | `writeups/schema-reviews/<collection>.md` | ✅ yes (inline-postable) |
+| Rendered image | `screenshots/schema-review-<collection>.png` | ❌ no — `screenshots/` is gitignored; it's posted to the PR, not committed |
+
+## Step 1 — Get the schema JSON
+Obtain the field-definition JSON for the collection (the `fieldsFile`, or the MCP
+`design_schema` output). Save it to a file, e.g. `/tmp/<collection>.schema.json`. The
+renderer accepts any of these shapes:
+- `{ "collection": "products", "fields": { ... } }`
+- `{ "fields": { ... } }`
+- a flat map `{ "name": { "type": "string" }, ... }` (pass `--collection <name>`).
+
+Each field follows the crouton schema (see the `crouton` skill): `type`, optional `meta`
+(`required`, `unique`, `primaryKey`, `default`, `precision`/`scale`, `options` +
+`displayAs`, `optionsCollection`…), `translatable`, and `refTarget`/`refScope` for relations.
+
+## Step 2 — Render the review
+```bash
+node .claude/skills/schema-review/render-schema.mjs /tmp/<collection>.schema.json
+# → writes writeups/schema-reviews/<collection>.html + .md, and prints the Markdown table
+# options: --collection <name>   --out-dir <dir>
+```
+
+## Step 3 — Render to PNG (shared renderer from #308)
+```bash
+node .claude/skills/ui-proposal/render.mjs \
+  writeups/schema-reviews/<collection>.html \
+  screenshots/schema-review-<collection>.png
+```
+Uses the repo's Playwright headless Chromium — offline, no network.
+
+## Step 4 — Hand off
+- **Commit** the `.html` + `.md` (via `/commit`, scope `docs`).
+- **Post** the PNG (and/or the Markdown table) for review. The gate + revision loop that
+  hold `crouton config` until approval are wired in **#316** (which reuses the generic
+  approval loop from #310). When running this skill by hand, post the PNG/table yourself.
+
+## Conventions
+- One review per collection; re-render after every schema edit so the artifact never drifts.
+- The field table is the source of truth for review — keep it honest (mirror the actual JSON,
+  including primary keys 🔑, `unique`, defaults, and every relationship).
+- Keep it focused on the one collection under discussion.

--- a/.claude/skills/schema-review/SKILL.md
+++ b/.claude/skills/schema-review/SKILL.md
@@ -63,11 +63,21 @@ node .claude/skills/ui-proposal/render.mjs \
 ```
 Uses the repo's Playwright headless Chromium — offline, no network.
 
-## Step 4 — Hand off
-- **Commit** the `.html` + `.md` (via `/commit`, scope `docs`).
-- **Post** the PNG (and/or the Markdown table) for review. The gate + revision loop that
-  hold `crouton config` until approval are wired in **#316** (which reuses the generic
-  approval loop from #310). When running this skill by hand, post the PNG/table yourself.
+## Step 4 — Hand off (review happens on the DIFF)
+**The committed Markdown is the actionable review surface — not the image.** A PNG can't be
+commented on; the reviewer would have to copy text and describe which field they mean. The
+`.md` lands in the PR's "Files changed", one field per row, so the reviewer can click the `+`
+on any line and leave an **inline comment pinned to that exact field** ("make this `decimal`",
+"add a `slug` field here") — no copying, no describing.
+
+- **Commit** `writeups/schema-reviews/<collection>.md` **and** `.html` (via `/commit`, scope
+  `docs`) so the `.md` appears in the PR diff. This is where feedback goes.
+- The **PNG** is the optional at-a-glance visual — post it in the PR description/comment, but
+  steer feedback to the diff.
+- The gate + revision loop that hold `crouton config` until approval are wired in **#316**
+  (reusing the generic approval loop from #310): it reads the **inline review comments** on the
+  committed `.md`, revises the schema field-by-field, re-renders, and replies to/resolves each
+  thread. When running this skill by hand, point the reviewer at the committed `.md` in the diff.
 
 ## Conventions
 - One review per collection; re-render after every schema edit so the artifact never drifts.

--- a/.claude/skills/schema-review/example.schema.json
+++ b/.claude/skills/schema-review/example.schema.json
@@ -1,0 +1,17 @@
+{
+  "collection": "products",
+  "fields": {
+    "id": { "type": "string", "meta": { "primaryKey": true } },
+    "name": { "type": "string", "meta": { "required": true, "maxLength": 255 }, "translatable": true },
+    "description": { "type": "text", "translatable": true },
+    "price": { "type": "decimal", "meta": { "required": true, "precision": 10, "scale": 2 } },
+    "active": { "type": "boolean", "meta": { "default": true } },
+    "status": {
+      "type": "string",
+      "meta": { "required": true, "displayAs": "optionsSelect", "options": ["draft", "published", "archived"] }
+    },
+    "sku": { "type": "string", "meta": { "unique": true } },
+    "categoryId": { "type": "string", "refTarget": "categories" },
+    "supplierId": { "type": "string", "refTarget": "suppliers", "refScope": "adapter" }
+  }
+}

--- a/.claude/skills/schema-review/render-schema.mjs
+++ b/.claude/skills/schema-review/render-schema.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * schema-review renderer — turn a crouton collection schema (field-definition JSON)
+ * into a human-readable artifact for sign-off BEFORE any code is generated:
+ *   - an offline, self-contained HTML field table + relationships sketch
+ *   - a terse Markdown table (for inline PR/issue use)
+ *
+ *   node render-schema.mjs <schema.json> [--collection NAME] [--out-dir DIR]
+ *
+ *   --collection NAME   override the collection name (else taken from the JSON)
+ *   --out-dir DIR       output dir (default: writeups/schema-reviews)
+ *
+ * Outputs <out-dir>/<collection>.html and <out-dir>/<collection>.md, and prints the
+ * Markdown to stdout. Rasterise the HTML to a PNG with the SHARED renderer from #308:
+ *   node .claude/skills/ui-proposal/render.mjs <out-dir>/<collection>.html \
+ *        screenshots/schema-review-<collection>.png
+ *
+ * Dependency-free Node (mirrors epic-digest's render.mjs).
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+
+const argv = process.argv.slice(2)
+function opt(flag, def) {
+  const i = argv.indexOf(flag)
+  if (i === -1) return def
+  const v = argv[i + 1]
+  argv.splice(i, 2)
+  return v
+}
+let outDir = opt('--out-dir', 'writeups/schema-reviews')
+const collectionOverride = opt('--collection', null)
+const [input] = argv.filter((a) => !a.startsWith('--'))
+
+if (!input) {
+  console.error('Usage: render-schema.mjs <schema.json> [--collection NAME] [--out-dir DIR]')
+  process.exit(1)
+}
+
+const raw = JSON.parse(readFileSync(resolve(input), 'utf8'))
+
+// ── Normalise: accept { collection, fields:{} } | { fields:{} } | flat {name:def} ──
+const collection =
+  collectionOverride || raw.collection || raw.name || raw.collectionName || 'collection'
+const fieldsObj = raw.fields && typeof raw.fields === 'object' ? raw.fields : raw
+
+function isFieldDef(def) {
+  return def && typeof def === 'object' && (def.type || def.refTarget || def.meta || def.properties)
+}
+
+function typeLabel(def) {
+  const meta = def.meta || {}
+  let t = def.type || 'string'
+  if (t === 'decimal' && (meta.precision || meta.scale)) {
+    t += `(${meta.precision ?? '?'},${meta.scale ?? 0})`
+  }
+  if (meta.displayAs === 'optionsSelect') {
+    if (Array.isArray(meta.options)) t = `select [${meta.options.join(', ')}]`
+    else if (meta.optionsCollection) t = `select ← ${meta.optionsCollection}.${meta.optionsField ?? '?'}`
+  }
+  if (t === 'repeater' && Array.isArray(def.translatableProperties)) {
+    t = `repeater {${Object.keys(def.properties || {}).join(', ')}}`
+  }
+  return t
+}
+
+const rows = []
+for (const [name, def] of Object.entries(fieldsObj)) {
+  if (!isFieldDef(def)) continue
+  const meta = def.meta || {}
+  rows.push({
+    name,
+    type: typeLabel(def),
+    required: !!(meta.required ?? def.required),
+    translatable: !!(def.translatable ?? meta.translatable ?? def.translatableProperties?.length),
+    primaryKey: !!meta.primaryKey,
+    unique: !!meta.unique,
+    default: meta.default ?? def.default ?? '',
+    refTarget: def.refTarget || '',
+    refScope: def.refScope || '',
+  })
+}
+
+const relations = rows.filter((r) => r.refTarget)
+
+// ── Markdown ──
+const yn = (b) => (b ? '✓' : '')
+const md = [
+  `### Schema review — \`${collection}\``,
+  '',
+  `${rows.length} field${rows.length === 1 ? '' : 's'}${relations.length ? ` · ${relations.length} relationship${relations.length === 1 ? '' : 's'}` : ''}`,
+  '',
+  '| Field | Type | Required | Translatable | Default | → References |',
+  '|---|---|:--:|:--:|---|---|',
+  ...rows.map(
+    (r) =>
+      `| \`${r.name}\`${r.primaryKey ? ' 🔑' : ''}${r.unique ? ' ·uniq' : ''} | ${r.type} | ${yn(r.required)} | ${yn(r.translatable)} | ${r.default === '' ? '' : `\`${r.default}\``} | ${r.refTarget ? `\`${r.refTarget}\`${r.refScope ? ` (${r.refScope})` : ''}` : ''} |`,
+  ),
+  '',
+  relations.length
+    ? `**Relationships:** ${relations.map((r) => `\`${collection}.${r.name}\` → \`${r.refTarget}\``).join(' · ')}`
+    : '_No relationships._',
+  '',
+].join('\n')
+
+// ── HTML (offline, self-contained — same dark palette as ui-proposal) ──
+const esc = (s) => String(s).replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c])
+const chip = (on, label) =>
+  on ? `<span class="chip on">${label}</span>` : `<span class="chip">·</span>`
+
+const rowHtml = rows
+  .map(
+    (r) => `      <tr>
+        <td class="fname">${esc(r.name)}${r.primaryKey ? '<span class="pk" title="primary key">🔑</span>' : ''}${r.unique ? '<span class="u" title="unique">uniq</span>' : ''}</td>
+        <td><code>${esc(r.type)}</code></td>
+        <td class="c">${chip(r.required, 'req')}</td>
+        <td class="c">${chip(r.translatable, 'i18n')}</td>
+        <td>${r.default === '' ? '<span class="muted">—</span>' : `<code>${esc(r.default)}</code>`}</td>
+        <td>${r.refTarget ? `<span class="ref">→ ${esc(r.refTarget)}</span>${r.refScope ? ` <span class="muted">(${esc(r.refScope)})</span>` : ''}` : '<span class="muted">—</span>'}</td>
+      </tr>`,
+  )
+  .join('\n')
+
+const relHtml = relations.length
+  ? relations
+      .map(
+        (r) =>
+          `<li><code>${esc(collection)}.${esc(r.name)}</code> <span class="arrow">→</span> <code>${esc(r.refTarget)}</code>${r.refScope ? ` <span class="muted">(${esc(r.refScope)})</span>` : ''}</li>`,
+      )
+      .join('\n')
+  : '<li class="muted">No relationships — this collection stands alone.</li>'
+
+const html = `<!DOCTYPE html>
+<!-- schema-review — generated by .claude/skills/schema-review/render-schema.mjs. No JS/CDN. -->
+<html lang="en"><head><meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Schema review — ${esc(collection)}</title>
+<style>
+  :root{--page:#0a0e17;--ink:#e8edf6;--muted:#8b97ad;--card:#151b27;--card-2:#11161f;
+    --line:#222b3a;--green:#34d399;--green-d:#0e3a2a;}
+  *{box-sizing:border-box;}
+  body{margin:0;background:radial-gradient(1100px 500px at 75% -10%,#16213c 0%,var(--page) 55%);
+    color:var(--ink);line-height:1.5;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;-webkit-font-smoothing:antialiased;}
+  .wrap{max-width:900px;margin:0 auto;padding:36px 22px 60px;}
+  .eyebrow{text-transform:uppercase;letter-spacing:.18em;font-size:12px;color:var(--green);font-weight:700;}
+  h1{font-size:30px;margin:6px 0 2px;}
+  h1 code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:.8em;background:rgba(52,211,153,.12);color:#a9f0d2;padding:2px 10px;border-radius:8px;}
+  .lede{color:var(--muted);font-size:14px;margin:0 0 24px;}
+  table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:14px;overflow:hidden;}
+  th,td{text-align:left;padding:11px 14px;border-bottom:1px solid var(--line);font-size:13.5px;vertical-align:top;}
+  th{background:var(--card-2);color:var(--muted);text-transform:uppercase;letter-spacing:.06em;font-size:11px;}
+  td.c{text-align:center;} tr:last-child td{border-bottom:none;}
+  .fname{font-family:ui-monospace,Menlo,Consolas,monospace;font-weight:600;color:#fff;}
+  .pk{margin-left:6px;} .u{margin-left:6px;font-size:10px;color:var(--muted);border:1px solid var(--line);border-radius:5px;padding:0 4px;font-family:inherit;}
+  code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:.92em;color:#cdd6e6;}
+  .chip{display:inline-block;min-width:34px;font-size:11px;color:var(--muted);}
+  .chip.on{color:#04231a;background:var(--green);font-weight:700;border-radius:999px;padding:1px 8px;}
+  .ref{color:var(--green);} .arrow{color:var(--muted);} .muted{color:var(--muted);}
+  h3{margin:28px 0 10px;font-size:15px;}
+  .rel{background:#101725;border:1px solid var(--line);border-radius:14px;padding:14px 18px;}
+  .rel ul{margin:0;padding:0;list-style:none;display:grid;gap:8px;font-size:13.5px;}
+  footer{margin-top:26px;color:var(--muted);font-size:12px;text-align:center;}
+</style></head>
+<body><div class="wrap">
+  <span class="eyebrow">nuxt-crouton · schema review</span>
+  <h1>Collection <code>${esc(collection)}</code></h1>
+  <p class="lede">${rows.length} field${rows.length === 1 ? '' : 's'}${relations.length ? ` · ${relations.length} relationship${relations.length === 1 ? '' : 's'}` : ''} — review the data model before generating Form / List / API / migration.</p>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Req</th><th>i18n</th><th>Default</th><th>References</th></tr></thead>
+    <tbody>
+${rowHtml}
+    </tbody>
+  </table>
+  <h3>Relationships</h3>
+  <div class="rel"><ul>
+${relHtml}
+  </ul></div>
+  <footer>Schema review · generated offline · approve the fields, then generate the collection.</footer>
+</div></body></html>
+`
+
+mkdirSync(resolve(outDir), { recursive: true })
+const htmlPath = join(outDir, `${collection}.html`)
+const mdPath = join(outDir, `${collection}.md`)
+writeFileSync(resolve(htmlPath), html)
+writeFileSync(resolve(mdPath), md)
+
+console.log(md)
+console.log(`\n✓ HTML → ${htmlPath}`)
+console.log(`✓ MD   → ${mdPath}`)
+console.log(
+  `→ PNG:  node .claude/skills/ui-proposal/render.mjs ${htmlPath} screenshots/schema-review-${collection}.png`,
+)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/dependency-sweep/SKILL.md` | The "get dependencies current" flow — sweep, triage (safe/deliberate/wait), bump the pnpm catalog, prove it with the typecheck + e2e gate. No update bot by design (#141); run on-demand or when the quarterly sweep ticket is due |
 | Skill | `.claude/skills/task-decompose/SKILL.md` | Entry point to the recursive task-decomposition pipeline (`/task-decompose`) — one task → an epic + tree of sub-issues → agents. See "Task Decomposition Pipeline" below |
 | Skill | `.claude/skills/ui-proposal/SKILL.md` | Generate a before/after UI mockup (offline HTML/CSS/SVG) + render it to PNG for design sign-off before building UI. Part of the UI sign-off loop (#307) |
+| Skill | `.claude/skills/schema-review/SKILL.md` | Render a collection schema (field-definition JSON) into a human-readable field table + relationships (HTML + PNG + Markdown) for data-model sign-off before `crouton config` generates code. Part of the schema sign-off loop (#314) |
 | Agent | `.claude/agents/task-orchestrator.md` | Reads an epic, fans it into 2–6 top-level sub-issues, spawns a decomposer per child |
 | Agent | `.claude/agents/task-decomposer.md` | Recursive: LEAF TEST one issue → spawn a worker (leaf) or split into sub-issues + spawn a decomposer per child |
 | Agent | `.claude/agents/task-worker.md` | Implements one leaf issue on an isolated worktree branch → `pnpm typecheck` → `/commit` → PR (`Closes #NN`) |

--- a/scripts/gen-skills-doc.mjs
+++ b/scripts/gen-skills-doc.mjs
@@ -23,6 +23,7 @@ const OUT = join(ROOT, 'writeups/architecture/skills-and-triggers.html')
 const META = {
   crouton: { group: 'build', triggers: ['ask'] },
   'ui-proposal': { group: 'build', triggers: ['flow', 'ask'] },
+  'schema-review': { group: 'build', triggers: ['flow', 'ask'] },
   'task-decompose': { group: 'build', triggers: ['ask', 'flow'] },
   'github-tasks': { group: 'plan', triggers: ['ask', 'flow'] },
   'epic-digest': { group: 'plan', triggers: ['ask'] },

--- a/writeups/architecture/skills-and-triggers.html
+++ b/writeups/architecture/skills-and-triggers.html
@@ -92,6 +92,10 @@
         <p class="what">This skill helps generate complete CRUD collections for Nuxt Crouton applications.</p>
       </div>
       <div class="skill">
+        <div class="skill-head"><span class="name">/schema-review</span><span class="badges"><span class="b flow">in flow</span><span class="b ask">on ask</span></span></div>
+        <p class="what">Render a crouton collection schema (the field-definition JSON) into a human-readable field table + relationships sketch (HTML + PNG + a terse Markdown table), so a human can sign off on the DATA MODEL before any code is generated. Use when an agent drafts or changes a collection schema (before `crouton config` / `generate_collection`), or when asked to "review a schema", "show the data model", "check these fields".</p>
+      </div>
+      <div class="skill">
         <div class="skill-head"><span class="name">/task-decompose</span><span class="badges"><span class="b ask">on ask</span><span class="b flow">in flow</span></span></div>
         <p class="what">Turn one task into a tree of GitHub issues worked by agents. Creates (or reuses) an epic issue, then launches the recursive orchestrator → decomposer → worker pipeline. Use when asked to "decompose a task", "break this down into issues and work it", "spawn agents to build X", or run via /task-decompose.</p>
       </div>


### PR DESCRIPTION
First sub-issue of epic **#314** (schema review gate). The reusable piece that makes a collection schema human-reviewable, so the **data model** can be signed off before `crouton config` generates Form / List / API / migration from it.

## 👤 For humans

A new `schema-review` skill turns a collection's raw field-definition JSON into a skimmable **field table + relationships sketch** — HTML, a rendered PNG, and a terse Markdown table. Sanity-check the fields at a glance instead of reading JSON; a wrong type or missing relationship is cheap to fix here and expensive after generation.

## 🤖 For agents

- **`.claude/skills/schema-review/render-schema.mjs`** — dependency-free Node. Accepts `{ collection, fields }`, `{ fields }`, or a flat field map. Emits `writeups/schema-reviews/<collection>.{html,md}` and prints the Markdown. Columns: name · type (+ decimal precision, select options, `optionsCollection`, repeater props) · required · translatable · default · `refTarget`(+`refScope`); flags 🔑 primaryKey & `unique`; lists relationships.
- **PNG via the shared `ui-proposal/render.mjs` (#308)** — not duplicated, per the issue.
- **`SKILL.md`** (mirrors `ui-proposal`) + **`example.schema.json`** (worked `products` sample).
- Registered in `gen-skills-doc.mjs` META + the `CLAUDE.md` skills table; regenerated `writeups/architecture/skills-and-triggers.html` (the `skills-doc.yml` CI gate).

## 🧪 How to test

```bash
node .claude/skills/schema-review/render-schema.mjs .claude/skills/schema-review/example.schema.json
node .claude/skills/ui-proposal/render.mjs writeups/schema-reviews/products.html screenshots/schema-review-products.png
```
Verified: the `products` sample renders **9 fields / 2 relationships** correctly (decimal precision, select options, 🔑/unique flags, `categoryId→categories`, `supplierId→suppliers (adapter)`). No TS — `pnpm typecheck` N/A.

## Note on sequencing

The other half of #314 — **#316** (gate `crouton config` on schema approval + revision loop) — explicitly **reuses the #310 approval loop** and edits `task-worker.md`/`CLAUDE.md`. That machinery is in PR #373 (epic #307), not yet on `main`, so #316 is intentionally **deferred until #373 merges** to avoid duplicating the loop and conflicting on the same files.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VL6iKWWi3MA4m8BLi3k9j

---
_Generated by [Claude Code](https://claude.ai/code/session_013VL6iKWWi3MA4m8BLi3k9j)_