### PR TITLE
fix(crouton-cli): crouton-seed must not discover providers from devDependencies (#303)

### DIFF
--- a/packages/crouton-cli/lib/seed-app.ts
+++ b/packages/crouton-cli/lib/seed-app.ts
@@ -50,9 +50,17 @@ async function tsImport(jiti: ReturnType<typeof createJiti>, specifier: string):
   return mod
 }
 
-/** The `@fyit/crouton-*` dependency names declared in a package.json object. */
+/**
+ * The `@fyit/crouton-*` *runtime* dependency names declared in a package.json
+ * object — `dependencies` + `peerDependencies` only. `devDependencies` are
+ * deliberately excluded: a package contributes runtime tables only if the app
+ * actually extends it, whereas build-time devDeps (e.g. `@fyit/crouton-cli` and
+ * the `@fyit/crouton-*` packages it transitively pulls in) ship no migrations
+ * for this app. Including them made the BFS over-discover providers and emit
+ * `INSERT`s into non-existent tables (#303).
+ */
 function croutonDepNames(pkg: any): string[] {
-  const deps = { ...pkg?.dependencies, ...pkg?.devDependencies, ...pkg?.peerDependencies }
+  const deps = { ...pkg?.dependencies, ...pkg?.peerDependencies }
   return Object.keys(deps).filter(name => name.startsWith('@fyit/crouton'))
 }
 


### PR DESCRIPTION
## 🎯 The bet

**We think that** scoping `crouton-seed`'s package discovery to *runtime* deps (instead of also walking `devDependencies`) will stop it seeding providers for packages an app doesn't actually extend — **and** that's what we want, because those phantom providers were emitting `INSERT`s into non-existent tables and failing the seed.

**We'll be right if** an app that only extends `core`/`auth`/`i18n` produces seed SQL with no `pages_pages` / `sales_events` inserts, while an app that genuinely extends pages/sales (fanfare) is unchanged.

## What changed

`croutonDepNames` in `packages/crouton-cli/lib/seed-app.ts` merged `dependencies` + **`devDependencies`** + `peerDependencies`. Because `@fyit/crouton-cli` is a devDependency (and it transitively pulls in other `@fyit/crouton-*` packages), the BFS over-reached: `pocs/blog` (extends only core/auth/i18n) discovered `pages` and `sales` providers and emitted `INSERT INTO pages_pages` / `sales_events` — tables it has no migrations for.

Now `croutonDepNames` merges **`dependencies` + `peerDependencies` only**. A package contributes runtime seed tables only when the app actually extends it; build-time devDeps ship no migrations for the app, so they no longer drag in providers.

## Verification

- ✅ All **263 crouton-cli tests pass** (`pnpm --filter @fyit/crouton-cli test`)
- ✅ Transitively-bundled *runtime* layers (e.g. `crouton-auth` via `crouton-core`'s `dependencies`) are still discovered — unchanged path
- ✅ `apps/fanfare` extends `pages`/`sales` as real `dependencies` → its seed is unaffected

## Follow-ups (out of scope, noted on the issue)

- Optional "skip a provider when its target table is missing (warn, don't fail the batch)" hardening
- Align the POC scaffold's bespoke seed template to use `crouton-seed` once this lands

Part of epic #291.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ro9BhjKA1nhY3HDQMmLchk)_