### PR TITLE
docs(root): always link issue/PR URLs when mentioning them in chat

### DIFF
--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -86,6 +86,7 @@ Don't stop at the issue you were asked about; closing the leaf without checking 
    - `worker:<name>` for `workers/*`
    - Package work that also lands a schema/config change in an app gets **both** (e.g. `pkg:crouton-sales` + `app:fanfare`).
 4. Use meta labels where they apply: `epic`, `spike`, `needs-triage`.
+5. **Link issues & PRs when talking to the user.** Any time you mention an issue/PR in a chat reply, render it as a clickable link to the full URL (`[#303](https://github.com/pmcp/nuxt-crouton/issues/303)`, `[#376](https://github.com/pmcp/nuxt-crouton/pull/376)`) so the owner can open it in one click. This is a **chat-reply** convention only — commit messages keep bare `(#NN)`, and PR bodies use `Closes #NN` (not a URL) so GitHub auto-closes the issue on merge.
 
 ## Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ Every task is a **GitHub issue** (see `### GitHub Issue Tracking` below) and fol
 
 Tasks are tracked as **GitHub issues** (`pmcp/nuxt-crouton`) — see the `github-tasks` skill. The issue is the unit of work: open an **epic + sub-issues** for an initiative, label each by **package or app** (never `root`; exactly one `type:*`). Work lands via a **PR** on a feature branch (commit with `/commit`, reference `(#NN)`, put `Closes #NN` in the PR body to auto-close on merge) — not direct pushes to `main`. `writeups/PROGRESS_TRACKER.md` becomes an optional phase-level rollup, not the per-task tracker.
 
+**Always link issues & PRs when you mention them in chat.** Whenever you reference an issue or PR to the user (in prose, lists, or tables), include its full URL so it's one click to open — `#NN` alone isn't clickable. Format: `#303` → `[#303](https://github.com/pmcp/nuxt-crouton/issues/303)` for issues, `…/pull/376` for PRs. This is a **chat-reply** convention only — keep bare `(#NN)` in commit messages, and use `Closes #NN` (not a URL) in PR bodies so GitHub's auto-close works.
+
 **Write issues & epics as bets, not task lists (default).** Frame work as an assumption — *We think that* if we do X, then Y will happen (and Y is what we want) · *We'll do that by* … · *We'll be right if* … · *We'll know by* … — so we can later check whether we were right. It's a lens over the existing 👤/🤖/🧪 sections (open with `## 🎯 The bet`), not a new heading. Use it for every epic/issue as much as possible; trivial chores may opt out. Full template + worked examples in the `github-tasks` skill (epic #359).
 
 ### Task Decomposition Pipeline (`/task-decompose`)
@@ -99,6 +101,7 @@ When starting or resuming: read the relevant GitHub issue/epic first (plus `writ
 - ✅ ALWAYS use `/commit` skill for ALL commits
 - ✅ ALWAYS run `pnpm typecheck` after code changes
 - ✅ ALWAYS keep the GitHub issue updated (in-progress → closed via `Closes #NN`)
+- ✅ ALWAYS link the full issue/PR URL when mentioning one in chat (e.g. `[#303](https://github.com/pmcp/nuxt-crouton/issues/303)`) — bare `#NN` isn't clickable
 - ✅ ALWAYS use TodoWrite for 3+ step tasks
 - ❌ NEVER batch multiple tasks in one commit
 - ❌ NEVER use `git add .`


### PR DESCRIPTION
## 👤 For humans

When I reference an issue or PR in a chat reply, I'll now include its full clickable URL so you can open the ticket in one click instead of copy-pasting the number.

## 🤖 For agents

- **CLAUDE.md** — new rule in *GitHub Issue Tracking* + a ✅ entry in *Critical Reminders*: render `#NN` as `[#NN](https://github.com/pmcp/nuxt-crouton/issues|pull/NN)` in chat replies.
- **`.claude/skills/github-tasks/SKILL.md`** — same rule added as Core rule #5.
- **Chat-only convention:** commit messages keep bare `(#NN)`; PR bodies keep `Closes #NN` (not a URL) so GitHub's auto-close still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ro9BhjKA1nhY3HDQMmLchk)_