### PR TITLE
Add a mobile-friendly db-clone "Run workflow" button

### DIFF
--- a/.claude/skills/db-clone/SKILL.md
+++ b/.claude/skills/db-clone/SKILL.md
@@ -19,6 +19,14 @@ node scripts/db-clone.mjs --app <app> --from <env> --to <env> [--dry-run] [--yes
 `<env>` is `prod` (the wrangler.jsonc top level) or any key under `env.*`
 (`staging`, `preview`, …).
 
+**Mobile / no-laptop:** there's also a `db-clone` GitHub Action
+(`.github/workflows/db-clone.yml`) — *Actions → Run workflow → app/from/to* from
+the GitHub app. It reuses the repo's `CLOUDFLARE_*` secrets (no Cloudflare site
+needed); a prod target requires the `confirm_target_db` input (passed as
+`--confirm`), and the pre-clone backup is uploaded as an artifact. For
+non-interactive runs the script takes `--confirm <db>` in place of the typed
+prompt.
+
 ## When to use this — and when NOT to
 
 | Situation | Use |

--- a/.github/workflows/db-clone.yml
+++ b/.github/workflows/db-clone.yml
@@ -1,0 +1,111 @@
+name: db-clone
+
+# Mobile-friendly D1 clone (#382). Trigger from the GitHub app:
+# Actions → "db-clone" → Run workflow → pick app / from / to.
+#
+# Reuses the CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN repo secrets the deploy
+# workflows already use (that token has D1 Edit), so there is nothing to set up on
+# Cloudflare. Wraps scripts/db-clone.mjs (full mirror: source → target).
+#
+# Cloning INTO prod is guarded: set `confirm_target_db` to the exact target db
+# name or the run aborts. The pre-clone prod backup is uploaded as an artifact.
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: 'App whose databases to clone'
+        required: true
+        type: choice
+        options:
+          - velo
+          - fanfare
+          - triage
+          - alexdeforce
+          - blog
+          - kvr
+          - sintlukas
+          - three-demo
+      from:
+        description: 'Source environment (the keeper — read only)'
+        required: true
+        default: 'prod'
+        type: choice
+        options:
+          - prod
+          - staging
+          - preview
+      to:
+        description: 'Target environment (OVERWRITTEN — becomes a copy of source)'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - preview
+          - prod
+      confirm_target_db:
+        description: 'Only when target is PROD: type the exact target db name to confirm'
+        required: false
+        type: string
+
+jobs:
+  clone:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Never let two clones race on the same target database.
+    concurrency:
+      group: db-clone-${{ inputs.app }}-${{ inputs.to }}
+      cancel-in-progress: false
+    env:
+      APP: ${{ inputs.app }}
+      FROM: ${{ inputs.from }}
+      TO: ${{ inputs.to }}
+      CONFIRM: ${{ inputs.confirm_target_db }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # The script shells out to `npx wrangler`; install it globally so there's no
+      # interactive download prompt and no full monorepo install needed.
+      - name: Install wrangler
+        run: npm install --global wrangler@4
+
+      - name: Clone database
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          # Inputs come in via env (not inline interpolation) to avoid injection.
+          ARGS=(--app "$APP" --from "$FROM" --to "$TO")
+          if [ -n "$CONFIRM" ]; then ARGS+=(--confirm "$CONFIRM"); fi
+          node scripts/db-clone.mjs "${ARGS[@]}"
+
+      # Prod-target runs write a timestamped backup to .db-backups/ before
+      # overwriting — keep it as a downloadable artifact.
+      - name: Upload pre-clone backup
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-clone-backup-${{ inputs.app }}-${{ github.run_id }}
+          path: .db-backups/**
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### db-clone — \`$APP\`"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| source | \`$FROM\` (read-only) |"
+            echo "| target | \`$TO\` (overwritten) |"
+            echo "| result | ${{ job.status }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/db-clone.mjs
+++ b/scripts/db-clone.mjs
@@ -52,9 +52,11 @@ function parseArgs(argv) {
     else if (a === '--app') out.app = argv[++i]
     else if (a === '--from') out.from = argv[++i]
     else if (a === '--to') out.to = argv[++i]
+    else if (a === '--confirm') out.confirm = argv[++i]
     else if (a.startsWith('--app=')) out.app = a.slice(6)
     else if (a.startsWith('--from=')) out.from = a.slice(7)
     else if (a.startsWith('--to=')) out.to = a.slice(5)
+    else if (a.startsWith('--confirm=')) out.confirm = a.slice(10)
     else {
       console.error(`Unknown argument: ${a}`)
       out.help = true
@@ -73,6 +75,8 @@ Options:
   --from <env>   Source environment: "prod" (top-level config) or any env.<name>
   --to <env>     Target environment (overwritten — becomes an exact copy of source)
   --dry-run      Print the planned wrangler commands and exit; touches nothing
+  --confirm <db> Non-interactive prod confirmation: must equal the target db name
+                 (use in CI in place of the typed prompt)
   --yes, -y      Skip the typed confirmation when the target is prod (still backs up)
   -h, --help     Show this help
 
@@ -229,11 +233,19 @@ async function main() {
   if (target.isProd) {
     console.log('  ⚠  The TARGET is a PRODUCTION database. It will be overwritten.')
     if (!args.yes) {
-      const ok = await confirmTyped(target.name)
-      if (!ok) {
-        console.error('  Confirmation did not match — aborting.')
-        process.exit(1)
+      let ok
+      if (args.confirm !== undefined) {
+        // Non-interactive (CI): the provided value must match the target db name.
+        ok = args.confirm.trim() === target.name
+        if (!ok) console.error(`  --confirm "${args.confirm}" does not match target db name "${target.name}" — aborting.`)
+      } else if (process.stdin.isTTY) {
+        ok = await confirmTyped(target.name)
+        if (!ok) console.error('  Confirmation did not match — aborting.')
+      } else {
+        ok = false
+        console.error(`  Target is prod. In a non-interactive run, pass --confirm "${target.name}" (or --yes) to proceed.`)
       }
+      if (!ok) process.exit(1)
     }
     mkdirSync(backupDir, { recursive: true })
     console.log(`  Backing up target → ${backupPath}`)

--- a/writeups/guides/db-clone-guide.md
+++ b/writeups/guides/db-clone-guide.md
@@ -34,6 +34,20 @@ node scripts/db-clone.mjs --app velo --from staging --to prod
 node scripts/db-clone.mjs --app velo --from prod --to staging --dry-run
 ```
 
+## Run it from your phone (no Cloudflare site, no laptop)
+
+There's a **`db-clone` GitHub Action** for mobile use: in the GitHub app go to
+**Actions → "db-clone" → Run workflow**, pick *app / from / to*, and run. It uses
+the `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` repo secrets the deploy
+workflows already use, so there's nothing to set up on Cloudflare.
+
+- Cloning **into prod** requires the `confirm_target_db` input to equal the exact
+  target db name, or the run aborts (the workflow passes it as `--confirm`).
+- The pre-clone prod backup is uploaded as a **downloadable artifact**
+  (`db-clone-backup-<app>-<run_id>`).
+
+Defined in `.github/workflows/db-clone.yml`.
+
 ## Safety
 
 Cloning **overwrites the target**, so the dangerous direction is writing *into*


### PR DESCRIPTION
## 👤 For humans

Cloning a D1 database no longer needs a laptop or the Cloudflare website. This adds a **tap-to-run button**: in the **GitHub mobile app → Actions → "db-clone" → Run workflow**, pick *app / from / to*, and it clones the database in CI.

It works because it **reuses the `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` secrets GitHub already has** (the deploy workflows use them; that token has D1 Edit) — so there's nothing to set up on Cloudflare and no token to copy anywhere.

Safety is kept for the dangerous direction: cloning **into prod** requires you to type the exact target db name in a confirm field, and the pre-clone backup is uploaded as a downloadable artifact.

```mermaid
flowchart LR
  M[📱 GitHub app<br/>Run workflow] --> W[db-clone.yml]
  W -->|reuses existing<br/>GitHub secrets| C[scripts/db-clone.mjs]
  C -->|prod backup → artifact| A[(.db-backups upload)]
  C --> R[(target D1 mirrored)]
```

## 🤖 For agents

- **`.github/workflows/db-clone.yml`** (`workflow_dispatch`): `app`/`from`/`to` choice inputs + `confirm_target_db` string; `permissions: contents: read`; checkout → setup-node → `npm i -g wrangler@4` → run `scripts/db-clone.mjs`; uploads `.db-backups/**`; writes `$GITHUB_STEP_SUMMARY`. Inputs flow through `env:` (not inline `${{ }}`) to avoid script injection; `concurrency` keyed on app+target.
- **`scripts/db-clone.mjs`**: new `--confirm <db>` flag — non-interactive prod confirmation that must equal the target db name (replaces the TTY prompt in CI). Non-TTY without `--yes`/`--confirm` aborts with a clear message. Non-prod targets ignore it. `--help` updated.
- Docs: button documented in `writeups/guides/db-clone-guide.md` and `db-clone` SKILL.md.

## 🧪 How to test

- **Mobile:** GitHub app → Actions → "db-clone" → Run workflow → `velo / prod / staging` → it mirrors the DB; a prod *target* without a matching `confirm_target_db` fails fast; prod runs attach a backup artifact.
- **Local (no creds):** `node scripts/db-clone.mjs --app velo --from staging --to prod --confirm velo-db --dry-run` prints the plan; `--confirm WRONG` on a real prod run aborts non-zero. Verified: lint clean, dry-run + confirm-match/mismatch exit codes correct, workflow YAML parses.

Closes #382. Supersedes the mobile use-case of #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0133yNK1zwBsGR6Byp58fDkq)_