### PR TITLE
Add a read-only db-counts button to inspect D1 row counts from mobile

### DIFF
--- a/.claude/skills/db-clone/SKILL.md
+++ b/.claude/skills/db-clone/SKILL.md
@@ -31,6 +31,7 @@ prompt.
 
 | Situation | Use |
 |-----------|-----|
+| "Is the data still there?" / "how many rows / bookings / users" — *check before cloning* | **`pnpm db:counts --app <app> --env <env>`** (read-only) or the `db-counts` Action |
 | "Make staging look exactly like prod" / "refresh staging" / "seed a preview from staging" | **this skill** |
 | "Reconstitute the wiped staging DB" (and prod still has the data) | **this skill** (`--from prod --to staging`) |
 | Load a *specific* org / CSV import into a fresh DB | the app's `seedData/` + seed endpoints — NOT this |

--- a/.github/workflows/db-counts.yml
+++ b/.github/workflows/db-counts.yml
@@ -1,0 +1,62 @@
+name: db-counts
+
+# Read-only D1 inspection from the GitHub app (#384):
+# Actions → "db-counts" → Run workflow → pick app / env.
+#
+# Prints the row count of every table in the chosen database to the run summary.
+# It only runs SELECTs — nothing is written or overwritten — so it's the safe way
+# to CHECK what's in a database before deciding whether to clone/restore it.
+#
+# Reuses the CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN repo secrets (read is
+# covered by the same token the deploy workflows use). Wraps scripts/db-counts.mjs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: 'App whose database to inspect'
+        required: true
+        type: choice
+        options:
+          - velo
+          - fanfare
+          - triage
+          - alexdeforce
+          - blog
+          - kvr
+          - sintlukas
+          - three-demo
+      env:
+        description: 'Environment to inspect'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - prod
+          - preview
+
+jobs:
+  counts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      APP: ${{ inputs.app }}
+      DB_ENV: ${{ inputs.env }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install wrangler
+        run: npm install --global wrangler@4
+
+      - name: Count rows
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: node scripts/db-counts.mjs --app "$APP" --env "$DB_ENV"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typecheck:mcp": "pnpm --filter nuxt-crouton-mcp-server typecheck",
     "poc:scaffold-deploy": "node scripts/scaffold-poc-deploy.mjs",
     "db:clone": "node scripts/db-clone.mjs",
+    "db:counts": "node scripts/db-counts.mjs",
     "app:shots": "node scripts/app-shots.mjs",
     "publish:packages": "./scripts/publish-packages.sh",
     "publish:packages:dry": "./scripts/publish-packages.sh --dry-run",

--- a/scripts/db-clone.mjs
+++ b/scripts/db-clone.mjs
@@ -24,19 +24,15 @@
  * WITHOUT invoking wrangler (and needs no Cloudflare credentials).
  *
  * A real run needs CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN in the env.
- * D1 databases are resolved by NAME at the account level, so this runs from the
- * repo root and does not depend on a wrangler config being present.
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { spawnSync } from 'node:child_process'
 import { createInterface } from 'node:readline'
+import { PROD_ENVS, resolveAppDb, runWrangler, queryD1Json } from './lib/wrangler-d1.mjs'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
-const PROD_ENVS = new Set(['prod', 'production'])
-const APP_ROOTS = ['apps', 'pocs', 'workers']
 
 // ---------------------------------------------------------------------------
 // args
@@ -87,78 +83,19 @@ Examples:
 `
 
 // ---------------------------------------------------------------------------
-// wrangler.jsonc resolution
+// helpers
 // ---------------------------------------------------------------------------
 
-/** Minimal JSONC → JSON (strips // and block comments + trailing commas, keeps strings). */
-function parseJsonc(text) {
-  const noComments = text.replace(
-    /("(?:\\.|[^"\\])*")|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
-    (_m, str) => str ?? ''
-  )
-  return JSON.parse(noComments.replace(/,(\s*[}\]])/g, '$1'))
-}
-
-function findWranglerConfig(app) {
-  for (const root of APP_ROOTS) {
-    const p = join(repoRoot, root, app, 'wrangler.jsonc')
-    if (existsSync(p)) return p
-  }
-  return null
-}
-
-/** Resolve the D1 database name for an app + env from its wrangler.jsonc. */
-function resolveDb(config, app, env) {
-  const isProd = PROD_ENVS.has(env)
-  const scope = isProd ? config : config.env?.[env]
-  if (!scope) {
-    const envs = ['prod', ...Object.keys(config.env ?? {})]
-    throw new Error(
-      `App "${app}" has no environment "${env}". Available: ${envs.join(', ')}`
-    )
-  }
-  const db = scope.d1_databases?.[0]
-  if (!db?.database_name) {
-    throw new Error(`App "${app}" env "${env}" has no d1_databases[0].database_name in wrangler.jsonc`)
-  }
-  return { name: db.database_name, isProd }
-}
-
-// ---------------------------------------------------------------------------
-// wrangler invocation
-// ---------------------------------------------------------------------------
-
-function wranglerArgs(args) {
-  return ['wrangler', ...args]
-}
+const wrangler = (args, opts) => runWrangler(args, { cwd: repoRoot, ...opts })
 
 function printCmd(args) {
-  console.log(`    $ npx ${wranglerArgs(args).join(' ')}`)
+  console.log(`    $ npx wrangler ${args.join(' ')}`)
 }
 
-function runWrangler(args, { capture = false } = {}) {
-  const res = spawnSync('npx', wranglerArgs(args), {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    stdio: capture ? ['inherit', 'pipe', 'inherit'] : 'inherit'
-  })
-  if (res.status !== 0) {
-    throw new Error(`wrangler exited with code ${res.status}: npx ${wranglerArgs(args).join(' ')}`)
-  }
-  return res.stdout ?? ''
-}
-
-/** Query the target's user tables so we can drop them for a clean mirror. */
+/** List the db's user tables (so we can drop them for a clean mirror). */
 function listTables(dbName) {
-  const out = runWrangler(
-    ['d1', 'execute', dbName, '--remote', '--json',
-      '--command', 'SELECT name FROM sqlite_master WHERE type=\'table\' AND name NOT LIKE \'sqlite_%\''],
-    { capture: true }
-  )
-  // wrangler --json emits an array of result sets: [{ results: [{ name }], ... }]
-  const parsed = JSON.parse(out)
-  const rows = Array.isArray(parsed) ? (parsed[0]?.results ?? []) : (parsed.results ?? [])
-  return rows.map(r => r.name)
+  const sql = `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`
+  return queryD1Json(dbName, sql, { cwd: repoRoot }).map(r => r.name)
 }
 
 function confirmTyped(expected) {
@@ -182,17 +119,10 @@ async function main() {
     process.exit(args.help ? 0 : 1)
   }
 
-  const configPath = findWranglerConfig(args.app)
-  if (!configPath) {
-    console.error(`Unknown app "${args.app}": no wrangler.jsonc under ${APP_ROOTS.map(r => `${r}/${args.app}`).join(', ')}`)
-    process.exit(1)
-  }
-  const config = parseJsonc(readFileSync(configPath, 'utf8'))
-
   let source, target
   try {
-    source = resolveDb(config, args.app, args.from)
-    target = resolveDb(config, args.app, args.to)
+    source = resolveAppDb(args.app, args.from, repoRoot)
+    target = resolveAppDb(args.app, args.to, repoRoot)
   } catch (err) {
     console.error(err.message)
     process.exit(1)
@@ -249,11 +179,11 @@ async function main() {
     }
     mkdirSync(backupDir, { recursive: true })
     console.log(`  Backing up target → ${backupPath}`)
-    runWrangler(['d1', 'export', target.name, '--remote', '--output', backupPath])
+    wrangler(['d1', 'export', target.name, '--remote', '--output', backupPath])
   }
 
   console.log(`  Exporting source ${source.name} → ${dumpPath}`)
-  runWrangler(['d1', 'export', source.name, '--remote', '--output', dumpPath])
+  wrangler(['d1', 'export', source.name, '--remote', '--output', dumpPath])
 
   console.log(`  Resetting target ${target.name} …`)
   const tables = listTables(target.name)
@@ -262,7 +192,7 @@ async function main() {
       + tables.map(t => `DROP TABLE IF EXISTS "${t}";`).join('\n') + '\n'
     const dropPath = join(tmpdir(), `db-clone-drop-${target.name}-${stamp}.sql`)
     writeFileSync(dropPath, dropSql)
-    runWrangler(['d1', 'execute', target.name, '--remote', '--file', dropPath])
+    wrangler(['d1', 'execute', target.name, '--remote', '--file', dropPath])
     rmSync(dropPath, { force: true })
     console.log(`    dropped ${tables.length} table(s)`)
   } else {
@@ -270,7 +200,7 @@ async function main() {
   }
 
   console.log(`  Importing into target ${target.name} …`)
-  runWrangler(['d1', 'execute', target.name, '--remote', '--file', dumpPath])
+  wrangler(['d1', 'execute', target.name, '--remote', '--file', dumpPath])
   rmSync(dumpPath, { force: true })
 
   const newTables = listTables(target.name)

--- a/scripts/db-counts.mjs
+++ b/scripts/db-counts.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * db-counts.mjs — print row counts for every table in one Cloudflare D1 database.
+ *
+ * READ-ONLY: it only runs SELECTs — nothing is written, dropped, or overwritten.
+ * The safe way to *check* what's in a database (e.g. "are velo's imported users
+ * and bookings still in staging?") before deciding whether to clone/restore.
+ *
+ *   node scripts/db-counts.mjs --app velo --env staging
+ *   node scripts/db-counts.mjs --app velo --env prod
+ *   node scripts/db-counts.mjs --app velo --env staging --dry-run
+ *
+ * Discovers the db NAME from the app's wrangler.jsonc (apps/pocs/workers). A real
+ * run needs CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN; --dry-run needs neither.
+ */
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { appendFileSync } from 'node:fs'
+import { resolveAppDb, queryD1Json } from './lib/wrangler-d1.mjs'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function parseArgs(argv) {
+  const out = { dryRun: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--dry-run') out.dryRun = true
+    else if (a === '--help' || a === '-h') out.help = true
+    else if (a === '--app') out.app = argv[++i]
+    else if (a === '--env') out.env = argv[++i]
+    else if (a.startsWith('--app=')) out.app = a.slice(6)
+    else if (a.startsWith('--env=')) out.env = a.slice(6)
+    else {
+      console.error(`Unknown argument: ${a}`)
+      out.help = true
+    }
+  }
+  return out
+}
+
+const HELP = `db-counts — row counts for every table in one D1 database (read-only)
+
+Usage:
+  node scripts/db-counts.mjs --app <name> --env <env> [--dry-run]
+
+Options:
+  --app <name>   App whose wrangler.jsonc defines the database (apps/pocs/workers)
+  --env <env>    Environment: "prod" (top-level config) or any env.<name> (staging, …)
+  --dry-run      Print the planned wrangler command and exit; touches nothing
+  -h, --help     Show this help
+`
+
+const listTablesSql = `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`
+
+/** Append a markdown table to GITHUB_STEP_SUMMARY when running in Actions. */
+function writeSummary(lines) {
+  const file = process.env.GITHUB_STEP_SUMMARY
+  if (!file) return
+  try {
+    appendFileSync(file, lines.join('\n') + '\n')
+  } catch { /* best-effort */ }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help || !args.app || !args.env) {
+    console.log(HELP)
+    process.exit(args.help ? 0 : 1)
+  }
+
+  let db
+  try {
+    db = resolveAppDb(args.app, args.env, repoRoot)
+  } catch (err) {
+    console.error(err.message)
+    process.exit(1)
+  }
+
+  console.log(`\n  db-counts: ${args.app} / ${args.env} → ${db.name}${db.isProd ? '  (prod)' : ''}\n`)
+  console.log('  Read-only — runs SELECT COUNT(*) per table:')
+  console.log(`    $ npx wrangler d1 execute ${db.name} --remote --json --command "<list tables>"`)
+  console.log(`    $ npx wrangler d1 execute ${db.name} --remote --json --command "SELECT COUNT(*) … UNION ALL …"\n`)
+
+  if (args.dryRun) {
+    console.log('  --dry-run: no query run.\n')
+    return
+  }
+
+  const tables = queryD1Json(db.name, listTablesSql, { cwd: repoRoot }).map(r => r.name)
+  if (tables.length === 0) {
+    console.log('  (no tables)\n')
+    writeSummary([`### db-counts — \`${db.name}\` (${args.env})`, '', '_No tables._'])
+    return
+  }
+
+  // One round-trip: COUNT(*) for every table via UNION ALL.
+  const countSql = tables
+    .map(t => `SELECT '${t.replace(/'/g, `''`)}' AS tbl, COUNT(*) AS n FROM "${t}"`)
+    .join(' UNION ALL ')
+  const rows = queryD1Json(db.name, countSql, { cwd: repoRoot })
+  const counts = new Map(rows.map(r => [r.tbl, Number(r.n)]))
+
+  const pad = Math.max(...tables.map(t => t.length), 5)
+  let total = 0
+  console.log(`  ${'table'.padEnd(pad)}  rows`)
+  console.log(`  ${'-'.repeat(pad)}  ----`)
+  for (const t of tables) {
+    const n = counts.get(t) ?? 0
+    total += n
+    console.log(`  ${t.padEnd(pad)}  ${n}`)
+  }
+  console.log(`  ${'-'.repeat(pad)}  ----`)
+  console.log(`  ${'TOTAL'.padEnd(pad)}  ${total}\n`)
+
+  writeSummary([
+    `### db-counts — \`${db.name}\` (${args.env})`,
+    '',
+    '| table | rows |',
+    '|---|---:|',
+    ...tables.map(t => `| \`${t}\` | ${counts.get(t) ?? 0} |`),
+    `| **total** | **${total}** |`
+  ])
+}
+
+main().catch((err) => {
+  console.error(`\n  db-counts failed: ${err.message}\n`)
+  process.exit(1)
+})

--- a/scripts/lib/wrangler-d1.mjs
+++ b/scripts/lib/wrangler-d1.mjs
@@ -1,0 +1,76 @@
+/**
+ * wrangler-d1.mjs — shared helpers for the D1 tooling scripts (db-clone, db-counts).
+ *
+ * Discovers a Cloudflare D1 database NAME from an app's wrangler.jsonc and wraps
+ * `npx wrangler d1` calls. D1 databases are resolved by NAME at the account level,
+ * so callers run from the repo root and don't need a wrangler config in cwd.
+ */
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+export const PROD_ENVS = new Set(['prod', 'production'])
+export const APP_ROOTS = ['apps', 'pocs', 'workers']
+
+/** Minimal JSONC → JSON (strips // and block comments + trailing commas, keeps strings). */
+export function parseJsonc(text) {
+  const noComments = text.replace(
+    /("(?:\\.|[^"\\])*")|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+    (_m, str) => str ?? ''
+  )
+  return JSON.parse(noComments.replace(/,(\s*[}\]])/g, '$1'))
+}
+
+/** Locate an app's wrangler.jsonc under apps/, pocs/, or workers/. */
+export function findWranglerConfig(app, repoRoot) {
+  for (const root of APP_ROOTS) {
+    const p = join(repoRoot, root, app, 'wrangler.jsonc')
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+/** Resolve the D1 database name for an app + env from its parsed wrangler.jsonc. */
+export function resolveDb(config, app, env) {
+  const isProd = PROD_ENVS.has(env)
+  const scope = isProd ? config : config.env?.[env]
+  if (!scope) {
+    const envs = ['prod', ...Object.keys(config.env ?? {})]
+    throw new Error(`App "${app}" has no environment "${env}". Available: ${envs.join(', ')}`)
+  }
+  const db = scope.d1_databases?.[0]
+  if (!db?.database_name) {
+    throw new Error(`App "${app}" env "${env}" has no d1_databases[0].database_name in wrangler.jsonc`)
+  }
+  return { name: db.database_name, isProd }
+}
+
+/** Load + resolve in one step: returns { name, isProd, configPath }. Throws on unknown app/env. */
+export function resolveAppDb(app, env, repoRoot) {
+  const configPath = findWranglerConfig(app, repoRoot)
+  if (!configPath) {
+    throw new Error(`Unknown app "${app}": no wrangler.jsonc under ${APP_ROOTS.map(r => `${r}/${app}`).join(', ')}`)
+  }
+  return { ...resolveDb(parseJsonc(readFileSync(configPath, 'utf8')), app, env), configPath }
+}
+
+/** Run `npx wrangler …` from repoRoot. Returns stdout when capture is set; throws on non-zero. */
+export function runWrangler(args, { cwd, capture = false } = {}) {
+  const full = ['wrangler', ...args]
+  const res = spawnSync('npx', full, {
+    cwd,
+    encoding: 'utf8',
+    stdio: capture ? ['inherit', 'pipe', 'inherit'] : 'inherit'
+  })
+  if (res.status !== 0) {
+    throw new Error(`wrangler exited with code ${res.status}: npx ${full.join(' ')}`)
+  }
+  return res.stdout ?? ''
+}
+
+/** Run a remote SELECT and return the first result set's rows (wrangler --json shape). */
+export function queryD1Json(dbName, sql, { cwd } = {}) {
+  const out = runWrangler(['d1', 'execute', dbName, '--remote', '--json', '--command', sql], { cwd, capture: true })
+  const parsed = JSON.parse(out)
+  return Array.isArray(parsed) ? (parsed[0]?.results ?? []) : (parsed.results ?? [])
+}

--- a/writeups/guides/db-clone-guide.md
+++ b/writeups/guides/db-clone-guide.md
@@ -48,6 +48,15 @@ workflows already use, so there's nothing to set up on Cloudflare.
 
 Defined in `.github/workflows/db-clone.yml`.
 
+### Check before you clone (read-only `db-counts`)
+
+To *inspect* a database without changing it, use the **`db-counts`** button
+(Actions → "db-counts" → app/env) or `pnpm db:counts --app <app> --env <env>`.
+It prints the row count of every table (users, organizations, bookings, …) to
+the run summary — SELECT only, nothing written. Use it to confirm whether data
+is present before deciding to clone/restore. Defined in
+`.github/workflows/db-counts.yml` / `scripts/db-counts.mjs`.
+
 ## Safety
 
 Cloning **overwrites the target**, so the dangerous direction is writing *into*


### PR DESCRIPTION
## 👤 For humans

The companion to the clone button — a **read-only** check. In the **GitHub app → Actions → "db-counts" → Run workflow → app/env**, it prints the row count of every table (users, organizations, bookings, …) to the run summary. It **only reads** — nothing is written or overwritten.

This is the "verify first" step for the velo data question: tap **`velo / staging`** to see whether the imported users/bookings are actually there, compare against **`velo / prod`**, and only then decide whether to clone/restore. No laptop, no Cloudflare site (reuses the secrets GitHub already has).

```mermaid
flowchart LR
  M[📱 GitHub app<br/>db-counts] --> S[scripts/db-counts.mjs]
  S -->|SELECT COUNT(*) per table| D[(D1 — read only)]
  S --> R[row-count table in run summary]
```

## 🤖 For agents

Two atomic commits:
1. **`refactor(root)`** — extract `scripts/lib/wrangler-d1.mjs` (`parseJsonc`, `findWranglerConfig`, `resolveDb`/`resolveAppDb`, `runWrangler`, `queryD1Json`) from `db-clone.mjs`; `db-clone` now imports it. No behaviour change (dry-run/confirm re-verified).
2. **`feat(root)`** — `scripts/db-counts.mjs` (read-only: lists tables, one `UNION ALL` of `COUNT(*)`, prints a table + writes markdown to `$GITHUB_STEP_SUMMARY`) + `.github/workflows/db-counts.yml` (`workflow_dispatch`, `permissions: contents: read`, app/env choice inputs, reuses `CLOUDFLARE_*` secrets) + `pnpm db:counts` + docs.

SELECT-only; no writes anywhere. Inputs flow through `env:` (no inline interpolation).

## 🧪 How to test

- **Mobile:** Actions → "db-counts" → `velo / staging` → summary shows each table + row count; re-run `velo / prod` to compare.
- **Local (no creds):** `node scripts/db-counts.mjs --app velo --env staging --dry-run` resolves `velo-staging-db` and exits 0; unknown app/env error non-zero. `db-clone --dry-run` still works unchanged. Verified: lint clean on all three scripts, both workflow YAMLs parse.

Closes #384. Relates to #324 / #382 — the "verify before clone" piece for the velo data-recovery question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0133yNK1zwBsGR6Byp58fDkq)_