### PR TITLE
Canary: run the with-assets e2e fixture in the official Playwright container

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,12 @@ jobs:
   e2e:
     name: E2E (${{ matrix.fixture }})
     runs-on: ubuntu-latest
+    # Canary (#393): only `with-assets` runs inside the official, version-matched
+    # Playwright image (Chromium + system libs baked in) to prove the container
+    # approach kills the flaky `--with-deps` apt step before we roll it out to all
+    # four fixtures (#394). An empty value (the other three) means "run on the
+    # host", unchanged. The tag must track @playwright/test ^1.57 — see #395.
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +40,9 @@ jobs:
         # CI once stable"), with-collab stays a local-only spike until the package
         # is type-clean. Its runtime smoke passes; only the typecheck gate blocks it.
         fixture: [minimal, with-pages, with-bookings, with-assets]
+        include:
+          - fixture: with-assets
+            container: mcr.microsoft.com/playwright:v1.57.0-jammy
     env:
       # Better-auth needs a secret present; the value is irrelevant in CI.
       BETTER_AUTH_SECRET: ci-placeholder-secret
@@ -42,6 +51,13 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
       - uses: actions/checkout@v4
+
+      # In-container only (canary #393): the repo is checked out as root inside the
+      # Playwright image, so mark the workspace safe to keep git from tripping on
+      # dubious ownership. No-op on the host fixtures (guarded by matrix.container).
+      - name: Trust workspace dir (container)
+        if: ${{ matrix.container }}
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -71,13 +87,19 @@ jobs:
       - name: Type-check the generated fixture
         run: pnpm --filter "e2e-fixture-${{ matrix.fixture }}" typecheck
 
+      # Host path only: fetch the browser + apt system deps at runtime. Skipped
+      # in-container (#393) — the Playwright image already ships Chromium at
+      # /ms-playwright (PLAYWRIGHT_BROWSERS_PATH preset), so there's nothing to
+      # install and no flaky `--with-deps` apt step to hang on.
       - name: Cache Playwright browsers
+        if: ${{ !matrix.container }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Playwright (chromium)
+        if: ${{ !matrix.container }}
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run e2e smoke


### PR DESCRIPTION
Part of #392. Closes #393.

## 👤 For humans
Our e2e suite occasionally hangs ~an hour on the step that downloads the browser's system libraries over apt. This canaries the fix on **one** fixture: `with-assets` now runs inside Microsoft's ready-made Playwright container (those libraries already baked in), so there's nothing to download. The other three fixtures are unchanged — this is a safe, reversible probe before we switch everything over (#394).

## 🤖 For agents
`.github/workflows/e2e.yml` only:
- matrix `include` gives **only** `with-assets` a `container: mcr.microsoft.com/playwright:v1.57.0-jammy` (matches `@playwright/test ^1.57`); job-level `container: ${{ matrix.container }}` → empty for the other three ⇒ host path, untouched.
- Host-only steps **Cache Playwright browsers** + **Install Playwright (chromium)** guarded with `if: ${{ !matrix.container }}` — skipped in-container (Chromium ships at `/ms-playwright`, `PLAYWRIGHT_BROWSERS_PATH` preset; no `--with-deps` apt).
- Added a **safe.directory** guard for in-container git (runs as root).

## 🧪 We'll be right if / We'll know by
- ✅ `E2E (with-assets)` is **green**.
- ✅ Its log shows **no `apt-get`** and **no Chromium download** (browsers already present).
- ✅ `E2E (minimal / with-pages / with-bookings)` still green on the host path (behaviour unchanged).

If the container + checkout/cache combo misbehaves, this PR is where we capture the fix before rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frb6RNQyBC7mxPBTakMomL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Frb6RNQyBC7mxPBTakMomL)_