### PR TITLE
Skill conventions: Playwright tag-sync + record rejected alternatives

### DIFF
--- a/.claude/skills/dependency-sweep/SKILL.md
+++ b/.claude/skills/dependency-sweep/SKILL.md
@@ -52,6 +52,12 @@ issue and hold the floor. Don't force a red bump into the safe PR.
   (#140). If you bump `vue`/`nuxt`, bump their `pnpm.overrides` floor to match so
   the lockfile actually moves.
 - Keep package **peer** ranges wide (`^3 || ^4`) — untouched.
+- **`@playwright/test` is special — sync the E2E container tag.** If you bump it,
+  also bump the CI image tag in `.github/workflows/e2e.yml`
+  (`container: mcr.microsoft.com/playwright:v<x.y.z>-jammy`) to the **same**
+  version. The image ships the matching Chromium + system libs, so a drift makes
+  Playwright warn about a browser/library version mismatch — and the whole point
+  of that container is to be version-matched (#392/#395).
 
 ```bash
 pnpm install            # regenerates the lockfile

--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -41,6 +41,20 @@ A precise, structured block an AI can act on without guessing: scope, exact file
 
 Use explicit headings (`## 👤 For humans` / `## 🤖 For agents`) so both are obvious. Scale to the change — a one-line human summary is fine for something small — but **always include both**.
 
+## Record what you *didn't* do (Considered & rejected)
+
+A **"why not" is as load-bearing as a "why"** — it's the evidence the chosen path beat *something*, with reasons that may later expire. Whenever a decision had genuine alternatives, **write them down**, so future-us (and agents doing archaeology) stop re-litigating settled questions and understand the *shape* of a decision, not just its outcome.
+
+- Add a short **`Considered & rejected`** note — one line per option: `option → ❌ why not`. It lives in the **🤖 For agents** block by default (or its own small block, or a comment on the issue/epic).
+- **Required only when alternatives were actually weighed** — trivial chores opt out (same as the bet framing).
+- The **epic** is the natural home for a cross-cutting "why not": post it as a comment *when the decision is made*, while the reasoning is fresh.
+
+Worked example (from epic #392):
+> **Considered & rejected — E2E perf**
+> - Bump Playwright workers → ❌ the harness shares one dev server + SQLite *per job*; parallel workers race on mutated state → flaky.
+> - Shared "build packages once" prebuild job → ❌ serialises a parallel matrix; saves CI *minutes*, not wall-clock.
+> - Cache the built packages → ❌ a stale cache makes the regression smoke pass *falsely* — defeating its purpose.
+
 ## How to test (REQUIRED on every closeable issue/PR — written for a human)
 
 Every issue that changes observable behaviour, and every PR, MUST carry a **`## 🧪 How to test`** section written for someone who knows the *app concept* but not the code. It is not "run the unit tests" — it is *where a person clicks and what they should see*. Treat it as the acceptance check: if a non-developer can't follow it to confirm the change, it's not done.


### PR DESCRIPTION
Closes #395. Closes #399.

Two small, independent skill-doc conventions (one atomic commit each):

## 👤 For humans
1. **Playwright tag-sync** (#395) — the `dependency-sweep` skill now reminds us that bumping Playwright also means bumping the e2e CI container image to the same version (or it warns about a mismatch). Closes the last follow-up of the e2e-container epic (#392).
2. **"Considered & rejected"** (#399) — the `github-tasks` skill now formalizes recording *why we didn't* do something, not just why we did — so settled questions stop getting re-asked. The worked example is the E2E-perf decision from #392.

## 🤖 For agents
- `dependency-sweep/SKILL.md` Step 3: `@playwright/test` bump ⇒ also bump `mcr.microsoft.com/playwright:v<x.y.z>-jammy` in `.github/workflows/e2e.yml`.
- `github-tasks/SKILL.md`: new "Record what you didn't do (Considered & rejected)" section — `option → ❌ why not`, in the For-agents block, required only when alternatives were weighed.
- `node scripts/gen-skills-doc.mjs` run → no inventory-doc diff (content-only edits), so `skills-doc.yml` stays green.

## 🧪 How to test
Read both skill files: the tag-sync bullet in dependency-sweep Step 3, and the "Considered & rejected" section in github-tasks. No runtime surface — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frb6RNQyBC7mxPBTakMomL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Frb6RNQyBC7mxPBTakMomL)_