### PR TITLE
docs + feat: agent-flow diagram and the postmortem (retro) loop

### DIFF
--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -81,7 +81,8 @@ A merged PR auto-closes the issues in its `Closes #NN` lines — but **a parent 
 1. Resolve the parent: `mcp__github__issue_read` (`method: get`) → `parent_issue_url`, or read the epic's `get_sub_issues`.
 2. If the issue has a parent, check whether **all** of the parent's children are now `closed` (`get_sub_issues` → every child's `state`).
 3. **If they are, the epic is ready to close — but the epic is the *verification* unit, so never silently close it.** Post the `## 🧪 Verify the whole thing` rollup (above) as a comment on the epic, then **explicitly ask the owner to close it** (e.g. "All N sub-issues are merged — close the epic?") and close it as `completed` **only on their confirmation** (or after the end-to-end pass passes). If a sub-issue couldn't be auto-verified (needs a device, a manual check), say so in the rollup rather than implying it's confirmed.
-4. Recurse: a parent can itself be a child of a grander epic — keep walking up until you hit one with open siblings or no parent.
+4. **Postmortem before closing (verify = *does it work?*; postmortem = *how did it go?*).** After the verify rollup and **before** the epic is closed, run the **`postmortem`** skill on the epic — it posts a retro (what went well / what was hard, evidence-backed / 1–3 improvement proposals) and offers to mint accepted, not-already-tracked proposals as `workflow` issues. This is how the loop tightens over time (epic #403). Skip only for a trivial epic.
+5. Recurse: a parent can itself be a child of a grander epic — keep walking up until you hit one with open siblings or no parent.
 
 Don't stop at the issue you were asked about; closing the leaf without checking the branch above it leaves the epic falsely "in progress".
 
@@ -133,7 +134,7 @@ GitHub issues slot into the repo's task-execution flow (see `CLAUDE.md`):
 4. **Commit** — use the `/commit` skill, referencing the issue in the body (e.g. `(#NN)`).
 5. **Open a PR** — early is fine. Put `Closes #NN` in the body so the issue auto-closes on merge. Let CI run and fix failures (the PR can be watched/autofixed).
 6. **Squash-merge** → the issue closes automatically and the branch is deleted. Don't push feature work straight to `main`.
-7. **Walk up the epic tree (REQUIRED — part of the merge, not an afterthought).** The moment the merge auto-closes the leaf issue, run the parent check in *"Closing a child? Always check the parent"* above. If that merge closed the epic's **last** open child, post the `## 🧪 Verify the whole thing` rollup on the epic and **ask the owner to close it** (close on confirmation). A merge is not "done" until the parent epic is either closed or explicitly handed off for the verify pass. When watching/auto-merging a PR, do this walk-up as soon as the merge lands.
+7. **Walk up the epic tree (REQUIRED — part of the merge, not an afterthought).** The moment the merge auto-closes the leaf issue, run the parent check in *"Closing a child? Always check the parent"* above. If that merge closed the epic's **last** open child, post the `## 🧪 Verify the whole thing` rollup on the epic, run the **`postmortem`** skill (retro + improvement proposals — see step 4 there), and **ask the owner to close it** (close on confirmation). A merge is not "done" until the parent epic is either closed or explicitly handed off for the verify + postmortem pass. When watching/auto-merging a PR, do this walk-up as soon as the merge lands.
 
 Work lands via **PRs**, not direct pushes to `main`. Issues are the source of truth for *what* to do; `docs/PROGRESS_TRACKER.md` (if used) becomes an optional phase-level rollup, not the per-task tracker.
 

--- a/.claude/skills/postmortem/SKILL.md
+++ b/.claude/skills/postmortem/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: postmortem
+description: At the close of an epic (or a difficult issue), post a postmortem roundup comment — what went well, what was hard (backed by evidence), and 1–3 concrete proposals to improve the skills/flows — then offer to turn accepted proposals into their own `workflow`-labeled tasks. Use at epic close, after the "verify the whole thing" rollup, or when asked to "do a retro", "postmortem this epic", "what did we learn", "how do we improve the workflow".
+allowed-tools: mcp__github__issue_read, mcp__github__add_issue_comment, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, Read, Bash
+---
+
+# Postmortem — learn from the epic, tighten the loop
+
+Turns a just-finished epic (or a difficult issue) into a short, honest **retro
+comment on the epic**, plus an offer to spin the good ideas into tracked
+`workflow` tasks. The point isn't ceremony — it's that **the loop only gets
+tighter if we feed each run's friction back into the skills and flows**. See
+epic #403.
+
+This runs **after** the `github-tasks` "## 🧪 Verify the whole thing" rollup
+(verify = *does it work?*) and **before** the epic is closed (postmortem =
+*how did building it go, and how do we improve?*).
+
+## When to use
+- **Default:** at epic close, once all sub-issues have merged.
+- A single **difficult issue** worth a retro on its own (lots of blocks, re-work).
+- On ask: "do a retro / postmortem on #NN", "what did we learn".
+- **Skip** for a trivial chore — not every issue needs a retro.
+
+## What it produces
+A single **comment on the epic** (`add_issue_comment`) with three sections, and
+— on your go-ahead — one or more new issues labelled `workflow`.
+
+## Step 1 — Resolve scope
+- Input is an **epic number** (default) or a single issue number.
+- Read it + its children: `issue_read` (`get`, `get_sub_issues`). Note which
+  children merged cleanly vs. needed re-work.
+
+## Step 2 — Gather the difficulty signals (evidence, not vibes)
+Pull what's available so "what was hard" is backed by facts. (Deeper mining is
+tracked in #406; until then, best-effort from labels/timeline + the PRs.)
+- **Blocked time** — how long any child carried `status:blocked`.
+- **Sign-off rounds** — revision iterations on UI/schema gates (sticky-comment
+  edits / review threads on the draft PR).
+- **Fix-bot attempts** — `claude/issue-*` retries before green (when #336 is live).
+- **Reopens** — issues/PRs reopened after close.
+- **Time-in-progress** — `status:in-progress` → closed duration per child.
+**Be honest:** where a signal isn't available, say so — never imply a measurement
+you didn't make.
+
+## Step 3 — Write the roundup comment
+Keep it terse and human-first (the `github-tasks` two-audience convention). Three
+sections:
+
+- **✅ What went well** — what was smooth / worth keeping. Name it concretely.
+- **⚠️ What was hard** — the friction, each line tied to a signal or a specific
+  issue (e.g. *"#NN sat blocked 3 days waiting on a sibling; the schema gate took
+  2 revision rounds"*).
+- **🔧 Proposals (1–3)** — concrete, actionable changes to a **skill / agent /
+  flow** that would remove that friction next time. Each proposal = a candidate
+  `workflow` task with a one-line "why".
+
+Post it with `add_issue_comment` on the epic.
+
+## Step 4 — Offer to turn proposals into work
+Ask the human (plain): *"Open these as `workflow` tasks?"* On a yes, for each
+accepted proposal create an issue with `issue_write`:
+- Labels: **`workflow`** + **`meta:agents`** + one `type:*` (usually `type:chore`
+  or `type:feat`).
+- Body: the proposal as a small **bet** (what we change, why, how we'll know it
+  helped). Reference the source epic.
+- If several relate, group them under a small tracking parent via `sub_issue_write`.
+
+Don't open issues the human didn't accept; don't pad with filler proposals — 1–3
+real ones beat ten generic ones.
+
+## Step 5 — Hand off
+Report: the epic comment URL, and the list of `workflow` issues opened (with URLs).
+This closes the learning loop — the proposals are now on the board, ready to be
+picked up like any other work.
+
+## Conventions & gotchas
+- **After verify, before close.** Don't close the epic until the postmortem is
+  posted (the `github-tasks` epic-close walk-up sequences this).
+- **Headless = no dialogs.** If running unattended, post the roundup + proposals
+  and @mention the owner rather than blocking on a prompt; the owner converts
+  proposals to issues by replying.
+- **Bot-comment filter.** The roundup is informational; it should not itself
+  trip the agent-resume triggers (`resume-on-comment.yml` ignores bot authors).
+- **Signals are best-effort.** Prefer a smaller, true set of evidence over a
+  complete-looking but guessed one.

--- a/.claude/skills/postmortem/SKILL.md
+++ b/.claude/skills/postmortem/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: postmortem
 description: At the close of an epic (or a difficult issue), post a postmortem roundup comment — what went well, what was hard (backed by evidence), and 1–3 concrete proposals to improve the skills/flows — then offer to turn accepted proposals into their own `workflow`-labeled tasks. Use at epic close, after the "verify the whole thing" rollup, or when asked to "do a retro", "postmortem this epic", "what did we learn", "how do we improve the workflow".
-allowed-tools: mcp__github__issue_read, mcp__github__add_issue_comment, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, Read, Bash
+allowed-tools: mcp__github__issue_read, mcp__github__add_issue_comment, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__list_issues, mcp__github__search_issues, mcp__github__list_commits, Read, Bash
 ---
 
 # Postmortem — learn from the epic, tighten the loop
@@ -31,17 +31,24 @@ A single **comment on the epic** (`add_issue_comment`) with three sections, and
 - Read it + its children: `issue_read` (`get`, `get_sub_issues`). Note which
   children merged cleanly vs. needed re-work.
 
-## Step 2 — Gather the difficulty signals (evidence, not vibes)
-Pull what's available so "what was hard" is backed by facts. (Deeper mining is
-tracked in #406; until then, best-effort from labels/timeline + the PRs.)
-- **Blocked time** — how long any child carried `status:blocked`.
-- **Sign-off rounds** — revision iterations on UI/schema gates (sticky-comment
-  edits / review threads on the draft PR).
-- **Fix-bot attempts** — `claude/issue-*` retries before green (when #336 is live).
-- **Reopens** — issues/PRs reopened after close.
-- **Time-in-progress** — `status:in-progress` → closed duration per child.
-**Be honest:** where a signal isn't available, say so — never imply a measurement
-you didn't make.
+## Step 2 — Mine the difficulty signals (evidence, not vibes)
+For each child issue (and its PR), pull what the available tools can give. Each signal
+below lists **how** to get it and how **precise** it is — be honest about the gaps, and
+**never imply a measurement you didn't make**.
+
+| Signal | How to get it (GitHub MCP) | Precision |
+|---|---|---|
+| **Time-in-progress** | `get_sub_issues` → per child `created_at` → `closed_at` | rough (proxy for build effort) |
+| **Sign-off rounds** | `issue_read get_comments` on the child's PR → count revisions on the `<!-- ui-proposal:* -->` / `<!-- schema-review:* -->` sticky thread + review replies | good (markers are explicit) |
+| **Asked-for-help / blocks** | `get_comments` → count `@`-mention + "blocked" comments; `get_labels` → is `status:blocked` still on it | good for *count* |
+| **Blocked duration** | not exposed directly (label add/remove timestamps aren't in these MCP methods) → approximate from the gap between the blocking comment and the resuming comment | weak — **state it's an approximation** |
+| **Re-work / commit churn** | `list_commits` on the PR branch → many "fix"/"oops" rounds = friction | available now |
+| **Fix-bot attempts** | the `claude/issue-*` retry count (from #336 watch-to-merge) | only when #336 is live → say "n/a" otherwise |
+| **Reopens** | `issue_read get` per child → reopened-after-close | approx |
+
+Aggregate into **3–5 "what was hard" lines**, each tied to a specific child + its signal.
+Prefer a few true signals over a complete-looking guess; where a signal is unavailable,
+write "n/a (not measurable with current tooling)" rather than inventing a number.
 
 ## Step 3 — Write the roundup comment
 Keep it terse and human-first (the `github-tasks` two-audience convention). Three

--- a/.claude/skills/postmortem/SKILL.md
+++ b/.claude/skills/postmortem/SKILL.md
@@ -57,17 +57,29 @@ sections:
 
 Post it with `add_issue_comment` on the epic.
 
-## Step 4 — Offer to turn proposals into work
-Ask the human (plain): *"Open these as `workflow` tasks?"* On a yes, for each
-accepted proposal create an issue with `issue_write`:
-- Labels: **`workflow`** + **`meta:agents`** + one `type:*` (usually `type:chore`
-  or `type:feat`).
-- Body: the proposal as a small **bet** (what we change, why, how we'll know it
-  helped). Reference the source epic.
+## Step 4 — Dedup against existing follow-ups, then offer to turn proposals into work
+
+**First, dedup — don't mint duplicates.** Before proposing anything new, search for an
+existing home for each proposal: an open follow-up / "harden X" **epic** or issues that
+already capture it. Use `search_issues` with the proposal's keywords (and `label:epic`),
+and check the source epic's own linked follow-ups. If a proposal is already tracked,
+**link to that issue/epic in the roundup instead of opening a new one**; add only a
+*genuinely-new* proposal to that epic as a sub-issue (`sub_issue_write`). The roundup
+should state, per proposal, **where it's tracked** (existing #NN, or "new").
+
+> Why this matters: the #274 dogfood found its proposals already lived in epic #291 —
+> the right move was to link #291, not open parallel `workflow` issues.
+
+Then ask the human (plain): *"Open the remaining (untracked) proposals as `workflow`
+tasks?"* On a yes, for each accepted, **not-already-tracked** proposal create an issue
+with `issue_write`:
+- Labels: **`workflow`** + **`meta:agents`** + one `type:*` (usually `type:chore` or `type:feat`).
+- Body: the proposal as a small **bet** (what we change, why, how we'll know it helped). Reference the source epic.
 - If several relate, group them under a small tracking parent via `sub_issue_write`.
 
-Don't open issues the human didn't accept; don't pad with filler proposals — 1–3
-real ones beat ten generic ones.
+Don't open issues the human didn't accept; don't pad with filler — 1–3 real ones beat ten
+generic ones; and **never open a `workflow` issue that duplicates an existing follow-up
+epic** — link it instead.
 
 ## Step 5 — Hand off
 Report: the epic comment URL, and the list of `workflow` issues opened (with URLs).
@@ -84,3 +96,6 @@ picked up like any other work.
   trip the agent-resume triggers (`resume-on-comment.yml` ignores bot authors).
 - **Signals are best-effort.** Prefer a smaller, true set of evidence over a
   complete-looking but guessed one.
+- **Dedup first.** A proposal already owned by a follow-up/hardening epic gets a
+  link in the roundup, not a fresh `workflow` issue (proven by the #274 dogfood,
+  whose learnings already lived in #291).

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -188,6 +188,9 @@
 - name: "auto-decompose"
   color: "0e8a16"
   description: "Opt this issue into the auto task-decomposition pipeline (decompose-on-issue.yml)"
+- name: "workflow"
+  color: "006b75"
+  description: "Loop/skill/flow improvement (often minted by a postmortem)"
 
 # ── Status ──
 - name: "status:in-progress"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/task-decompose/SKILL.md` | Entry point to the recursive task-decomposition pipeline (`/task-decompose`) — one task → an epic + tree of sub-issues → agents. See "Task Decomposition Pipeline" below |
 | Skill | `.claude/skills/ui-proposal/SKILL.md` | Generate a before/after UI mockup (offline HTML/CSS/SVG) + render it to PNG for design sign-off before building UI. Part of the UI sign-off loop (#307) |
 | Skill | `.claude/skills/schema-review/SKILL.md` | Render a collection schema (field-definition JSON) into a human-readable field table + relationships (HTML + PNG + Markdown) for data-model sign-off before `crouton config` generates code. Part of the schema sign-off loop (#314) |
+| Skill | `.claude/skills/postmortem/SKILL.md` | At epic close (after the verify rollup, before closing): post a retro comment — what went well / what was hard (evidence-backed) / 1–3 proposals — and offer to mint accepted proposals as `workflow` issues. Tightens the loop over time (#403) |
 | Agent | `.claude/agents/task-orchestrator.md` | Reads an epic, fans it into 2–6 top-level sub-issues, spawns a decomposer per child |
 | Agent | `.claude/agents/task-decomposer.md` | Recursive: LEAF TEST one issue → spawn a worker (leaf) or split into sub-issues + spawn a decomposer per child |
 | Agent | `.claude/agents/task-worker.md` | Implements one leaf issue on an isolated worktree branch → `pnpm typecheck` → `/commit` → PR (`Closes #NN`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ Scopes (canonical list lives in the `/commit` skill): `crouton` | `crouton-core`
 
 ### Issue Status Updates
 - Move the issue through its states: open → in-progress → closed (via the PR's `Closes #NN` on merge)
+- **At epic close**: after the `## 🧪 Verify the whole thing` rollup and **before** closing, run the **`postmortem`** skill — a retro (what went well / what was hard / improvement proposals) that mints `workflow` issues so the loop tightens over time (epic #403). See the `github-tasks` skill's epic-close flow.
 - `writeups/PROGRESS_TRACKER.md` is an **optional** phase-level rollup, not the per-task tracker — update it only when keeping a phase summary current.
 
 ### Multi-Agent Continuity

--- a/scripts/gen-skills-doc.mjs
+++ b/scripts/gen-skills-doc.mjs
@@ -34,6 +34,7 @@ const META = {
   review: { group: 'review', triggers: ['ask'] },
   audit: { group: 'review', triggers: ['ask'] },
   'i18n-audit': { group: 'review', triggers: ['ask'] },
+  postmortem: { group: 'review', triggers: ['flow', 'ask'] },
   deploy: { group: 'deploy', triggers: ['ask'] },
   'deploy-production': { group: 'deploy', triggers: ['ask'] },
   'poc-deploy': { group: 'deploy', triggers: ['ask'] },

--- a/writeups/architecture/agent-flow.html
+++ b/writeups/architecture/agent-flow.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
-<!-- Hand-authored. The agent task flow: how /task-decompose fans a task into a tree of
-     issues, works the leaves, and surfaces help-pings / sign-offs / screenshots / preview
-     links on the ticket. Sources: .claude/agents/{CLAUDE.md,task-orchestrator,task-decomposer,
-     task-worker}.md · poc-deploy skill · agent-orchestration-architecture.md. Offline · no JS.
+<!-- Hand-authored. The user journey for the agent pipeline: what YOU do, what the AGENTS do,
+     the gates where you decide, the skill that fires at each stop, and the daily digest that
+     rolls up across all of it. Sources: .claude/agents/*.md · .claude/skills/* · poc-deploy ·
+     epic-digest (#357) · screenshots #311 · e2e video #356 · watch-to-merge #336.
      Style: clean line art — white ground, thick black lines, one highlight (human-in-the-loop). -->
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>nuxt-crouton — the agent task flow</title>
+<title>nuxt-crouton — the user journey</title>
 <style>
-  :root{ --ink:#111316; --muted:#555a63; --faint:#8a909a; --hair:#e3e5e9; --hl:#ffe14d; --radius:10px; }
+  :root{ --ink:#111316; --muted:#555a63; --faint:#8a909a; --hair:#e3e5e9; --hl:#ffe14d; --hl-bg:#fffdf2; --radius:10px; }
   *{box-sizing:border-box;}
   body{margin:0; background:#fff; color:var(--ink); line-height:1.55;
     font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif; -webkit-font-smoothing:antialiased;}
@@ -20,15 +20,45 @@
   .lede{color:var(--muted); font-size:16px; max-width:72ch; margin:0 0 20px;}
   .lede strong{color:var(--ink);}
   code{font-family:ui-monospace,Menlo,Consolas,monospace; font-size:.86em; color:var(--ink); background:#f4f5f6; border:1px solid var(--hair); border-radius:4px; padding:.5px 5px;}
-  .hl{background:var(--hl); padding:0 4px; border-radius:2px; box-decoration-break:clone; -webkit-box-decoration-break:clone;}
+  .hl{background:var(--hl); padding:0 4px; border-radius:2px;}
   .keynote{display:inline-flex; align-items:center; gap:9px; font-size:13px; color:var(--ink); border:2px solid var(--ink); border-radius:8px; padding:7px 13px; margin-bottom:6px;}
   .keynote .sw{width:15px;height:13px;border:1.5px solid var(--ink);background:var(--hl);border-radius:2px;flex:none;}
-  /* shared section heads */
-  h2{font-size:19px; margin:46px 0 4px; display:flex; align-items:center; gap:11px;}
+  h2{font-size:19px; margin:48px 0 4px; display:flex; align-items:center; gap:11px;}
   h2 .num{display:inline-grid;place-items:center;width:27px;height:27px;border-radius:7px;background:#fff;border:2px solid var(--ink);font-size:14px;color:var(--ink);font-weight:700;}
   .grp-sub{color:var(--muted); font-size:13.5px; margin:0 0 16px; max-width:82ch;}
   .grp-sub strong{color:var(--ink);}
-  /* fan-out canvas */
+
+  /* ── swimlane ── */
+  .lanes{display:grid; grid-template-columns:1fr 1fr; column-gap:40px; margin:6px 0 0;}
+  .lane-head{font-weight:700; font-size:12px; text-transform:uppercase; letter-spacing:.1em; border:2px solid var(--ink); border-radius:8px; padding:9px; text-align:center;}
+  .lane-head.you{background:var(--hl);}
+  .journey{position:relative; margin-top:14px;}
+  .journey::before{content:""; position:absolute; left:50%; top:2px; bottom:2px; width:2px; background:var(--ink); transform:translateX(-1px);}
+  .row{display:grid; grid-template-columns:1fr 1fr; column-gap:40px; margin-bottom:14px; position:relative;}
+  .row::after{content:""; position:absolute; left:50%; top:19px; width:9px; height:9px; border:2px solid var(--ink); background:#fff; border-radius:50%; transform:translateX(-50%);}
+  .jcard{background:#fff; border:2px solid var(--ink); border-radius:var(--radius); padding:12px 14px; position:relative;}
+  .row.left .jcard{grid-column:1; border-left:6px solid var(--hl);}
+  .row.right .jcard{grid-column:2;}
+  .row.left .jcard::after{content:""; position:absolute; top:21px; right:-20px; width:20px; height:2px; background:var(--ink);}
+  .row.right .jcard::after{content:""; position:absolute; top:21px; left:-20px; width:20px; height:2px; background:var(--ink);}
+  .row.gate{grid-template-columns:1fr;}
+  .row.gate::after{display:none;}
+  .row.gate .jcard{grid-column:1; justify-self:center; max-width:68%; border-left:6px solid var(--hl); background:var(--hl-bg);}
+  .who{font-family:ui-monospace,Menlo,Consolas,monospace; font-size:10px; font-weight:700; letter-spacing:.05em; border:1.5px solid var(--ink); border-radius:999px; padding:1px 8px; display:inline-block; margin-bottom:6px;}
+  .who.hl{background:var(--hl);}
+  .jcard .h{font-size:14px; font-weight:700; margin:0 0 4px;}
+  .jcard .p{font-size:12.5px; color:var(--muted); margin:0;}
+  .jcard .p strong{color:var(--ink);}
+  .skill{display:inline-block; margin-top:9px; font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); background:#f4f5f6; border:1px solid var(--hair); border-radius:5px; padding:2px 8px;}
+
+  /* ── ambient daily digest band ── */
+  .ambient{margin:18px 0 4px; border:2px dashed var(--ink); border-radius:var(--radius); padding:15px 17px; background:var(--hl-bg); display:flex; gap:14px; align-items:flex-start;}
+  .ambient .who{margin-bottom:0; flex:none;}
+  .ambient .h{font-size:14.5px; font-weight:700; margin:0 0 4px;}
+  .ambient .p{font-size:12.8px; color:var(--muted); margin:0;}
+  .ambient .p strong{color:var(--ink);}
+
+  /* ── fan-out canvas ── */
   .strip{margin:22px 0 8px; background:#fff; border:2px solid var(--ink); border-radius:var(--radius); padding:20px 16px; overflow-x:auto;}
   .strip svg{width:100%; height:auto; min-width:860px; display:block;}
   .strip text{fill:var(--ink); font-family:inherit;}
@@ -39,25 +69,19 @@
   .band{fill:none; stroke:var(--ink); stroke-width:1.4; stroke-dasharray:3 5;}
   .cap{color:var(--muted); font-size:13.5px; margin:12px 2px 0; max-width:82ch;}
   .cap strong{color:var(--ink);}
-  /* worker lifecycle */
-  .flow{display:flex; flex-direction:column; gap:10px;}
-  .step{display:flex; gap:14px; align-items:flex-start; background:#fff; border:2px solid var(--ink); border-radius:var(--radius); padding:14px 16px;}
-  .step .n{font-family:ui-monospace,Menlo,Consolas,monospace; font-weight:700; font-size:13px; width:22px; flex:none; padding-top:1px;}
-  .step .body{flex:1; min-width:0;}
-  .step .h{font-size:14.5px; font-weight:700; margin:0 0 3px;}
-  .step .p{font-size:13px; color:var(--muted); margin:0;}
-  .step .p strong{color:var(--ink);}
-  .step .tech{display:inline-block; margin-top:9px; font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); background:#f4f5f6; border:1px solid var(--hair); border-radius:5px; padding:2px 8px;}
-  .tag{font-size:10.5px; font-weight:700; padding:1.5px 8px; border-radius:999px; margin-left:8px; white-space:nowrap; background:var(--hl); border:1.5px solid var(--ink); vertical-align:middle;}
-  /* touchpoint cards */
+
+  /* ── touchpoint cards ── */
   .grid{display:grid; grid-template-columns:1fr; gap:14px;}
   @media(min-width:720px){.grid{grid-template-columns:1fr 1fr;}}
   .card{background:#fff; border:2px solid var(--ink); border-radius:var(--radius); padding:16px;}
+  .card.future{border-style:dashed;}
   .card .h{font-size:15px; font-weight:700; margin:0 0 7px;}
+  .card .tagf{font-size:10px; font-weight:700; letter-spacing:.05em; border:1.5px solid var(--ink); border-radius:999px; padding:1px 7px; margin-left:8px;}
   .card .p{font-size:12.8px; color:var(--muted); margin:0;}
   .card .p strong{color:var(--ink);}
-  .card .tech{display:inline-block; margin-top:11px; font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); background:#f4f5f6; border:1px solid var(--hair); border-radius:5px; padding:2px 8px;}
-  /* safety + note */
+  .card .skill{margin-top:11px;}
+
+  /* ── safety + note ── */
   .safety{display:flex; flex-direction:column; gap:8px; margin-top:14px;}
   .pill{display:flex; gap:11px; align-items:baseline; background:#fff; border:2px solid var(--ink); padding:10px 14px; border-radius:8px; font-size:13px; color:var(--muted);}
   .pill b{color:var(--ink); white-space:nowrap;}
@@ -70,16 +94,148 @@
 <body>
 <div class="wrap">
 
-  <span class="eyebrow">nuxt-crouton · agent orchestration</span>
-  <h1>How one task becomes shipped code</h1>
-  <p class="lede">A request like <code>/task-decompose "build X"</code> doesn't go to one agent — it
-    <strong>fans out</strong> into a tree of GitHub issues, and each leaf is built, sign-off-gated, and
-    turned into a PR by its own worker. This is that flow in one frame: the fan-out, and the four moments
-    the work surfaces back <strong>on the ticket</strong>.</p>
+  <span class="eyebrow">nuxt-crouton · the user journey</span>
+  <h1>From your ticket to shipped code — the road</h1>
+  <p class="lede">You write a ticket; the agents take it from there — fanning it out, pausing at
+    <strong>gates</strong> where only you can decide, and handing the result back as something you can see
+    and click. This is that road, lane by lane: <strong>what you do</strong>, <strong>what the agents
+    do</strong>, and <strong>the skill that fires</strong> at each stop.</p>
 
-  <div class="keynote"><span class="sw"></span> <span><span class="hl">Highlighted</span> = a moment a human is in the loop. Everything else runs on its own.</span></div>
+  <div class="keynote"><span class="sw"></span> <span><span class="hl">Highlighted</span> = a moment <strong>you</strong> are in the loop. Everything else the agents run on their own.</span></div>
 
-  <!-- ───────────────────────── FAN-OUT TREE ───────────────────────── -->
+  <!-- ───────────────────────── THE SWIMLANE ───────────────────────── -->
+  <div class="lanes">
+    <div class="lane-head you">👤 You</div>
+    <div class="lane-head">🤖 The agents</div>
+  </div>
+
+  <div class="journey">
+
+    <div class="row left"><div class="jcard">
+      <span class="who hl">YOU</span>
+      <p class="h">Create the ticket</p>
+      <p class="p">Describe the work as a <strong>bet</strong> — what you want, and how you'll know it worked. One issue, or a whole epic.</p>
+      <span class="skill">/github-tasks &nbsp;·&nbsp; /task-decompose</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">ORCHESTRATOR</span>
+      <p class="h">Fan the epic out</p>
+      <p class="p">Reads the goal and opens <strong>2–6 sub-issues</strong> on a shared epic branch.</p>
+      <span class="skill">/task-decompose &nbsp;·&nbsp; Sonnet</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">DECOMPOSER</span>
+      <p class="h">Split, or decide it's small enough</p>
+      <p class="p">Runs the <strong>LEAF TEST</strong> on each issue. Too big → splits again (recurses). Small enough → hands it to a worker.</p>
+      <span class="skill">LEAF TEST · MAX_DEPTH 3 · MAX_CHILDREN 6</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">WORKER</span>
+      <p class="h">Pick up a leaf</p>
+      <p class="p">Claims one issue in its own git worktree and checks its prerequisites exist.</p>
+      <span class="skill">label status:in-progress · Opus</span>
+    </div></div>
+
+    <div class="row gate"><div class="jcard">
+      <span class="who hl">GATE · YOU ANSWER</span>
+      <p class="h">If it's stuck, it asks — it never guesses</p>
+      <p class="p">A missing prerequisite or a real decision → it pings you and waits. Your reply restarts it; no special command.</p>
+      <span class="skill">comment + @you + status:blocked</span>
+    </div></div>
+
+    <div class="row gate"><div class="jcard">
+      <span class="who hl">GATE · YOU APPROVE</span>
+      <p class="h">Sign off on the data model <em>(only if it changes a schema)</em></p>
+      <p class="p">You get a <strong>field table</strong> on a draft PR <strong>before any code is generated</strong> — cheap to fix a wrong type here, expensive after.</p>
+      <span class="skill">/schema-review → draft PR + status:blocked</span>
+    </div></div>
+
+    <div class="row gate"><div class="jcard">
+      <span class="who hl">GATE · YOU APPROVE</span>
+      <p class="h">Sign off on the look <em>(only if it changes a screen)</em></p>
+      <p class="p">You get a <strong>mockup</strong> before the real component is built. Feedback goes inline on the committed file; resumes on <code>lgtm</code> / 👍.</p>
+      <span class="skill">/ui-proposal → draft PR + status:blocked</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">WORKER</span>
+      <p class="h">Build it</p>
+      <p class="p">Generates the collection and writes the real code on its branch.</p>
+      <span class="skill">/crouton</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">WORKER</span>
+      <p class="h">Tidy up before committing</p>
+      <p class="p">Docs synced to the change; translations checked — automatically, before the commit lands.</p>
+      <span class="skill">/sync-docs &nbsp;·&nbsp; /i18n-check</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">WORKER</span>
+      <p class="h">Typecheck, then commit</p>
+      <p class="p">Green typecheck is non-negotiable; small atomic commits, <strong>never squashed</strong>.</p>
+      <span class="skill">/commit</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">WORKER</span>
+      <p class="h">Open the pull request</p>
+      <p class="p">Body carries <code>Closes #NN</code>, so the issue closes itself on merge. Targets the epic branch.</p>
+      <span class="skill">create_pull_request · base: epic/&lt;NN&gt;-slug</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">WORKER</span>
+      <p class="h">Show the result</p>
+      <p class="p">Posts a real <strong>before/after screenshot</strong> of the change on the PR. (A full e2e <em>video</em> + trace is also captured — but as a downloadable CI artifact, not inline yet.)</p>
+      <span class="skill">app-shots.mjs (#311) · e2e video (#356)</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">WORKER</span>
+      <p class="h">Hand back a clickable preview</p>
+      <p class="p">For a POC, CI deploys a staging copy and posts an <strong>auth-working URL</strong> — a link you can log into and click around, not just a diff.</p>
+      <span class="skill">/poc-deploy → https://&lt;name&gt;.pmcp.dev</span>
+    </div></div>
+
+    <div class="row right"><div class="jcard">
+      <span class="who">CI · partly built</span>
+      <p class="h">Drive it to merged</p>
+      <p class="p">Green → it merges itself; red → a fix-bot tries (~3×); touches shared <code>packages/</code> → it waits for you.</p>
+      <span class="skill">watch-to-merge (#336)</span>
+    </div></div>
+
+    <div class="row left"><div class="jcard">
+      <span class="who hl">YOU</span>
+      <p class="h">Verify the whole thing &amp; close</p>
+      <p class="p">When all sub-issues merge, you get a single <strong>"verify the whole thing"</strong> pass on the deployed result — then the epic closes.</p>
+      <span class="skill">epic verify rollup</span>
+    </div></div>
+
+  </div>
+
+  <!-- daily digest: ambient, spans the whole road -->
+  <div class="ambient">
+    <span class="who hl">EVERY DAY · FOR YOU</span>
+    <div>
+      <p class="h">📊 Meanwhile — the daily digest</p>
+      <p class="p">Running <em>across</em> every ticket on the road, not a single step: a once-a-day
+        <strong>"where are we?"</strong> rollup — what moved in the last 24h plus a progress snapshot of
+        every open epic — so you glance instead of hunting the board. Render-only today (HTML + text);
+        email + scheduling are planned follow-ups.</p>
+      <span class="skill">/epic-digest (#357)</span>
+    </div>
+  </div>
+
+  <!-- ───────────────────────── ZOOM: FAN-OUT ───────────────────────── -->
+  <h2><span class="num">▸</span> Zoom: the recursive fan-out</h2>
+  <p class="grp-sub">Steps 2–4 above, drawn out. One task becomes a tree — each node decides
+    <strong>split</strong> or <strong>build</strong>, and workers run as isolated parallel leaves.</p>
+
   <div class="strip">
     <svg viewBox="0 0 880 412" role="img" aria-label="The recursive fan-out from a task to a tree of issues and workers">
       <defs>
@@ -145,108 +301,50 @@
         <text class="s-s" x="730" y="380" text-anchor="middle">→ PR (Closes #N)</text></g>
     </svg>
   </div>
-  <p class="cap"><strong>Every node runs the LEAF TEST.</strong> A single coherent change with bounded
-    files, clear acceptance, doable in one focused run → build it (spawn a worker). Otherwise → split it
-    into sub-issues and recurse. Hard stops keep it from running away: <code>MAX_DEPTH = 3</code>,
-    <code>MAX_CHILDREN = 6</code>. Orchestrator and decomposer only read/write issues, so they run on
-    <strong>Sonnet</strong>; only the worker writes real code, on <strong>Opus</strong>.</p>
+  <p class="cap"><strong>Every node runs the LEAF TEST.</strong> Orchestrator and decomposer only read/write
+    issues, so they run on <strong>Sonnet</strong>; only the worker writes real code, on <strong>Opus</strong>.</p>
 
-  <!-- ───────────────────────── WORKER LIFECYCLE ───────────────────────── -->
-  <h2><span class="num">▸</span> Inside one worker — a leaf, end to end</h2>
-  <p class="grp-sub">Each leaf runs in its own git worktree, off the shared <code>epic/&lt;NN&gt;-slug</code>
-    branch so it sees its siblings' merged work.</p>
-
-  <div class="flow">
-    <div class="step">
-      <span class="n">1</span><div class="body">
-        <p class="h">Claim the issue</p>
-        <p class="p">Reads the issue + its epic, sets the board moving.</p>
-        <span class="tech">label status:in-progress</span></div>
-    </div>
-    <div class="step">
-      <span class="n">2</span><div class="body">
-        <p class="h">Prerequisite &amp; invariant check — block, don't improvise<span class="tag">asks for help</span></p>
-        <p class="p">If something a sibling issue was meant to create isn't there yet, it does <strong>not</strong>
-          scaffold a second copy — it stops and asks. (The #325 post-mortem fix: parallel workers once built
-          three conflicting copies of one package.)</p>
-        <span class="tech">comment + @pmcp + status:blocked → STOP</span></div>
-    </div>
-    <div class="step">
-      <span class="n">3</span><div class="body">
-        <p class="h">Branch off the epic branch</p>
-        <p class="p">One issue → one branch → one PR.</p>
-        <span class="tech">claude/issue-&lt;N&gt;-&lt;slug&gt;</span></div>
-    </div>
-    <div class="step">
-      <span class="n">4</span><div class="body">
-        <p class="h">Sign-off gate — propose before you build<span class="tag">you approve</span></p>
-        <p class="p">Changing a screen or a data model? It mocks it first — a UI mockup or a schema
-          field-table — posts it on a <strong>draft</strong> PR, and <strong>holds</strong>. You review on
-          the committed <code>.md</code> in the diff; it resumes on <code>lgtm</code> / 👍 / <code>ui-approved</code>.</p>
-        <span class="tech">ui-proposal · schema-review → draft PR + status:blocked</span></div>
-    </div>
-    <div class="step">
-      <span class="n">5</span><div class="body">
-        <p class="h">Implement → typecheck → commit</p>
-        <p class="p">Builds it, makes typecheck green (non-negotiable), commits in small atomic pieces, pushes immediately.</p>
-        <span class="tech">pnpm typecheck · /commit (no git add .) · never squash</span></div>
-    </div>
-    <div class="step">
-      <span class="n">6</span><div class="body">
-        <p class="h">Open the PR — into the epic branch</p>
-        <p class="p">Body carries <code>Closes #NN</code> so the issue auto-closes on merge; one epic→main PR is the single human review.</p>
-        <span class="tech">create_pull_request · base: epic/&lt;NN&gt;-slug</span></div>
-    </div>
-    <div class="step">
-      <span class="n">7</span><div class="body">
-        <p class="h">Prove the mockup became reality<span class="tag">screenshot</span></p>
-        <p class="p">After an approved UI build, it captures a real before/after of the changed surface and posts it on the PR.</p>
-        <span class="tech">scripts/app-shots.mjs → before/after on the PR (#311)</span></div>
-    </div>
-    <div class="step">
-      <span class="n">8</span><div class="body">
-        <p class="h">Hand back a clickable preview<span class="tag">preview link</span></p>
-        <p class="p">For a POC, CI auto-provisions and deploys a staging Worker, then posts the
-          <strong>auth-working</strong> URL on the PR — a link you can log into, not just code on a branch.</p>
-        <span class="tech">poc-deploy → https://&lt;name&gt;.pmcp.dev on the PR</span></div>
-    </div>
-  </div>
-
-  <!-- ───────────────────────── FOUR TOUCHPOINTS ───────────────────────── -->
-  <h2><span class="num">★</span> The four moments it reaches you</h2>
-  <p class="grp-sub">The agents are headless, so they never pop a dialog. Everything that needs a human
-    happens <strong>as a comment, label, or attachment on the GitHub issue/PR</strong> — which is exactly
-    why this surface ports cleanly (Linear can mirror it, Slack can notify on it, pi can post to it).</p>
+  <!-- ───────────────────────── FOUR + 1 TOUCHPOINTS ───────────────────────── -->
+  <h2><span class="num">★</span> Where the work reaches you</h2>
+  <p class="grp-sub">The agents are headless — they never pop a dialog. Everything that needs you happens
+    <strong>as a comment, label, or attachment on the ticket</strong> — which is exactly why this surface
+    ports cleanly (Linear can mirror it, Slack can notify on it, pi can post to it).</p>
 
   <div class="grid">
     <div class="card">
       <p class="h">Asks for help — never guesses</p>
-      <p class="p">On a real blocker, it comments what's blocking, @mentions you, and marks the ticket blocked.
-        Your reply resumes it — no special command.</p>
-      <span class="tech">add_issue_comment + @pmcp + status:blocked</span>
+      <p class="p">On a real blocker it comments what's wrong, @mentions you, and marks the ticket blocked. Your reply resumes it.</p>
+      <span class="skill">add_issue_comment + @you + status:blocked</span>
     </div>
     <div class="card">
       <p class="h">Shows you a change before building it</p>
-      <p class="p">UI and schema changes get a rendered mockup / field-table on a draft PR. You give feedback
-        inline on the committed <code>.md</code> — pinned to the exact line — and approve when it's right.</p>
-      <span class="tech">sticky comment · lgtm / 👍 / ui-approved</span>
+      <p class="p">UI / schema changes get a rendered mockup or field-table on a draft PR; you approve inline.</p>
+      <span class="skill">/ui-proposal · /schema-review</span>
     </div>
     <div class="card">
       <p class="h">Proves it built what it showed</p>
-      <p class="p">After the build, a real before/after screenshot of the surface lands on the PR — no checking
-        out the branch to see it.</p>
-      <span class="tech">app-shots.mjs · separate sticky comment</span>
+      <p class="p">A real before/after screenshot of the surface lands on the PR after the build.</p>
+      <span class="skill">app-shots.mjs (#311)</span>
     </div>
     <div class="card">
       <p class="h">Hands back a link you can click</p>
-      <p class="p">Every POC PR deploys an isolated staging environment and posts a working, loggable-in URL —
-        the deliverable is a preview, not a diff.</p>
-      <span class="tech">https://&lt;name&gt;.pmcp.dev · auth seeded</span>
+      <p class="p">Every POC PR posts a working, loggable-in preview URL — the deliverable is a preview, not a diff.</p>
+      <span class="skill">/poc-deploy</span>
+    </div>
+    <div class="card">
+      <p class="h">Tells you where everything stands</p>
+      <p class="p">The daily digest rolls up the last 24h + every open epic, so status is a glance, not a hunt.</p>
+      <span class="skill">/epic-digest (#357)</span>
+    </div>
+    <div class="card future">
+      <p class="h">Shows the feature in motion <span class="tagf">PLANNED</span></p>
+      <p class="p">A short clip of how the feature <em>looks &amp; reacts</em>, posted inline on the ticket — the demo-video evolution of the screenshot. (Recording is easy; inline upload is the piece to solve.)</p>
+      <span class="skill">demo clip · evolves #311 / #356</span>
     </div>
   </div>
 
   <!-- ───────────────────────── SAFETY RAILS ───────────────────────── -->
-  <h2><span class="num">⛨</span> What keeps the fan-out safe</h2>
+  <h2><span class="num">⛨</span> What keeps the road safe</h2>
   <p class="grp-sub">The pipeline can run unattended, so the guardrails are structural, not vibes.</p>
   <div class="safety">
     <span class="pill"><b>epic branch</b> siblings integrate before main — no duplicate scaffolding</span>
@@ -257,16 +355,15 @@
   </div>
 
   <div class="note">
-    <strong>Today vs. nearly-there.</strong> The fan-out, sign-off gates, help-pings, screenshots, and
-    preview links above are live. The fully-autonomous <em>watch-to-merged</em> loop — sticky CI status,
-    auto-merge on green, a fix-bot on red — is partially built (epic <a href="https://github.com/pmcp/nuxt-crouton/issues/336">#336</a>);
-    until it lands, an attended session babysits the PR to merge.
+    <strong>Today vs. nearly-there.</strong> Everything solid above is live. Drawn as <em>partly built</em> or
+    <em>planned</em>: the autonomous <a href="https://github.com/pmcp/nuxt-crouton/issues/336">watch-to-merge</a> loop,
+    digest email/scheduling (<a href="https://github.com/pmcp/nuxt-crouton/issues/357">#357</a>), and the inline feature-demo clip.
   </div>
 
   <footer>
     Hand-authored companion to <code>skills-and-triggers.html</code> ("what fires when"). Sources:
-    <code>.claude/agents/{CLAUDE.md, task-orchestrator, task-decomposer, task-worker}.md</code>,
-    the <code>poc-deploy</code> / <code>ui-proposal</code> / <code>schema-review</code> skills, and
+    <code>.claude/agents/*.md</code>, the <code>task-decompose · github-tasks · schema-review · ui-proposal ·
+    crouton · sync-docs · i18n-check · commit · poc-deploy · epic-digest</code> skills, and
     <code>agent-orchestration-architecture.md</code>. Inline SVG · no JS · renders offline.
   </footer>
 

--- a/writeups/architecture/agent-flow.html
+++ b/writeups/architecture/agent-flow.html
@@ -343,6 +343,78 @@
   </div>
 
   <!-- ───────────────────────── SAFETY RAILS ───────────────────────── -->
+  <!-- ───────────────────────── COMMENTS = THE BUS ───────────────────────── -->
+  <h2><span class="num">💬</span> Comments are the steering wheel</h2>
+  <p class="grp-sub">There's no dashboard and no buttons — <strong>the whole thing is driven by comments and
+    labels on issues and PRs</strong>. That's how you direct it, and how it talks back. Each of these is a
+    real GitHub Action listening for a real comment.</p>
+
+  <div class="grid">
+    <div class="card">
+      <p class="h"><span class="hl">You</span> → <code>@claude</code> on any issue or PR</p>
+      <p class="p">Type <code>@claude</code> with what you want; an agent picks up that comment and acts on it.</p>
+      <span class="skill">claude.yml · issue_comment / review_comment</span>
+    </div>
+    <div class="card">
+      <p class="h"><span class="hl">You</span> → reply on a blocked issue</p>
+      <p class="p">Any comment on a <code>status:blocked</code> issue wakes the paused agent and it continues — no command needed.</p>
+      <span class="skill">resume-on-comment.yml</span>
+    </div>
+    <div class="card">
+      <p class="h"><span class="hl">You</span> → label an issue <code>auto-decompose</code></p>
+      <p class="p">Open or tag an issue with <code>auto-decompose</code> and the whole fan-out pipeline kicks off on its own.</p>
+      <span class="skill">decompose-on-issue.yml · opened / labeled</span>
+    </div>
+    <div class="card">
+      <p class="h"><span class="hl">You</span> → inline-comment a draft PR</p>
+      <p class="p">Comment on the committed mockup or schema; the agent revises it in place, then resumes when you reply <code>lgtm</code> / 👍.</p>
+      <span class="skill">sign-off revision loop (#310)</span>
+    </div>
+    <div class="card">
+      <p class="h">Agent → comments back</p>
+      <p class="p">The agent's own comments <em>are</em> the output: it asks for help, posts the screenshot, the preview URL, and the CI status.</p>
+      <span class="skill">add_issue_comment</span>
+    </div>
+  </div>
+
+  <!-- ───────────────────────── IT KEEPS FLOWING ───────────────────────── -->
+  <h2><span class="num">↻</span> It keeps flowing — work creates work</h2>
+  <p class="grp-sub">The road isn't a dead end. A finished task routinely <strong>mints the next one</strong> —
+    so the pipeline loops instead of stopping.</p>
+
+  <div class="strip">
+    <svg viewBox="0 0 880 192" role="img" aria-label="The pipeline loops: merged work mints new issues that feed back onto the board">
+      <defs>
+        <marker id="arL" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="#111316"/>
+        </marker>
+      </defs>
+
+      <line class="edge" x1="200" y1="57" x2="232" y2="57" marker-end="url(#arL)"/>
+      <line class="edge" x1="420" y1="57" x2="452" y2="57" marker-end="url(#arL)"/>
+      <line class="edge" x1="640" y1="57" x2="672" y2="57" marker-end="url(#arL)"/>
+      <path class="edge" d="M770,84 L770,156 L106,156 L106,86" marker-end="url(#arL)"/>
+      <text class="s-d" x="438" y="148" text-anchor="middle">…and it flows again — every merge can mint the next issue</text>
+
+      <g><rect class="node" x="12"  y="30" width="188" height="54" rx="9"/>
+        <text class="s-t" x="106" y="61" text-anchor="middle">Issues on the board</text></g>
+      <g><rect class="node" x="232" y="30" width="188" height="54" rx="9"/>
+        <text class="s-t" x="326" y="53" text-anchor="middle">Agents work the leaves</text>
+        <text class="s-s" x="326" y="69" text-anchor="middle">claim → build → PR</text></g>
+      <g><rect class="node" x="452" y="30" width="188" height="54" rx="9"/>
+        <text class="s-t" x="546" y="53" text-anchor="middle">Review → merge</text>
+        <text class="s-s" x="546" y="69" text-anchor="middle">Closes #NN</text></g>
+      <g><rect class="node" x="672" y="30" width="196" height="54" rx="9"/>
+        <text class="s-t" x="770" y="53" text-anchor="middle">New work is born</text>
+        <text class="s-s" x="770" y="69" text-anchor="middle">new issues &amp; epics</text></g>
+    </svg>
+  </div>
+  <p class="cap"><strong>New issues &amp; epics get minted four ways</strong> — <strong>recursion</strong> (a
+    decomposer opens sub-issues), a <strong>request</strong> (your <code>@claude</code> or
+    <code>auto-decompose</code> comment spins up a task or a whole epic), a <strong>regression</strong> (a
+    post-merge break opens a fresh issue, #336), and a <strong>follow-up</strong> (the verify or review pass
+    surfaces more). Each drops a new issue on the board — and the agents pick it up again.</p>
+
   <h2><span class="num">⛨</span> What keeps the road safe</h2>
   <p class="grp-sub">The pipeline can run unattended, so the guardrails are structural, not vibes.</p>
   <div class="safety">

--- a/writeups/architecture/agent-flow.html
+++ b/writeups/architecture/agent-flow.html
@@ -383,30 +383,52 @@
     so the pipeline loops instead of stopping.</p>
 
   <div class="strip">
-    <svg viewBox="0 0 880 192" role="img" aria-label="The pipeline loops: merged work mints new issues that feed back onto the board">
+    <svg viewBox="0 0 880 300" role="img" aria-label="The pipeline loops: merged work and four sources mint new issues that feed back onto the board">
       <defs>
         <marker id="arL" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
           <path d="M0,0 L10,5 L0,10 z" fill="#111316"/>
         </marker>
       </defs>
 
-      <line class="edge" x1="200" y1="57" x2="232" y2="57" marker-end="url(#arL)"/>
-      <line class="edge" x1="420" y1="57" x2="452" y2="57" marker-end="url(#arL)"/>
-      <line class="edge" x1="640" y1="57" x2="672" y2="57" marker-end="url(#arL)"/>
-      <path class="edge" d="M770,84 L770,156 L106,156 L106,86" marker-end="url(#arL)"/>
-      <text class="s-d" x="438" y="148" text-anchor="middle">…and it flows again — every merge can mint the next issue</text>
+      <!-- forward chain -->
+      <line class="edge" x1="248" y1="52" x2="328" y2="52" marker-end="url(#arL)"/>
+      <line class="edge" x1="552" y1="52" x2="632" y2="52" marker-end="url(#arL)"/>
 
-      <g><rect class="node" x="12"  y="30" width="188" height="54" rx="9"/>
-        <text class="s-t" x="106" y="61" text-anchor="middle">Issues on the board</text></g>
-      <g><rect class="node" x="232" y="30" width="188" height="54" rx="9"/>
-        <text class="s-t" x="326" y="53" text-anchor="middle">Agents work the leaves</text>
-        <text class="s-s" x="326" y="69" text-anchor="middle">claim → build → PR</text></g>
-      <g><rect class="node" x="452" y="30" width="188" height="54" rx="9"/>
-        <text class="s-t" x="546" y="53" text-anchor="middle">Review → merge</text>
-        <text class="s-s" x="546" y="69" text-anchor="middle">Closes #NN</text></g>
-      <g><rect class="node" x="672" y="30" width="196" height="54" rx="9"/>
-        <text class="s-t" x="770" y="53" text-anchor="middle">New work is born</text>
-        <text class="s-s" x="770" y="69" text-anchor="middle">new issues &amp; epics</text></g>
+      <!-- merge drops into the regeneration hub; hub loops back up to the board -->
+      <path class="edge" d="M744,78 L744,178 L582,178" marker-end="url(#arL)"/>
+      <path class="edge" d="M300,178 L136,178 L136,80" marker-end="url(#arL)"/>
+      <text class="s-d" x="146" y="150" text-anchor="start">loops back ↑</text>
+
+      <!-- four feeders into the hub -->
+      <line class="edge" x1="332" y1="238" x2="332" y2="208" marker-end="url(#arL)"/>
+      <line class="edge" x1="404" y1="238" x2="404" y2="208" marker-end="url(#arL)"/>
+      <line class="edge" x1="476" y1="238" x2="476" y2="208" marker-end="url(#arL)"/>
+      <line class="edge" x1="548" y1="238" x2="548" y2="208" marker-end="url(#arL)"/>
+
+      <!-- top chain -->
+      <g><rect class="node" x="24"  y="26" width="224" height="52" rx="9"/>
+        <text class="s-t" x="136" y="56" text-anchor="middle">Issues on the board</text></g>
+      <g><rect class="node" x="328" y="26" width="224" height="52" rx="9"/>
+        <text class="s-t" x="440" y="48" text-anchor="middle">Agents work the leaves</text>
+        <text class="s-s" x="440" y="64" text-anchor="middle">claim → build → PR</text></g>
+      <g><rect class="node" x="632" y="26" width="224" height="52" rx="9"/>
+        <text class="s-t" x="744" y="48" text-anchor="middle">Review → merge</text>
+        <text class="s-s" x="744" y="64" text-anchor="middle">Closes #NN</text></g>
+
+      <!-- regeneration hub -->
+      <g><rect class="node" x="300" y="150" width="280" height="56" rx="9"/>
+        <text class="s-t" x="440" y="174" text-anchor="middle">New issues &amp; epics are born</text>
+        <text class="s-s" x="440" y="191" text-anchor="middle">…then drop back onto the board</text></g>
+
+      <!-- feeder sources -->
+      <g><rect class="node" x="300" y="238" width="64" height="40" rx="8"/>
+        <text class="s-s" x="332" y="262" text-anchor="middle">recursion</text></g>
+      <g><rect class="node" x="372" y="238" width="64" height="40" rx="8"/>
+        <text class="s-s" x="404" y="262" text-anchor="middle">a request</text></g>
+      <g><rect class="node" x="444" y="238" width="64" height="40" rx="8"/>
+        <text class="s-s" x="476" y="262" text-anchor="middle">a break</text></g>
+      <g><rect class="node" x="516" y="238" width="64" height="40" rx="8"/>
+        <text class="s-s" x="548" y="262" text-anchor="middle">a follow-up</text></g>
     </svg>
   </div>
   <p class="cap"><strong>New issues &amp; epics get minted four ways</strong> — <strong>recursion</strong> (a

--- a/writeups/architecture/agent-flow.html
+++ b/writeups/architecture/agent-flow.html
@@ -113,106 +113,106 @@
 
     <div class="row left"><div class="jcard">
       <span class="who hl">YOU</span>
-      <p class="h">Create the ticket</p>
-      <p class="p">Describe the work as a <strong>bet</strong> — what you want, and how you'll know it worked. One issue, or a whole epic.</p>
+      <p class="h">You open a GitHub issue</p>
+      <p class="p">You write the issue as a <strong>bet</strong> — what you want, and how you'll know it worked. Multi-step work becomes an epic with sub-issues.</p>
       <span class="skill">/github-tasks &nbsp;·&nbsp; /task-decompose</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">ORCHESTRATOR</span>
-      <p class="h">Fan the epic out</p>
-      <p class="p">Reads the goal and opens <strong>2–6 sub-issues</strong> on a shared epic branch.</p>
+      <p class="h">The orchestrator opens 2–6 sub-issues</p>
+      <p class="p">It reads the epic and <strong>creates sub-issues</strong> under it, on a new shared epic branch.</p>
       <span class="skill">/task-decompose &nbsp;·&nbsp; Sonnet</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">DECOMPOSER</span>
-      <p class="h">Split, or decide it's small enough</p>
-      <p class="p">Runs the <strong>LEAF TEST</strong> on each issue. Too big → splits again (recurses). Small enough → hands it to a worker.</p>
+      <p class="h">The decomposer splits, or hands off</p>
+      <p class="p">For each sub-issue it runs the <strong>LEAF TEST</strong>: too big → it <strong>creates more sub-issues</strong> (recurses); small enough → it <strong>spawns a worker</strong>.</p>
       <span class="skill">LEAF TEST · MAX_DEPTH 3 · MAX_CHILDREN 6</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">WORKER</span>
-      <p class="h">Pick up a leaf</p>
-      <p class="p">Claims one issue in its own git worktree and checks its prerequisites exist.</p>
+      <p class="h">The worker claims the issue</p>
+      <p class="p">It <strong>adds the <code>status:in-progress</code> label</strong>, opens its own branch in an isolated worktree, and checks its prerequisites exist.</p>
       <span class="skill">label status:in-progress · Opus</span>
     </div></div>
 
     <div class="row gate"><div class="jcard">
-      <span class="who hl">GATE · YOU ANSWER</span>
-      <p class="h">If it's stuck, it asks — it never guesses</p>
-      <p class="p">A missing prerequisite or a real decision → it pings you and waits. Your reply restarts it; no special command.</p>
-      <span class="skill">comment + @you + status:blocked</span>
+      <span class="who hl">GATE · IT ASKS, YOU REPLY</span>
+      <p class="h">Stuck → the agent comments on the issue</p>
+      <p class="p"><strong>The agent posts a comment on the issue</strong>, @mentions you, and adds the <code>status:blocked</code> label — then stops. <strong>You reply on the issue</strong>, and that comment resumes it. No special command.</p>
+      <span class="skill">agent: comment + @you + status:blocked</span>
     </div></div>
 
     <div class="row gate"><div class="jcard">
-      <span class="who hl">GATE · YOU APPROVE</span>
-      <p class="h">Sign off on the data model <em>(only if it changes a schema)</em></p>
-      <p class="p">You get a <strong>field table</strong> on a draft PR <strong>before any code is generated</strong> — cheap to fix a wrong type here, expensive after.</p>
-      <span class="skill">/schema-review → draft PR + status:blocked</span>
+      <span class="who hl">GATE · IT SHOWS, YOU APPROVE</span>
+      <p class="h">Schema change → it posts a field table on a draft PR</p>
+      <p class="p"><em>(only if it changes a data model)</em> <strong>The agent posts the field table on a draft PR</strong> and adds <code>status:blocked</code>. <strong>You approve inline on the PR</strong>; only then does it generate the code.</p>
+      <span class="skill">/schema-review → draft PR comment</span>
     </div></div>
 
     <div class="row gate"><div class="jcard">
-      <span class="who hl">GATE · YOU APPROVE</span>
-      <p class="h">Sign off on the look <em>(only if it changes a screen)</em></p>
-      <p class="p">You get a <strong>mockup</strong> before the real component is built. Feedback goes inline on the committed file; resumes on <code>lgtm</code> / 👍.</p>
-      <span class="skill">/ui-proposal → draft PR + status:blocked</span>
+      <span class="who hl">GATE · IT SHOWS, YOU APPROVE</span>
+      <p class="h">Screen change → it posts a mockup on a draft PR</p>
+      <p class="p"><em>(only if it changes UI)</em> <strong>The agent posts a mockup image on a draft PR</strong> and waits. <strong>You comment <code>lgtm</code> / 👍</strong> (or inline edits) to approve; only then does it build the real component.</p>
+      <span class="skill">/ui-proposal → draft PR comment</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">WORKER</span>
-      <p class="h">Build it</p>
-      <p class="p">Generates the collection and writes the real code on its branch.</p>
+      <p class="h">The agent generates &amp; writes the code</p>
+      <p class="p">It generates the collection and writes the real code on its branch.</p>
       <span class="skill">/crouton</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">WORKER</span>
-      <p class="h">Tidy up before committing</p>
-      <p class="p">Docs synced to the change; translations checked — automatically, before the commit lands.</p>
+      <p class="h">The agent syncs docs &amp; checks i18n</p>
+      <p class="p">It runs sync-docs and i18n-check and <strong>folds any fixes into the change</strong> — automatically, before committing.</p>
       <span class="skill">/sync-docs &nbsp;·&nbsp; /i18n-check</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">WORKER</span>
-      <p class="h">Typecheck, then commit</p>
-      <p class="p">Green typecheck is non-negotiable; small atomic commits, <strong>never squashed</strong>.</p>
+      <p class="h">The agent typechecks, then commits</p>
+      <p class="p">It <strong>runs <code>pnpm typecheck</code></strong> (must be green), then <strong>commits</strong> in small atomic pieces — never squashed.</p>
       <span class="skill">/commit</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">WORKER</span>
-      <p class="h">Open the pull request</p>
-      <p class="p">Body carries <code>Closes #NN</code>, so the issue closes itself on merge. Targets the epic branch.</p>
+      <p class="h">The agent opens a pull request</p>
+      <p class="p">It opens a PR whose body says <code>Closes #NN</code>, targeting the epic branch — so the issue <strong>closes itself on merge</strong>.</p>
       <span class="skill">create_pull_request · base: epic/&lt;NN&gt;-slug</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">WORKER</span>
-      <p class="h">Show the result</p>
-      <p class="p">Posts a real <strong>before/after screenshot</strong> of the change on the PR. (A full e2e <em>video</em> + trace is also captured — but as a downloadable CI artifact, not inline yet.)</p>
-      <span class="skill">app-shots.mjs (#311) · e2e video (#356)</span>
+      <p class="h">The agent posts a screenshot on the PR</p>
+      <p class="p"><strong>It posts a real before/after screenshot as a comment on the PR.</strong> (A full e2e <em>video</em> is also recorded — but downloaded from CI, not inline yet.)</p>
+      <span class="skill">agent: screenshot comment (#311) · e2e video (#356)</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">WORKER</span>
-      <p class="h">Hand back a clickable preview</p>
-      <p class="p">For a POC, CI deploys a staging copy and posts an <strong>auth-working URL</strong> — a link you can log into and click around, not just a diff.</p>
-      <span class="skill">/poc-deploy → https://&lt;name&gt;.pmcp.dev</span>
+      <p class="h">CI deploys &amp; the agent posts the link</p>
+      <p class="p">For a POC, CI deploys a staging copy; <strong>the agent posts the auth-working URL as a comment on the PR</strong> — a link you can log into.</p>
+      <span class="skill">/poc-deploy → PR comment with URL</span>
     </div></div>
 
     <div class="row right"><div class="jcard">
       <span class="who">CI · partly built</span>
-      <p class="h">Drive it to merged</p>
-      <p class="p">Green → it merges itself; red → a fix-bot tries (~3×); touches shared <code>packages/</code> → it waits for you.</p>
+      <p class="h">CI drives the PR to merged</p>
+      <p class="p"><strong>CI posts the test status on the PR.</strong> Green → it merges itself; red → a fix-bot pushes a fix (~3×); touches shared <code>packages/</code> → it waits for you.</p>
       <span class="skill">watch-to-merge (#336)</span>
     </div></div>
 
     <div class="row left"><div class="jcard">
       <span class="who hl">YOU</span>
-      <p class="h">Verify the whole thing &amp; close</p>
-      <p class="p">When all sub-issues merge, you get a single <strong>"verify the whole thing"</strong> pass on the deployed result — then the epic closes.</p>
+      <p class="h">You run the final check &amp; close the epic</p>
+      <p class="p"><strong>The agent posts a "verify the whole thing" checklist on the epic</strong>; <strong>you run one end-to-end pass</strong> on the deployed result, then close the epic.</p>
       <span class="skill">epic verify rollup</span>
     </div></div>
 
@@ -222,11 +222,10 @@
   <div class="ambient">
     <span class="who hl">EVERY DAY · FOR YOU</span>
     <div>
-      <p class="h">📊 Meanwhile — the daily digest</p>
-      <p class="p">Running <em>across</em> every ticket on the road, not a single step: a once-a-day
-        <strong>"where are we?"</strong> rollup — what moved in the last 24h plus a progress snapshot of
-        every open epic — so you glance instead of hunting the board. Render-only today (HTML + text);
-        email + scheduling are planned follow-ups.</p>
+      <p class="h">📊 Meanwhile — the agent generates a daily digest</p>
+      <p class="p">Running <em>across</em> every ticket, not a single step: once a day <strong>the agent generates a
+        "where are we?" digest</strong> — what moved in the last 24h plus a progress snapshot of every open
+        epic — and saves it for you to read. Render-only today (HTML + text); email + scheduling are planned.</p>
       <span class="skill">/epic-digest (#357)</span>
     </div>
   </div>

--- a/writeups/architecture/agent-flow.html
+++ b/writeups/architecture/agent-flow.html
@@ -434,8 +434,9 @@
   <p class="cap"><strong>New issues &amp; epics get minted four ways</strong> — <strong>recursion</strong> (a
     decomposer opens sub-issues), a <strong>request</strong> (your <code>@claude</code> or
     <code>auto-decompose</code> comment spins up a task or a whole epic), a <strong>regression</strong> (a
-    post-merge break opens a fresh issue, #336), and a <strong>follow-up</strong> (the verify or review pass
-    surfaces more). Each drops a new issue on the board — and the agents pick it up again.</p>
+    post-merge break opens a fresh issue, #336), and a <strong>follow-up</strong> (the verify/review pass, or
+    the <strong>postmortem</strong> at epic close, mints <code>workflow</code> improvement issues — #403).
+    Each drops a new issue on the board — and the agents pick it up again.</p>
 
   <h2><span class="num">⛨</span> What keeps the road safe</h2>
   <p class="grp-sub">The pipeline can run unattended, so the guardrails are structural, not vibes.</p>

--- a/writeups/architecture/agent-flow.html
+++ b/writeups/architecture/agent-flow.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<!-- Hand-authored. The agent task flow: how /task-decompose fans a task into a tree of
+     issues, works the leaves, and surfaces help-pings / sign-offs / screenshots / preview
+     links on the ticket. Sources: .claude/agents/{CLAUDE.md,task-orchestrator,task-decomposer,
+     task-worker}.md · poc-deploy skill · agent-orchestration-architecture.md. Offline · no JS.
+     Style: clean line art — white ground, thick black lines, one highlight (human-in-the-loop). -->
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>nuxt-crouton — the agent task flow</title>
+<style>
+  :root{ --ink:#111316; --muted:#555a63; --faint:#8a909a; --hair:#e3e5e9; --hl:#ffe14d; --radius:10px; }
+  *{box-sizing:border-box;}
+  body{margin:0; background:#fff; color:var(--ink); line-height:1.55;
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif; -webkit-font-smoothing:antialiased;}
+  .wrap{max-width:1060px; margin:0 auto; padding:46px 22px 90px;}
+  .eyebrow{text-transform:uppercase; letter-spacing:.16em; font-size:12px; font-weight:700; color:var(--muted);}
+  h1{font-size:clamp(28px,4vw,40px); margin:10px 0 8px; line-height:1.08; letter-spacing:-.01em;}
+  .lede{color:var(--muted); font-size:16px; max-width:72ch; margin:0 0 20px;}
+  .lede strong{color:var(--ink);}
+  code{font-family:ui-monospace,Menlo,Consolas,monospace; font-size:.86em; color:var(--ink); background:#f4f5f6; border:1px solid var(--hair); border-radius:4px; padding:.5px 5px;}
+  .hl{background:var(--hl); padding:0 4px; border-radius:2px; box-decoration-break:clone; -webkit-box-decoration-break:clone;}
+  .keynote{display:inline-flex; align-items:center; gap:9px; font-size:13px; color:var(--ink); border:2px solid var(--ink); border-radius:8px; padding:7px 13px; margin-bottom:6px;}
+  .keynote .sw{width:15px;height:13px;border:1.5px solid var(--ink);background:var(--hl);border-radius:2px;flex:none;}
+  /* shared section heads */
+  h2{font-size:19px; margin:46px 0 4px; display:flex; align-items:center; gap:11px;}
+  h2 .num{display:inline-grid;place-items:center;width:27px;height:27px;border-radius:7px;background:#fff;border:2px solid var(--ink);font-size:14px;color:var(--ink);font-weight:700;}
+  .grp-sub{color:var(--muted); font-size:13.5px; margin:0 0 16px; max-width:82ch;}
+  .grp-sub strong{color:var(--ink);}
+  /* fan-out canvas */
+  .strip{margin:22px 0 8px; background:#fff; border:2px solid var(--ink); border-radius:var(--radius); padding:20px 16px; overflow-x:auto;}
+  .strip svg{width:100%; height:auto; min-width:860px; display:block;}
+  .strip text{fill:var(--ink); font-family:inherit;}
+  .s-t{font-size:13px; font-weight:700;} .s-s{font-size:10.5px; fill:var(--muted);}
+  .s-d{font-size:10px; fill:var(--faint); letter-spacing:.06em;}
+  .node{fill:#fff; stroke:var(--ink); stroke-width:2;}
+  .edge{stroke:var(--ink); stroke-width:2.2; fill:none;}
+  .band{fill:none; stroke:var(--ink); stroke-width:1.4; stroke-dasharray:3 5;}
+  .cap{color:var(--muted); font-size:13.5px; margin:12px 2px 0; max-width:82ch;}
+  .cap strong{color:var(--ink);}
+  /* worker lifecycle */
+  .flow{display:flex; flex-direction:column; gap:10px;}
+  .step{display:flex; gap:14px; align-items:flex-start; background:#fff; border:2px solid var(--ink); border-radius:var(--radius); padding:14px 16px;}
+  .step .n{font-family:ui-monospace,Menlo,Consolas,monospace; font-weight:700; font-size:13px; width:22px; flex:none; padding-top:1px;}
+  .step .body{flex:1; min-width:0;}
+  .step .h{font-size:14.5px; font-weight:700; margin:0 0 3px;}
+  .step .p{font-size:13px; color:var(--muted); margin:0;}
+  .step .p strong{color:var(--ink);}
+  .step .tech{display:inline-block; margin-top:9px; font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); background:#f4f5f6; border:1px solid var(--hair); border-radius:5px; padding:2px 8px;}
+  .tag{font-size:10.5px; font-weight:700; padding:1.5px 8px; border-radius:999px; margin-left:8px; white-space:nowrap; background:var(--hl); border:1.5px solid var(--ink); vertical-align:middle;}
+  /* touchpoint cards */
+  .grid{display:grid; grid-template-columns:1fr; gap:14px;}
+  @media(min-width:720px){.grid{grid-template-columns:1fr 1fr;}}
+  .card{background:#fff; border:2px solid var(--ink); border-radius:var(--radius); padding:16px;}
+  .card .h{font-size:15px; font-weight:700; margin:0 0 7px;}
+  .card .p{font-size:12.8px; color:var(--muted); margin:0;}
+  .card .p strong{color:var(--ink);}
+  .card .tech{display:inline-block; margin-top:11px; font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11px; color:var(--muted); background:#f4f5f6; border:1px solid var(--hair); border-radius:5px; padding:2px 8px;}
+  /* safety + note */
+  .safety{display:flex; flex-direction:column; gap:8px; margin-top:14px;}
+  .pill{display:flex; gap:11px; align-items:baseline; background:#fff; border:2px solid var(--ink); padding:10px 14px; border-radius:8px; font-size:13px; color:var(--muted);}
+  .pill b{color:var(--ink); white-space:nowrap;}
+  .note{margin-top:20px; font-size:12.8px; color:var(--muted); border:2px solid var(--ink); border-radius:8px; padding:13px 15px;}
+  .note strong{color:var(--ink);}
+  .note a{color:var(--ink); text-decoration:underline; text-decoration-thickness:2px;}
+  footer{margin-top:48px; padding-top:18px; border-top:2px solid var(--ink); color:var(--muted); font-size:12.5px;}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <span class="eyebrow">nuxt-crouton · agent orchestration</span>
+  <h1>How one task becomes shipped code</h1>
+  <p class="lede">A request like <code>/task-decompose "build X"</code> doesn't go to one agent — it
+    <strong>fans out</strong> into a tree of GitHub issues, and each leaf is built, sign-off-gated, and
+    turned into a PR by its own worker. This is that flow in one frame: the fan-out, and the four moments
+    the work surfaces back <strong>on the ticket</strong>.</p>
+
+  <div class="keynote"><span class="sw"></span> <span><span class="hl">Highlighted</span> = a moment a human is in the loop. Everything else runs on its own.</span></div>
+
+  <!-- ───────────────────────── FAN-OUT TREE ───────────────────────── -->
+  <div class="strip">
+    <svg viewBox="0 0 880 412" role="img" aria-label="The recursive fan-out from a task to a tree of issues and workers">
+      <defs>
+        <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" fill="#111316"/>
+        </marker>
+      </defs>
+
+      <text class="s-d" x="874" y="120" text-anchor="end">depth 0</text>
+      <text class="s-d" x="874" y="204" text-anchor="end">depth 1</text>
+      <text class="s-d" x="874" y="288" text-anchor="end">depth 2</text>
+      <text class="s-d" x="874" y="372" text-anchor="end">leaves</text>
+
+      <line class="edge" x1="440" y1="54"  x2="440" y2="92"  marker-end="url(#ar)"/>
+      <line class="edge" x1="440" y1="138" x2="150" y2="176" marker-end="url(#ar)"/>
+      <line class="edge" x1="440" y1="138" x2="440" y2="176" marker-end="url(#ar)"/>
+      <line class="edge" x1="440" y1="138" x2="730" y2="176" marker-end="url(#ar)"/>
+      <line class="edge" x1="150" y1="222" x2="80"  y2="260" marker-end="url(#ar)"/>
+      <line class="edge" x1="150" y1="222" x2="220" y2="260" marker-end="url(#ar)"/>
+      <line class="edge" x1="80"  y1="304" x2="80"  y2="346" marker-end="url(#ar)"/>
+      <line class="edge" x1="220" y1="304" x2="220" y2="346" marker-end="url(#ar)"/>
+      <line class="edge" x1="440" y1="222" x2="440" y2="346" marker-end="url(#ar)"/>
+      <line class="edge" x1="730" y1="222" x2="730" y2="346" marker-end="url(#ar)"/>
+
+      <rect class="band" x="8" y="338" width="800" height="58" rx="9"/>
+      <text class="s-d" x="14" y="333">isolated git worktrees · parallel · no collisions</text>
+
+      <g><rect class="node" x="334" y="20" width="212" height="34" rx="8"/>
+        <text class="s-t" x="440" y="42" text-anchor="middle">/task-decompose · epic #NN</text></g>
+
+      <g><rect class="node" x="316" y="92" width="248" height="46" rx="9"/>
+        <text class="s-t" x="440" y="113" text-anchor="middle">task-orchestrator · depth 0</text>
+        <text class="s-s" x="440" y="129" text-anchor="middle">reads epic → 2–6 sub-issues</text></g>
+
+      <g><rect class="node" x="70" y="176" width="160" height="46" rx="9"/>
+        <text class="s-t" x="150" y="197" text-anchor="middle">task-decomposer</text>
+        <text class="s-s" x="150" y="213" text-anchor="middle">too big → split (recurse)</text></g>
+      <g><rect class="node" x="360" y="176" width="160" height="46" rx="9"/>
+        <text class="s-t" x="440" y="197" text-anchor="middle">task-decomposer</text>
+        <text class="s-s" x="440" y="213" text-anchor="middle">leaf → spawn worker</text></g>
+      <g><rect class="node" x="650" y="176" width="160" height="46" rx="9"/>
+        <text class="s-t" x="730" y="197" text-anchor="middle">task-decomposer</text>
+        <text class="s-s" x="730" y="213" text-anchor="middle">leaf → spawn worker</text></g>
+
+      <g><rect class="node" x="15" y="260" width="130" height="44" rx="9"/>
+        <text class="s-t" x="80" y="280" text-anchor="middle">decomposer</text>
+        <text class="s-s" x="80" y="296" text-anchor="middle">leaf → worker</text></g>
+      <g><rect class="node" x="155" y="260" width="130" height="44" rx="9"/>
+        <text class="s-t" x="220" y="280" text-anchor="middle">decomposer</text>
+        <text class="s-s" x="220" y="296" text-anchor="middle">leaf → worker</text></g>
+
+      <g><rect class="node" x="15"  y="346" width="130" height="40" rx="9"/>
+        <text class="s-t" x="80"  y="366" text-anchor="middle">task-worker</text>
+        <text class="s-s" x="80"  y="380" text-anchor="middle">→ PR (Closes #N)</text></g>
+      <g><rect class="node" x="155" y="346" width="130" height="40" rx="9"/>
+        <text class="s-t" x="220" y="366" text-anchor="middle">task-worker</text>
+        <text class="s-s" x="220" y="380" text-anchor="middle">→ PR (Closes #N)</text></g>
+      <g><rect class="node" x="375" y="346" width="130" height="40" rx="9"/>
+        <text class="s-t" x="440" y="366" text-anchor="middle">task-worker</text>
+        <text class="s-s" x="440" y="380" text-anchor="middle">→ PR (Closes #N)</text></g>
+      <g><rect class="node" x="665" y="346" width="130" height="40" rx="9"/>
+        <text class="s-t" x="730" y="366" text-anchor="middle">task-worker</text>
+        <text class="s-s" x="730" y="380" text-anchor="middle">→ PR (Closes #N)</text></g>
+    </svg>
+  </div>
+  <p class="cap"><strong>Every node runs the LEAF TEST.</strong> A single coherent change with bounded
+    files, clear acceptance, doable in one focused run → build it (spawn a worker). Otherwise → split it
+    into sub-issues and recurse. Hard stops keep it from running away: <code>MAX_DEPTH = 3</code>,
+    <code>MAX_CHILDREN = 6</code>. Orchestrator and decomposer only read/write issues, so they run on
+    <strong>Sonnet</strong>; only the worker writes real code, on <strong>Opus</strong>.</p>
+
+  <!-- ───────────────────────── WORKER LIFECYCLE ───────────────────────── -->
+  <h2><span class="num">▸</span> Inside one worker — a leaf, end to end</h2>
+  <p class="grp-sub">Each leaf runs in its own git worktree, off the shared <code>epic/&lt;NN&gt;-slug</code>
+    branch so it sees its siblings' merged work.</p>
+
+  <div class="flow">
+    <div class="step">
+      <span class="n">1</span><div class="body">
+        <p class="h">Claim the issue</p>
+        <p class="p">Reads the issue + its epic, sets the board moving.</p>
+        <span class="tech">label status:in-progress</span></div>
+    </div>
+    <div class="step">
+      <span class="n">2</span><div class="body">
+        <p class="h">Prerequisite &amp; invariant check — block, don't improvise<span class="tag">asks for help</span></p>
+        <p class="p">If something a sibling issue was meant to create isn't there yet, it does <strong>not</strong>
+          scaffold a second copy — it stops and asks. (The #325 post-mortem fix: parallel workers once built
+          three conflicting copies of one package.)</p>
+        <span class="tech">comment + @pmcp + status:blocked → STOP</span></div>
+    </div>
+    <div class="step">
+      <span class="n">3</span><div class="body">
+        <p class="h">Branch off the epic branch</p>
+        <p class="p">One issue → one branch → one PR.</p>
+        <span class="tech">claude/issue-&lt;N&gt;-&lt;slug&gt;</span></div>
+    </div>
+    <div class="step">
+      <span class="n">4</span><div class="body">
+        <p class="h">Sign-off gate — propose before you build<span class="tag">you approve</span></p>
+        <p class="p">Changing a screen or a data model? It mocks it first — a UI mockup or a schema
+          field-table — posts it on a <strong>draft</strong> PR, and <strong>holds</strong>. You review on
+          the committed <code>.md</code> in the diff; it resumes on <code>lgtm</code> / 👍 / <code>ui-approved</code>.</p>
+        <span class="tech">ui-proposal · schema-review → draft PR + status:blocked</span></div>
+    </div>
+    <div class="step">
+      <span class="n">5</span><div class="body">
+        <p class="h">Implement → typecheck → commit</p>
+        <p class="p">Builds it, makes typecheck green (non-negotiable), commits in small atomic pieces, pushes immediately.</p>
+        <span class="tech">pnpm typecheck · /commit (no git add .) · never squash</span></div>
+    </div>
+    <div class="step">
+      <span class="n">6</span><div class="body">
+        <p class="h">Open the PR — into the epic branch</p>
+        <p class="p">Body carries <code>Closes #NN</code> so the issue auto-closes on merge; one epic→main PR is the single human review.</p>
+        <span class="tech">create_pull_request · base: epic/&lt;NN&gt;-slug</span></div>
+    </div>
+    <div class="step">
+      <span class="n">7</span><div class="body">
+        <p class="h">Prove the mockup became reality<span class="tag">screenshot</span></p>
+        <p class="p">After an approved UI build, it captures a real before/after of the changed surface and posts it on the PR.</p>
+        <span class="tech">scripts/app-shots.mjs → before/after on the PR (#311)</span></div>
+    </div>
+    <div class="step">
+      <span class="n">8</span><div class="body">
+        <p class="h">Hand back a clickable preview<span class="tag">preview link</span></p>
+        <p class="p">For a POC, CI auto-provisions and deploys a staging Worker, then posts the
+          <strong>auth-working</strong> URL on the PR — a link you can log into, not just code on a branch.</p>
+        <span class="tech">poc-deploy → https://&lt;name&gt;.pmcp.dev on the PR</span></div>
+    </div>
+  </div>
+
+  <!-- ───────────────────────── FOUR TOUCHPOINTS ───────────────────────── -->
+  <h2><span class="num">★</span> The four moments it reaches you</h2>
+  <p class="grp-sub">The agents are headless, so they never pop a dialog. Everything that needs a human
+    happens <strong>as a comment, label, or attachment on the GitHub issue/PR</strong> — which is exactly
+    why this surface ports cleanly (Linear can mirror it, Slack can notify on it, pi can post to it).</p>
+
+  <div class="grid">
+    <div class="card">
+      <p class="h">Asks for help — never guesses</p>
+      <p class="p">On a real blocker, it comments what's blocking, @mentions you, and marks the ticket blocked.
+        Your reply resumes it — no special command.</p>
+      <span class="tech">add_issue_comment + @pmcp + status:blocked</span>
+    </div>
+    <div class="card">
+      <p class="h">Shows you a change before building it</p>
+      <p class="p">UI and schema changes get a rendered mockup / field-table on a draft PR. You give feedback
+        inline on the committed <code>.md</code> — pinned to the exact line — and approve when it's right.</p>
+      <span class="tech">sticky comment · lgtm / 👍 / ui-approved</span>
+    </div>
+    <div class="card">
+      <p class="h">Proves it built what it showed</p>
+      <p class="p">After the build, a real before/after screenshot of the surface lands on the PR — no checking
+        out the branch to see it.</p>
+      <span class="tech">app-shots.mjs · separate sticky comment</span>
+    </div>
+    <div class="card">
+      <p class="h">Hands back a link you can click</p>
+      <p class="p">Every POC PR deploys an isolated staging environment and posts a working, loggable-in URL —
+        the deliverable is a preview, not a diff.</p>
+      <span class="tech">https://&lt;name&gt;.pmcp.dev · auth seeded</span>
+    </div>
+  </div>
+
+  <!-- ───────────────────────── SAFETY RAILS ───────────────────────── -->
+  <h2><span class="num">⛨</span> What keeps the fan-out safe</h2>
+  <p class="grp-sub">The pipeline can run unattended, so the guardrails are structural, not vibes.</p>
+  <div class="safety">
+    <span class="pill"><b>epic branch</b> siblings integrate before main — no duplicate scaffolding</span>
+    <span class="pill"><b>wave-gating</b> foundation issues run before the work that depends on them</span>
+    <span class="pill"><b>packages/ HARD GATE</b> a hook blocks shared-code edits unless the epic is approved</span>
+    <span class="pill"><b>no-squash</b> atomic, blameable commits land on main — built for later archaeology</span>
+    <span class="pill"><b>block, don't improvise</b> a missing prerequisite is a STOP, never a guess</span>
+  </div>
+
+  <div class="note">
+    <strong>Today vs. nearly-there.</strong> The fan-out, sign-off gates, help-pings, screenshots, and
+    preview links above are live. The fully-autonomous <em>watch-to-merged</em> loop — sticky CI status,
+    auto-merge on green, a fix-bot on red — is partially built (epic <a href="https://github.com/pmcp/nuxt-crouton/issues/336">#336</a>);
+    until it lands, an attended session babysits the PR to merge.
+  </div>
+
+  <footer>
+    Hand-authored companion to <code>skills-and-triggers.html</code> ("what fires when"). Sources:
+    <code>.claude/agents/{CLAUDE.md, task-orchestrator, task-decomposer, task-worker}.md</code>,
+    the <code>poc-deploy</code> / <code>ui-proposal</code> / <code>schema-review</code> skills, and
+    <code>agent-orchestration-architecture.md</code>. Inline SVG · no JS · renders offline.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/writeups/architecture/skills-and-triggers.html
+++ b/writeups/architecture/skills-and-triggers.html
@@ -157,6 +157,10 @@
         <p class="what">This skill performs a systematic translation completeness audit across all packages in the monorepo, using parallel subagents. It can also generate fix prompts or auto-fix individual packages.</p>
       </div>
       <div class="skill">
+        <div class="skill-head"><span class="name">/postmortem</span><span class="badges"><span class="b flow">in flow</span><span class="b ask">on ask</span></span></div>
+        <p class="what">At the close of an epic (or a difficult issue), post a postmortem roundup comment — what went well, what was hard (backed by evidence), and 1–3 concrete proposals to improve the skills/flows — then offer to turn accepted proposals into their own `workflow`-labeled tasks. Use at epic close, after the "verify the whole thing" rollup, or when asked to "do a retro", "postmortem this epic", "what did we learn", "how do we improve the workflow".</p>
+      </div>
+      <div class="skill">
         <div class="skill-head"><span class="name">/review</span><span class="badges"><span class="b ask">on ask</span></span></div>
         <p class="what">Code Review Assistant. Reviews uncommitted changes or recent commits for pattern violations, security issues, and bugs. Optimized for solo dev moving fast. Use when reviewing code before or after committing.</p>
       </div>


### PR DESCRIPTION
## 👤 For humans

Two things land here, both about *how we work* (not product code):

1. **One diagram of the agent workflow** — the user journey (you ↔ the agents, with the gates), how **comments steer it**, and the **"it keeps flowing" loop** where work mints more work. For onboarding colleagues and as the base for the multi-repo / pi / Linear thinking. Open `writeups/architecture/agent-flow.html` in a browser to view it (GitHub shows `.html` as source).
2. **The postmortem (retro) loop** — at epic close, an agent posts a roundup (what went well / what was hard, evidence-backed / 1–3 improvement proposals) and offers to mint `workflow` issues, so the workflow **tightens itself over time** instead of repeating the same friction.

The postmortem already proved its worth: dogfooding it on the blog POC (#274) surfaced a real gap in the skill (it would have duplicated proposals already tracked in #291), which we fixed before merge.

## 🤖 For agents

- **Diagram:** new `writeups/architecture/agent-flow.html` (offline HTML/SVG, no JS; companion to `skills-and-triggers.html`). Renders via `.claude/skills/ui-proposal/render.mjs`.
- **`workflow` label** in `.github/labels.yml` (meta label for loop/skill/flow improvements).
- **`/postmortem` skill** (`.claude/skills/postmortem/SKILL.md`): scope → mine difficulty signals (per-signal extraction table, honest about gaps) → 3-section roundup → **dedup against existing follow-up epics** → offer to mint `workflow` issues.
- **Wired into epic-close:** `github-tasks` SKILL.md (close-the-parent flow + task-workflow walk-up) and root `CLAUDE.md` now run the postmortem after the verify rollup, before closing.
- Registered in `scripts/gen-skills-doc.mjs`; `skills-and-triggers.html` regenerated.
- **Merge policy:** do **not** squash — commits are atomic and curated.
- **Epic #403 left open on purpose** — so it gets its own verify + `/postmortem` pass after merge (dogfooding the loop on itself), then closes.

## 🧪 How to test

- Open `writeups/architecture/agent-flow.html` (or render a PDF) → see the journey, the "Comments are the steering wheel" cards, and the loop with its four feeders.
- Read `.claude/skills/postmortem/SKILL.md` → the roundup sections, the dedup pass, and the difficulty-signal table.
- Read the `github-tasks` epic-close flow + `CLAUDE.md` "Issue Status Updates" → the postmortem step sits after verify, before close.

Closes #397 #404 #405 #406 #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LeoaS6R9bvh8nwoKiavrD

---
_Generated by [Claude Code](https://claude.ai/code/session_014LeoaS6R9bvh8nwoKiavrD)_