### PR TITLE
docs(root): epic-digest skill table reflects the live scheduled posting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,7 +440,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/sync-docs/SKILL.md` | Doc sync before commits |
 | Skill | `.claude/skills/i18n-audit.md` | Translation audit + fix |
 | Skill | `.claude/skills/github-tasks/SKILL.md` | GitHub issue tracking (epics, labels, workflow) |
-| Skill | `.claude/skills/epic-digest/SKILL.md` | Daily "where are we?" digest — render-only HTML+text email of last-24h activity + a progress snapshot of every open epic (gathers via GitHub MCP, renders dependency-free). For a status rapport / "what moved this week". Sending + scheduling are follow-ups (#357) |
+| Skill | `.claude/skills/epic-digest/SKILL.md` | Daily "where are we?" digest — last-24h activity + a progress snapshot of every open epic, rendered dependency-free (HTML/text, or Markdown). Interactive run gathers via GitHub MCP; a scheduled GitHub Action (`gather.mjs` → `render.mjs` → `post-comment.sh`) posts it to a standing issue every morning with no LLM/secrets (#357, #408). For a status rapport / "what moved this week" |
 | Skill | `.claude/skills/ecosystem-check/SKILL.md` | Check Nuxt/UnJS/Vite/OSS prior art before building |
 | Skill | `.claude/skills/e2e-smoke/SKILL.md` | Run the Playwright fixture smoke harness (boot + auth + CRUD) after a dep bump or `packages/` change |
 | Skill | `.claude/skills/db-migrations/SKILL.md` | The migrate step (`db:generate` schema.mjs-after-build gotcha) + package-owned infra tables. App collections use the `crouton` CLI, not this |


### PR DESCRIPTION
## 🤖 Doc sync

The epic-digest entry in CLAUDE.md's Available Artifacts table still described the skill as *"render-only… Sending + scheduling are follow-ups (#357)"*. Scheduling + posting-to-a-standing-issue shipped (#408) and the epic (#357) is closed, so this updates the description to match: interactive run via GitHub MCP, plus a scheduled Action (`gather.mjs` → `render.mjs` → `post-comment.sh`) that posts to a standing issue every morning with no LLM/secrets.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JabpzDAoxaesp9aqVNDGzX)_