### PR TITLE
docs: show /postmortem in the agent-flow close step (follow-up to #411)

### DIFF
--- a/writeups/architecture/agent-flow.html
+++ b/writeups/architecture/agent-flow.html
@@ -211,9 +211,9 @@
 
     <div class="row left"><div class="jcard">
       <span class="who hl">YOU</span>
-      <p class="h">You run the final check &amp; close the epic</p>
-      <p class="p"><strong>The agent posts a "verify the whole thing" checklist on the epic</strong>; <strong>you run one end-to-end pass</strong> on the deployed result, then close the epic.</p>
-      <span class="skill">epic verify rollup</span>
+      <p class="h">Verify, retro, then close the epic</p>
+      <p class="p"><strong>The agent posts a "verify the whole thing" checklist</strong> (you run one end-to-end pass), <strong>then a <code>/postmortem</code> retro</strong> — what went well / what was hard / proposals that become <code>workflow</code> issues — and only then closes the epic.</p>
+      <span class="skill">verify rollup → /postmortem (#403) → close</span>
     </div></div>
 
   </div>


### PR DESCRIPTION
## 👤 For humans

Small follow-up to #411. The agent-flow diagram's epic-close step said only "verify rollup" — it now reads **verify → `/postmortem` → close**, so the retro step is visible where it actually happens.

## 🤖 For agents

- `writeups/architecture/agent-flow.html`: final journey step names `/postmortem` + the verify→retro→close sequence (skill chip + prose). One-line diagram fix; no behaviour change.
- Relates to epic #403 (closed). No issue to auto-close.

## 🧪 How to test

Open `writeups/architecture/agent-flow.html` (or the PDF) → the last journey step shows "Verify, retro, then close the epic" with `verify rollup → /postmortem (#403) → close`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LeoaS6R9bvh8nwoKiavrD

---
_Generated by [Claude Code](https://claude.ai/code/session_014LeoaS6R9bvh8nwoKiavrD)_