### PR TITLE
docs(root): recurring chores are standalone, never epic sub-issues

### DIFF
--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -100,6 +100,8 @@ A merged PR auto-closes the issues in its `Closes #NN` lines — but **a parent 
 
 Don't stop at the issue you were asked about; closing the leaf without checking the branch above it leaves the epic falsely "in progress".
 
+**Recurring/standing chores are standalone, never epic sub-issues.** A ticket that's re-armed on a cadence and intentionally never permanently closed (e.g. the quarterly dependency sweep) must **not** be a sub-issue of a deliverable epic. A future-dated child that legitimately never closes silently defeats the "are all children closed?" check above, so a fully-delivered epic is pinned open forever and never reaches its verify + postmortem close-out — the most common stale-tracking bug, just slower to spot (the #233 → #244 case: the epic sat done-but-open for days behind the next quarterly sweep). File the recurring chore **standalone** (it may *link* the originating epic for context, not parent to it), and when it re-arms, open the next occurrence standalone too. (#422)
+
 **Titles are human-first too.** Issue/PR titles read like plain English that anyone grasps at a glance ("Run the whole app on a Raspberry Pi and print directly"), not jargon ("node-server preset + in-process TCP drainer"). Keep the technical specifics in the 🤖 body, never the title.
 
 ## Core rules


### PR DESCRIPTION
## 👤 For humans

A recurring/standing chore (like the quarterly dependency sweep) filed as an **epic sub-issue** never closes — so it silently pins a fully-delivered epic open and the close-out (verify + postmortem) never runs. This adds a rule to the `github-tasks` skill so it doesn't happen again.

Found by a board audit: epic #233 (deps current) had shipped all 7 deliverables but sat open for days, held by its only remaining child #244 — the *next* quarterly sweep, due September, which by design never closes. #244 has been re-parented out, #233 closed; this PR is the durable fix.

## 🤖 For agents

- `.claude/skills/github-tasks/SKILL.md`: new rule under *"Closing a child? Always check the parent"* — a never-closing recurring child defeats the "all children closed?" trigger, so recurring chores are filed **standalone** (link the epic, don't parent), and re-armed standalone.
- Surfaced by the #233 postmortem.

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011krN42xNu4ZA7dxXKDSZip)_