### PR TITLE
Make bug-archaeology the first step of bug work

### DIFF
--- a/.claude/skills/bug-archaeology/SKILL.md
+++ b/.claude/skills/bug-archaeology/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: bug-archaeology
+description: When a bug or regression is reported, the FIRST step — before fixing — is to research how and when it was introduced (git archaeology), then record that finding on the tracking issue/PR. Use the moment a bug, error, broken build, or "this used to work" is reported, before writing a fix. Produces a first-bad-commit (or "not a code regression") note you paste onto the issue.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Bug Archaeology — find out *how & when* it broke, before you fix it
+
+**The reflex for any bug is: research origin first, fix second.** Jumping
+straight to a fix hides the real story and produces symptom-patches. The recent
+case that motivated this (issue #424): a fanfare build warned that
+`@fyit/crouton-printing/server/database/schema` "could not be resolved". It
+*looked* like a code bug — but archaeology showed the code and lockfile were
+correct since #329; the real cause was a **stale local install** (a missing pnpm
+workspace symlink). A symptom-first reflex would have "fixed" package code that
+was never broken.
+
+So before you touch the code: **establish when the behaviour changed, what
+change introduced it, and whether it's even a code regression at all** — then
+write that down where the next person (or agent doing `git blame`/`git bisect`)
+will find it.
+
+## When to use
+- **Default / first step** the moment a bug, crash, error, failed build, broken
+  test, or "this used to work" is reported — *before* writing a fix.
+- On ask: "when was this introduced", "find the regression", "root-cause this".
+- **Skip** only for a brand-new feature that never worked (nothing to regress
+  from) or a one-line obvious typo in code you just wrote this session.
+
+## The protocol
+
+### 1. Reproduce / pin the symptom
+Get the exact error string, failing file, or observable. You need a concrete
+needle to search history for.
+
+### 2. Decide: code regression, or environment/state?
+Before blaming a commit, rule out the non-code causes — they're common and
+archaeology on the *wrong* axis wastes time:
+- **Stale install** — `node_modules`/symlinks out of date vs the lockfile
+  (run `pnpm install`; compare `ls -la node_modules/...` link mtimes to the dep's
+  introduction date). This was the #424 cause.
+- **Env/secrets/config** — a value differs between machines/envs, not the code.
+- **Data/state** — a migration, a seeded row, an external service.
+
+If it's one of these, that *is* the finding — record it and stop (don't go
+commit-hunting for a regression that isn't in the code).
+
+### 3. Git archaeology — find the first bad change
+Pick the tool that fits the needle:
+
+```bash
+# A symbol/string appeared or vanished — pickaxe is the fastest first move:
+git log -S '<exact string>' --oneline -- <path>     # commits that add/remove the literal
+git log -G '<regex>' --oneline -- <path>             # commits whose diff matches a regex
+
+# When did this file/area last change, and in what commit?
+git log --oneline -- <path>
+git log --oneline -L '<start>,<end>:<path>'          # history of a specific line range
+
+# Who last touched the exact line, and why (read that commit's message):
+git blame -L <line>,<line> -- <path>
+git show <sha>                                       # the introducing change + its rationale
+
+# Behaviour regression with no obvious line — bisect between a known-good and known-bad:
+git bisect start <bad-sha> <good-sha>
+git bisect run <command-that-exits-nonzero-on-the-bug>
+git bisect reset
+```
+
+Tie the first-bad commit back to its **PR/issue** (`git log` shows the `(#NN)`
+merge ref) so the finding links the original change.
+
+### 4. Record the finding (REQUIRED — this is the deliverable)
+Archaeology that isn't written down gets re-done. Post the finding **on the
+tracking issue/PR** as a comment, or in the bug issue body. If no issue exists
+yet, open one (per `github-tasks`) — the finding is its first content. Keep the
+bare `(#NN)` convention in commits; link full URLs in chat replies.
+
+## Finding template (copy-paste)
+
+```markdown
+## 🔬 Archaeology
+
+- **Symptom:** <the exact error / observable>
+- **First introduced:** <commit SHA> (<PR #NN>, <YYYY-MM-DD>) — `<one-line what that change did>`
+  <!-- OR, when it's not a code regression: -->
+- **Not a code regression:** <stale install | env/secret | data/state> — <what was actually wrong>
+- **How found:** <git log -S '…' / git bisect / symlink mtime vs dep introduction / …>
+- **Fix:** <the change that addresses the *root* cause, not the symptom>
+```
+
+A good finding states either a **first-bad commit (SHA + PR + date)** *or* an
+explicit **"not a code regression — <cause>"**. "Looks broken, fixed it" is not
+a finding.
+
+## How this fits the workflow
+This is **step 0** of bug work in `CLAUDE.md`'s Task Execution Workflow: research
+origin and record it *before* the fix. It pairs with `/review` (which inspects a
+diff for problems) and `github-tasks` (where the finding is recorded). The
+durable archaeology note is exactly what a future `git blame`/`git bisect` lands
+on — so we stop re-litigating settled regressions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ Every task is a **GitHub issue** (see `### GitHub Issue Tracking` below) and fol
 5. Git Commit        → ALWAYS use /commit skill, reference (#NN) — NEVER git commit directly
 ```
 
+**ARCHAEOLOGY-FIRST for bugs (HARD GATE): research how & when a bug was introduced BEFORE fixing it.** The moment a bug, crash, failed build, broken test, or "this used to work" is reported, step 0 is to find the first-bad commit (`git log -S`/`-G`, `git blame`, `git bisect`) — or determine it's *not* a code regression (stale install, env, data) — and **record that finding on the tracking issue/PR** (open one if none exists). A symptom-first fix can "repair" code that was never broken. Run the **`bug-archaeology`** skill; it carries the protocol + the finding template. (#424)
+
 ### GitHub Issue Tracking
 
 **ISSUE-FIRST (HARD GATE): open the tracking issue BEFORE writing code.** For any new feature/package/app/initiative, the *first* action is creating the GitHub issue (epic + sub-issues for anything multi-step) via the `github-tasks` skill — not after the work, not at PR time. If you catch yourself editing files for an initiative that has no issue, STOP and open it first. New package or app? It also needs its `pkg:`/`app:` label in `.github/labels.yml`. This is the step most easily skipped — treat a missing issue like a failing build.
@@ -450,6 +452,7 @@ This applies to every agent and sub-agent, and every capture method: Playwright 
 | Skill | `.claude/skills/ui-proposal/SKILL.md` | Generate a before/after UI mockup (offline HTML/CSS/SVG) + render it to PNG for design sign-off before building UI. Part of the UI sign-off loop (#307) |
 | Skill | `.claude/skills/schema-review/SKILL.md` | Render a collection schema (field-definition JSON) into a human-readable field table + relationships (HTML + PNG + Markdown) for data-model sign-off before `crouton config` generates code. Part of the schema sign-off loop (#314) |
 | Skill | `.claude/skills/postmortem/SKILL.md` | At epic close (after the verify rollup, before closing): post a retro comment — what went well / what was hard (evidence-backed) / 1–3 proposals — and offer to mint accepted proposals as `workflow` issues. Tightens the loop over time (#403) |
+| Skill | `.claude/skills/bug-archaeology/SKILL.md` | First step of bug work (HARD GATE): research how & when a bug was introduced — `git log -S`/`blame`/`bisect` to the first-bad commit, or rule it a non-code cause (stale install/env/data) — and record the finding on the issue/PR before fixing. Use the moment a bug/regression/broken build is reported (#424) |
 | Agent | `.claude/agents/task-orchestrator.md` | Reads an epic, fans it into 2–6 top-level sub-issues, spawns a decomposer per child |
 | Agent | `.claude/agents/task-decomposer.md` | Recursive: LEAF TEST one issue → spawn a worker (leaf) or split into sub-issues + spawn a decomposer per child |
 | Agent | `.claude/agents/task-worker.md` | Implements one leaf issue on an isolated worktree branch → `pnpm typecheck` → `/commit` → PR (`Closes #NN`) |

--- a/scripts/gen-skills-doc.mjs
+++ b/scripts/gen-skills-doc.mjs
@@ -35,6 +35,7 @@ const META = {
   audit: { group: 'review', triggers: ['ask'] },
   'i18n-audit': { group: 'review', triggers: ['ask'] },
   postmortem: { group: 'review', triggers: ['flow', 'ask'] },
+  'bug-archaeology': { group: 'review', triggers: ['flow', 'ask'] },
   deploy: { group: 'deploy', triggers: ['ask'] },
   'deploy-production': { group: 'deploy', triggers: ['ask'] },
   'poc-deploy': { group: 'deploy', triggers: ['ask'] },

--- a/writeups/architecture/skills-and-triggers.html
+++ b/writeups/architecture/skills-and-triggers.html
@@ -153,6 +153,10 @@
         <p class="what">Audit packages for documentation completeness, detect drift between code and docs, and maintain documentation quality across the monorepo. Use when checking package docs, running audits, or reviewing documentation health.</p>
       </div>
       <div class="skill">
+        <div class="skill-head"><span class="name">/bug-archaeology</span><span class="badges"><span class="b flow">in flow</span><span class="b ask">on ask</span></span></div>
+        <p class="what">When a bug or regression is reported, the FIRST step — before fixing — is to research how and when it was introduced (git archaeology), then record that finding on the tracking issue/PR. Use the moment a bug, error, broken build, or "this used to work" is reported, before writing a fix. Produces a first-bad-commit (or "not a code regression") note you paste onto the issue.</p>
+      </div>
+      <div class="skill">
         <div class="skill-head"><span class="name">/i18n-audit</span><span class="badges"><span class="b ask">on ask</span></span></div>
         <p class="what">This skill performs a systematic translation completeness audit across all packages in the monorepo, using parallel subagents. It can also generate fix prompts or auto-fix individual packages.</p>
       </div>


### PR DESCRIPTION
## 👤 For humans

Makes **"research how & when a bug was introduced, then write it down"** the first reflex for any bug — before fixing. A symptom-first fix can "repair" code that was never broken: the fanfare `crouton-printing` "could not be resolved" warning *looked* like a code bug, but it was a stale local install (a missing pnpm symlink), correct in code since #329.

This ships a `bug-archaeology` skill (the `git log -S`/`blame`/`bisect` recipe + a finding template) and a HARD-GATE bullet in `CLAUDE.md` that names archaeology-first as step 0 of bug work.

## 🤖 For agents

- **`.claude/skills/bug-archaeology/SKILL.md`** — new skill: protocol (reproduce → rule out non-code causes → pickaxe/blame/bisect) + copy-paste **Finding** template (first-bad commit + PR + date, *or* "not a code regression — <cause>").
- **`CLAUDE.md`** — ARCHAEOLOGY-FIRST hard gate in Task Execution Workflow + a row in the Available Artifacts table.
- **`scripts/gen-skills-doc.mjs`** — added to `META` (review group, `flow`+`ask` triggers).
- **`writeups/architecture/skills-and-triggers.html`** — regenerated (23 skills); `skills-doc` CI stays green.

## 🧪 How to test

This is a process/docs change — "testing" is using it:
1. With a sample bug, trigger the `bug-archaeology` skill → it walks `git log`/`blame`/`bisect` and produces a finding note.
2. `node scripts/gen-skills-doc.mjs` runs clean and leaves no uncommitted diff (CI `skills-doc.yml` enforces this).
3. `CLAUDE.md` Task Execution Workflow reads "archaeology first" for bugs and links the skill.

Closes #424
