### PR TITLE
fix(root): move id-token:write to job level in claude/decompose workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,10 +16,15 @@ jobs:
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
+    # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to
+    # be here or the claude-code-action OIDC token request fails
+    # ("Could not fetch an OIDC token"). A workflow-level block would be silently shadowed.
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,9 +36,3 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 25"
-
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -14,10 +14,15 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'auto-decompose')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
+    # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to
+    # be here or the claude-code-action OIDC token request fails
+    # ("Could not fetch an OIDC token"). A workflow-level block would be silently shadowed.
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,9 +37,3 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: "/task-decompose #${{ github.event.issue.number }}"
           claude_args: "--max-turns 30"
-
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write


### PR DESCRIPTION
## 👤 For humans

The `auto-decompose` and `@claude` automations were failing before they could even call Claude — every run died at `Could not fetch an OIDC token`. So labelling an issue `auto-decompose` (e.g. #428) silently did nothing. This fixes the permission so the orchestration flow can authenticate and run.

## 🤖 For agents

**Root cause:** GitHub job-level `permissions` *fully overrides* (does not merge with) the workflow-level block. `claude.yml` and `decompose-on-issue.yml` each declared `id-token: write` only in a workflow-level block at the bottom of the file, which is silently shadowed by the job's own `permissions` block → `anthropics/claude-code-action` can't mint its OIDC token → `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`, fails after 3 attempts.

Evidence: issue #428's decompose runs `27839609568` / `27839609549` both failed with this exact error.

**Fix:** move `id-token: write` into the job-level `permissions` block and drop the dead workflow-level block in both files, mirroring the already-correct `resume-on-comment.yml`. Added the same explanatory comment to prevent regression.

**Context:** [#284](https://github.com/pmcp/nuxt-crouton/issues/284) fixed this identical bug but only in `resume-on-comment.yml` — it didn't sweep the two sibling workflows that share the pattern. This completes that sweep.

## 🧪 How to test

After merge to `main` (issue-triggered workflows run from the default branch): remove and re-add the `auto-decompose` label on #428 → confirm the `decompose` job gets past `setupGitHubToken` with no OIDC error and starts `/task-decompose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_