### PR TITLE
fix(root): @mention the owner only for actionable asks, not status FYIs

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -48,6 +48,11 @@ cheaper (slightly blunter) split, or raise them to `opus` if decomposition quali
   GitHub/app notification), apply `status:blocked`, and stop — the human answers by
   replying on the issue. Small ambiguities are decided with a default + a noted
   assumption (no ping). Change the handle in this file and in the task-decompose skill.
+- **An @mention is a request for action, not a broadcast.** Only @mention `NOTIFY_HANDLE`
+  when you need the human to *do* something: answer a blocking question, give a sign-off,
+  or unblock you. **Pure progress/status updates** ("spawning the worker for #NN", "wave 2
+  of 4 starting", "preview deploying") are posted as **plain comments with no @mention** —
+  they're FYIs, not asks. If nothing is required of the human, do not ping them.
 - **Workers are isolated.** The decomposer spawns workers with `isolation: "worktree"`
   so parallel leaves never collide on branches/files. One issue → one branch → one PR
   with `Closes #NN`. Workers obey the `packages/` HARD GATE and the `/commit` + no-squash

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -141,6 +141,10 @@ surfaces in the GitHub / Claude mobile app):
 
 - **Small ambiguity** → decide with a sensible default, record the assumption in the
   issue body, keep going. *No mention* (don't spam).
+- **Progress / status update** ("spawning the worker for #NN", "wave 2 of 4 starting",
+  "preview deploying") → a plain `add_issue_comment` with **no @mention**. An @mention is
+  a request for the human to *act*; an FYI is not. If nothing is required of the owner,
+  do not ping them — post the update unmentioned (or skip it).
 - **Real blocker / decision needed** → `add_issue_comment` on the issue with a tight
   question + options, **@mention `NOTIFY_HANDLE`**, apply the `status:blocked` label,
   then **stop** that branch. The owner replies on the issue; a resume trigger (or a


### PR DESCRIPTION
Closes #435.

## 👤 For humans

Agents were @mentioning you on plain progress updates (e.g. [`@pmcp — spawning decomposer for #431 now…`](https://github.com/pmcp/nuxt-crouton/issues/428#issuecomment-4753618704)) — not actionable, so just noise. After this, an @mention means "I need you": status updates are posted as plain comments with no ping; only blockers, decisions, and sign-off requests notify you.

## 🤖 For agents

Tightened the `NOTIFY_HANDLE = @pmcp` convention in both canonical places:
- `.claude/agents/CLAUDE.md` — added a bullet: an @mention is a request for action, not a broadcast; progress/status → plain comment, no mention.
- `.claude/skills/task-decompose/SKILL.md` — added a "Progress / status update" case to *Notifications & async Q&A* (plain comment, no @mention).

Blocker/decision/sign-off behaviour (comment + @mention + `status:blocked` + stop) is unchanged.

## 🧪 How to test

Next pipeline run posts progress comments **without** @pmcp; only a genuine blocking question or sign-off request produces a notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_