### PR TITLE
chore(root): show full Claude output in agent workflow logs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 25"
+          show_full_output: true

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -37,3 +37,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: "/task-decompose #${{ github.event.issue.number }}"
           claude_args: "--max-turns 30"
+          show_full_output: true

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -44,3 +44,4 @@ jobs:
             thread (the latest comment is their answer), incorporate it, remove the
             `status:blocked` label, then continue via /task-decompose #${{ github.event.issue.number }}.
           claude_args: "--max-turns 30"
+          show_full_output: true


### PR DESCRIPTION
## 👤 For humans

The Actions logs were truncating the agent's output — *"Rerun in debug mode or enable `show_full_output: true`…"*. This enables it, so the full Claude execution log shows inline. No more re-running in debug to see what the agent did.

## 🤖 For agents

Added `show_full_output: true` to the `claude-code-action` step in `decompose-on-issue.yml`, `resume-on-comment.yml`, and `claude.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_