### PR TITLE
fix(root): decompose only on fresh `delegate`, not every label change

### DIFF
--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -9,9 +9,13 @@ on:
 
 jobs:
   decompose:
-    # Only fire for issues explicitly opted in. (On `labeled` this also covers the case
-    # where the label is added later; on `opened` the label must already be present.)
-    if: contains(github.event.issue.labels.*.name, 'delegate')
+    # Fire ONLY when `delegate` is freshly applied (or present at creation) — NOT on every
+    # later label change while `delegate` happens to still be on the issue. Otherwise the
+    # worker adding `status:in-progress` re-fires this workflow as claude[bot], which then
+    # dies on the bot-actor guard (the mystery duplicate failures). Gate on the *added* label.
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'delegate') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully


### PR DESCRIPTION
## 👤 For humans

Stops the agent pipeline from **re-firing (and failing) every time a worker adds a label** to a delegated issue. Diagnosed live on #454: the worker set `status:in-progress`, which re-triggered `decompose-on-issue` as `claude[bot]`, which then died on the bot-actor guard — the source of the recurring "duplicate failure" runs all session.

## 🤖 For agents

Root cause: the trigger used `contains(github.event.issue.labels.*.name, 'delegate')`, which is true on **every** `labeled` event as long as `delegate` is still on the issue. Fix gates on the *added* label:

```yaml
if: |
  (github.event.action == 'labeled' && github.event.label.name == 'delegate') ||
  (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate'))
```

Now it fires only when `delegate` is freshly applied (or present at creation) — not when a worker later adds `status:in-progress` etc.

## 🧪 How to test

Label an issue `delegate` → one run fires. While it runs, the worker adds `status:in-progress` → **no** second run (previously: a bot-actor failure). Remove + re-add `delegate` → fires again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_