### PR TITLE
feat(root): artifact-gate — a run fails if the agent produced nothing

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -40,6 +40,12 @@ cheaper (slightly blunter) split, or raise them to `opus` if decomposition quali
   one `pkg:*`/`app:*`; `epic` carries no type; never `root`).
 - **Idempotency.** Agents may be re-run (sessions are ephemeral). Before creating
   children, check `get_sub_issues` and don't duplicate — re-spawn for unworked children.
+- **Verify, don't narrate (artifact-gate, #461).** NEVER report a step done from *intent*.
+  Re-read the issue/PR and confirm the artifact actually exists — the comment posted, the PR
+  opened, the file written — before you say it's done or end your turn. Describing the plan
+  ("the worker is now creating the schemas…") is **not** doing it: that exact no-op (a run
+  that exits `success` having produced nothing) is what the **artifact-gate** in
+  `decompose-on-issue.yml` now turns into a **red** run. Do the work, then prove it landed.
 - **Stop-conditions live in `task-decomposer.md`:** `MAX_DEPTH = 3`, `MAX_CHILDREN = 6`,
   and the four-part LEAF TEST. Tune them there (+ orchestrator's MAX_CHILDREN).
 - **Async human-in-the-loop (`NOTIFY_HANDLE = @pmcp`).** Agents may run headless, so they

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Timestamp the run start so the artifact-gate can tell "produced during this run"
+      # from pre-existing comments/PRs.
+      - id: t0
+        run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
       # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
       # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
@@ -42,3 +47,50 @@ jobs:
           prompt: "/task-decompose #${{ github.event.issue.number }}"
           claude_args: "--max-turns 30"
           show_full_output: true
+
+      # ── Artifact-gate (#461) ──────────────────────────────────────────────────
+      # A run is only allowed to be GREEN if the agent produced an OBSERVABLE
+      # deliverable on the issue during this run: a comment (sign-off / breadcrumb /
+      # orchestration note) OR a linked PR (`Closes #NN`). A worker that narrates
+      # "I'm now creating X / posting Y…" and then stops — exiting `success` with
+      # nothing to show (the #454 no-op: 8/30 turns, $0.74, zero output) — must go
+      # RED, not masquerade as done. Deterministic, no LLM. Uses GITHUB_TOKEN (not
+      # the claude OIDC), so it never trips the bot-actor guard.
+      - name: Artifact-gate — fail if the agent produced nothing
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number
+            const since = '${{ steps.t0.outputs.ts }}'
+            const sinceMs = new Date(since).getTime()
+
+            // (a) any comment posted on this issue during the run
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo, issue_number, since,
+            })
+            const newComment = comments.length > 0
+
+            // (b) any PR that cross-references this issue, created during the run
+            const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+              ...context.repo, issue_number,
+            })
+            const linkedPR = timeline.some(e =>
+              e.event === 'cross-referenced' &&
+              e.source && e.source.issue && e.source.issue.pull_request &&
+              new Date(e.created_at).getTime() >= sinceMs
+            )
+
+            if (newComment || linkedPR) {
+              core.info(`Artifact-gate OK for #${issue_number}: newComment=${newComment} linkedPR=${linkedPR}`)
+              return
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo, issue_number,
+              body: '⚠️ **Artifact-gate failed (#461).** This run finished without producing any '
+                + 'observable deliverable on this issue — no new comment, no linked PR. That is the '
+                + '"narrate-the-plan-then-stop" no-op: the agent described work it never did. The run '
+                + 'is marked **failed** so it is not mistaken for done. Re-apply `delegate` to retry.',
+            })
+            core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no comment, no linked PR).`)


### PR DESCRIPTION
Closes #461.

## 👤 For humans

Stops "green runs that did nothing." After the agent runs, a deterministic check confirms it actually produced something on the issue — a comment **or** a linked PR. If not, the run **goes red** and posts *why*, instead of looking done. This is the fix that makes the pipeline trustworthy on weaker / local (Pi-class) models — proven need: the #454 run exited `success` at 8/30 turns ($0.74) having created **nothing**, just narrating a plan.

## 🤖 For agents

- `decompose-on-issue.yml` — a `t0` timestamp step, then an `if: always()` **Artifact-gate** (`github-script`): passes only if, since run start, the issue gained a new comment **or** a cross-referenced PR; otherwise it comments the failure and `core.setFailed()`. Uses `GITHUB_TOKEN`, so it never trips the bot-actor guard.
- `agents/CLAUDE.md` — new contract rule **"Verify, don't narrate"**: never report a step done from intent; re-read and confirm the artifact exists first.

Relates to the OSS/Pi north-star (#458) and the eval harness (#447) — this is the deterministic "did the deliverable land" check.

## 🧪 How to test

Delegate an issue. If the agent stops without posting a comment or opening a PR, the run is now **red** (was green) with a `⚠️ Artifact-gate failed` comment. A real deliverable → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_