### PR TITLE
fix(root): artifact-gate v2 — kind-aware (PR for builds, hold for sign-offs)

### DIFF
--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -81,16 +81,25 @@ jobs:
               new Date(e.created_at).getTime() >= sinceMs
             )
 
-            if (newComment || linkedPR) {
-              core.info(`Artifact-gate OK for #${issue_number}: newComment=${newComment} linkedPR=${linkedPR}`)
+            // (c) is the issue now HELD as a sign-off gate? (worker posted a review + status:blocked)
+            const issue = await github.rest.issues.get({ ...context.repo, issue_number })
+            const blocked = issue.data.labels.some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
+
+            // KIND-AWARE pass: a build/deploy issue must yield a PR; a sign-off gate must
+            // post a review AND hold (status:blocked + a comment). A bare progress comment
+            // ("spawning the worker…") with no PR and no hold is the no-op → FAIL.
+            const signoffHeld = blocked && newComment
+            if (linkedPR || signoffHeld) {
+              core.info(`Artifact-gate OK for #${issue_number}: linkedPR=${linkedPR} signoffHeld=${signoffHeld}`)
               return
             }
 
             await github.rest.issues.createComment({
               ...context.repo, issue_number,
-              body: '⚠️ **Artifact-gate failed (#461).** This run finished without producing any '
-                + 'observable deliverable on this issue — no new comment, no linked PR. That is the '
-                + '"narrate-the-plan-then-stop" no-op: the agent described work it never did. The run '
-                + 'is marked **failed** so it is not mistaken for done. Re-apply `delegate` to retry.',
+              body: '⚠️ **Artifact-gate failed (#461).** This run produced no real deliverable on this '
+                + 'issue: no PR was opened, and it is not held for sign-off (`status:blocked` + a review). '
+                + 'A bare progress comment ("spawning the worker…") does not count — that is the '
+                + '"narrate-the-plan-then-stop" no-op. The run is marked **failed** so it is not mistaken '
+                + 'for done. Re-apply `delegate` to retry.',
             })
-            core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no comment, no linked PR).`)
+            core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no PR, not held for sign-off).`)


### PR DESCRIPTION
Hardens #461 (follow-up to PR #463).

## 👤 For humans

Closes a loophole in the artifact-gate. A **build** issue that only posted *"spawning the worker…"* and opened **no PR** used to pass (any comment counted). Now:
- a **build/deploy** issue must produce a **PR**, and
- a **sign-off** issue must post a review **and hold** (`status:blocked`).

A bare progress comment no longer counts as done.

## 🤖 For agents

`decompose-on-issue.yml` gate is now kind-aware: **pass iff `linkedPR || (status:blocked && newComment)`**. It re-fetches the issue's current labels to detect the held sign-off state. This catches the build-issue no-ops that v1 (`comment OR PR`) let slip.

No regression: #454's schema run passes via `status:blocked && review-comment`; a real build passes via its PR.

## 🧪 How to test

A build issue whose run opens a PR → green. A build run that only comments and stops → **red**. A schema run that posts the review + `status:blocked` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_