### PR TITLE
fix(root): kill the "background agent" misconception (#455 root cause)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -46,6 +46,15 @@ cheaper (slightly blunter) split, or raise them to `opus` if decomposition quali
   ("the worker is now creating the schemas…") is **not** doing it: that exact no-op (a run
   that exits `success` having produced nothing) is what the **artifact-gate** in
   `decompose-on-issue.yml` now turns into a **red** run. Do the work, then prove it landed.
+- **Spawned agents are SYNCHRONOUS — there is NO "background" execution (the #455 root cause).**
+  The `Agent`/Task tool runs a sub-agent **to completion and returns its result within your
+  turn**. Nothing keeps running after you stop: when your turn ends, the GitHub Action **job
+  ends and all work halts**. So you must **NEVER** end your turn saying *"the worker is running
+  in the background — watch for the PR"* — that belief is **false** and is exactly how the #455
+  build burned `$0.52` at `num_turns: 1` and produced nothing. After you spawn a worker you
+  **already hold its result** — read it, confirm the PR/comment actually exists, and only then
+  report. If the spawn didn't deliver, you are **not done**: spawn again (and wait), or do the
+  work yourself. There is no fire-and-forget.
 - **Stop-conditions live in `task-decomposer.md`:** `MAX_DEPTH = 3`, `MAX_CHILDREN = 6`,
   and the four-part LEAF TEST. Tune them there (+ orchestrator's MAX_CHILDREN).
 - **Async human-in-the-loop (`NOTIFY_HANDLE = @pmcp`).** Agents may run headless, so they

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -88,6 +88,13 @@ number.
    - prompt: `{ issue_number: <child number>, depth: 1, epic: <epic number>, epic_branch: <epic_branch> }`
      plus a one-line summary **and the epic's design invariants** so the child has context
      without a round-trip and can't silently diverge.
+   - **The `Agent` call is SYNCHRONOUS — it returns only when the child has finished.** There
+     is no background continuation (the #455 root cause: the orchestrator said "the worker is
+     running in the background, watch for the PR" at `num_turns: 1` and nothing ran). When a
+     child returns, **verify its deliverable actually exists** — the child's PR (`Closes #N`),
+     or its sign-off comment + `status:blocked` — before you report. A child that returned
+     without producing it is **not done**: re-spawn it (and wait). Never end your turn on a
+     described-but-unverified handoff.
 8. **The final epic→`main` PR (the review gate).** The epic is NOT done when its children
    merge into `epic_branch` — it's done when `epic_branch` merges to `main` behind one
    human review. On an idempotent re-run, once **all** children are closed/merged into the


### PR DESCRIPTION
## 👤 For humans

The root cause of *every* build-wave no-op this session, diagnosed from the #455 log. The agent literally believed the worker it spawned **"runs in the background"** and would open the PR *after* the session ended — so it wrote *"watch for the PR,"* stopped at **`num_turns: 1`** (`$0.52`), and **nothing ran**. Spawned agents are **synchronous**; nothing survives the session ending.

## 🤖 For agents

- `agents/CLAUDE.md` — new contract rule: the `Agent`/Task tool is **synchronous** and returns the child's result *within your turn*; nothing runs after you stop; **never** end on *"the worker is running in the background, watch for the PR"*; after spawning you already hold the result → verify the PR/comment exists.
- `task-orchestrator.md` step 7 — the `Agent` call returns only when the child finishes; verify its deliverable before reporting; re-spawn if missing.

**Evidence:** run `27849494614` on #455 — `num_turns: 1`, `stop_reason: end_turn`, result narrated a background worker that never executed. Caught (red) by the artifact-gate (#461); this PR fixes the *cause*.

## 🧪 How to test

Re-delegate a build issue → the run should now spawn the worker, **wait**, confirm the PR exists, and only then finish (green with a real PR) — or honestly fail. No more "watch for the PR" at 1 turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_