### PR TITLE
feat(root): artifact-gate failure comment pings @pmcp + links the run

### DIFF
--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -94,12 +94,15 @@ jobs:
               return
             }
 
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             await github.rest.issues.createComment({
               ...context.repo, issue_number,
-              body: '⚠️ **Artifact-gate failed (#461).** This run produced no real deliverable on this '
-                + 'issue: no PR was opened, and it is not held for sign-off (`status:blocked` + a review). '
-                + 'A bare progress comment ("spawning the worker…") does not count — that is the '
+              body: '⚠️ **Artifact-gate failed (#461).** @pmcp — this run produced no real deliverable on '
+                + 'this issue: no PR was opened, and it is not held for sign-off (`status:blocked` + a review). '
+                + 'A bare progress comment ("spawning the worker…") does not count — the '
                 + '"narrate-the-plan-then-stop" no-op. The run is marked **failed** so it is not mistaken '
-                + 'for done. Re-apply `delegate` to retry.',
+                + 'for done.\n\n'
+                + `🔗 **Run log:** ${runUrl}\n`
+                + '↻ Re-apply the `delegate` label to retry.',
             })
             core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no PR, not held for sign-off).`)


### PR DESCRIPTION
## 👤 For humans

When the artifact-gate fails a run, its comment now **@mentions you** (a failed build *is* actionable — it needs a re-trigger or a look) and includes a **direct link to the run log**, so it's one click to the diagnosis instead of hunting the Actions tab.

## 🤖 For agents

`decompose-on-issue.yml` gate failure comment: prepends `@pmcp` and appends `🔗 Run log: ${context.serverUrl}/.../actions/runs/${context.runId}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaovXCDWyivwBm4EvLQWSn)_