### PR TITLE
feat(root): dispatch the pipeline by commenting /delegate or /deploy

### DIFF
--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -76,6 +76,10 @@ chose a different design. Four rules now prevent that:
 - **Automatic — issue opt-in:** add the **`delegate`** label to any issue and
   `.github/workflows/decompose-on-issue.yml` runs `/task-decompose #NN` for you (no
   command needed). Gate is the label, so only opted-in issues fire.
+- **By comment (mobile-friendly):** comment **`/delegate`** (or **`/deploy`**) on an issue —
+  `.github/workflows/comment-dispatch.yml` applies the `delegate` label for you (via a PAT, so
+  the run is human-actored). Same effect as labelling, but you can do it from the GitHub mobile
+  app where the label UI is awkward. Owner/members only.
 - **Automatic — resume after a blocker:** when an agent @mentions you and sets
   `status:blocked`, just **reply on the issue** — `.github/workflows/resume-on-comment.yml`
   picks it back up, removes the block, and continues.

--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -1,0 +1,60 @@
+name: Comment dispatch
+
+# Hand an issue to the agent pipeline by COMMENTING — mobile-friendly, no label UI.
+# Comment `/delegate` (or `/deploy`) on an issue and this applies the `delegate` label,
+# which fires decompose-on-issue.yml. Only the repo owner / members / collaborators can
+# trigger it.
+#
+# AUTH (critical): the label is applied with a PAT (DISPATCH_TOKEN, or PROJECTS_TOKEN) so
+# the dispatched decompose run is attributed to a HUMAN actor and passes claude-code-action's
+# bot-actor guard. With only GITHUB_TOKEN the run would be bot-initiated and fail. Without a
+# PAT this workflow no-ops (green) with a warning.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  dispatch:
+    # Owner/member/collaborator comment, on an issue (not a PR), containing the command.
+    if: |
+      !github.event.issue.pull_request &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      (contains(github.event.comment.body, '/delegate') ||
+       contains(github.event.comment.body, '/deploy'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.PROJECTS_TOKEN }}
+        with:
+          github-token: ${{ secrets.DISPATCH_TOKEN || secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            if (!process.env.DISPATCH_TOKEN) {
+              core.warning('No DISPATCH_TOKEN/PROJECTS_TOKEN — applying `delegate` via GITHUB_TOKEN would make '
+                + 'the dispatched run bot-initiated and fail the bot-actor guard. Set a PAT with issues:write. Skipping.')
+              return
+            }
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.issue.number
+            const comment_id = context.payload.comment.id
+
+            // Fire a FRESH `delegate` labeled event: decompose-on-issue only triggers on the
+            // label being *added* (not merely present), so if it's already there, remove first.
+            const cur = (context.payload.issue.labels || []).map(l => (typeof l === 'string' ? l : l.name))
+            if (cur.includes('delegate')) {
+              try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'delegate' }) } catch (e) {}
+            }
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['delegate'] })
+
+            // Acknowledge so the commenter sees it registered (handy on mobile).
+            try { await github.rest.reactions.createForIssueComment({ owner, repo, comment_id, content: 'rocket' }) } catch (e) {}
+            await github.rest.issues.createComment({ owner, repo, issue_number,
+              body: `▶️ Dispatched by comment — applied \`delegate\`, the agent pipeline is picking up #${issue_number}.` })
+            core.info(`Dispatched #${issue_number} via comment.`)


### PR DESCRIPTION
## 👤 For humans

Adds `comment-dispatch.yml`: commenting **`/delegate`** or **`/deploy`** on an issue applies the `delegate` label, which fires the agent pipeline (`decompose-on-issue.yml`). This lets you trigger the pipeline from the **GitHub mobile app**, where the label UI is awkward. Owner / members / collaborators only; issues only (not PRs).

## 🤖 For agents

- `.github/workflows/comment-dispatch.yml` — `issue_comment: created` → permission-gated (`OWNER`/`MEMBER`/`COLLABORATOR`) → **remove + re-add `delegate`** so a *fresh* `labeled` event fires (decompose-on-issue triggers only on the label being newly added).
- Label is applied via **`DISPATCH_TOKEN` / `PROJECTS_TOKEN`** (a PAT) so the dispatched run is **human-actored** and passes claude-code-action's bot-actor guard. Without a PAT it no-ops (green) with a warning — same pattern as `schedule-waves.yml`.
- Adds a usage note to `.claude/skills/task-decompose/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uhCE5doJNn4a6gz4jF7Zj)_