### PR TITLE
fix(root): pipeline hands off by spawning, not by applying `delegate`

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -55,6 +55,24 @@ cheaper (slightly blunter) split, or raise them to `opus` if decomposition quali
   **already hold its result** — read it, confirm the PR/comment actually exists, and only then
   report. If the spawn didn't deliver, you are **not done**: spawn again (and wait), or do the
   work yourself. There is no fire-and-forget.
+- **Hand off by SPAWNING, never by LABELING (the #457 root cause).** To get a child issue
+  worked you **spawn** it with the `Agent` tool (a `task-decomposer` or `task-worker`) in
+  THIS run and wait for its result. **NEVER apply the `delegate` label to a sub-issue to
+  "dispatch" it.** `delegate` is the *human* entry trigger only: applied from inside a run
+  you are `claude[bot]`, so it re-enters `decompose-on-issue.yml` as a **bot actor** → the
+  bot-actor guard rejects that child run → it produces nothing; worse, a sub-issue dispatched
+  that way runs `/task-decompose` on *itself as a fresh epic off `main`*, where the real
+  epic's scaffold doesn't exist. (This is exactly how the #457 deploy stalled: the
+  orchestrator applied `delegate` to #456/#457 instead of spawning workers — both child runs
+  were bot-rejected, no PR, no deploy.) There is no label-based hand-off: spawn the agent, or
+  do the leaf's work yourself in this run.
+- **A directly-dispatched child resolves to its parent's epic branch — never a new epic off
+  `main`.** When `/task-decompose` is invoked on an issue that is itself a **sub-issue** (its
+  `parent_issue_url` is set / it carries a parent epic), do **NOT** mint a fresh
+  `epic/<child>-<slug>` off `main`. Resolve the parent epic and use its existing
+  `epic/<parent>-<slug>` as the integration base, then work just that child there. Only a
+  true top-level epic creates a new epic branch. (This is what makes a human/`comment-dispatch`
+  `delegate`/`/deploy` on a single child issue land on the right branch instead of off `main`.)
 - **Stop-conditions live in `task-decomposer.md`:** `MAX_DEPTH = 3`, `MAX_CHILDREN = 6`,
   and the four-part LEAF TEST. Tune them there (+ orchestrator's MAX_CHILDREN).
 - **Async human-in-the-loop (`NOTIFY_HANDLE = @pmcp`).** Agents may run headless, so they

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -92,7 +92,13 @@ Report: "issue #N is leaf-sized (or at depth cap) → worker spawned in worktree
 - **Never exceed MAX_DEPTH or MAX_CHILDREN.** These are not suggestions.
 - Prefer **leaf** when in doubt at depth ≥ 2 — over-splitting produces issue noise and
   tiny PRs. The goal is the *smallest tree that cleanly covers the work*, not the deepest.
-- You do not write feature code. Decompose or delegate — nothing else.
+- You do not write feature code. Either split (spawn child decomposers) or spawn a
+  `task-worker` — nothing else.
+- **Hand off ONLY by spawning via the `Agent` tool — NEVER by applying the `delegate`
+  label.** Labeling a child from inside this run is bot-actored: it re-enters
+  `decompose-on-issue.yml` as `claude[bot]`, the guard rejects it, and it produces nothing
+  (a sub-issue dispatched that way also runs as its own epic off `main`). The #457 deploy
+  stalled exactly this way. Spawn the worker (Step 4), wait for it, and verify its PR exists.
 - Label every issue you create. Stick to the existing taxonomy (unknown label = error).
 
 ## Asking the human (async — never block)

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -32,9 +32,13 @@ number.
    Extract the goal, any constraints, the intended component(s), and the epic's stated
    **design invariants** (the rules every sub-issue must honour — you'll pass these down).
 2. **Idempotency check.** `get_sub_issues` on the epic. If it already has children,
-   do NOT create duplicates — re-spawn decomposers for any **open** children that have
-   no PR/▴children yet (passing `epic_branch`, below), and stop. (Sessions are ephemeral;
-   you may be a re-run.)
+   do NOT create duplicates — re-spawn decomposers (or, for a ready leaf, a worker) for any
+   **open** children that have no PR/▴children yet, **via the `Agent` tool** (passing
+   `epic_branch`, below), and stop. **Never apply the `delegate` label to a child to dispatch
+   it** — that's a bot-actored re-trigger the guard rejects, and it runs the child as its own
+   epic off `main` (the #457 failure). Hand off ONLY by spawning. A child that already has a
+   merged PR into the epic branch (e.g. its scaffold landed) is **done** — skip it. (Sessions
+   are ephemeral; you may be a re-run.)
 3. **Create the epic integration branch (#349).** All sub-issue work lands here first,
    not on `main` — so a later sub-issue sees what an earlier one built (no duplicate
    scaffolds), and the whole feature gets **one** human review at the end. From the main
@@ -46,6 +50,12 @@ number.
    Call this `epic_branch = epic/<epic_number>-<slug>`. Pass it to **every** decomposer/
    worker you (or they) spawn. (If branch creation isn't possible in this environment,
    note it on the epic and fall back to `main` as the base — but prefer the epic branch.)
+   - **If you were handed a CHILD issue, not a true epic** (the issue you read has a
+     `parent_issue_url` / a parent epic), do **NOT** create a new `epic/<this>-<slug>` off
+     `main`. Resolve the parent epic, reuse its existing `epic/<parent>-<slug>` as
+     `epic_branch`, and work *just this child* on it (spawn its worker, below) — never a
+     fresh epic off `main`. This is what makes a direct `delegate`/`/deploy` on one child
+     (e.g. a deploy sub-issue) land on the real epic branch where the scaffold exists.
 4. **Identify 2–6 top-level workstreams.** Slice by *coherent concern*, not by file.
    Fewer, well-bounded streams beat many thin ones. Hard cap: **MAX_CHILDREN = 6**.
    If the epic is genuinely a single concern, create exactly one child (the decomposer
@@ -124,6 +134,11 @@ just what you tell workers and how the approval propagates.
 - Label every issue (exactly one `type:*`, plus the component label). Applying a label
   that doesn't exist errors — stick to the taxonomy in `.github/labels.yml`.
 - Never push code or open PRs yourself.
+- **Never apply the `delegate` label to a child to "dispatch" it.** Hand a child off ONLY by
+  spawning a `task-decomposer`/`task-worker` via the `Agent` tool (steps 2 & 7), synchronously,
+  and verifying its PR/comment exists. Labeling from inside the run is bot-actored → the
+  guard rejects it → nothing happens (and the child runs as its own epic off `main`). This was
+  the #457 deploy stall.
 - If anything is ambiguous about the epic's intent, write your assumption into the
   child issue bodies rather than blocking — the human can correct via the issues.
 

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -116,6 +116,13 @@ chose a different design. Four rules now prevent that:
    - `subagent_type: "task-orchestrator"`
    - prompt: `{ epic_issue_number: <epic number>, depth: 0 }` + a short restatement of the
      task so it doesn't need an extra read.
+   - **If `#NN` is a CHILD issue (it has a `parent_issue_url`), not an epic** — e.g. someone
+     `delegate`'d / `/deploy`'d a single sub-issue from the mobile app — pass its parent epic
+     as `epic_issue_number` and name the child to work, OR pass the child with a note that it
+     is a child: the orchestrator must work it on the **parent's** `epic/<parent>-<slug>`
+     branch, **never** mint a new epic off `main` (where the scaffold wouldn't exist). The
+     pipeline hands off by **spawning** agents (`Agent` tool), never by applying the
+     `delegate` label from inside a run (that's bot-actored and self-rejecting).
 3. **Report** the epic url and that orchestration has started. The orchestrator creates the
    `epic/<NN>-<slug>` integration branch; the tree then builds itself onto it (decomposers
    recurse; workers open PRs into the epic branch with `Closes #NN`); a single epic→`main`


### PR DESCRIPTION
## 👤 For humans

The agent pipeline stalled on the library-catalog deploy (#457) because the **orchestrator dispatched child issues by applying the `delegate` label** instead of spawning a `task-worker`. From inside a run that label is **bot-actored**, so the child run is rejected by `claude-code-action`'s bot-actor guard — and a sub-issue dispatched that way runs `/task-decompose` on **itself as a fresh epic off `main`**, where the scaffold doesn't exist. Net: no PR, no deploy.

This makes the hand-off rule unmissable across the pipeline: **spawn (Agent tool), never label.** The worker spawn path itself already works — #470 (the scaffold) was built by a spawned worker — so this is a hand-off-mechanism fix only.

## 🤖 For agents

- `.claude/agents/CLAUDE.md` (agent contract) — "Hand off by SPAWNING, never by LABELING"; a directly-dispatched **child** resolves to its **parent's** `epic/<parent>-<slug>` branch, never a new epic off `main`.
- `.claude/agents/task-orchestrator.md` — step 2 (idempotency) + a guardrail: re-spawn via the `Agent` tool, never apply `delegate`; step 3: a child handed in (has `parent_issue_url`) reuses the parent's epic branch.
- `.claude/agents/task-decomposer.md` — disambiguate "delegate" → spawn a `task-worker`; never apply the label.
- `.claude/skills/task-decompose/SKILL.md` — entry note for a child `#NN` dispatched directly (e.g. `comment-dispatch` `/deploy`).

## 🧪 How to test

Re-apply `delegate` to epic #453 (human-actored). The orchestrator spawns the #457 deploy `task-worker` via the `Agent` tool on `epic/453-library-catalog` (no `delegate` re-label), the worker opens a PR into the epic branch, CI deploys, and posts `https://library-catalog.pmcp.dev`. No `claude[bot]`-actored `decompose-on-issue` runs should be spawned by the orchestrator.

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uhCE5doJNn4a6gz4jF7Zj)_