### PR TITLE
fix(root): digest preview-URL regex captured a trailing backtick

### DIFF
--- a/.claude/skills/epic-digest/gather.mjs
+++ b/.claude/skills/epic-digest/gather.mjs
@@ -113,7 +113,9 @@ const parseTestSteps = (body) =>
   stepsFrom(section(body, /^##\s.*how to test/i) || section(body, /^##\s.*🧪/i))
 // A staging/prod preview link if the author dropped one in the body.
 const parsePreviewUrl = (body) => {
-  const m = String(body || '').match(/https?:\/\/[^\s)]+\.(?:pmcp\.dev|friendlyinter\.net)[^\s)]*/)
+  // Exclude backtick/quotes/angle-brackets too, so a Markdown inline-code or
+  // linked URL (`https://…dev`) doesn't capture a trailing ` / " / > delimiter.
+  const m = String(body || '').match(/https?:\/\/[^\s)`"'<>]+\.(?:pmcp\.dev|friendlyinter\.net)[^\s)`"'<>]*/)
   return m ? m[0] : undefined
 }
 // A `fix · merged` / `feat · merged` badge from a conventional-commit title.


### PR DESCRIPTION
## 👤 For humans
Tiny cosmetic fix spotted while rendering a live digest: a staging-preview link came out as `https://library-catalog.pmcp.dev` **with a trailing backtick** (the #449 actionable). The URL matcher in `gather.mjs` was swallowing the closing `` ` `` of a Markdown inline-code/linked URL in the PR body. Now it stops at `` ` `` / quotes / angle-brackets.

## 🔎 Archaeology (root cause)
Introduced in **#496** (commit `b929610`) when the preview-URL parser was added — its char class `[^\s)]*` matched everything except whitespace and `)`, so a trailing `` ` `` got captured. Cosmetic only: it affected the *captured* `previewUrl` string, not whether a preview was detected. No earlier regression.

## 🤖 For agents
- `gather.mjs` `parsePreviewUrl`: `[^\s)]` → `` [^\s)`"'<>] `` on both sides of the domain.

## 🧪 How to test
```bash
node -e 'const re=/https?:\/\/[^\s)`"'"'"'<>]+\.(?:pmcp\.dev|friendlyinter\.net)[^\s)`"'"'"'<>]*/;
console.log("see [x](https://library-catalog.pmcp.dev`)".match(re)[0])'
# → https://library-catalog.pmcp.dev   (no trailing backtick)
```
Also: `node --check .claude/skills/epic-digest/gather.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTD2G13E5TjFRWvEt7GeuE)_