### PR TITLE
feat(root): postmortem propagates landed changes to neighbouring issues

### DIFF
--- a/.claude/skills/postmortem/SKILL.md
+++ b/.claude/skills/postmortem/SKILL.md
@@ -88,10 +88,27 @@ Don't open issues the human didn't accept; don't pad with filler — 1–3 real 
 generic ones; and **never open a `workflow` issue that duplicates an existing follow-up
 epic** — link it instead.
 
-## Step 5 — Hand off
-Report: the epic comment URL, and the list of `workflow` issues opened (with URLs).
-This closes the learning loop — the proposals are now on the board, ready to be
-picked up like any other work.
+## Step 5 — Propagate the change to neighbouring issues
+
+The epic's decisions often land on *other* tickets — a sibling epic, a consumer, something it
+supersedes. Tell them, so nobody works around a change they didn't know happened.
+
+- **Find neighbours:** issues/PRs referenced by the epic, its sub-issues, and their PR bodies;
+  plus a keyword `search_issues` on the change (reuse the Step-4 dedup search).
+- **Open neighbour → always comment:** one line of *what changed for you* + the link
+  (e.g. "#515's release now wires to this App — see #NN"). This is how live work wires *into* the
+  change instead of around it.
+- **Closed neighbour → comment ONLY if the change supersedes/contradicts what it decided** — a
+  terse "superseded / updated by #NN" forward-pointer for later archaeology. **Never** for mere
+  topical relevance (dead-ticket noise).
+- Keep it to the genuinely-affected few — a couple of true cross-links beat ten tangential
+  mentions (same spirit as the Step-4 dedup). Each comment carries the `🤖` provenance header and
+  is informational (won't trip agent-resume triggers).
+
+## Step 6 — Hand off
+Report: the epic comment URL, the list of `workflow` issues opened (with URLs), and the neighbour
+issues you cross-linked. This closes the learning loop — the proposals are on the board and the
+change is wired to everything it touches.
 
 ## Conventions & gotchas
 - **After verify, before close.** Don't close the epic until the postmortem is


### PR DESCRIPTION
Closes #524.

## 👤 For humans
After the retro, the `postmortem` flow now also **propagates the epic's landed changes to the issues they actually touched** — so related tickets stop drifting/duplicating and a future agent finds the change from a neighbour instead of re-discovering it. (This is the standing version of what I did by hand this session: cross-linking #515 ↔ the App epic #519.)

The rule, baked into the skill:
- **Open** neighbour → **always** cross-link + a one-line "what changed for you".
- **Closed** neighbour → comment **only when** the change supersedes/contradicts its decision (a "superseded by #NN" forward-pointer for archaeology) — never for mere relevance.

## 🤖 For agents
- `.claude/skills/postmortem/SKILL.md`: new **Step 5 — Propagate the change to neighbouring issues** (find neighbours via the epic/sub-issue/PR refs + the Step-4 dedup search; open→always, closed→only-when-superseding; provenance header; keep to the genuinely-affected few). Old **Step 5 (Hand off) → Step 6**, now also reports the neighbours cross-linked.
- Front-matter unchanged → `gen-skills-doc` output unchanged (ran it, no diff).

## 🧪 How to test
1. Run `/postmortem` on an epic that touched neighbours → each **open** affected issue gets a cross-link comment; a **superseded closed** one gets a "updated by #NN" pointer; unrelated closed ones get nothing.
2. Comments carry the `🤖` provenance header and read as plain "here's what changed for you".

---
**Per the new policy, I'm not auto-merging — this is ready for your review + manual merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTD2G13E5TjFRWvEt7GeuE)_