### PR TITLE
fix(crouton-cli): generate migrations build-first so a fresh scaffold ships them (#523)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -133,8 +133,25 @@ and SSR errors like `$setup.t is not a function`.
 2. **Installs** package via detected package manager (pnpm/yarn/npm)
 3. **Updates** `nuxt.config.ts` - adds to `extends` array
 4. **Updates** `server/db/schema.ts` - adds schema export (if applicable)
-5. **Generates** migrations with `npx nuxt db:generate` (if applicable)
+5. **Generates** migrations **build-first** (if applicable) — see below
 6. **Applies** migrations with `npx nuxt db:migrate` (if applicable)
+
+#### Build-first migration generation (the schema.mjs gotcha, #523)
+
+`drizzle-kit generate` (the app's `db:generate` script) reads the **bundled**
+schema at `.nuxt/hub/db/schema.mjs`, which NuxtHub only writes during
+**`nuxt build`** — `nuxt prepare` emits `schema.entry.ts`, NOT the `.mjs`. So
+running `db:generate` on a fresh tree finds no schema and emits **zero**
+migrations; the first deploy then fails the remote-migrate step with *"No
+migrations present"* (the #457 library-catalog failure).
+
+`lib/utils/generate-migrations.ts` (`generateMigrations(cwd)`) fixes this: it
+starts `NITRO_PRESET=node-server nuxt build`, waits for the bundle to appear
+(written early, before the slow Nitro stage), stops the build, then runs the
+app's own `db:generate`. Used by both `crouton add` (step 5) and `crouton init`
+(step 3). It **requires installed deps** (it builds); on a bare tree with no
+`node_modules` it returns `deps-missing` and the caller prints the exact manual
+sequence (`manualMigrationSteps()`) instead of silently shipping no migrations.
 
 ## Init Command (Full Pipeline)
 
@@ -166,8 +183,13 @@ crouton init my-app --dry-run
 
 1. **scaffold-app** — Creates the app skeleton (nuxt.config, package.json, schemas/, etc.)
 2. **generate** — Generates collections from `crouton.config.js` (if collections are defined)
-3. **doctor** — Validates everything is wired correctly
-4. **Summary** — Prints next steps (dev server, deploy)
+3. **migrations** — Generates the initial D1 migrations **build-first** (see the
+   `crouton add` section). Runs only when deps are already installed; on a bare
+   scaffold (no `node_modules`) it defers and the summary prints the exact
+   `pnpm install` → build → `db:generate` sequence — so a fresh app is never
+   silently shipped without its migrations (#523).
+4. **doctor** — Validates everything is wired correctly
+5. **Summary** — Prints next steps (dev server, deploy)
 
 ## Deploy Scaffolding — Cloudflare Workers (the crouton standard)
 
@@ -265,6 +287,7 @@ crouton db-pull --config ./custom-wrangler.jsonc
 | `lib/db-pull.ts` | Remote D1 → local dev pull |
 | `lib/module-registry.ts` | Module definitions for `crouton add` |
 | `lib/add-module.ts` | Module installation implementation |
+| `lib/utils/generate-migrations.ts` | Build-first migration generation (`generateMigrations`) — emits the `.nuxt/hub/db/schema.mjs` bundle, then `db:generate`; used by `add`+`init` (#523) |
 | `lib/utils/helpers.ts` | Case conversion, type mapping |
 | `lib/utils/dialects.ts` | PostgreSQL/SQLite configs |
 | `lib/utils/detect-package-manager.ts` | Detect pnpm/yarn/npm |

--- a/packages/crouton-cli/lib/add-module.ts
+++ b/packages/crouton-cli/lib/add-module.ts
@@ -10,6 +10,7 @@ import { loadModules, getModule, listModules } from './module-registry.ts'
 import { detectPackageManager, getInstallCommand } from './utils/detect-package-manager.ts'
 import { addToNuxtConfigExtends, isInNuxtConfigExtends } from './utils/update-nuxt-config.ts'
 import { addSchemaExport, getSchemaPath } from './utils/update-schema-index.ts'
+import { generateMigrations, manualMigrationSteps } from './utils/generate-migrations.ts'
 
 interface AddModuleOptions {
   skipInstall?: boolean
@@ -174,55 +175,49 @@ export async function addModule(moduleName: string, options: AddModuleOptions = 
   // Step 4: Generate & apply migrations (if module has tables)
   if (!skipMigrations && module.schemaExport && module.tables && module.tables.length > 0) {
     if (dryRun) {
-      console.log('   • Would run: npx nuxt db:generate')
+      console.log('   • Would build the schema bundle, then run: db:generate')
       console.log('   • Would run: npx nuxt db:migrate')
     } else {
-      // Generate migrations
-      consola.start('Generating migrations...')
-      try {
-        const genResult = spawnSync('npx', ['nuxt', 'db:generate'], {
-          cwd,
-          stdio: 'pipe',
-          encoding: 'utf-8'
-        })
-
-        if (genResult.status !== 0) {
-          consola.warn('Migration generation may have issues')
-          if (genResult.stderr) {
-            console.log(`   ${genResult.stderr.trim()}`)
-          }
-        } else {
-          consola.success('Generated migrations')
-        }
-      } catch (error) {
-        consola.warn('Could not generate migrations')
-        console.log(`   ${error.message}`)
+      // Generate migrations — BUILD-FIRST. drizzle-kit reads the bundled schema
+      // at .nuxt/hub/db/schema.mjs, which only exists after `nuxt build`; running
+      // db:generate without building emits zero migrations (the #523 root cause).
+      const genResult = await generateMigrations(cwd)
+      const migrationsGenerated = genResult.generated
+      if (!genResult.generated) {
+        consola.warn(`Could not generate migrations (${genResult.reason})`)
+        if (genResult.detail) console.log(`   ${genResult.detail}`)
+        console.log('   Run manually when ready:')
+        for (const step of manualMigrationSteps()) console.log(`     ${step}`)
       }
 
-      // Apply migrations
-      consola.start('Applying migrations...')
-      try {
-        const migrateResult = spawnSync('npx', ['nuxt', 'db:migrate'], {
-          cwd,
-          stdio: 'pipe',
-          encoding: 'utf-8'
-        })
+      // Apply migrations (only if we actually generated some)
+      if (!migrationsGenerated) {
+        console.log('   • Skipping migrate (no migrations generated)')
+      } else {
+        consola.start('Applying migrations...')
+        try {
+          const migrateResult = spawnSync('npx', ['nuxt', 'db:migrate'], {
+            cwd,
+            stdio: 'pipe',
+            encoding: 'utf-8'
+          })
 
-        if (migrateResult.status !== 0) {
-          consola.warn('Migration application may have issues')
-          if (migrateResult.stderr) {
-            console.log(`   ${migrateResult.stderr.trim()}`)
+          if (migrateResult.status !== 0) {
+            consola.warn('Migration application may have issues')
+            if (migrateResult.stderr) {
+              console.log(`   ${migrateResult.stderr.trim()}`)
+            }
+          } else {
+            consola.success('Applied migrations')
           }
-        } else {
-          consola.success('Applied migrations')
+        } catch (error) {
+          consola.warn('Could not apply migrations')
+          console.log(`   ${error.message}`)
         }
-      } catch (error) {
-        consola.warn('Could not apply migrations')
-        console.log(`   ${error.message}`)
       }
     }
   } else if (module.schemaExport) {
-    console.log('   • Skipping migrations (use npx nuxt db:generate && npx nuxt db:migrate when ready)')
+    console.log('   • Skipping migrations (build the schema bundle, then run db:generate && db:migrate when ready)')
   }
 
   // Success message

--- a/packages/crouton-cli/lib/init-app.ts
+++ b/packages/crouton-cli/lib/init-app.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 import { access } from 'node:fs/promises'
 import consola from 'consola'
 
+import { generateMigrations, manualMigrationSteps } from './utils/generate-migrations.ts'
+
 interface InitAppOptions {
   features?: string[]
   theme?: string
@@ -41,43 +43,76 @@ export async function initApp(name: string, options: InitAppOptions = {}): Promi
   // ── Step 2: generate (config-based) ───────────────────────────────────
   const configPath = join(appDir, 'crouton.config.js')
   const hasConfig = await access(configPath).then(() => true).catch(() => false)
+  let collectionsGenerated = false
 
   if (hasConfig) {
-    consola.start('Step 2/3 — Generating collections from config...')
+    consola.start('Step 2/4 — Generating collections from config...')
     try {
       const { runConfig } = await import('./generate-collection.ts')
       process.chdir(appDir)
       await runConfig({ configPath })
-      consola.success('Step 2/3 — Collections generated')
+      collectionsGenerated = true
+      consola.success('Step 2/4 — Collections generated')
     } catch (error) {
-      consola.warn('Step 2/3 — Generate skipped (no collections in config yet)')
+      consola.warn('Step 2/4 — Generate skipped (no collections in config yet)')
     }
   } else {
-    console.log('  Step 2/3 — No crouton.config.js found, skipping generate')
+    console.log('  Step 2/4 — No crouton.config.js found, skipping generate')
   }
 
-  // ── Step 3: doctor ────────────────────────────────────────────────────
-  consola.start('Step 3/3 — Running doctor checks...')
+  // ── Step 3: migrations (build-first) ──────────────────────────────────
+  // A scaffold ships a Drizzle schema but no migrations, so the first deploy
+  // fails the remote-migrate step ("No migrations present", #523). Generate them
+  // build-first IF deps are already installed; on a bare scaffold (no
+  // node_modules) we can't build — surface the exact manual sequence instead of
+  // silently shipping zero migrations.
+  let needsManualMigrations = false
+  if (collectionsGenerated) {
+    consola.start('Step 3/4 — Generating migrations...')
+    const result = await generateMigrations(appDir)
+    if (result.generated) {
+      consola.success('Step 3/4 — Migrations generated')
+    } else if (result.reason === 'deps-missing') {
+      needsManualMigrations = true
+      consola.info('Step 3/4 — Migrations deferred (install deps first; see next steps)')
+    } else {
+      needsManualMigrations = true
+      consola.warn(`Step 3/4 — Migrations skipped (${result.reason})`)
+      if (result.detail) console.log(`   ${result.detail}`)
+    }
+  } else {
+    console.log('  Step 3/4 — No collections generated, skipping migrations')
+  }
+
+  // ── Step 4: doctor ────────────────────────────────────────────────────
+  consola.start('Step 4/4 — Running doctor checks...')
   try {
     const { doctor, printReport } = await import('./doctor.ts')
     const result = await doctor(appDir)
-    consola.success('Step 3/3 — Doctor complete')
+    consola.success('Step 4/4 — Doctor complete')
     printReport(result)
   } catch (error) {
-    consola.warn('Step 3/3 — Doctor skipped (could not validate)')
+    consola.warn('Step 4/4 — Doctor skipped (could not validate)')
   }
 
   // ── Summary ───────────────────────────────────────────────────────────
-  printSummary(name, appDir, cf)
+  printSummary(name, appDir, cf, needsManualMigrations)
 }
 
-function printSummary(name: string, appDir: string, cf: boolean): void {
+function printSummary(name: string, appDir: string, cf: boolean, needsManualMigrations = false): void {
   console.log('  ─────────────────────────────────────')
   console.log(`  ${name} is ready!\n`)
   console.log('  Next steps:\n')
   console.log(`  1.  cd ${appDir}`)
   console.log('  2.  pnpm install')
-  console.log('  3.  pnpm dev')
+  if (needsManualMigrations) {
+    console.log('  3.  Generate migrations (needed before first deploy):')
+    // pnpm install is already step 2 — show the build-first generate sequence
+    for (const step of manualMigrationSteps().slice(1)) console.log(`        ${step}`)
+    console.log('  4.  pnpm dev')
+  } else {
+    console.log('  3.  pnpm dev')
+  }
   console.log()
   console.log('  Deploy:')
   if (cf) {

--- a/packages/crouton-cli/lib/utils/generate-migrations.ts
+++ b/packages/crouton-cli/lib/utils/generate-migrations.ts
@@ -1,0 +1,139 @@
+// generate-migrations.ts — build-first Drizzle migration generation.
+//
+// Why "build-first": drizzle-kit reads the *bundled* schema at
+// `.nuxt/hub/db/schema.mjs`, which NuxtHub only writes during `nuxt build`
+// (`nuxt prepare` emits `schema.entry.ts`, NOT the `.mjs`). So running
+// `db:generate` on a freshly scaffolded/added tree finds no schema and emits
+// ZERO migrations — the first deploy then fails the remote-migrate step with
+// "No migrations present" (hit on library-catalog, #457/#523).
+//
+// The fix mirrors the `db-migrations` skill: start `NITRO_PRESET=node-server
+// nuxt build` (the bundle is written early, before the slow Nitro stage), wait
+// for the bundle file to appear, stop the build, then run the app's own
+// `db:generate` script (which respects its drizzle.config.ts).
+
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import consola from 'consola'
+
+import { detectPackageManager } from './detect-package-manager.ts'
+
+// The two locations NuxtHub may write the bundled schema to (mirrors the
+// candidates in the generated drizzle.config.ts).
+const BUNDLE_PATHS = [
+  '.nuxt/hub/db/schema.mjs',
+  'node_modules/.cache/nuxt/.nuxt/hub/db/schema.mjs',
+]
+
+export type GenerateMigrationsResult =
+  | { generated: true }
+  | { generated: false; reason: 'deps-missing' | 'build-timeout' | 'generate-failed'; detail?: string }
+
+interface GenerateMigrationsOptions {
+  /** Max seconds to wait for the schema bundle to appear during build. */
+  buildTimeoutSec?: number
+  /** Skip the build if a bundle is already present (e.g. a prior build). */
+  reuseExistingBundle?: boolean
+}
+
+function bundleExists(cwd: string): boolean {
+  return BUNDLE_PATHS.some(p => existsSync(join(cwd, p)))
+}
+
+function runScriptCommand(pm: 'pnpm' | 'yarn' | 'npm', script: string): [string, string[]] {
+  // yarn runs scripts directly; pnpm/npm use `run`
+  if (pm === 'yarn') return ['yarn', [script]]
+  return [pm, ['run', script]]
+}
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+/**
+ * Build the app just far enough to emit the bundled Drizzle schema, then run
+ * its `db:generate` script so committed migrations land in
+ * `server/db/migrations/**`.
+ *
+ * Requires the app's dependencies to be installed (it runs `nuxt build`). On a
+ * bare scaffold with no `node_modules`, returns `{ generated: false,
+ * reason: 'deps-missing' }` so the caller can print the manual next-step rather
+ * than silently shipping zero migrations.
+ */
+export async function generateMigrations(
+  cwd: string = process.cwd(),
+  options: GenerateMigrationsOptions = {},
+): Promise<GenerateMigrationsResult> {
+  const { buildTimeoutSec = 180, reuseExistingBundle = true } = options
+
+  // Build (and the build-first dance) needs installed deps.
+  if (!existsSync(join(cwd, 'node_modules'))) {
+    return { generated: false, reason: 'deps-missing' }
+  }
+
+  const pm = detectPackageManager(cwd)
+
+  // 1) Ensure the bundled schema exists (build-first), unless already present.
+  if (!(reuseExistingBundle && bundleExists(cwd))) {
+    consola.start('Building schema bundle (one-time, needed to generate migrations)...')
+
+    const build = spawn('npx', ['nuxt', 'build'], {
+      cwd,
+      stdio: 'ignore',
+      env: { ...process.env, NITRO_PRESET: 'node-server' },
+    })
+
+    let buildExited = false
+    build.on('exit', () => { buildExited = true })
+
+    const deadline = Date.now() + buildTimeoutSec * 1000
+    while (!bundleExists(cwd) && !buildExited && Date.now() < deadline) {
+      await sleep(1500)
+    }
+
+    // Stop the build — we only needed the early-emitted schema bundle.
+    if (!buildExited) {
+      build.kill('SIGTERM')
+      // Give it a moment, then force-kill if still alive.
+      await sleep(1000)
+      if (!buildExited) build.kill('SIGKILL')
+    }
+
+    if (!bundleExists(cwd)) {
+      return {
+        generated: false,
+        reason: 'build-timeout',
+        detail: `schema bundle did not appear within ${buildTimeoutSec}s`,
+      }
+    }
+    consola.success('Schema bundle ready')
+  }
+
+  // 2) Generate migrations via the app's own db:generate script.
+  consola.start('Generating migrations...')
+  const [cmd, args] = runScriptCommand(pm, 'db:generate')
+  const gen = spawnSync(cmd, args, { cwd, stdio: 'pipe', encoding: 'utf-8' })
+
+  if (gen.status !== 0) {
+    return {
+      generated: false,
+      reason: 'generate-failed',
+      detail: (gen.stderr || gen.stdout || '').trim().split('\n').slice(-5).join('\n'),
+    }
+  }
+
+  consola.success('Generated migrations')
+  return { generated: true }
+}
+
+/**
+ * The exact manual sequence a human/agent should run when automatic generation
+ * was skipped (e.g. a fresh scaffold with no installed deps). Printed by callers.
+ */
+export function manualMigrationSteps(appDir?: string): string[] {
+  const cd = appDir ? `cd ${appDir} && ` : ''
+  return [
+    `${cd}pnpm install`,
+    'NITRO_PRESET=node-server nuxt build   # stop once .nuxt/hub/db/schema.mjs exists',
+    'pnpm db:generate                       # writes server/db/migrations/**',
+  ]
+}


### PR DESCRIPTION
## 👤 For humans

A freshly scaffolded crouton app used to ship a Drizzle schema but **no D1 migrations**, so the first deploy failed with *"No migrations present"* — the exact stall that bit **library-catalog (#457)**. Now `crouton add` and `crouton init` generate the migrations **build-first**, so a new app is deploy-ready. On a bare scaffold with no installed deps (where we can't build), it prints the precise `install → build → db:generate` steps instead of silently shipping nothing.

## 🤖 For agents

**Root cause:** the generated `drizzle.config.ts` reads the *bundled* schema at `.nuxt/hub/db/schema.mjs`, which NuxtHub only writes during **`nuxt build`** (`nuxt prepare` emits `schema.entry.ts`, not the `.mjs`). `add-module.ts` step 4 ran `npx nuxt db:generate` **without building first** → drizzle-kit found no schema → **zero** migrations. `init-app.ts` didn't generate migrations for collections at all.

- **NEW `lib/utils/generate-migrations.ts`** — `generateMigrations(cwd)`: starts `NITRO_PRESET=node-server nuxt build`, polls for the bundle (`.nuxt/hub/db/schema.mjs` or the nuxt cache path, written early before the slow Nitro stage), kills the build, then runs the app's own `db:generate` (respects `drizzle.config.ts`). Requires `node_modules`; otherwise returns `{ generated:false, reason:'deps-missing'|'build-timeout'|'generate-failed' }`. Exports `manualMigrationSteps()`.
- **`add-module.ts`** step 4 → uses `generateMigrations()` (build-first); `db:migrate` runs only when migrations were actually generated.
- **`init-app.ts`** → new build-first migration step after generate (now a 4-step pipeline); on `deps-missing` it defers and the summary prints the build-first sequence. **Scoped per maintainer decision:** `init` does **not** force a heavy `pnpm install` during scaffold.
- Mirrors the `db-migrations` skill's documented build-first trick; complements the flow-level workaround (#500/#501).

## 🧪 How to test

- `pnpm --filter @fyit/crouton-cli test` → 263 tests pass (incl. `init`/`add` integration).
- Type-clean (`generate-migrations.ts`, `init-app.ts`); per-app typecheck green (fanfare/triage/velo).
- Behaviour: in an installed app, `crouton add bookings` now produces committed `server/db/migrations/sqlite/**`; on a bare scaffold, `crouton init` prints the exact manual sequence instead of shipping zero migrations.

Closes #523. Related: #457, #500, #501, the `db-migrations` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uhCE5doJNn4a6gz4jF7Zj)_