### PR TITLE
refactor(ticket-editor): authenticate as the Crouton GitHub App (drop PAT) (#530)

### DIFF
--- a/workers/ticket-editor/README.md
+++ b/workers/ticket-editor/README.md
@@ -1,9 +1,13 @@
 # ticket-editor
 
 A tiny Excalidraw editor that commits edits **straight back to the repo** — the mobile
-round-trip for `ticket-diagram` diagrams with **zero third-party login** (the GitHub token is a
-Worker secret; your phone never authorizes anything). On Save, Excalidraw exports the PNG
-in-browser, so the committed image is exactly what you edited (WYSIWYG). Sub-issue #503 of epic #483.
+round-trip for `ticket-diagram` diagrams with **zero third-party login** (your phone never
+authorizes anything). On Save, Excalidraw exports the PNG in-browser, so the committed image is
+exactly what you edited (WYSIWYG). Sub-issue #503 of epic #483.
+
+Auth = the **Crouton GitHub App** (#519): the Worker mints a short-lived (~1h) installation token
+just-in-time (WebCrypto, dependency-free) and commits as `crouton[bot]` — no stored PAT. See
+`SECRETS.md` and `writeups/setup/secrets-and-tokens.md`.
 
 ## Routes
 
@@ -15,17 +19,20 @@ in-browser, so the committed image is exactly what you edited (WYSIWYG). Sub-iss
 ```bash
 cd workers/ticket-editor
 pnpm install
-npx wrangler secret put GITHUB_TOKEN     # fine-grained PAT, Contents: Read/Write on pmcp/nuxt-crouton
-npx wrangler deploy                       # → https://ticket-editor.<account>.workers.dev
+npx wrangler secret put GITHUB_APP_PRIVATE_KEY   # the Crouton App's PEM private key (only secret)
+# set GITHUB_APP_ID + GITHUB_APP_INSTALLATION_ID as wrangler vars (not sensitive)
+npx wrangler deploy                              # → https://ticket-editor.<account>.workers.dev
 ```
 
-Then open `https://ticket-editor.<account>.workers.dev/?slug=make-tickets-human-readable&branch=claude/excalidraw-ticket-diagrams`
-on your phone → edit → **Save** → a commit lands on the branch. Link that URL from each diagram's
-sticky comment as a one-tap **✏️ Edit**.
+Then open `https://ticket-editor.<account>.workers.dev/?slug=make-tickets-human-readable&branch=<branch>`
+on your phone → edit → **Save** → a commit (authored by `crouton[bot]`) lands on the branch. Link
+that URL from each diagram's sticky comment as a one-tap **✏️ Edit**.
 
 ## Notes
 
+- Auth is the **Crouton GitHub App** (#519) — short-lived installation tokens minted at runtime
+  directly with **WebCrypto** (dependency-free; sign an App JWT → exchange for an installation
+  token); **no stored PAT**. The one durable secret is the App private key. Full model in
+  `SECRETS.md` + `writeups/setup/secrets-and-tokens.md`.
 - The editor loads Excalidraw from the esm.sh CDN (runtime web app — fine; unlike our build-time
   renders, which stay offline). The exact ESM/CSS pins may need a small tweak after first deploy.
-- Token scope: a **fine-grained PAT** limited to this repo's Contents is enough. Keep it a Worker
-  secret — never commit it.

--- a/workers/ticket-editor/SECRETS.md
+++ b/workers/ticket-editor/SECRETS.md
@@ -1,46 +1,55 @@
 # ticket-editor — secrets to provision
 
-Context: `workers/ticket-editor` is a Cloudflare Worker that serves a mobile Excalidraw editor and,
-on Save, commits the edited diagram back to `pmcp/nuxt-crouton` via the GitHub Contents API. It
-touches **two systems for two reasons**:
+> **Updated for the Crouton GitHub App (#519).** This Worker no longer uses a stored GitHub PAT.
+> It authenticates as the **Crouton GitHub App**, minting a short-lived (~1h) installation token
+> just-in-time and committing as `crouton[bot]`. See `writeups/setup/secrets-and-tokens.md` (Tier 2
+> + the GitHub App section).
+
+This Worker (`workers/ticket-editor`) serves a mobile Excalidraw editor and, on Save, commits the
+edited diagram back to `pmcp/nuxt-crouton`. It touches **two systems for two reasons**:
 
 - **Cloudflare = deploy-time** — push the Worker's code.
-- **GitHub = run-time** — the deployed Worker commits edits back on its own (so there's no login on
-  the user's phone), using its own GitHub token.
+- **GitHub = run-time** — the deployed Worker commits edits back on its own (no login on the
+  user's phone), authenticating as the **Crouton GitHub App**.
 
-## Secrets
+## What to provision
 
 | Name | System | Purpose | Minimal scope | Stored as | New? |
 |---|---|---|---|---|---|
-| `CLOUDFLARE_API_TOKEN` | Cloudflare | `wrangler` deploys the Worker | Account → **Workers Scripts: Edit** (no D1/KV/R2 — this worker has no bindings; no Zone perms for a `*.workers.dev` URL) | GitHub Actions repo secret (and/or local env) | **Existing** — app deploys already use it; covers this worker |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare | `wrangler` deploys the Worker | Account → **Workers Scripts: Edit** (no D1/KV/R2; no Zone perms for a `*.workers.dev` URL) | GitHub Actions repo secret / local env | **Existing** — the consolidated `crouton-deploy` token covers it |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare | Which account to deploy into | identifier (not sensitive) | GitHub Actions repo secret / env | **Existing** |
-| **GitHub fine-grained PAT** | GitHub | The deployed Worker commits `<slug>.excalidraw` + `<slug>.png` back to the branch at runtime | Repo access: **`pmcp/nuxt-crouton` only** · Repository permissions → **Contents: Read and write** (Metadata: Read auto-included). Nothing else. | (a) **Cloudflare Worker secret** `GITHUB_TOKEN`; (b) optional GitHub Actions secret `TICKET_EDITOR_GH_TOKEN` (only if CI deploys) | **NEW — the only genuinely new ask** |
+| `GITHUB_APP_PRIVATE_KEY` | GitHub App | Signs a JWT to mint installation tokens at runtime | the **Crouton App** private key (PEM) | **Cloudflare Worker secret** (`wrangler secret put`) | **From #519** — the App's one durable secret, shared by all Tier-2 Workers |
+| `GITHUB_APP_ID` | GitHub App | Identifies the App when signing | not sensitive | Worker **var** (or secret) | from #519 |
+| `GITHUB_APP_INSTALLATION_ID` | GitHub App | The install on `pmcp/nuxt-crouton` to scope the token to | not sensitive | Worker **var** (or secret) | from #519 |
 
-## The new PAT — details
+**No PAT.** The old `GITHUB_TOKEN` (fine-grained PAT, Contents: R/W) is **retired** for this Worker —
+replaced by the App. (If the App isn't registered yet, a PAT is only a legitimate *stopgap*; the
+App is the chosen path.)
 
-- **Type:** GitHub fine-grained personal access token.
-- **Resource owner / repo:** `pmcp/nuxt-crouton` only.
-- **Permission:** Contents → **Read and write** (this is the entire blast radius if it leaks).
-- **Expiry:** set one; note it for rotation.
-- **Where it must end up:**
-  - **Cloudflare Worker secret** named `GITHUB_TOKEN` (runtime). Set with:
-    ```bash
-    cd workers/ticket-editor
-    npx wrangler secret put GITHUB_TOKEN   # paste the PAT
-    ```
-  - **(Only if deploying via CI)** also a **GitHub Actions repo secret** `TICKET_EDITOR_GH_TOKEN`
-    holding the same PAT, so the deploy workflow can pipe it into the Worker secret.
+## How the App auth works (why there's no long-lived token to leak)
 
-## Key distinctions (so nothing gets conflated)
+1. Sign a short JWT with the App **private key** → "I am the Crouton App".
+2. Exchange it for an **installation token**, scoped to one repo, valid ~1h.
+3. Commit with that token — it then expires on its own.
 
-- The new PAT is **not** `CLOUDFLARE_API_TOKEN` and **not** GitHub Actions' built-in `GITHUB_TOKEN`.
-  It's a standalone, narrowly-scoped GitHub token the Worker carries.
-- The PAT lives **encrypted in Cloudflare** (Worker secret) — never committed to the repo.
-- `CLOUDFLARE_API_TOKEN` only needs **Workers Scripts: Edit** for this worker (broader is fine but
-  not required); no D1/KV/R2/Zone scopes.
+We do all three directly with **WebCrypto** (no dependency — keeps the worker out of the monorepo
+lockfile; the RS256 + PKCS#1→PKCS#8 signing path is unit-tested in plain Node). We mint
+**just-in-time** per Save, so the ~1h life is enormous headroom and nothing long-lived is stored.
+The private key never hits the API — it only signs the App JWT.
 
-## TL;DR
+## App registration (one-time, #519 WS1)
 
+Register one **Crouton GitHub App** — permissions **Contents: write** (this Worker) **+ Pull
+requests: write** (the review-bridge half) — install it on `pmcp/nuxt-crouton`, then:
+
+```bash
+cd workers/ticket-editor
+npx wrangler secret put GITHUB_APP_PRIVATE_KEY    # paste the PEM
+# set GITHUB_APP_ID and GITHUB_APP_INSTALLATION_ID as wrangler vars (or secrets)
+```
+
+## TL;DR for the consolidation
 - **Reuse:** `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`.
-- **Create 1 new:** fine-grained GitHub PAT, `pmcp/nuxt-crouton` only, **Contents: Read/Write** →
-  store as Cloudflare Worker secret `GITHUB_TOKEN` (+ optional Actions secret `TICKET_EDITOR_GH_TOKEN`).
+- **From the App (#519), not a new per-feature PAT:** `GITHUB_APP_PRIVATE_KEY` (Worker secret) +
+  `GITHUB_APP_ID` + `GITHUB_APP_INSTALLATION_ID` (vars). One App private key serves **all** Tier-2
+  Workers (ticket-editor, review-bridge), so this isn't a per-Worker token.

--- a/workers/ticket-editor/src/index.ts
+++ b/workers/ticket-editor/src/index.ts
@@ -4,14 +4,24 @@
  *   GET  /?slug=<slug>&branch=<branch>   → the editor page (loads <slug>.excalidraw from the repo)
  *   POST /api/save  { slug, branch, scene, png }   → commits <slug>.excalidraw (+ <slug>.png) to the branch
  *
- * Mobile round-trip with ZERO third-party login: the GitHub token lives here as a Worker secret,
- * so the phone never authorizes anything. On Save, Excalidraw exports the PNG in-browser
- * (exportToBlob, scene embedded) — so the committed image is exactly what you edited (WYSIWYG).
+ * Mobile round-trip with ZERO third-party login: the phone never authorizes anything. On Save,
+ * Excalidraw exports the PNG in-browser (exportToBlob, scene embedded) — so the committed image
+ * is exactly what you edited (WYSIWYG).
  *
- * Setup:  wrangler secret put GITHUB_TOKEN   (a fine-grained PAT with contents:write on the repo)
+ * Auth = the **Crouton GitHub App** (#519): we mint a short-lived (~1h) installation token
+ * just-in-time and commit with it — no stored PAT, and commits post as `crouton[bot]`. The one
+ * durable secret is the App private key. The mint (sign an App JWT → exchange for an installation
+ * token) is done directly with WebCrypto — dependency-free, so the worker adds nothing to the
+ * monorepo lockfile (and the signing path is unit-testable in plain Node).
+ *
+ * Setup (Worker secrets / vars):
+ *   wrangler secret put GITHUB_APP_PRIVATE_KEY   (the App's PEM private key — the only secret)
+ *   GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID    (not sensitive — set as vars or secrets)
  */
 interface Env {
-  GITHUB_TOKEN: string
+  GITHUB_APP_ID: string
+  GITHUB_APP_PRIVATE_KEY: string // PEM; the one durable secret
+  GITHUB_APP_INSTALLATION_ID: string
   REPO: string // "pmcp/nuxt-crouton"
   DIAGRAMS_DIR: string // "writeups/diagrams"
 }
@@ -39,10 +49,69 @@ function toB64(str: string): string {
   return btoa(bin)
 }
 
-async function putFile(env: Env, branch: string, path: string, contentB64: string, message: string): Promise<void> {
+// ── GitHub App auth (WebCrypto, dependency-free) ─────────────────────────────
+function b64url(bytes: Uint8Array): string {
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// DER length octets for a given content length.
+function derLen(n: number): number[] {
+  if (n < 0x80) return [n]
+  const out: number[] = []
+  let x = n
+  while (x > 0) {
+    out.unshift(x & 0xff)
+    x >>= 8
+  }
+  return [0x80 | out.length, ...out]
+}
+
+// Wrap a PKCS#1 RSA key (GitHub's `BEGIN RSA PRIVATE KEY`) into PKCS#8, which WebCrypto requires.
+function pkcs1ToPkcs8(pkcs1: Uint8Array): Uint8Array {
+  const version = [0x02, 0x01, 0x00]
+  const algId = [0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00]
+  const octet = [0x04, ...derLen(pkcs1.length), ...Array.from(pkcs1)]
+  const body = [...version, ...algId, ...octet]
+  return new Uint8Array([0x30, ...derLen(body.length), ...body])
+}
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const isPkcs1 = pem.includes('BEGIN RSA PRIVATE KEY')
+  const b64 = pem.replace(/-----BEGIN [A-Z ]+-----/, '').replace(/-----END [A-Z ]+-----/, '').replace(/\s+/g, '')
+  const bin = atob(b64)
+  const der = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) der[i] = bin.charCodeAt(i)
+  const pkcs8 = isPkcs1 ? pkcs1ToPkcs8(der) : der
+  return crypto.subtle.importKey('pkcs8', pkcs8, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'])
+}
+
+// Sign a short App JWT (RS256) — iat backdated 30s for clock skew, ~9min expiry.
+async function appJwt(appId: string, pem: string): Promise<string> {
+  const now = Math.floor(Date.now() / 1000)
+  const enc = (o: unknown) => b64url(new TextEncoder().encode(JSON.stringify(o)))
+  const data = `${enc({ alg: 'RS256', typ: 'JWT' })}.${enc({ iat: now - 30, exp: now + 540, iss: appId })}`
+  const key = await importPrivateKey(pem)
+  const sig = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key, new TextEncoder().encode(data))
+  return `${data}.${b64url(new Uint8Array(sig))}`
+}
+
+// Mint a short-lived (~1h) installation token for the Crouton App — minted just-in-time, no PAT.
+async function installationToken(env: Env): Promise<string> {
+  const jwt = await appJwt(env.GITHUB_APP_ID, env.GITHUB_APP_PRIVATE_KEY)
+  const res = await fetch(
+    'https://api.github.com/app/installations/' + env.GITHUB_APP_INSTALLATION_ID + '/access_tokens',
+    { method: 'POST', headers: { authorization: 'Bearer ' + jwt, accept: 'application/vnd.github+json', 'user-agent': 'ticket-editor' } },
+  )
+  if (!res.ok) throw new Error('mint installation token → ' + res.status + ' ' + (await res.text()))
+  return ((await res.json()) as { token: string }).token
+}
+
+async function putFile(token: string, env: Env, branch: string, path: string, contentB64: string, message: string): Promise<void> {
   const api = 'https://api.github.com/repos/' + env.REPO + '/contents/' + path
   const headers = {
-    authorization: 'Bearer ' + env.GITHUB_TOKEN,
+    authorization: 'Bearer ' + token,
     accept: 'application/vnd.github+json',
     'user-agent': 'ticket-editor',
     'content-type': 'application/json',
@@ -70,10 +139,11 @@ async function save(req: Request, env: Env): Promise<Response> {
     if (!/^[a-z0-9][a-z0-9._-]*$/i.test(slug)) return json({ error: 'bad slug' }, 400)
     const dir = env.DIAGRAMS_DIR || 'writeups/diagrams'
     const msg = 'chore(diagrams): edit ' + slug + ' via ticket-editor'
-    await putFile(env, branch, dir + '/' + slug + '.excalidraw', toB64(JSON.stringify(scene, null, 2) + '\n'), msg)
+    const token = await installationToken(env) // one fresh ~1h token for both commits
+    await putFile(token, env, branch, dir + '/' + slug + '.excalidraw', toB64(JSON.stringify(scene, null, 2) + '\n'), msg)
     if (png) {
       const b64 = png.includes(',') ? png.split(',')[1] : png
-      await putFile(env, branch, dir + '/' + slug + '.png', b64, msg + ' (png)')
+      await putFile(token, env, branch, dir + '/' + slug + '.png', b64, msg + ' (png)')
     }
     return json({ ok: true })
   } catch (e) {

--- a/workers/ticket-editor/wrangler.jsonc
+++ b/workers/ticket-editor/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   // Minimal Worker that serves the Excalidraw ticket-editor and commits edits back to the repo.
-  // Secret (not in this file):  wrangler secret put GITHUB_TOKEN   (fine-grained PAT, contents:write)
+  // Auth = the Crouton GitHub App (#519): mints short-lived installation tokens at runtime.
+  //   wrangler secret put GITHUB_APP_PRIVATE_KEY   ← the App's PEM private key (the only secret)
+  // GITHUB_APP_ID + GITHUB_APP_INSTALLATION_ID are not sensitive — set them below once known,
+  // or as `wrangler secret put` if you prefer. (Left out here until the App is registered.)
   "name": "ticket-editor",
   "main": "src/index.ts",
   "compatibility_date": "2024-11-01",


### PR DESCRIPTION
## 👤 For humans

The ticket-editor Worker no longer carries a GitHub PAT. It now authenticates as the **Crouton GitHub App** ([#519](https://github.com/pmcp/nuxt-crouton/issues/519)): it signs a short App JWT with the App's private key, exchanges it for a **~1-hour installation token just-in-time** before each Save, and commits with that — so commits show as **`crouton[bot]`** and there's no long-lived token to leak. The one durable secret is the App private key.

## 🤖 For agents

Workstream #2 of #519 (ticket-editor half; review-bridge lives in `packages/crouton-devtools` → HARD GATE, separate).

- `workers/ticket-editor/src/index.ts` — `installationToken()` mints via **WebCrypto**: `appJwt()` (RS256) + `importPrivateKey()` (handles GitHub's PKCS#1 key by wrapping it to PKCS#8) → `POST /app/installations/:id/access_tokens`; `putFile()` uses the minted token.
- Secrets flip: `GITHUB_TOKEN` (PAT) → **`GITHUB_APP_PRIVATE_KEY`** (secret) + `GITHUB_APP_ID` + `GITHUB_APP_INSTALLATION_ID` (vars). `wrangler.jsonc`, `SECRETS.md`, `README` updated to the App model.

### Deviation from #519 WS2 (flagged)
WS2 says "wire `@octokit/auth-app`", but adding it **re-resolved the entire monorepo lockfile** (unrelated `@nuxt/*` / `@better-auth/*` churn). So the mint is hand-rolled with **WebCrypto — dependency-free, zero lockfile impact**. The RS256 + PKCS#1→PKCS#8 signing path is **verified in plain Node for both key formats** (Node WebCrypto == Workers WebCrypto). Trivial to swap to the library later if preferred (at the cost of the lockfile churn).

## 🧪 How to test

- Local crypto proof (done): generate an RSA key (PKCS#1 and PKCS#8) → `appJwt()` → the JWT verifies against the public key. ✅
- End-to-end needs the App **registered + installed** (#519 WS1) and `GITHUB_APP_*` set as Worker secrets/vars; then a Save commits both files as `crouton[bot]`.

Closes #530. Part of #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5DpQNEnD3kekVR75cEzWV)_