### PR TITLE
ticket-editor: fix editor load + correct bot name to nuxt-harness + App runbook

### DIFF
--- a/workers/ticket-editor/README.md
+++ b/workers/ticket-editor/README.md
@@ -6,7 +6,7 @@ authorizes anything). On Save, Excalidraw exports the PNG in-browser, so the com
 exactly what you edited (WYSIWYG). Sub-issue #503 of epic #483.
 
 Auth = the **Crouton GitHub App** (#519): the Worker mints a short-lived (~1h) installation token
-just-in-time (WebCrypto, dependency-free) and commits as `crouton[bot]` — no stored PAT. See
+just-in-time (WebCrypto, dependency-free) and commits as `nuxt-harness[bot]` — no stored PAT. See
 `SECRETS.md` and `writeups/setup/secrets-and-tokens.md`.
 
 ## Routes
@@ -25,7 +25,7 @@ npx wrangler deploy                              # → https://ticket-editor.<ac
 ```
 
 Then open `https://ticket-editor.<account>.workers.dev/?slug=make-tickets-human-readable&branch=<branch>`
-on your phone → edit → **Save** → a commit (authored by `crouton[bot]`) lands on the branch. Link
+on your phone → edit → **Save** → a commit (authored by `nuxt-harness[bot]`) lands on the branch. Link
 that URL from each diagram's sticky comment as a one-tap **✏️ Edit**.
 
 ## Notes

--- a/workers/ticket-editor/SECRETS.md
+++ b/workers/ticket-editor/SECRETS.md
@@ -2,7 +2,7 @@
 
 > **Updated for the Crouton GitHub App (#519).** This Worker no longer uses a stored GitHub PAT.
 > It authenticates as the **Crouton GitHub App**, minting a short-lived (~1h) installation token
-> just-in-time and committing as `crouton[bot]`. See `writeups/setup/secrets-and-tokens.md` (Tier 2
+> just-in-time and committing as `nuxt-harness[bot]`. See `writeups/setup/secrets-and-tokens.md` (Tier 2
 > + the GitHub App section).
 
 This Worker (`workers/ticket-editor`) serves a mobile Excalidraw editor and, on Save, commits the

--- a/workers/ticket-editor/src/index.ts
+++ b/workers/ticket-editor/src/index.ts
@@ -9,7 +9,7 @@
  * is exactly what you edited (WYSIWYG).
  *
  * Auth = the **Crouton GitHub App** (#519): we mint a short-lived (~1h) installation token
- * just-in-time and commit with it — no stored PAT, and commits post as `crouton[bot]`. The one
+ * just-in-time and commit with it — no stored PAT, and commits post as `nuxt-harness[bot]`. The one
  * durable secret is the App private key. The mint (sign an App JWT → exchange for an installation
  * token) is done directly with WebCrypto — dependency-free, so the worker adds nothing to the
  * monorepo lockfile (and the signing path is unit-testable in plain Node).
@@ -159,6 +159,19 @@ const PAGE = `<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 <title>Ticket diagram editor</title>
 <link rel="stylesheet" href="https://esm.sh/@excalidraw/excalidraw@0.17.6/index.css" />
+<!-- Import map so excalidraw's bare "react"/"react-dom" specifiers (it's loaded with
+     ?external=react,react-dom) resolve to the SAME esm.sh instances we import below.
+     Without this the page fails with "Failed to resolve module specifier react". -->
+<script type="importmap">
+{
+  "imports": {
+    "react": "https://esm.sh/react@18.3.1",
+    "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+    "react-dom": "https://esm.sh/react-dom@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client"
+  }
+}
+</script>
 <style>
   html,body,#root{margin:0;height:100%;width:100%;}
   #bar{position:fixed;z-index:10;top:0;left:0;right:0;height:48px;display:flex;align-items:center;gap:10px;
@@ -184,8 +197,8 @@ const PAGE = `<!DOCTYPE html>
   function setStatus(t){ statusEl.textContent = t; }
 
   Promise.all([
-    import('https://esm.sh/react@18.3.1'),
-    import('https://esm.sh/react-dom@18.3.1/client'),
+    import('react'),
+    import('react-dom/client'),
     import('https://esm.sh/@excalidraw/excalidraw@0.17.6?external=react,react-dom')
   ]).then(function(mods){
     var React = mods[0].default || mods[0];

--- a/writeups/setup/crouton-github-app.md
+++ b/writeups/setup/crouton-github-app.md
@@ -1,0 +1,116 @@
+# Crouton GitHub App — registration & wiring runbook (epic #519)
+
+> **Naming:** the App is registered as **"Nuxt Harness"** and posts as **`nuxt-harness[bot]`**
+> (App ID `4107840`, owned by the **FriendlyInternet** org). "Crouton GitHub App" is the project's
+> name for this same App in epic #519.
+
+> **Status:** already set up and verified for `pmcp/nuxt-crouton` (the ticket-editor Worker commits
+> as `nuxt-harness[bot]` with no PAT). This runbook is the canonical reference — for re-provisioning,
+> rotating the key, or onboarding a second tenant.
+
+The one-time human setup (WS1) for the App: the Tier-2 / multi-tenant identity that replaces
+per-feature PATs. Rationale lives in [`secrets-and-tokens.md`](./secrets-and-tokens.md); this is the
+*do-it* checklist.
+
+## Decisions (recorded)
+
+- **Owner = a GitHub organisation, not a personal account.** An org-owned App survives any one person
+  leaving, allows multiple admins, and is the correct home for a product others install. **Ownership
+  IS transferable** (App settings → Advanced → Transfer ownership; user→org supported, not to a team)
+  — App ID, private key, and installations all carry over. (We registered under @pmcp, then transferred
+  to the **FriendlyInternet** org.)
+- **Tenants do NOT need an org.** A GitHub App installs onto *any* account — personal or org. Owning
+  the App in an org is purely our side (durability/branding); it imposes nothing on installers.
+- **Visibility: public.** Because the org owns the App but it's installed on the personal
+  `pmcp/nuxt-crouton` repo, the App must be **"Any account"** (public). *Install-scope rule:* a
+  *private* App can only be installed on the account that **owns** it.
+
+## A. The org
+
+The product home is the **`FriendlyInternet`** org. To create one: GitHub → **+ (top-right) → New
+organization** → **Free** plan. (Ownership is transferable, so you can also register under a personal
+account first and transfer later.)
+
+## B. Register the App
+
+Navigate: `https://github.com/organizations/FriendlyInternet/settings/apps` → **New GitHub App**
+(or **Settings → Developer settings → GitHub Apps** under a personal account, then transfer).
+
+Fill the form (verbatim field labels; required marked):
+
+| Field | Value |
+|---|---|
+| **GitHub App name** *(req · global-unique · ≤~34 chars)* | `Nuxt Harness`. Commits/comments show as **`nuxt-harness[bot]`**. |
+| **Description** | optional — e.g. "Crouton runtime GitHub identity (diagram editor, review bridge, gates)." |
+| **Homepage URL** *(req)* | `https://github.com/pmcp/nuxt-crouton` |
+| **Identifying & authorizing users → Callback URL** | leave blank (no user-OAuth yet) |
+| **Webhook → Active** | **UNCHECK** — no endpoint yet (turn on for WS5; one webhook per App, toggleable later) |
+| Webhook URL / Webhook secret | leave blank (Active is off) |
+| **Repository permissions** | **Contents → Read & write**, **Pull requests → Read & write**. *(Metadata auto-forces to Read-only — expected.)* |
+| *(WS5)* | **Issues → Read & write** — needed so the App can apply the `delegate` label. |
+| *(futureproof, optional)* | **Checks → Read & write** — WS4 needs it; setting now saves a re-approval later. |
+| **Subscribe to events** | none (Active is off) |
+| **Where can this GitHub App be installed?** | **Any account** (public) — required so the org-owned App can install on the personal `pmcp/nuxt-crouton` repo. |
+
+→ **Create GitHub App.**
+
+> Adding permissions later (e.g. Issues for WS5, Checks for WS4) requires each installer to re-approve
+> — trivial while you're the only installer. Removing is immediate.
+
+## C. Generate the private key
+
+On the App's settings page → **Private keys → Generate a private key** (a PEM downloads; GitHub keeps
+only the public half — store it safely, a lost key can't be re-downloaded, just generate a new one).
+
+GitHub hands you **PKCS#1** (`-----BEGIN RSA PRIVATE KEY-----`). **No conversion needed** — the Worker
+imports the key with WebCrypto and converts PKCS#1→PKCS#8 *in-code* (dependency-free), so paste the PEM
+GitHub gave you as-is.
+
+Also note the **App ID** (a number on the settings page — what the Worker uses; *not* the Client ID).
+
+## D. Install it + get the installation ID
+
+App settings → **Install App** → install on the account that has `nuxt-crouton` (the personal `pmcp`
+account) → choose **Only select repositories → `nuxt-crouton`**.
+
+Then open the installation's **Configure** page and copy the **installation ID** from the URL:
+`.../settings/installations/<INSTALLATION_ID>`.
+
+## E. Wire the Worker, deploy, verify
+
+The ticket-editor Worker expects these three (App ID / installation ID aren't sensitive — put them in
+`wrangler.jsonc`'s `vars`, and keep only the key as a secret):
+
+```bash
+cd workers/ticket-editor
+npx wrangler secret put GITHUB_APP_PRIVATE_KEY        # paste the PEM GitHub gave you (PKCS#1 is fine)
+# set GITHUB_APP_ID and GITHUB_APP_INSTALLATION_ID as wrangler vars (or secrets)
+npx wrangler deploy
+```
+
+**Verify (the epic's "we'll know by"):** open the editor → edit a diagram → **Save** → the commit on
+the branch is authored by **`nuxt-harness[bot]`**, no PAT anywhere.
+
+## Forward-compat (so this setup carries to the product)
+
+- **GitHub Actions reuse (WS5):** to let the App also *trigger* the agent pipeline, store the App's
+  private key + id as Actions secrets (`HARNESS_APP_PRIVATE_KEY` / `HARNESS_APP_ID`) and mint an
+  installation token in-workflow (`actions/create-github-app-token`); Node accepts the PKCS#1 PEM.
+- **Webhooks (WS5):** one webhook per App, can't be deleted but can be toggled. When the receiver Worker
+  exists, set Webhook URL + a secret (GitHub HMAC-signs deliveries as `X-Hub-Signature-256`) and
+  subscribe to events. This is also #515's "appoint the App to release" signal.
+- **GitHub Checks (WS4):** the gates (artifact-gate / schema-review / UI sign-off / deploy) become
+  Check Runs instead of bot comments.
+- **review-bridge (other half of WS2):** the `/api/_review` endpoint (#491, in `packages/crouton-devtools`)
+  swaps its PAT for an App installation token the same way — tracked separately (package HARD GATE).
+- **Provenance:** once comments post as `nuxt-harness[bot]`, the `require-comment-provenance` hook
+  band-aid (#497) can be retired for App-posted comments.
+
+## Sources
+
+GitHub Docs: [registering a GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) ·
+[choosing permissions](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app) ·
+[managing private keys](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps) ·
+[installing your own app](https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app) ·
+[public vs private](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/making-a-github-app-public-or-private) ·
+[modifying a registration](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration).

--- a/writeups/setup/secrets-and-tokens.md
+++ b/writeups/setup/secrets-and-tokens.md
@@ -113,6 +113,10 @@ The **only** secret local dev needs is `BETTER_AUTH_SECRET`, and the session-sta
 
 ## Durable direction: one **Crouton GitHub App** (retires Tier 2)
 
+> 📋 **Setup runbook:** [`crouton-github-app.md`](./crouton-github-app.md) — register / key / install /
+> wire (step by step). The App is live: registered as **"Nuxt Harness"** (`nuxt-harness[bot]`, App ID
+> `4107840`, FriendlyInternet org), powering the ticket-editor Worker with no PAT.
+
 A shared PAT is a dead end the moment this goes **multi-tenant** (teams reviewing their own apps): one PAT can't represent N reviewers/teams and becomes a single high-value secret spanning every tenant.
 
 The convergent answer for **all of Tier 2** is a single **Crouton GitHub App** (permissions: Contents: write + Pull requests: write), **installed per repo/org**, minting **short-lived per-installation tokens**. One App:
@@ -140,7 +144,7 @@ The **one** durable secret is the **private key** (no expiry; it never touches t
 Swapping two PATs is the least of it. The App is a GitHub-native **identity + webhook receiver + per-tenant permission grant**, which unlocks:
 
 **Fixes things we currently do wrong**
-- **Posts as `crouton[bot]`, not @pmcp** — the *real* fix for the provenance problem we band-aided with the `require-comment-provenance` hook. Bot comments become unmistakable at the source.
+- **Posts as `nuxt-harness[bot]`, not @pmcp** — the *real* fix for the provenance problem we band-aided with the `require-comment-provenance` hook. Bot comments become unmistakable at the source.
 - **Retires the scattered per-feature PATs** and the **unauthenticated `/api/_review`** (actions tie to a real installation, not an open URL + shared low-trust token).
 - **Exact permissions** — no more "the bot token lacks `workflows`/`actions`" walls; grant only what's chosen.
 


### PR DESCRIPTION
Follow-up to #531 (which landed the App-auth ticket-editor on `main`). Carries the three pieces that were unique to the now-closed #534 and are missing from `main`. Part of epic #519.

## 👤 For humans

Three small, real gaps on `main` after #531:
1. **The editor page is broken** — it fails with *"Failed to resolve module specifier react"* (no import map for Excalidraw's `?external=react,react-dom`). This fixes it.
2. **Wrong bot name in docs** — the App is registered as **Nuxt Harness** (owned by the FriendlyInternet org), so it commits as **`nuxt-harness[bot]`**, not `crouton[bot]`. Synced.
3. **No setup runbook** — adds `writeups/setup/crouton-github-app.md` (register / key / install / wire), noting main's dependency-free worker takes the PKCS#1 key directly (no `openssl` step).

No change to main's App-auth implementation — it's the better, dependency-free one; this only adds what was missing.

## 🤖 For agents

- `workers/ticket-editor/src/index.ts`: `<script type="importmap">` for react/react-dom (+ jsx-runtime, react-dom/client); dynamic `import()`s use the mapped bare specifiers so Excalidraw shares one React instance. Bundle verified (`wrangler --dry-run`, 30 KiB).
- `s/crouton[bot]/nuxt-harness[bot]/` in `workers/ticket-editor/{README,SECRETS}.md` + `writeups/setup/secrets-and-tokens.md` (+ runbook link).
- New `writeups/setup/crouton-github-app.md`: org-owned + public, exact form values (Contents/PRs/Issues/Checks), no-conversion key step, install-id-from-URL, verify, WS4/5/6 forward-compat.

## 🧪 How to test

`cd workers/ticket-editor && npx wrangler deploy` → open `/?slug=…&branch=…` → the canvas renders (no console "module specifier" error) → **Save** → commit authored by `nuxt-harness[bot]`.

> Context: #530 was implemented twice in parallel (#531 by the pipeline, #534 by hand). #534 is closed as superseded; this salvages its unique deltas onto #531's base. Worth a line in the #519 postmortem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Th8HgDnxPszCoGupG3NZD7)_