### PR TITLE
WS5: App-driven delegate dispatch + allowed_bots (retire trigger PAT)

### DIFF
--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -5,10 +5,11 @@ name: Comment dispatch
 # which fires decompose-on-issue.yml. Only the repo owner / members / collaborators can
 # trigger it.
 #
-# AUTH (critical): the label is applied with a PAT (DISPATCH_TOKEN, or PROJECTS_TOKEN) so
-# the dispatched decompose run is attributed to a HUMAN actor and passes claude-code-action's
-# bot-actor guard. With only GITHUB_TOKEN the run would be bot-initiated and fail. Without a
-# PAT this workflow no-ops (green) with a warning.
+# AUTH (#519 WS5): the label is applied with a Nuxt Harness GitHub App installation token, so
+# the dispatched decompose run is attributed to `nuxt-harness[bot]` and passes claude-code-action's
+# bot-actor guard via its `allowed_bots` allow-list (see decompose-on-issue.yml). This retires the
+# human PAT (PROJECTS_TOKEN) from the trigger path. Needs Actions secrets HARNESS_APP_ID +
+# HARNESS_APP_PRIVATE_KEY, and the App granted Issues: write.
 
 on:
   issue_comment:
@@ -30,17 +31,20 @@ jobs:
        contains(github.event.comment.body, '/deploy'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
-        env:
-          DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.PROJECTS_TOKEN }}
+      # Mint a Nuxt Harness App installation token so the `delegate` label is applied by
+      # `nuxt-harness[bot]`. That makes the dispatched decompose run App-actored, which passes
+      # claude-code-action's bot-actor guard via `allowed_bots` (decompose-on-issue.yml) — no
+      # human PAT needed. An App installation token (unlike the built-in GITHUB_TOKEN) DOES
+      # trigger the downstream `labeled` workflow. (#535 / #519 WS5)
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          github-token: ${{ secrets.DISPATCH_TOKEN || secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            if (!process.env.DISPATCH_TOKEN) {
-              core.warning('No DISPATCH_TOKEN/PROJECTS_TOKEN — applying `delegate` via GITHUB_TOKEN would make '
-                + 'the dispatched run bot-initiated and fail the bot-actor guard. Set a PAT with issues:write. Skipping.')
-              return
-            }
             const { owner, repo } = context.repo
             const issue_number = context.payload.issue.number
             const comment_id = context.payload.comment.id

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -47,6 +47,10 @@ jobs:
           prompt: "/task-decompose #${{ github.event.issue.number }}"
           claude_args: "--max-turns 30"
           show_full_output: true
+          # WS5 (#535): the `delegate` label is now applied by the Nuxt Harness App, so this run is
+          # actored as nuxt-harness[bot]. Allow exactly that bot past the bot-actor guard — nothing
+          # else. (The pinned SHA already supports allowed_bots.)
+          allowed_bots: "nuxt-harness[bot]"
 
       # ── Artifact-gate (#461) ──────────────────────────────────────────────────
       # A run is only allowed to be GREEN if the agent produced an OBSERVABLE

--- a/.github/workflows/schedule-waves.yml
+++ b/.github/workflows/schedule-waves.yml
@@ -11,10 +11,10 @@ name: Wave scheduler
 # line. Fan-in matters — a dependent is only released when EVERY listed blocker is
 # closed (diamonds, not just lines).
 #
-# AUTH (critical): the label is applied with a PAT (DISPATCH_TOKEN, or PROJECTS_TOKEN)
-# so the resulting decompose run is attributed to a HUMAN actor and passes
-# claude-code-action's bot-actor guard. With only GITHUB_TOKEN the dispatched run would
-# be bot-initiated and die on that guard — so without a PAT this workflow no-ops (green).
+# AUTH (#519 WS5): the label is applied with a Nuxt Harness GitHub App installation token, so
+# the resulting decompose run is attributed to `nuxt-harness[bot]` and passes claude-code-action's
+# bot-actor guard via its `allowed_bots` allow-list (see decompose-on-issue.yml). Retires the human
+# PAT. Needs Actions secrets HARNESS_APP_ID + HARNESS_APP_PRIVATE_KEY, and the App granted Issues: write.
 
 on:
   issues:
@@ -30,19 +30,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
-        env:
-          DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN || secrets.PROJECTS_TOKEN }}
+      # Mint a Nuxt Harness App installation token so the released `delegate` label is applied by
+      # `nuxt-harness[bot]` → the dispatched decompose run passes the bot-actor guard via
+      # `allowed_bots` (decompose-on-issue.yml). Retires the human PAT here. (#535 / #519 WS5)
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          # Use the PAT for ALL calls so the addLabels event is human-actored.
-          github-token: ${{ secrets.DISPATCH_TOKEN || secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+      - uses: actions/github-script@v7
+        with:
+          # All calls use the App token so the addLabels event is actored as nuxt-harness[bot].
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            if (!process.env.DISPATCH_TOKEN) {
-              core.warning('No DISPATCH_TOKEN/PROJECTS_TOKEN set. Labeling via GITHUB_TOKEN would make the '
-                + 'dispatched decompose run bot-initiated and fail the bot-actor guard. Set a PAT with '
-                + 'issues:write to enable wave auto-advance. Skipping (no-op).')
-              return
-            }
             const { owner, repo } = context.repo
 
             // 1) What just completed?


### PR DESCRIPTION
Closes #535 · epic #519 (WS5, the payoff). **Draft** — needs a live smoke test after merge before the PAT is removed.

## 👤 For humans

The pipeline's human PAT only existed to make the `delegate` trigger look human (claude-code-action rejects bot actors). Now that the **Nuxt Harness** App exists, it can both *apply* the label and be *allow-listed* past the guard — so the PAT is no longer needed to trigger runs.

- `/delegate` comments and wave auto-advance now apply `delegate` as **`nuxt-harness[bot]`** (via an App installation token).
- `claude-code-action` is told `allowed_bots: "nuxt-harness[bot]"` so those runs pass the guard.
- The pinned action SHA **already supports `allowed_bots`** — no version bump, so interactive `@claude` (`claude.yml`) is untouched.

## 🤖 For agents

- `comment-dispatch.yml` + `schedule-waves.yml`: `actions/create-github-app-token` (`HARNESS_APP_ID` + `HARNESS_APP_PRIVATE_KEY`) → apply `delegate` with the install token. Dropped the `DISPATCH_TOKEN`/`PROJECTS_TOKEN` path + no-PAT guard. App install tokens (unlike built-in `GITHUB_TOKEN`) trigger the downstream `labeled` workflow.
- `decompose-on-issue.yml`: `allowed_bots: "nuxt-harness[bot]"`.
- `resume-on-comment.yml`: unchanged (human-triggered).

## ✅ Prereqs (done)
- App granted **Issues: Read & write** (+ re-approved on the install).
- Actions secrets `HARNESS_APP_ID`, `HARNESS_APP_PRIVATE_KEY` added.

## 🧪 Smoke test (the merge gate — why this is a draft)
Workflows run from the **default branch**, so this can only be exercised once on `main`. Plan:
1. Merge.
2. Comment `/delegate` on a throwaway issue → confirm: the `delegate` label event shows **`nuxt-harness[bot]`**, and the decompose run **starts** (passes the guard) rather than dying on the bot-actor check.
3. ⚠️ Watch for the closed-bug #1133 residue: `allowed_bots` bypasses `checkHumanActor` but historically not `checkWritePermissions` (bots aren't collaborators → 404). If the run dies there, bump the action SHA to a release with the fix (keeping `claude.yml`/`resume-on-comment.yml` in sync).
4. Only once green: delete `PROJECTS_TOKEN`/`DISPATCH_TOKEN` from the trigger path (that deletion is **#521**).

`PROJECTS_TOKEN` stays in place until the smoke test passes, so rollback = revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Th8HgDnxPszCoGupG3NZD7)_