### PR TITLE
ticket-editor: derive RAW URL from REPO var (org-migration prep)

### DIFF
--- a/workers/ticket-editor/src/index.ts
+++ b/workers/ticket-editor/src/index.ts
@@ -31,7 +31,7 @@ export default {
     const url = new URL(req.url)
     if (req.method === 'POST' && url.pathname === '/api/save') return save(req, env)
     if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/edit')) {
-      return new Response(PAGE, { headers: { 'content-type': 'text/html; charset=utf-8' } })
+      return new Response(PAGE.replace(/__REPO__/g, env.REPO), { headers: { 'content-type': 'text/html; charset=utf-8' } })
     }
     return new Response('Not found', { status: 404 })
   },
@@ -190,7 +190,7 @@ const PAGE = `<!DOCTYPE html>
   var params = new URLSearchParams(location.search);
   var slug = params.get('slug') || '';
   var branch = params.get('branch') || 'main';
-  var RAW = 'https://raw.githubusercontent.com/pmcp/nuxt-crouton/' + branch + '/writeups/diagrams/' + slug + '.excalidraw';
+  var RAW = 'https://raw.githubusercontent.com/__REPO__/' + branch + '/writeups/diagrams/' + slug + '.excalidraw';
   window.EXCALIDRAW_ASSET_PATH = 'https://esm.sh/@excalidraw/excalidraw@0.17.6/dist/';
   var statusEl = document.getElementById('status');
   var saveEl = document.getElementById('save');


### PR DESCRIPTION
Part of epic #546 (org migration). Pre-transfer prep: makes the ticket-editor's GitHub touchpoints owner-agnostic so the worker survives the transfer with just a `REPO` var change + redeploy.

## 👤 For humans
The editor hardcoded `pmcp/nuxt-crouton` in its raw-content URL — that wouldn't redirect after the org transfer. Now both the read (raw URL) and write (contents API) derive from the single `REPO` var. After transfer: set `REPO` to `FriendlyInternet/nuxt-crouton` in `wrangler.jsonc` and redeploy.

## 🤖 For agents
- `src/index.ts`: `__REPO__` placeholder in the PAGE raw URL, injected via `PAGE.replace(/__REPO__/g, env.REPO)` in the GET handler. Contents API already used `env.REPO`. Bundle verified (`wrangler --dry-run`, 30 KiB).

Safe to merge now (no behaviour change while `REPO` is still `pmcp/nuxt-crouton`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Th8HgDnxPszCoGupG3NZD7)_