### PR TITLE
fix(crouton-auth): repair invitation-resend authz (ReferenceError + swapped args)

### DIFF
--- a/packages/crouton-auth/server/api/auth/invitations/[id]/resend.post.ts
+++ b/packages/crouton-auth/server/api/auth/invitations/[id]/resend.post.ts
@@ -59,7 +59,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Verify the current user is an admin or owner of the organization
-  const membership = await getOrganizationMembershipDirect(currentUserId, result.organizationId)
+  const membership = await getOrganizationMembershipDirect(result.organizationId, currentUserId)
   if (!membership || !['admin', 'owner'].includes(membership.role)) {
     throw createError({ status: 403, statusText: 'Only team admins can resend invitations' })
   }

--- a/packages/crouton-auth/server/utils/team.ts
+++ b/packages/crouton-auth/server/utils/team.ts
@@ -477,11 +477,11 @@ export async function getOrganizationMembershipDirect(
   const db = useDB()
 
   const result = await db
-    .select({ role: member.role })
-    .from(member)
+    .select({ role: memberTable.role })
+    .from(memberTable)
     .where(and(
-      eq(member.organizationId, organizationId),
-      eq(member.userId, userId)
+      eq(memberTable.organizationId, organizationId),
+      eq(memberTable.userId, userId)
     ))
     .limit(1)
 


### PR DESCRIPTION
## 👤 For humans

Resending a pending team invitation (as an admin/owner) was broken — the request errored out *before* the permission check even ran, so it always failed with a 500. This fixes it: resend works again for admins/owners, and non-admins are correctly rejected with a 403. Found by the new red-team agent (#540) on its first run, then verified by reading the code.

## 🤖 For agents

Two one-line fixes in `@crouton/auth`:
- `server/utils/team.ts` — `getOrganizationMembershipDirect` referenced a bare `member` symbol that isn't imported (the file imports `member as memberTable`) → `ReferenceError: member is not defined`. Switched the query to `memberTable`.
- `server/api/auth/invitations/[id]/resend.post.ts:62` — call was `(currentUserId, result.organizationId)` but the signature is `(organizationId, userId)`; swapped to `(result.organizationId, currentUserId)`.

Born-broken since `3d65280` (PR #248), **not** a regression; failed **closed** (threw before any check ⇒ no auth bypass), so it's a correctness/authz-plumbing bug, tracked publicly. `pnpm -r --filter './apps/*' typecheck` green (fanfare/triage/velo).

## 🧪 How to test
As a team **admin/owner**: Team → Invitations → **Resend** a pending invite. Before: 500 (`member is not defined`). After: succeeds. As a non-admin **member**: resend is rejected with 403 (the role gate now actually runs). An expired/non-pending invite still 400s.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015qUXhXiEGdTj6vhWnYtqxF)_