### PR TITLE
fix(crouton-auth): harden scoped-access token refresh

### DIFF
--- a/packages/crouton-auth/app/composables/useScopedAccess.ts
+++ b/packages/crouton-auth/app/composables/useScopedAccess.ts
@@ -301,21 +301,22 @@ export function useScopedAccess(
   }
 
   /**
-   * Refresh session expiration
+   * Refresh session expiration.
    *
-   * @param additionalHours - Hours to add to expiration (default: 8)
+   * The new expiry is governed server-side by the token's GRANT policy (its
+   * tokenTtl) — the client no longer chooses the duration, and the token is sent
+   * via the canonical `x-scoped-token` header rather than the body.
+   *
+   * @param _additionalHours - retained for backward compatibility; ignored.
    * @returns True if refresh succeeded
    */
-  async function refreshSession(additionalHours = 8): Promise<boolean> {
+  async function refreshSession(_additionalHours = 8): Promise<boolean> {
     if (!session.value?.token) return false
 
     try {
       const response = await $fetch<{ expiresAt: string }>('/api/auth/scoped-access/refresh', {
         method: 'POST',
-        body: {
-          token: session.value.token,
-          additionalTime: additionalHours * 60 * 60 * 1000
-        }
+        headers: { 'x-scoped-token': session.value.token }
       })
 
       if (response.expiresAt) {

--- a/packages/crouton-auth/server/api/auth/scoped-access/refresh.post.ts
+++ b/packages/crouton-auth/server/api/auth/scoped-access/refresh.post.ts
@@ -3,25 +3,20 @@
  *
  * POST /api/auth/scoped-access/refresh
  *
- * Extends the expiration of a scoped access token.
+ * Slides the expiry of the CALLER'S OWN scoped token forward, bounded by the
+ * token's grant TTL policy. The token is taken from the authenticated request
+ * (the canonical x-scoped-token header / cookie), never from the body, so only
+ * the legitimate holder of a currently-valid token can refresh it — and an
+ * expired token cannot be revived (the holder must re-redeem the grant).
  */
-import { extendScopedToken } from '../../../utils/scoped-access'
+import { requireScopedAccess, extendScopedToken } from '../../../utils/scoped-access'
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
-  const { token, additionalTime } = body
+  // Authenticates the holder (header → cookie → Bearer) and rejects an
+  // invalid/expired token with 401.
+  const access = await requireScopedAccess(event)
 
-  if (!token) {
-    throw createError({
-      status: 400,
-      statusText: 'Token is required'
-    })
-  }
-
-  // Default to 8 hours if not specified
-  const timeToAdd = additionalTime || 8 * 60 * 60 * 1000
-
-  const newExpiresAt = await extendScopedToken(token, timeToAdd)
+  const newExpiresAt = await extendScopedToken(access.token)
 
   if (!newExpiresAt) {
     throw createError({

--- a/packages/crouton-auth/server/utils/scoped-access.ts
+++ b/packages/crouton-auth/server/utils/scoped-access.ts
@@ -55,6 +55,8 @@ export interface CreateScopedTokenOptions {
 export interface ScopedAccessResult {
   /** Token ID */
   id: string
+  /** The token string itself (used by refresh to slide its own expiry) */
+  token: string
   /** Organization/team ID */
   organizationId: string
   /** Resource type */
@@ -162,6 +164,7 @@ export async function validateScopedToken(
 
   return {
     id: record.id,
+    token: record.token,
     organizationId: record.organizationId,
     resourceType: record.resourceType,
     resourceId: record.resourceId,
@@ -393,26 +396,62 @@ export async function listScopedTokensForResource(
   return records
 }
 
+/** Fallback token lifetime when a token has no backing grant (mint-issued). */
+const DEFAULT_SCOPED_TOKEN_TTL = 8 * 60 * 60 * 1000 // 8 hours
+
 /**
- * Extend token expiration
+ * Look up the grant governing a token's resource, for its TTL policy.
+ * Returns null when no active grant backs the resource (e.g. mint-issued tokens).
+ */
+async function getScopedGrant(
+  organizationId: string,
+  resourceType: string,
+  resourceId: string,
+  credentialType = 'pin'
+): Promise<{ tokenTtl: number | null } | null> {
+  const db = useDB()
+  const [grant] = await db
+    .select({ tokenTtl: scopedAccessGrant.tokenTtl })
+    .from(scopedAccessGrant)
+    .where(
+      and(
+        eq(scopedAccessGrant.organizationId, organizationId),
+        eq(scopedAccessGrant.resourceType, resourceType),
+        eq(scopedAccessGrant.resourceId, resourceId),
+        eq(scopedAccessGrant.credentialType, credentialType),
+        eq(scopedAccessGrant.isActive, true)
+      )
+    )
+    .limit(1)
+  return grant ?? null
+}
+
+/**
+ * Extend (slide forward) a scoped token's expiration.
  *
- * @param token - Token string
- * @param additionalTime - Additional time in milliseconds
- * @returns New expiration date or null if token not found
+ * The new expiry is bounded by the token's grant policy (its tokenTtl), and an
+ * already-expired token cannot be refreshed — see the body for the rationale.
+ *
+ * @param token - Token string (of a currently-valid token)
+ * @returns New expiration date, or null if the token is missing/inactive/expired
  */
 export async function extendScopedToken(
-  token: string,
-  additionalTime: number
+  token: string
 ): Promise<Date | null> {
   const db = useDB()
+  const now = new Date()
 
+  // Only a still-active, NOT-yet-expired token can be refreshed. Expiry is the
+  // revocation mechanism for scoped tokens, so a lapsed token must stay dead —
+  // the holder must re-redeem the grant rather than reviving it here.
   const [record] = await db
     .select()
     .from(scopedAccessToken)
     .where(
       and(
         eq(scopedAccessToken.token, token),
-        eq(scopedAccessToken.isActive, true)
+        eq(scopedAccessToken.isActive, true),
+        gt(scopedAccessToken.expiresAt, now)
       )
     )
     .limit(1)
@@ -421,7 +460,12 @@ export async function extendScopedToken(
     return null
   }
 
-  const newExpiresAt = new Date(Math.max(record.expiresAt.getTime(), Date.now()) + additionalTime)
+  // Slide the expiry forward to a window bounded by the token's GRANT policy
+  // (its tokenTtl), never an unbounded client-supplied amount. Tokens with no
+  // backing grant (e.g. mint-issued) fall back to the default ceiling.
+  const grant = await getScopedGrant(record.organizationId, record.resourceType, record.resourceId)
+  const ttl = grant?.tokenTtl ?? DEFAULT_SCOPED_TOKEN_TTL
+  const newExpiresAt = new Date(now.getTime() + ttl)
 
   await db
     .update(scopedAccessToken)

--- a/packages/crouton-auth/tests/unit/server/scoped-access.test.ts
+++ b/packages/crouton-auth/tests/unit/server/scoped-access.test.ts
@@ -518,38 +518,38 @@ describe('server/utils/scoped-access', () => {
   })
 
   describe('extendScopedToken', () => {
-    it('should extend token expiration', async () => {
+    it('should slide expiry forward, bounded by the grant TTL', async () => {
+      // First select → the valid token; second select → its grant (tokenTtl).
       const currentExpiry = new Date(Date.now() + 3600000)
-      selectResults = [{ id: 'token-id-1', expiresAt: currentExpiry }]
+      selectResults = [{ id: 'token-id-1', organizationId: 'org-1', resourceType: 'event', resourceId: 'event-1', expiresAt: currentExpiry, tokenTtl: 2 * 60 * 60 * 1000 }]
 
-      const additionalTime = 2 * 60 * 60 * 1000 // 2 hours
-      const result = await extendScopedToken('token-to-extend', additionalTime)
+      const before = Date.now()
+      const result = await extendScopedToken('token-to-extend')
+      const after = Date.now()
 
       expect(result).not.toBeNull()
-      expect(result!.getTime()).toBeGreaterThan(currentExpiry.getTime())
+      // New expiry is now + grant tokenTtl (2h) — a policy-bounded sliding window,
+      // NOT an unbounded client-supplied extension.
+      expect(result!.getTime()).toBeGreaterThanOrEqual(before + 2 * 60 * 60 * 1000)
+      expect(result!.getTime()).toBeLessThanOrEqual(after + 2 * 60 * 60 * 1000)
     })
 
     it('should return null for non-existent token', async () => {
       selectResults = []
 
-      const result = await extendScopedToken('non-existent-token', 3600000)
+      const result = await extendScopedToken('non-existent-token')
 
       expect(result).toBeNull()
     })
 
-    it('should use current time if token already expired', async () => {
-      const expiredTime = new Date(Date.now() - 3600000) // 1 hour ago
-      selectResults = [{ id: 'token-id-1', expiresAt: expiredTime }]
+    it('should NOT refresh an expired token (query excludes it → null)', async () => {
+      // The handler filters on expiresAt > now, so an expired token is not found.
+      // Expiry is the revocation mechanism — a lapsed token must stay dead.
+      selectResults = []
 
-      const additionalTime = 60 * 60 * 1000 // 1 hour
-      const before = Date.now()
-      const result = await extendScopedToken('token', additionalTime)
-      const after = Date.now()
+      const result = await extendScopedToken('expired-token')
 
-      expect(result).not.toBeNull()
-      // Should be based on current time, not expired time
-      expect(result!.getTime()).toBeGreaterThanOrEqual(before + additionalTime)
-      expect(result!.getTime()).toBeLessThanOrEqual(after + additionalTime)
+      expect(result).toBeNull()
     })
   })
 


### PR DESCRIPTION
Hardens the public scoped-access `refresh` endpoint. Found by the red-team agent (#540).

## 👤 For humans

Scoped-access tokens — the PIN-derived credentials a POS helper or booking guest gets — are deliberately **short-lived**, and their expiry is how they're revoked. The refresh endpoint that extends them was too loose, weakening that guarantee. This tightens it so a token can only be slid forward **by its legitimate holder**, **within the lifetime its grant defines**, and **a token that has actually expired stays dead** (you must re-redeem the PIN).

No visible change for legitimate use — helper/guest sessions still refresh transparently in the UI.

## 🤖 For agents

- **`server/utils/scoped-access.ts`**
  - `extendScopedToken(token)` — now requires `isActive` **and** `expiresAt > now` (an expired token returns `null`, no revival), and caps the new expiry to `now + grant.tokenTtl` via a new `getScopedGrant()` helper (`DEFAULT_SCOPED_TOKEN_TTL` fallback for mint-issued tokens). Dropped the unbounded client `additionalTime`.
  - Added `token` to `ScopedAccessResult` (additive) so the endpoint can refresh the *authenticated* token.
- **`server/api/auth/scoped-access/refresh.post.ts`** — authenticate via `requireScopedAccess(event)` (canonical `x-scoped-token` header/cookie) instead of trusting a body `token`; removed `additionalTime` from the API surface.
- **`app/composables/useScopedAccess.ts` → `refreshSession`** — sends the token via the `x-scoped-token` header, no body `token`/`additionalTime`; param retained (ignored) for back-compat.
- **Tests** updated to the new contract (grant-bounded slide; expired → `null`).

**Archaeology:** born this way in `3d65280` (PR #248, 2026-06-17) — the loose refresh has existed since scoped-access landed; **not** a regression. Failed open in the sense it over-extended, but required possession of a token string.

`pnpm -r --filter './apps/*' typecheck` green (fanfare/triage/velo); 61 scoped-access unit tests pass.

Follow-up (separate): rate-limit the public scoped-access endpoints (#540 finding #3).

## 🧪 How to test
Redeem a PIN to get a scoped token (POS helper / booking guest), then:
- **Sliding window:** refresh a still-valid token → expiry moves forward, but never beyond the grant's `tokenTtl` (a year-long push is clamped).
- **Expired is dead:** let a token lapse, then refresh → rejected (must re-redeem). Previously it could be revived.
- **Holder-only:** refresh with no valid `x-scoped-token` (only a known token string in the body) → 401. Previously it succeeded.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015qUXhXiEGdTj6vhWnYtqxF)_