### PR TITLE
fix(crouton-auth): restrict scoped-access mint to team admins

### DIFF
--- a/packages/crouton-auth/server/api/auth/scoped-access/mint.post.ts
+++ b/packages/crouton-auth/server/api/auth/scoped-access/mint.post.ts
@@ -42,6 +42,13 @@ export default defineEventHandler(async (event) => {
     throw createError({ status: 403, statusText: 'Not a team member' })
   }
 
+  // Minting a delegation token is an administrative act: it stamps a trusted
+  // resource `role` onto the token. Restrict to admins/owners so a plain member
+  // cannot mint a token carrying an elevated role for the resource.
+  if (!['admin', 'owner'].includes(membership.role)) {
+    throw createError({ status: 403, statusText: 'Only team admins can mint scoped tokens' })
+  }
+
   const { token, expiresAt } = await createScopedToken({
     organizationId: team.id,
     resourceType,


### PR DESCRIPTION
Found by the red-team agent (#540). Privilege-escalation hardening of the scoped-access **mint** endpoint.

## 👤 For humans
`/api/auth/scoped-access/mint` lets a team member mint a scoped delegation token (give someone resource access without a PIN). It stamped the token's `role` from the request body while only checking the caller was *any* member — so a plain **member** could mint a token carrying an elevated resource role (e.g. `owner`). Minting a delegation credential is an administrative act, so it now requires **admin/owner**.

## 🤖 For agents
- `server/api/auth/scoped-access/mint.post.ts`: after the existing `getMembership` check, require `membership.role ∈ {admin, owner}` → non-admin gets 403. Checked on the `body.teamId` membership directly (not `requireTeamAdmin`, which resolves the team from route/session — a different source).
- No app calls this endpoint yet (only generated route-type stubs; no client `mint()`), so the restriction breaks nothing.
- `tokenTtl` is still taken unbounded from the body — acceptable now that mint is admin-only (trusted); noted as a possible later cap.

`pnpm -r --filter './apps/*' typecheck` green (fanfare/triage/velo).

## 🧪 How to test
As a team **member** (not admin), mint a token for a resource in your team → now **403** (previously succeeded, and you could pass `role: 'owner'`). As an **admin/owner**, mint still works and stamps the role you pass. Non-members still get 403.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015qUXhXiEGdTj6vhWnYtqxF)_