### PR TITLE
fix: make the agent pipeline self-complete (merge-on-approval, artifact-gate sub-issues, honest approval wording)

### DIFF
--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -185,10 +185,11 @@ things:
   the sticky comment in place** (append `- rN: <what changed>`), and **reply to / resolve each
   inline thread** you addressed so it's clear what's done. Commit (`/commit`, scope `docs`) and
   push — the diff updates in place. The hold stays.
-- **Approval signal** — **any one of**:
-  - a human PR comment whose body contains **`approve`** or **`lgtm`** (case-insensitive), or
-  - a **👍 reaction** on the sticky mockup comment, or
-  - the **`ui-approved`** label on the PR.
+- **Approval signal** — a human **comment** on the issue whose body contains **`approve`** or
+  **`lgtm`** (case-insensitive). This is the ONLY signal that resumes the pipeline: only
+  `issue_comment` fires `resume-on-comment.yml` — a 👍 **reaction** raises no workflow event, and
+  nothing listens for an `ui-approved` label, so neither one will unblock a gate (#572). Tell the
+  reviewer to *reply* `lgtm`/`approve`, not react.
 
   On approval: remove `status:blocked`, drop a short "approved → building/generating" note on the
   sticky comment, and **resume** (step 6 onward) — build the UI, or run `crouton config` to

--- a/.claude/skills/crouton.md
+++ b/.claude/skills/crouton.md
@@ -274,7 +274,8 @@ export default {
 skill on the fieldsFile to render a readable field table + relationships, post it, and **wait for
 sign-off** — a wrong type or missing relationship is cheap to fix now and expensive after
 generation. Feedback goes inline on the committed `writeups/schema-reviews/<collection>.md`;
-revise the schema JSON and re-render until approved (`lgtm`/👍/`ui-approved`). Only then run Step
+revise the schema JSON and re-render until approved (a **comment** containing `lgtm`/`approve` —
+a reaction/label won't resume the pipeline, #572). Only then run Step
 4. (This is the human gate on top of the machine `validate_schema`; reuses the #310 loop.)
 
 ### Step 4: Run Generator

--- a/.claude/skills/ticket-diagram/SKILL.md
+++ b/.claude/skills/ticket-diagram/SKILL.md
@@ -111,8 +111,9 @@ The human reviews **on the diff**: they inline-comment, or they edit the scene a
 exported PNG** to a comment. Both are change requests. **Ignore bot/self comments**
 (`user.type === 'Bot'`).
 
-**Approval** = a comment containing `approve`/`lgtm`, a 👍 on the sticky comment, or an `approved`
-label. On approval, mark the PR ready / merge per the epic flow.
+**Approval** = a **comment** containing `approve`/`lgtm`. (A 👍 reaction or a label does **not**
+resume the pipeline — only `issue_comment` triggers `resume-on-comment.yml`, #572.) On approval,
+mark the PR ready / merge per the epic flow.
 
 ## 4 · Round-trip a human edit back IN
 

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -91,14 +91,27 @@ jobs:
             const blocked = issue.data.labels.some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
             const alreadyClosed = issue.data.state === 'closed' // already done
 
+            // (d) did THIS run create sub-issues? An orchestrator/epic run's deliverable is a
+            // tree of newly-created sub-issues, NOT a PR — so creating them this run is a real
+            // artifact (#572: the #566 epic decompose was falsely failed for "no PR"). Scope to
+            // `created_at >= since` so a re-run that creates nothing still fails honestly.
+            let createdSubIssues = false
+            try {
+              const subs = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues', {
+                ...context.repo, issue_number, per_page: 100,
+              })
+              createdSubIssues = subs.some(s => new Date(s.created_at).getTime() >= sinceMs)
+            } catch (e) { core.warning(`sub-issue check skipped: ${e.message}`) }
+
             // KIND-AWARE pass: a build/deploy issue must yield a PR; a sign-off gate must post a
-            // review AND hold (status:blocked + a comment). A bare progress comment with no PR and
-            // no hold is the no-op → FAIL. BUT a re-dispatch of an ALREADY-satisfied issue (it
-            // already has a linked PR, or is closed) correctly reports "already done" — pass it,
-            // don't red-flag (#500/WS4: the #457 re-dispatch false-failure).
+            // review AND hold (status:blocked + a comment); an orchestrator/epic run yields
+            // sub-issues. A bare progress comment with no PR, no hold, and no sub-issues is the
+            // no-op → FAIL. BUT a re-dispatch of an ALREADY-satisfied issue (it already has a
+            // linked PR, or is closed) correctly reports "already done" — pass it, don't red-flag
+            // (#500/WS4: the #457 re-dispatch false-failure).
             const signoffHeld = blocked && newComment
-            if (linkedPR || signoffHeld || alreadyLinkedPR || alreadyClosed) {
-              core.info(`Artifact-gate OK for #${issue_number}: linkedPR=${linkedPR} signoffHeld=${signoffHeld} alreadyLinkedPR=${alreadyLinkedPR} alreadyClosed=${alreadyClosed}`)
+            if (linkedPR || signoffHeld || alreadyLinkedPR || alreadyClosed || createdSubIssues) {
+              core.info(`Artifact-gate OK for #${issue_number}: linkedPR=${linkedPR} signoffHeld=${signoffHeld} alreadyLinkedPR=${alreadyLinkedPR} alreadyClosed=${alreadyClosed} createdSubIssues=${createdSubIssues}`)
               return
             }
 

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -45,3 +45,59 @@ jobs:
             `status:blocked` label, then continue via /task-decompose #${{ github.event.issue.number }}.
           claude_args: "--max-turns 30"
           show_full_output: true
+
+      # ── Merge-on-approval (#572) ───────────────────────────────────────────────
+      # The pipeline's design is that a sign-off gate's sub-PR merges into the EPIC
+      # branch once approved — the owner's `approve`/`lgtm` IS the review. Nothing
+      # implemented that, so approved gates STALLED: the gate PR stayed a draft, its
+      # issue never closed, and schedule-waves never released the next workstream.
+      # This deterministically completes the handoff on an approval comment, regardless
+      # of what the agent step above did. Uses GITHUB_TOKEN (not OIDC) so it never trips
+      # the bot-actor guard. Merge commit — NOT squash (preserve curated commits; merge
+      # policy). Once merged, schedule-waves (pull_request: closed) closes the issue and
+      # releases the next workstream — no other machinery needed.
+      - name: Merge the gate PR on approval
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number
+            const body = context.payload.comment.body || ''
+            // Approval only — a change-request reply must NOT merge anything.
+            if (!/\b(approve|approved|lgtm)\b/i.test(body)) {
+              core.info('Comment is not an approval — nothing to merge.'); return
+            }
+            // Find the PR(s) that close THIS issue, via the issue timeline cross-references.
+            const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+              ...context.repo, issue_number,
+            })
+            const prNums = [...new Set(timeline
+              .filter(e => e.event === 'cross-referenced' && e.source && e.source.issue && e.source.issue.pull_request)
+              .map(e => e.source.issue.number))]
+            let merged = false
+            for (const n of prNums) {
+              let pr
+              try { pr = (await github.rest.pulls.get({ ...context.repo, pull_number: n })).data } catch { continue }
+              if (pr.state !== 'open' || pr.merged) continue
+              // Only the gate PR: it says "Closes #<issue>" and targets an epic branch.
+              if (!new RegExp(`\\bcloses\\s+#${issue_number}\\b`, 'i').test(pr.body || '')) continue
+              if (!/^epic\//.test(pr.base.ref)) {
+                core.info(`PR #${n} base ${pr.base.ref} is not an epic branch — skipping.`); continue
+              }
+              // Mark ready (REST can't flip draft→ready; GraphQL can), then merge.
+              if (pr.draft) {
+                try {
+                  await github.graphql(
+                    `mutation($id:ID!){ markPullRequestReadyForReview(input:{pullRequestId:$id}){ pullRequest { id } } }`,
+                    { id: pr.node_id })
+                } catch (e) { core.warning(`markReady #${n}: ${e.message}`) }
+              }
+              try {
+                await github.rest.pulls.merge({ ...context.repo, pull_number: n, merge_method: 'merge' })
+                merged = true
+                core.info(`Merged gate PR #${n} into ${pr.base.ref}.`)
+              } catch (e) { core.warning(`merge #${n} failed: ${e.message}`) }
+            }
+            // Clear the block defensively so the issue can close cleanly.
+            try { await github.rest.issues.removeLabel({ ...context.repo, issue_number, name: 'status:blocked' }) } catch (e) {}
+            core.info(merged ? 'Gate PR merged — schedule-waves will advance the chain.' : 'No gate PR merged (none matched / already merged).')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,9 +384,12 @@ artifact (the UI "what changes" list `<slug>.md`, or a schema's `.md` field tabl
 up in the PR's "Files changed" — inline-comment the exact line, no copying. The agent reads
 those inline review comments and revises that specific item.
 
-**What counts as approval** (the sign-off signal): a reply containing `approve`/`lgtm`, a 👍 on
-the mockup comment, or the `ui-approved` label. Anything else is a change request — revise the
-mockup in place (edit the same sticky comment, re-render the PNG) and iterate until approved (#310).
+**What counts as approval** (the sign-off signal): a **reply comment** containing `approve`/`lgtm`.
+That comment is the *only* thing that resumes the pipeline — a 👍 reaction and the `ui-approved`
+label do **not** trigger anything (`resume-on-comment.yml` fires only on `issue_comment`; reactions
+raise no event and no workflow listens for the label) (#572). Anything else is a change request —
+revise the mockup in place (edit the same sticky comment, re-render the PNG) and iterate until
+approved (#310).
 
 ## Schema Sign-Off (review the data model before you generate) — epic #314
 
@@ -398,8 +401,8 @@ migration derives from it, so a wrong type or missing relationship is cheap to f
 expensive after. This sits **after** the machine `validate_schema` step (the human gate on top of
 it). In the agent pipeline it's a gate in `.claude/agents/task-worker.md`; interactively, do the
 same by hand. It **reuses the same revision/approval loop and signal as the UI gate** (#310) —
-feedback goes inline on the committed `<collection>.md` in the diff; approval (`lgtm`/👍/
-`ui-approved`) unblocks generation.
+feedback goes inline on the committed `<collection>.md` in the diff; approval (a **comment**
+containing `lgtm`/`approve` — not a reaction or label, #572) unblocks generation.
 
 ## Documentation Organization
 


### PR DESCRIPTION
Fixes the three pipeline defects that surfaced running the #566 library-catalog full-flow test. Goal: the decompose pipeline advances through its sign-off gates **without manual intervention**.

## The defects (diagnosed, root-caused)

**1. Resume-on-approval stalled (the big one).** The design *assumes* "sub-PRs auto-merge into the epic branch" (task-decompose SKILL) but **nothing implemented it**. On approval, `resume-on-comment` re-ran the agent but never merged the gate PR → the issue never closed → `schedule-waves` never released the next workstream. Observed live: #567 approved, but PR #571 stayed a draft, #567 stayed `status:blocked`, WS2 never started.

**2. Approval wording was false.** Gate text + `CLAUDE.md` claimed a 👍 reaction or `ui-approved` label approve a gate. Neither can: Actions has no reaction event, and nothing listens for the label — only an `issue_comment` resumes (`resume-on-comment.yml`).

**3. Artifact-gate false-positive.** The epic decomposition run was flagged "failed: no deliverable" despite creating sub-issues #567–#570 — the gate only counted a PR or a held sign-off, never created sub-issues.

## The fixes (3 atomic commits)

1. **`fix(root): artifact-gate counts created sub-issues`** — `decompose-on-issue.yml` adds a `createdSubIssues` term (sub-issues created since run start) to the pass condition. Orchestrator runs yield sub-issues; leaf runs yield a PR/held gate; a true no-op still fails.
2. **`fix(root): merge the gate PR on approval`** — `resume-on-comment.yml` gains a deterministic post-step (github-script, `GITHUB_TOKEN` — no OIDC, no bot-actor guard): on an `approve`/`lgtm` comment it finds the `Closes #<issue>` PR targeting an `epic/*` branch, marks it ready, **merges it (merge commit, not squash)**, and clears `status:blocked`. `schedule-waves` then closes the issue + releases the next workstream — no new machinery.
3. **`docs(root): approval = a comment, not a reaction/label`** — corrects the wording in `task-worker.md`, `CLAUDE.md` (×2), `crouton.md`, `ticket-diagram/SKILL.md`.

## How to verify (after merge)
These run from the **default branch**, so they only take effect once merged. Then a fresh POC run should: pass the epic artifact-gate (sub-issues counted) → on the schema `approve` comment, auto-merge the gate PR and advance to scaffold → no gate text promising reactions/labels.

## Design note for review (commit 2)
I chose **merge-on-approval inside `resume-on-comment`** over per-PR GitHub auto-merge because the latter needs branch-protection + a real PR *review* approval, which contradicts the comment-based approval signal the rest of the pipeline uses. The merge step is idempotent and only acts on a gate PR (`Closes #<issue>` + `epic/*` base). Worth a careful look since it touches core CI behavior for every gate.

Closes #572. Found during #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bJaMaBZL4uLVQt2ePNrb)_