### PR TITLE
fix: merge the gate PR with the App token so the resume cascade fires

### DIFF
--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -46,20 +46,35 @@ jobs:
           claude_args: "--max-turns 30"
           show_full_output: true
 
+      # Mint a Nuxt Harness App token for the merge step. CRUCIAL: the merge MUST use the
+      # App token, NOT the default GITHUB_TOKEN — GitHub suppresses workflow triggers for
+      # events initiated by GITHUB_TOKEN, so a GITHUB_TOKEN merge's `pull_request: closed`
+      # event would NOT reach schedule-waves and the chain stalls (the #572 first-attempt
+      # regression). An App installation token is a non-GITHUB_TOKEN actor, so its merge
+      # fires schedule-waves → close issue → release next workstream. (#535/#519 WS5.)
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        if: always()
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       # ── Merge-on-approval (#572) ───────────────────────────────────────────────
       # The pipeline's design is that a sign-off gate's sub-PR merges into the EPIC
       # branch once approved — the owner's `approve`/`lgtm` IS the review. Nothing
       # implemented that, so approved gates STALLED: the gate PR stayed a draft, its
       # issue never closed, and schedule-waves never released the next workstream.
       # This deterministically completes the handoff on an approval comment, regardless
-      # of what the agent step above did. Uses GITHUB_TOKEN (not OIDC) so it never trips
-      # the bot-actor guard. Merge commit — NOT squash (preserve curated commits; merge
-      # policy). Once merged, schedule-waves (pull_request: closed) closes the issue and
-      # releases the next workstream — no other machinery needed.
+      # of what the agent step above did. Merge commit — NOT squash (preserve curated
+      # commits; merge policy). Merges with the App token so the resulting
+      # `pull_request: closed` event TRIGGERS schedule-waves → close issue → release the
+      # next workstream (a GITHUB_TOKEN merge does NOT cascade — #572).
       - name: Merge the gate PR on approval
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const issue_number = context.payload.issue.number
             const body = context.payload.comment.body || ''


### PR DESCRIPTION
Follow-up to #573. The merge-on-approval step worked (PR #571 merged on `approve`), but the run **still stalled**: `schedule-waves` never fired, so #567 didn't close and WS2 wasn't released.

## Root cause
GitHub **suppresses workflow triggers for events initiated by the default `GITHUB_TOKEN`** (anti-recursion). My merge step used `GITHUB_TOKEN`, so the resulting `pull_request: closed` event never reached `schedule-waves` — the exact same reason the dispatch path already uses the Harness App token (WS5).

## Fix
`resume-on-comment.yml`: mint a Nuxt Harness App token (`actions/create-github-app-token`, `owner: FriendlyInternet`) and have the merge `github-script` step use it instead of the implicit `GITHUB_TOKEN`. An App installation token is a non-`GITHUB_TOKEN` actor, so its merge's `pull_request: closed` event **does** trigger `schedule-waves` → close the gate issue → release the next workstream. End-to-end cascade restored.

## Verify (after merge)
On the next approved gate, the `approve` comment should merge the gate PR **and** auto-advance to the next workstream with no manual issue-close.

Closes #572 (completes it). Found verifying #573 on the #566 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bJaMaBZL4uLVQt2ePNrb)_