### PR TITLE
feat(ticket-editor): post a handoff comment on Save (#583)

### DIFF
--- a/.claude/skills/ticket-diagram/SKILL.md
+++ b/.claude/skills/ticket-diagram/SKILL.md
@@ -165,6 +165,11 @@ human has hand-arranged the scene, prefer the importer in §4 to preserve their 
   `.excalidraw`, which we no longer commit. (If you want one-tap deep-link editing back, run the
   generator with `--excalidraw`, commit the loose file, and link `https://excalidraw.com/#url=<raw
   url>`.)
+- **One-tap mobile editing = the hosted `ticket-editor` Worker** (`workers/ticket-editor`, epic
+  #483). Link `…/?slug=<slug>&branch=<branch>&issue=<NN>` — pass **`&issue=<NN>`** so that on Save
+  the editor posts/refreshes a handoff comment on issue `NN` (the edit shows in the timeline, not
+  just a `nuxt-harness[bot]` commit). Requires the loose `<slug>.excalidraw` committed (generate
+  with `--excalidraw`), since the editor reads it.
 - **Round-trip needs "Embed scene" ON** in Excalidraw's export, or the importer can't find the
   scene (it errors clearly).
 - **Reuse the slug** across regenerations, or you'll orphan the old PNG and the sticky image link.

--- a/workers/ticket-editor/README.md
+++ b/workers/ticket-editor/README.md
@@ -11,8 +11,8 @@ just-in-time (WebCrypto, dependency-free) and commits as `nuxt-harness[bot]` —
 
 ## Routes
 
-- `GET /?slug=<slug>&branch=<branch>` — the editor (loads `writeups/diagrams/<slug>.excalidraw`).
-- `POST /api/save` `{ slug, branch, scene, png }` — commits `<slug>.excalidraw` (+ `<slug>.png`) to `<branch>`.
+- `GET /?slug=<slug>&branch=<branch>[&issue=<NN>]` — the editor (loads `writeups/diagrams/<slug>.excalidraw`). Pass `issue` to get a handoff comment on Save.
+- `POST /api/save` `{ slug, branch, scene, png, issue? }` — commits `<slug>.excalidraw` (+ `<slug>.png`) to `<branch>`. If `issue` is set, it also **creates-or-updates a sticky comment** (`<!-- ticket-editor-saved:<slug> -->`) on that issue with the refreshed diagram, so a Save is a visible handoff marker, not just a bot commit (#583). The comment is non-fatal — a commit always wins.
 
 ## Deploy (Cloudflare Workers)
 

--- a/workers/ticket-editor/src/index.ts
+++ b/workers/ticket-editor/src/index.ts
@@ -127,25 +127,78 @@ async function putFile(token: string, env: Env, branch: string, path: string, co
   if (!putRes.ok) throw new Error('PUT ' + path + ' → ' + putRes.status + ' ' + (await putRes.text()))
 }
 
+// Create-or-update a per-slug sticky comment on the linked issue, so a Save is a visible handoff
+// marker in the timeline (not just a silent bot commit). Updates in place on repeated saves. (#583)
+async function upsertComment(token: string, env: Env, issue: number, slug: string, branch: string, origin: string): Promise<void> {
+  const headers = {
+    authorization: 'Bearer ' + token,
+    accept: 'application/vnd.github+json',
+    'user-agent': 'ticket-editor',
+    'content-type': 'application/json',
+  }
+  const dir = env.DIAGRAMS_DIR || 'writeups/diagrams'
+  const marker = '<!-- ticket-editor-saved:' + slug + ' -->'
+  // Cache-bust the raw PNG so GitHub's image cache shows the just-saved version.
+  const png = 'https://raw.githubusercontent.com/' + env.REPO + '/' + branch + '/' + dir + '/' + slug + '.png?v=' + Date.now()
+  const editUrl = origin + '/?slug=' + encodeURIComponent(slug) + '&branch=' + encodeURIComponent(branch) + '&issue=' + issue
+  const body =
+    marker + '\n' +
+    '✏️ **`' + slug + '`** edited via the [ticket-editor](' + editUrl + ') — committed to `' + branch + '`.\n\n' +
+    '![' + slug + '](' + png + ')\n\n' +
+    '_Updated ' + new Date().toISOString() + ' · this comment refreshes in place on each save._'
+  // Find an existing sticky for this slug (first page of comments is plenty).
+  const listRes = await fetch(
+    'https://api.github.com/repos/' + env.REPO + '/issues/' + issue + '/comments?per_page=100',
+    { headers },
+  )
+  if (listRes.ok) {
+    const comments = (await listRes.json()) as Array<{ id: number; body?: string }>
+    const existing = comments.find((c) => (c.body || '').includes(marker))
+    if (existing) {
+      const patch = await fetch('https://api.github.com/repos/' + env.REPO + '/issues/comments/' + existing.id, {
+        method: 'PATCH', headers, body: JSON.stringify({ body }),
+      })
+      if (!patch.ok) throw new Error('PATCH comment → ' + patch.status + ' ' + (await patch.text()))
+      return
+    }
+  }
+  const post = await fetch('https://api.github.com/repos/' + env.REPO + '/issues/' + issue + '/comments', {
+    method: 'POST', headers, body: JSON.stringify({ body }),
+  })
+  if (!post.ok) throw new Error('POST comment → ' + post.status + ' ' + (await post.text()))
+}
+
 async function save(req: Request, env: Env): Promise<Response> {
   try {
-    const { slug, branch, scene, png } = (await req.json()) as {
+    const { slug, branch, scene, png, issue } = (await req.json()) as {
       slug?: string
       branch?: string
       scene?: unknown
       png?: string
+      issue?: number | string
     }
     if (!slug || !branch || !scene) return json({ error: 'slug, branch and scene are required' }, 400)
     if (!/^[a-z0-9][a-z0-9._-]*$/i.test(slug)) return json({ error: 'bad slug' }, 400)
     const dir = env.DIAGRAMS_DIR || 'writeups/diagrams'
     const msg = 'chore(diagrams): edit ' + slug + ' via ticket-editor'
-    const token = await installationToken(env) // one fresh ~1h token for both commits
+    const token = await installationToken(env) // one fresh ~1h token for the commits + comment
     await putFile(token, env, branch, dir + '/' + slug + '.excalidraw', toB64(JSON.stringify(scene, null, 2) + '\n'), msg)
     if (png) {
       const b64 = png.includes(',') ? png.split(',')[1] : png
       await putFile(token, env, branch, dir + '/' + slug + '.png', b64, msg + ' (png)')
     }
-    return json({ ok: true })
+    // Optional handoff comment: the commit is the source of truth, so a comment failure is non-fatal.
+    let comment: string | undefined
+    const issueNum = issue != null && /^[0-9]+$/.test(String(issue)) ? Number(issue) : undefined
+    if (issueNum) {
+      try {
+        await upsertComment(token, env, issueNum, slug, branch, new URL(req.url).origin)
+        comment = 'commented on #' + issueNum
+      } catch (e) {
+        comment = 'comment failed: ' + String((e as Error)?.message || e)
+      }
+    }
+    return json({ ok: true, comment })
   } catch (e) {
     return json({ error: String((e as Error)?.message || e) }, 500)
   }
@@ -244,6 +297,7 @@ const PAGE = `<!DOCTYPE html>
   var params = new URLSearchParams(location.search);
   var slug = params.get('slug') || '';
   var branch = params.get('branch') || 'main';
+  var issue = params.get('issue') || '';
   var RAW = 'https://raw.githubusercontent.com/__REPO__/' + branch + '/writeups/diagrams/' + slug + '.excalidraw';
   var statusEl = document.getElementById('status');
   var saveEl = document.getElementById('save');
@@ -306,10 +360,10 @@ const PAGE = `<!DOCTYPE html>
             for (var i=0;i<bytes.length;i++) bin += String.fromCharCode(bytes[i]);
             var pngB64 = btoa(bin);
             var scene = { type:'excalidraw', version:2, source:location.origin, elements: elements, appState:{ viewBackgroundColor:'#ffffff' }, files: files };
-            return fetch('/api/save', { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ slug: slug, branch: branch, scene: scene, png: pngB64 }) });
+            return fetch('/api/save', { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify({ slug: slug, branch: branch, scene: scene, png: pngB64, issue: issue }) });
           })
           .then(function(r){ return r.json(); })
-          .then(function(res){ setStatus(res.ok ? 'saved ✓ committed to ' + branch : 'error: ' + (res.error||'?')); saveEl.disabled = false; })
+          .then(function(res){ setStatus(res.ok ? ('saved ✓ committed to ' + branch + (res.comment ? ' · ' + res.comment : '')) : 'error: ' + (res.error||'?')); saveEl.disabled = false; })
           .catch(function(e){ setStatus('error: ' + e); saveEl.disabled = false; });
       };
     });


### PR DESCRIPTION
## 👤 For humans

A Save in the ticket-editor used to be invisible — just a `nuxt-harness[bot]` commit. Now, if the editor is opened with `&issue=NN`, **Save also posts (and refreshes in place) a comment on that issue** showing the updated diagram + a link back to the editor. An edit becomes a visible "your turn" handoff marker in the timeline.

## 🤖 For agents

- `workers/ticket-editor/src/index.ts`:
  - The page reads `&issue` and forwards it in the `/api/save` body.
  - `save()` accepts `issue`; after committing, calls new `upsertComment()` (same installation token): lists issue comments → finds the `<!-- ticket-editor-saved:<slug> -->` marker → **PATCH** it, else **POST** a new one (cache-busted PNG so GitHub shows the fresh image). **Non-fatal** — a comment failure still returns `{ ok: true }`; the commit is the source of truth. Status bar shows `· commented on #NN`.
- **Design note:** the comment posts as `nuxt-harness[bot]`, which `resume-on-comment.yml` ignores — so it's a *human-visible* handoff marker, **not** an agent auto-trigger (a push-based trigger is a separate follow-up).
- Docs: README routes + `ticket-diagram` SKILL (link Edit with `&issue=NN`).
- **Validated offline:** `esbuild` transpile clean; `node --check` on every served inline `<script>`.

Closes #583. Relates to #581 / epic #483.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ANiCX4pLDemDjvoNWQRuA)_