### PR TITLE
feat(ticket-editor): handoff comment invites an explicit approve/lgtm sign-off

### DIFF
--- a/workers/ticket-editor/src/index.ts
+++ b/workers/ticket-editor/src/index.ts
@@ -145,6 +145,7 @@ async function upsertComment(token: string, env: Env, issue: number, slug: strin
     marker + '\n' +
     '✏️ **`' + slug + '`** edited via the [ticket-editor](' + editUrl + ') — committed to `' + branch + '`.\n\n' +
     '![' + slug + '](' + png + ')\n\n' +
+    'When it looks right, reply **`approve`** / **`lgtm`** to sign off — nothing continues automatically.\n\n' +
     '_Updated ' + new Date().toISOString() + ' · this comment refreshes in place on each save._'
   // Find an existing sticky for this slug (first page of comments is plenty).
   const listRes = await fetch(


### PR DESCRIPTION
## 👤 For humans

The Save handoff comment now spells out the next step: **reply `approve` / `lgtm` to sign off — nothing continues automatically.** Matches the preferred model: a human gives an explicit approval comment; no auto-continue.

## 🤖 For agents

- `workers/ticket-editor/src/index.ts` `upsertComment()`: body adds a line prompting for an `approve`/`lgtm` reply (the existing #310 / `resume-on-comment` human gate). The bot comment stays non-triggering by design.
- Validated: `esbuild` transpile + `node --check` clean.

Follow-up to #583 / epic #483. (The push-based auto-trigger floated earlier is intentionally **not** pursued — explicit human approval is the chosen model.)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ANiCX4pLDemDjvoNWQRuA)_