### PR TITLE
chore(ticket-editor): route under excalidraw.pmcp.dev (custom domain)

### DIFF
--- a/workers/ticket-editor/README.md
+++ b/workers/ticket-editor/README.md
@@ -21,12 +21,17 @@ cd workers/ticket-editor
 pnpm install
 npx wrangler secret put GITHUB_APP_PRIVATE_KEY   # the Crouton App's PEM private key (only secret)
 # set GITHUB_APP_ID + GITHUB_APP_INSTALLATION_ID as wrangler vars (not sensitive)
-npx wrangler deploy                              # → https://ticket-editor.<account>.workers.dev
+npx wrangler deploy                              # → https://excalidraw.pmcp.dev (+ the .workers.dev URL)
 ```
 
-Then open `https://ticket-editor.<account>.workers.dev/?slug=make-tickets-human-readable&branch=<branch>`
-on your phone → edit → **Save** → a commit (authored by `nuxt-harness[bot]`) lands on the branch. Link
-that URL from each diagram's sticky comment as a one-tap **✏️ Edit**.
+The custom domain `excalidraw.pmcp.dev` is declared in `wrangler.jsonc` (`routes` with
+`custom_domain: true`); Wrangler provisions the route + DNS on deploy — no manual dashboard step
+(the `pmcp.dev` zone must be in the account, and the API token needs zone Workers Routes + DNS edit).
+
+Then open `https://excalidraw.pmcp.dev/?slug=make-tickets-human-readable&branch=<branch>&issue=<NN>`
+on your phone → edit → **Save** → a commit (authored by `nuxt-harness[bot]`) lands on the branch, and
+(with `&issue=<NN>`) a comment with the frozen diagram is posted on that issue. Link that URL from each
+diagram's comment as a one-tap **✏️ Edit**.
 
 ## Notes
 

--- a/workers/ticket-editor/wrangler.jsonc
+++ b/workers/ticket-editor/wrangler.jsonc
@@ -8,6 +8,13 @@
   "main": "src/index.ts",
   "compatibility_date": "2024-11-01",
   "compatibility_flags": ["nodejs_compat"],
+  // Custom domain — Wrangler auto-provisions the route + DNS on deploy (the pmcp.dev zone must be
+  // in this Cloudflare account; the API token needs zone Workers Routes + DNS edit). The .workers.dev
+  // URL keeps working too. The editor builds its Edit links from the request origin, so links posted
+  // when reached via this host use https://excalidraw.pmcp.dev automatically.
+  "routes": [
+    { "pattern": "excalidraw.pmcp.dev", "custom_domain": true }
+  ],
   "vars": {
     "REPO": "FriendlyInternet/nuxt-crouton",
     "DIAGRAMS_DIR": "writeups/diagrams"


### PR DESCRIPTION
## 👤 For humans

Serve the ticket-editor at **`https://excalidraw.pmcp.dev`** instead of the long `.workers.dev` URL.

## 🤖 For agents

- `workers/ticket-editor/wrangler.jsonc`: add `routes: [{ pattern: "excalidraw.pmcp.dev", custom_domain: true }]` — Wrangler auto-provisions the route + DNS on deploy (the `pmcp.dev` zone must be in the account; the API token needs zone Workers Routes + DNS edit). The `.workers.dev` URL keeps working.
- No code change: the editor builds Edit links from the request origin, so links posted when reached via `excalidraw.pmcp.dev` use that host automatically.
- README deploy steps + links updated.

Relates to #581 / epic #483.

## ⚠️ After merge
Redeploy once to provision the domain: `cd workers/ticket-editor && npx wrangler deploy`. DNS may take a minute to go live.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ANiCX4pLDemDjvoNWQRuA)_