### PR TITLE
chore(ticket-editor): rename custom domain → diagram.pmcp.dev (provider-agnostic)

### DIFF
--- a/workers/ticket-editor/README.md
+++ b/workers/ticket-editor/README.md
@@ -21,14 +21,14 @@ cd workers/ticket-editor
 pnpm install
 npx wrangler secret put GITHUB_APP_PRIVATE_KEY   # the Crouton App's PEM private key (only secret)
 # set GITHUB_APP_ID + GITHUB_APP_INSTALLATION_ID as wrangler vars (not sensitive)
-npx wrangler deploy                              # → https://excalidraw.pmcp.dev (+ the .workers.dev URL)
+npx wrangler deploy                              # → https://diagram.pmcp.dev (+ the .workers.dev URL)
 ```
 
-The custom domain `excalidraw.pmcp.dev` is declared in `wrangler.jsonc` (`routes` with
+The custom domain `diagram.pmcp.dev` is declared in `wrangler.jsonc` (`routes` with
 `custom_domain: true`); Wrangler provisions the route + DNS on deploy — no manual dashboard step
 (the `pmcp.dev` zone must be in the account, and the API token needs zone Workers Routes + DNS edit).
 
-Then open `https://excalidraw.pmcp.dev/?slug=make-tickets-human-readable&branch=<branch>&issue=<NN>`
+Then open `https://diagram.pmcp.dev/?slug=make-tickets-human-readable&branch=<branch>&issue=<NN>`
 on your phone → edit → **Save** → a commit (authored by `nuxt-harness[bot]`) lands on the branch, and
 (with `&issue=<NN>`) a comment with the frozen diagram is posted on that issue. Link that URL from each
 diagram's comment as a one-tap **✏️ Edit**.

--- a/workers/ticket-editor/wrangler.jsonc
+++ b/workers/ticket-editor/wrangler.jsonc
@@ -11,9 +11,10 @@
   // Custom domain — Wrangler auto-provisions the route + DNS on deploy (the pmcp.dev zone must be
   // in this Cloudflare account; the API token needs zone Workers Routes + DNS edit). The .workers.dev
   // URL keeps working too. The editor builds its Edit links from the request origin, so links posted
-  // when reached via this host use https://excalidraw.pmcp.dev automatically.
+  // when reached via this host use https://diagram.pmcp.dev automatically. Name is provider-agnostic
+  // (not "excalidraw") so the renderer can be swapped without changing the URL.
   "routes": [
-    { "pattern": "excalidraw.pmcp.dev", "custom_domain": true }
+    { "pattern": "diagram.pmcp.dev", "custom_domain": true }
   ],
   "vars": {
     "REPO": "FriendlyInternet/nuxt-crouton",


### PR DESCRIPTION
## 👤 For humans

Use a **provider-agnostic** custom domain — **`diagram.pmcp.dev`** instead of `excalidraw.pmcp.dev` — so the renderer can be swapped away from Excalidraw later without changing the URL.

## 🤖 For agents

- `wrangler.jsonc`: `routes` pattern `excalidraw.pmcp.dev` → `diagram.pmcp.dev`. README updated.
- No code change (Edit links derive from the request origin).

## ⚠️ After merge
`cd workers/ticket-editor && npx wrangler deploy` to provision `diagram.pmcp.dev`. If `excalidraw.pmcp.dev` was ever actually provisioned in Cloudflare, remove that custom domain in the dashboard (Wrangler won't necessarily delete an orphaned one).

Relates to epic #483.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ANiCX4pLDemDjvoNWQRuA)_