### PR TITLE
fix: pipeline hardening — no-op-proof resume + red-team verdict gate (#603 P0/P1)

### DIFF
--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -44,6 +44,12 @@ jobs:
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
+        # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found
+        # nothing high/critical, which was turning every PR red on a flake (#499, #602; #603 P1).
+        # `continue-on-error` makes the "Gate on high/critical" step below the sole decider:
+        # no verdict ⇒ inconclusive pass; a high/critical in the verdict ⇒ fail.
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Timestamp run start so the artifact-gate (below) can tell "produced during THIS run".
+      - id: t0
+        run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
       # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
       # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
@@ -116,3 +120,62 @@ jobs:
             // Clear the block defensively so the issue can close cleanly.
             try { await github.rest.issues.removeLabel({ ...context.repo, issue_number, name: 'status:blocked' }) } catch (e) {}
             core.info(merged ? 'Gate PR merged — schedule-waves will advance the chain.' : 'No gate PR merged (none matched / already merged).')
+
+      # ── Artifact-gate (#603 P0) ────────────────────────────────────────────────
+      # A resume must PRODUCE something — otherwise a no-op silently exits green and the
+      # run looks done while nothing advanced. That exact failure bit #590: a plan-gate
+      # `approve` resumed, cleared `status:blocked`, but created ZERO sub-issues; the green
+      # run hid it and it took a manual re-/delegate to notice. `decompose-on-issue` already
+      # has this gate; the resume path didn't. Now a no-op resume goes RED (visible →
+      # re-dispatch). Uses GITHUB_TOKEN (read-only check), never trips the bot-actor guard.
+      - name: Artifact-gate — fail if the resume produced nothing
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number
+            const since = '${{ steps.t0.outputs.ts }}'
+            const sinceMs = new Date(since).getTime()
+
+            // (a) sub-issues created this run (a plan/decompose gate proceeding)
+            let createdSubIssues = false
+            try {
+              const subs = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues', {
+                ...context.repo, issue_number, per_page: 100,
+              })
+              createdSubIssues = subs.some(s => new Date(s.created_at).getTime() >= sinceMs)
+            } catch (e) { core.warning(`sub-issue check skipped: ${e.message}`) }
+
+            // (b) a comment posted this run (an answer / progress / revision note)
+            const comments = await github.paginate(github.rest.issues.listComments, { ...context.repo, issue_number, since })
+            const newComment = comments.length > 0
+
+            // (c) issue state now
+            const issue = (await github.rest.issues.get({ ...context.repo, issue_number })).data
+            const closed = issue.state === 'closed'
+            const stillBlocked = issue.labels.some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
+
+            // (d) a gate PR merged this run (a sign-off gate approved + merged)
+            let mergedPR = false
+            try {
+              const tl = await github.paginate(github.rest.issues.listEventsForTimeline, { ...context.repo, issue_number })
+              const prNums = [...new Set(tl.filter(e => e.event === 'cross-referenced' && e.source && e.source.issue && e.source.issue.pull_request).map(e => e.source.issue.number))]
+              for (const n of prNums) {
+                const pr = (await github.rest.pulls.get({ ...context.repo, pull_number: n })).data
+                if (pr.merged_at && new Date(pr.merged_at).getTime() >= sinceMs) { mergedPR = true; break }
+              }
+            } catch (e) { core.warning(`merged-PR check skipped: ${e.message}`) }
+
+            // PASS if the resume did anything observable, OR it's still holding (legit "still
+            // iterating" — not a no-op). FAIL only when the block was cleared yet nothing came
+            // of it — the silent no-op.
+            if (createdSubIssues || mergedPR || closed || newComment || stillBlocked) {
+              core.info(`Resume artifact OK: subIssues=${createdSubIssues} mergedPR=${mergedPR} closed=${closed} newComment=${newComment} stillBlocked=${stillBlocked}`)
+              return
+            }
+            await github.rest.issues.createComment({ ...context.repo, issue_number,
+              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _resume artifact-gate (#603)_\n\n'
+                + '⚠️ The resume ran but produced **nothing** (no sub-issues, no merged gate PR, no new '
+                + 'comment, not closed, and the block was cleared) — a silent no-op (the #590 failure mode). '
+                + 'Re-dispatch with `/delegate` to retry.' })
+            core.setFailed(`Resume on #${issue_number} produced no artifact — likely a no-op; re-dispatch.`)


### PR DESCRIPTION
First two fixes of the pipeline-hardening epic #603 — the reliability gaps that made runs need babysitting.

## P0 — `resume-on-comment` artifact-gate
A resume that produces nothing now goes **red** instead of silently green. This is the #590 failure: a plan-gate `approve` resumed, cleared `status:blocked`, but created **zero sub-issues** — the green run hid it and it took a manual re-`/delegate` to notice. `decompose-on-issue` already had this gate; the resume path didn't.
- Adds a run-start timestamp + a final github-script gate. **PASS** if the run created sub-issues, merged a gate PR, closed the issue, posted a comment, or is still `status:blocked` (legit "still iterating"); **FAIL** only when the block was cleared yet nothing was produced.

## P1 — red-team gate decided by the verdict, not the agent's exit code
Every PR showed a red `red-team` check whenever the agent hit `max_turns`, even with no findings (#499, #602). 
- `continue-on-error` on the agent step → the **"Gate on high/critical"** step (reads `red-team-verdict.json`) is the sole decider: no verdict ⇒ inconclusive **pass**, high/critical ⇒ **fail**.

## How to verify (after merge)
- A resume that no-ops → red run with a "re-dispatch" comment (instead of silent green).
- A red-team run that times out with no findings → **green** check (not red).

Part of #603 (P0, P1). P2–P4 to follow. Then the library-catalog end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bJaMaBZL4uLVQt2ePNrb)_