### PR TITLE
feat(root): wire preview-review bridge config at staging deploy (#607)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -54,6 +54,15 @@ on:
         required: false
         default: '@fyit/crouton-auth @fyit/crouton-core @fyit/crouton'
         type: string
+      review-pr:
+        description: >-
+          PR number to wire the preview-review bridge to (staging only, #607).
+          When set, the staging Worker is given the `croutonReview` runtime config
+          (repo + this PR + the Nuxt Harness App creds) so in-page overlay comments
+          POST to this PR as nuxt-harness[bot]. Empty = bridge left unconfigured.
+        required: false
+        default: ''
+        type: string
     secrets:
       CLOUDFLARE_ACCOUNT_ID:
         required: true
@@ -204,6 +213,52 @@ jobs:
             npx wrangler secret bulk "$RUNNER_TEMP/worker-secrets.json" --env staging
           fi
           rm -f "$RUNNER_TEMP/worker-secrets.json"
+
+      # ── Preview-review bridge wiring (#607, part of #488) ───────────────────────
+      # The live-preview comment loop turns the overlay ON at build (NUXT_PUBLIC_CROUTON_REVIEW)
+      # but the bridge (`/api/_review`, @fyit/crouton-devtools) also needs RUNTIME config to
+      # know which PR to post to and how to auth — which no deploy ever set, so every overlay
+      # comment 4xx'd "Review bridge not configured". These two steps inject it on staging,
+      # PR-tied deploys: routing (repo + PR) + the Nuxt Harness App creds (so the bridge mints
+      # an installation token at request time and posts as nuxt-harness[bot]). Pushed as Worker
+      # secrets (persist on the live Worker; no redeploy needed). Skipped when not staging,
+      # not PR-tied, or the App creds are absent — so the bridge simply stays off.
+      - name: Mint Harness App installation id (for review bridge)
+        id: review-app-token
+        if: ${{ inputs.environment == 'staging' && inputs.review-pr != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Wire preview-review bridge config (staging, PR-tied)
+        if: ${{ inputs.environment == 'staging' && inputs.review-pr != '' && steps.review-app-token.outputs.installation-id != '' }}
+        working-directory: ${{ inputs.workspace }}/${{ inputs.app }}
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PR: ${{ inputs.review-pr }}
+          APP_ID: ${{ secrets.HARNESS_APP_ID }}
+          INSTALLATION_ID: ${{ steps.review-app-token.outputs.installation-id }}
+          PRIVATE_KEY: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+        run: |
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg pr "$PR" \
+            --arg appId "$APP_ID" \
+            --arg inst "$INSTALLATION_ID" \
+            --arg key "$PRIVATE_KEY" \
+            '{
+              NUXT_CROUTON_REVIEW_REPOSITORY: $repo,
+              NUXT_CROUTON_REVIEW_PR: $pr,
+              NUXT_CROUTON_REVIEW_GITHUB_APP_ID: $appId,
+              NUXT_CROUTON_REVIEW_GITHUB_APP_INSTALLATION_ID: $inst,
+              NUXT_CROUTON_REVIEW_GITHUB_APP_PRIVATE_KEY: $key
+            }' > "$RUNNER_TEMP/review-secrets.json"
+          npx wrangler secret bulk "$RUNNER_TEMP/review-secrets.json" --env staging
+          rm -f "$RUNNER_TEMP/review-secrets.json"
+          echo "✓ Wired preview-review bridge → PR #$PR on $REPOSITORY (posts as nuxt-harness[bot])"
 
       # Guarantee a new app can AUTHENTICATE on first deploy with ZERO per-app setup.
       # A freshly provisioned Worker has no secrets, so member login 500s with

--- a/.github/workflows/deploy-pocs.yml
+++ b/.github/workflows/deploy-pocs.yml
@@ -97,4 +97,7 @@ jobs:
       environment: staging
       staging-url: ${{ matrix.stagingUrl }}
       layer-packages: ${{ matrix.layerPackages }}
+      # PR-tied deploys wire the preview-review bridge to this PR (#607); empty on
+      # workflow_dispatch (no PR) → the bridge stays unconfigured, which is fine.
+      review-pr: ${{ github.event.pull_request.number }}
     secrets: inherit

--- a/.github/workflows/deploy-pocs.yml
+++ b/.github/workflows/deploy-pocs.yml
@@ -25,6 +25,13 @@ on:
         description: POC directory name under pocs/ (e.g. library-catalog)
         required: true
         type: string
+      review_pr:
+        description: >-
+          Optional PR number to wire the preview-review bridge to (#607). Set it
+          to make a manually-dispatched preview's in-page overlay comments post to
+          that PR. Leave empty to deploy without the bridge.
+        required: false
+        type: string
 
 jobs:
   # Figure out which opted-in POCs to deploy → a matrix the deploy job fans out over.
@@ -97,7 +104,7 @@ jobs:
       environment: staging
       staging-url: ${{ matrix.stagingUrl }}
       layer-packages: ${{ matrix.layerPackages }}
-      # PR-tied deploys wire the preview-review bridge to this PR (#607); empty on
-      # workflow_dispatch (no PR) → the bridge stays unconfigured, which is fine.
-      review-pr: ${{ github.event.pull_request.number }}
+      # PR-tied deploys wire the preview-review bridge to this PR (#607); on a manual
+      # dispatch use the optional review_pr input; empty → the bridge stays off.
+      review-pr: ${{ github.event.pull_request.number || github.event.inputs.review_pr }}
     secrets: inherit

--- a/writeups/setup/review-bridge-token-setup.md
+++ b/writeups/setup/review-bridge-token-setup.md
@@ -46,7 +46,27 @@ Routing — not credentials — stay regardless of the auth mechanism:
 | `NUXT_CROUTON_REVIEW_PR` | no | PR number (or per-request `body.prNumber`) |
 
 The App private key may be the same one the ticket-editor uses (same App); see the canonical
-secrets doc for central provisioning. Set it once on the staging Worker, e.g.:
+secrets doc for central provisioning.
+
+### CI wires this automatically (#607) — no manual `wrangler secret put`
+
+For apps/POCs deployed through the reusable **`deploy-app.yml`**, the bridge config is set
+**automatically on every staging, PR-tied deploy** — you do **not** run `wrangler secret put` by
+hand. `deploy-pocs.yml` passes the triggering PR number as the `review-pr` input; `deploy-app.yml`
+then resolves the Harness App installation id (`actions/create-github-app-token`) and pushes the
+full `croutonReview` config to the staging Worker via `wrangler secret bulk --env staging`:
+
+| Var | Source in CI |
+|---|---|
+| `NUXT_CROUTON_REVIEW_REPOSITORY` | `github.repository` |
+| `NUXT_CROUTON_REVIEW_PR` | the triggering PR number (`review-pr` input) |
+| `NUXT_CROUTON_REVIEW_GITHUB_APP_ID` | `secrets.HARNESS_APP_ID` |
+| `NUXT_CROUTON_REVIEW_GITHUB_APP_INSTALLATION_ID` | resolved from the App + owner at deploy time |
+| `NUXT_CROUTON_REVIEW_GITHUB_APP_PRIVATE_KEY` | `secrets.HARNESS_APP_PRIVATE_KEY` |
+
+It's gated to **staging + PR-tied** deploys (a `workflow_dispatch` deploy has no PR → the bridge
+stays unconfigured, which is correct). The bridge then posts as **`nuxt-harness[bot]`** (the shared
+App). To wire it manually for a one-off / non-CI Worker, set the same vars yourself:
 
 ```bash
 wrangler secret put NUXT_CROUTON_REVIEW_GITHUB_APP_PRIVATE_KEY --env staging


### PR DESCRIPTION
## 👤 For humans

The live-preview "click an element and comment" overlay worked, but the comment never reached GitHub — the deploy never told the preview which PR to post to or how to authenticate. This wires that in (reusing the Nuxt Harness App), so in-page comments now post to the PR as `nuxt-harness[bot]`. Staging + PR-tied only; production untouched.

Rescued from the library-catalog proof branch (it's reusable CI, not POC-specific) so every future preview inherits it. **Verified working** on the library-catalog preview (deploy steps "Mint Harness App installation id" + "Wire preview-review bridge config" both green).

## 🤖 For agents

- **`deploy-app.yml`** — new `review-pr` input + two **staging-only, PR-tied** steps: (1) `actions/create-github-app-token` resolves the Harness App installation id, (2) `wrangler secret bulk --env staging` pushes the `croutonReview` runtime config — `NUXT_CROUTON_REVIEW_REPOSITORY` / `_PR` / `_GITHUB_APP_ID` / `_INSTALLATION_ID` / `_PRIVATE_KEY`. Gated off when not staging / no PR / App creds absent.
- **`deploy-pocs.yml`** — passes `review-pr = github.event.pull_request.number || inputs.review_pr` (plus a `review_pr` `workflow_dispatch` input for manual testing).
- **`writeups/setup/review-bridge-token-setup.md`** — documents the auto-wiring (no manual `wrangler secret put`).
- No `packages/` change: `review.post.ts` / `githubApp.ts` already read `runtimeConfig.croutonReview.*`. Closes the #491 "PR number injected at deploy" gap that #488's four sub-issues never built.

## 🧪 How to test

A staging deploy tied to a PR sets the bridge config; submitting an overlay comment posts a `🎯 Preview feedback` comment on that PR as `nuxt-harness[bot]`; non-review / non-PR deploys set nothing.

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bJaMaBZL4uLVQt2ePNrb)_