### PR TITLE
perf(root): run only the E2E fixtures a change can affect (#622)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,13 @@
 name: E2E
 
-# Boots each crouton fixture app and runs the Playwright smoke (login + CRUD).
-# Catches regressions — e.g. a dependency bump that breaks a generated app —
-# before merge. Matrix = one job per fixture (see fixtures/* + e2e/CLAUDE.md).
+# Boots crouton fixture apps and runs the Playwright smoke (login + CRUD + package
+# surfaces). Catches regressions — e.g. a dependency bump or packages/ change that
+# breaks a generated app — before merge. See fixtures/* + e2e/CLAUDE.md.
+#
+# Smart selection (#622): on a PR we run ONLY the fixtures a change can affect, computed
+# by the `detect` job from the changed paths + each fixture's e2e.manifest.json `packages`
+# list (mirrors deploy-pocs.yml's detect→matrix pattern). Backstops keep coverage honest:
+# push to `main` and the nightly schedule always run the FULL matrix.
 on:
   push:
     branches: [main]
@@ -20,9 +25,89 @@ on:
       - 'e2e/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/e2e.yml'
+  schedule:
+    - cron: '0 4 * * *'   # nightly full-matrix backstop (selection can't silently hide a regression)
+  workflow_dispatch:        # manual full-matrix run
 
 jobs:
+  # Decide which fixtures to run. PR → only what's affected; everything else → all.
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+      any: ${{ steps.set.outputs.any }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need history for the PR base...head diff
+      - id: set
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # CI fixtures (with-collab is intentionally excluded — its crouton-collab package
+          # has pre-existing type errors that fail the #197 typecheck gate; #210 keeps it a
+          # local-only spike until type-clean).
+          ALL="minimal with-pages with-bookings with-assets with-maps"
+          # Packages whose change can affect EVERY fixture (shared base + generator + harness inputs).
+          UNIVERSAL="crouton crouton-core crouton-i18n crouton-cli crouton-auth"
+
+          pick=""
+          add() { case " $pick " in *" $1 "*) ;; *) pick="$pick $1";; esac; }
+
+          if [ "$EVENT" != "pull_request" ]; then
+            # push to main / schedule / manual → full matrix backstop.
+            pick="$ALL"
+            echo "Non-PR event ($EVENT) → full matrix."
+          else
+            changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)
+            echo "Changed files:"; echo "$changed" | sed 's/^/  /'
+            # Universal surfaces: the harness itself, the lockfile, or this workflow → run all.
+            if printf '%s\n' "$changed" | grep -qE '^(e2e/|pnpm-lock\.yaml$|\.github/workflows/e2e\.yml$)'; then
+              pick="$ALL"
+              echo "Harness / lockfile / workflow changed → full matrix."
+            else
+              force_all=false
+              while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                case "$f" in
+                  fixtures/*/*)
+                    fx=$(printf '%s' "$f" | cut -d/ -f2)
+                    case " $ALL " in *" $fx "*) add "$fx";; esac   # ignore non-CI fixtures (with-collab)
+                    ;;
+                  packages/*/*)
+                    pkg=$(printf '%s' "$f" | cut -d/ -f2)
+                    case " $UNIVERSAL " in *" $pkg "*) force_all=true; continue;; esac
+                    matched=false
+                    for fx in $ALL; do
+                      if jq -e --arg p "$pkg" '(.packages // []) | index($p)' "fixtures/$fx/e2e.manifest.json" >/dev/null 2>&1; then
+                        add "$fx"; matched=true
+                      fi
+                    done
+                    # A changed package no fixture covers → run minimal as a baseline boot check.
+                    [ "$matched" = false ] && add minimal
+                    ;;
+                esac
+              done <<< "$changed"
+              [ "$force_all" = true ] && pick="$ALL"
+            fi
+          fi
+
+          # Rebuild in canonical order (dedupes; stable matrix naming).
+          ordered=""
+          for fx in $ALL; do case " $pick " in *" $fx "*) ordered="$ordered $fx";; esac; done
+          arr=$(printf '%s\n' $ordered | sed '/^$/d' | jq -R . | jq -cs .)
+          matrix=$(jq -cn --argjson f "$arr" '{fixture:$f}')
+          if [ "$(printf '%s' "$arr" | jq 'length')" -gt 0 ]; then any=true; else any=false; fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "any=$any" >> "$GITHUB_OUTPUT"
+          echo "Selected fixtures: ${ordered:-<none>}"
+
   e2e:
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
     name: E2E (${{ matrix.fixture }})
     runs-on: ubuntu-latest
     # Every fixture runs inside the official, version-matched Playwright image
@@ -33,13 +118,7 @@ jobs:
     container: mcr.microsoft.com/playwright:v1.57.0-jammy
     strategy:
       fail-fast: false
-      matrix:
-        # with-collab is intentionally NOT here yet: the #197 gate type-checks each
-        # fixture, and the crouton-collab package it extends has pre-existing type
-        # errors (CollabCursors/useCollabPresence/avatar/ws.ts). Per #210 ("add to
-        # CI once stable"), with-collab stays a local-only spike until the package
-        # is type-clean. Its runtime smoke passes; only the typecheck gate blocks it.
-        fixture: [minimal, with-pages, with-bookings, with-assets, with-maps]
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
     env:
       # Better-auth needs a secret present; the value is irrelevant in CI.
       BETTER_AUTH_SECRET: ci-placeholder-secret

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -122,22 +122,47 @@ cd apps/with-i18n && node ../../packages/crouton-cli/bin/crouton-generate.js con
 mv apps/with-i18n fixtures/with-i18n
 #    set package.json "name": "e2e-fixture-with-i18n"
 
-# 3. Declare what to smoke
+# 3. Declare what to smoke (incl. `packages` so smart CI selection runs it on the right changes)
 cat > fixtures/with-i18n/e2e.manifest.json <<'JSON'
-{ "collections": [ { "key": "mainItems", "heading": "Main Items", "create": { "name": "e2e item" } } ] }
+{ "packages": ["crouton-i18n"], "collections": [ { "key": "mainItems", "heading": "Main Items", "create": { "name": "e2e item" } } ] }
 JSON
 
 # 4. Register + run
 pnpm install
 E2E_FIXTURE=with-i18n pnpm test:e2e
+
+# 5. Add it to the CI matrix: append the fixture name to ALL="…" in .github/workflows/e2e.yml
+#    (the detect job's candidate list). Without this it runs locally but never in CI.
 ```
 
 `fixtures/*` is already a workspace glob, so step 4's install picks it up.
 **No new test code** — the generic spec covers any fixture via its manifest.
 
+### Smart CI selection (#622)
+
+`e2e.yml` doesn't run every fixture on every change. A `detect` job (mirroring
+`deploy-pocs.yml`) computes the matrix from the changed paths + each manifest's `packages`:
+
+- `packages/<pkg>/**` → every fixture whose `packages` lists `<pkg>`; a package no fixture
+  covers → `minimal` (baseline boot).
+- `fixtures/<name>/**` → that fixture.
+- **Universal** (`crouton`, `crouton-core`, `crouton-i18n`, `crouton-cli`, `crouton-auth`,
+  `e2e/**`, `pnpm-lock.yaml`, the workflow) → **all** fixtures.
+- **Backstops:** push to `main` and the **nightly schedule** always run the full matrix, so
+  selection can never silently hide a regression.
+
+When you add a fixture, set its `packages` (step 3) **and** add it to `ALL` in the workflow
+(step 5) — otherwise the detect job never selects it.
+
 ### Manifest format
 ```jsonc
 {
+  // Feature packages this fixture exercises ON TOP OF the shared base (core/i18n/auth).
+  // Drives smart CI selection (#622): a PR touching packages/<pkg> runs only the fixtures
+  // whose `packages` list includes <pkg>. Include meaningful transitive deps the fixture
+  // actually renders (e.g. with-pages lists crouton-editor, which crouton-pages pulls in).
+  // Leave `[]` for a baseline fixture (minimal) — it always runs for uncovered/core changes.
+  "packages": ["crouton-pages", "crouton-editor"],
   "collections": [
     {
       "key": "mainItems",          // route segment + registered config key

--- a/fixtures/CLAUDE.md
+++ b/fixtures/CLAUDE.md
@@ -22,6 +22,10 @@ authenticates, and does CRUD** after a `packages/` change or dependency bump.
 - **To change what gets smoked, edit the fixture's `e2e.manifest.json`** — it
   declares the collections to CRUD and any package `surfaces` to assert. The
   shared specs in `e2e/` read it; you almost never write test code per fixture.
+- **The manifest's `packages` list drives smart CI selection (#622).** It names the
+  feature packages the fixture exercises, so a PR touching `packages/<pkg>` runs only
+  the fixtures that list `<pkg>` (push to `main` + nightly still run all). Keep it
+  current when a fixture starts/stops exercising a package. See `e2e/CLAUDE.md`.
 - **They live in `fixtures/`, not `tests/`**, on purpose: pnpm ignores `test*/`
   during workspace discovery, so a fixture there would be invisible to
   `pnpm --filter`.

--- a/fixtures/minimal/e2e.manifest.json
+++ b/fixtures/minimal/e2e.manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages": [],
   "collections": [
     {
       "key": "mainItems",

--- a/fixtures/with-assets/e2e.manifest.json
+++ b/fixtures/with-assets/e2e.manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages": ["crouton-assets"],
   "collections": [
     {
       "key": "mainItems",

--- a/fixtures/with-bookings/e2e.manifest.json
+++ b/fixtures/with-bookings/e2e.manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages": ["crouton-bookings"],
   "collections": [
     {
       "key": "mainItems",

--- a/fixtures/with-collab/e2e.manifest.json
+++ b/fixtures/with-collab/e2e.manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages": ["crouton-collab"],
   "collections": [
     {
       "key": "mainItems",

--- a/fixtures/with-maps/e2e.manifest.json
+++ b/fixtures/with-maps/e2e.manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages": ["crouton-maps"],
   "collections": [
     {
       "key": "mainItems",

--- a/fixtures/with-pages/e2e.manifest.json
+++ b/fixtures/with-pages/e2e.manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages": ["crouton-pages", "crouton-editor"],
   "collections": [
     {
       "key": "mainItems",


### PR DESCRIPTION
Closes #622.

## 👤 For humans
E2E ran **all 5 fixtures on every `packages/**` change** — so a `crouton-maps` PR needlessly rebuilt + regenerated + smoked `with-pages`/`with-bookings`/`with-assets`, and ~18 packages with no fixture coverage still triggered all 5. Now a PR runs **only the fixtures a change can affect**; push to `main` + a nightly run still execute the full matrix so nothing regresses silently.

## 🤖 What changed
- **`.github/workflows/e2e.yml`** — new `detect` job (mirrors `deploy-pocs.yml`'s detect→matrix). It computes the fixture matrix from `git diff <base>...<head>` + each manifest's `packages`:
  | Changed | Runs |
  |---|---|
  | `packages/<pkg>/**` | every fixture whose manifest `packages` lists `<pkg>` |
  | a package no fixture covers | `minimal` (baseline boot) |
  | `fixtures/<name>/**` | that fixture |
  | universal: `crouton`/`crouton-core`/`crouton-i18n`/`crouton-cli`/`crouton-auth`, `e2e/**`, `pnpm-lock.yaml`, the workflow | **all** |
  - **Backstops:** push to `main`, a **nightly cron**, and `workflow_dispatch` always run the full matrix.
- **`fixtures/*/e2e.manifest.json`** — new `packages` field per fixture (the feature packages it exercises). `with-pages` includes `crouton-editor` (the transitive dep it actually renders); `minimal` is `[]`. `with-collab` carries one too, though it stays out of the CI `ALL` list (the #210 type-clean gate).
- **Docs** — `e2e/CLAUDE.md` (manifest `packages` field, "Smart CI selection" section, add-fixture step 5 = also add to the workflow's `ALL`) + `fixtures/CLAUDE.md`.

## 🧪 How to test
- **Self-test:** this PR touches `e2e/**` + the workflow → the universal rule selects the **full matrix**, so all 5 fixtures run here (proves the "run everything" path).
- Local verification of the selection logic across 10 scenarios passed: `crouton-maps`→`with-maps`, `crouton-editor`→`with-pages`, `crouton-core`→all, `crouton-charts`(uncovered)→`minimal`, `pnpm-lock.yaml`→all, `fixtures/with-bookings/**`→`with-bookings`, `crouton-pages`+`crouton-bookings`→both, etc.
- Follow-up signal: a later PR that only touches one feature package should show just that fixture's job in checks.

Source of truth is the per-fixture manifest (colocated, can't drift from a central map), per the design agreed on the issue. Relates to #609 end-goal #8 (first-run reliability — the e2e gate that guards the flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DHZCABxJWQaKZVpHbWofJ)_