### PR TITLE
fix(root): fix-bot pushes via the Harness App token so CI re-triggers (#626)

### DIFF
--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -100,19 +100,36 @@ jobs:
             core.setOutput('attempt', String(next))
             core.info(`Fix attempt ${next}/${MAX} for PR #${pr.number} (issue #${issueNumber}).`)
 
+      # Mint a Harness App token so the fix PUSH is App-authored. CRUCIAL: a push made with
+      # the default GITHUB_TOKEN does NOT re-trigger workflows (GitHub's loop guard), so a
+      # GITHUB_TOKEN-authored fix would never re-run CI — the retry loop would stall after
+      # one attempt and never verify its own fix. An App-token push fires `pull_request:
+      # synchronize` → CI re-runs → workflow_run gives the fix-bot its next attempt (bounded
+      # by the ci-fix-attempts cap). Same reason automerge/resume/schedule-waves use it (#626).
+      - if: steps.gate.outputs.proceed == 'true'
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       - if: steps.gate.outputs.proceed == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.gate.outputs.head_branch }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       # ── The fix attempt ─────────────────────────────────────────────────────────
       # AUTH: headless/unattended → MUST use an API key (never a subscription OAuth token;
       # Anthropic terms). Pinned to the same SHA as claude.yml — keep in sync when bumping.
+      # github_token is the App token so the agent's git push re-triggers CI (above).
       - if: steps.gate.outputs.proceed == 'true'
         uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
           claude_args: "--max-turns 30"
           show_full_output: true
           prompt: |


### PR DESCRIPTION
## 👤 For humans

Follow-up to the fix-bot (#338) merged in #625. It pushed its fix with the default `GITHUB_TOKEN`, which GitHub blocks from re-triggering workflows — so a fix never re-ran CI and the retry loop stalled after one attempt. It now pushes as the **Harness App**, so a fix re-runs CI and the bot gets its next attempt (still capped at 3).

## 🤖 For agents

- `fix-ci-on-failure.yml`: added an `actions/create-github-app-token@v1` step and passed its token to `actions/checkout` (`token:`) so the agent's push is App-authored → fires `pull_request: synchronize` → CI re-runs → `workflow_run` gives the next attempt. Also passed `github_token:` to `claude-code-action`.
- Same cascade pattern as `automerge-epic-subpr.yml` / `resume-on-comment.yml` / `schedule-waves.yml` (documented in `agents/CLAUDE.md`).
- The `ci-fix-attempts:N` cap (MAX=3) still bounds the now-live loop, so App-authored re-triggers can't run away.
- Validated: YAML + embedded gate JS (`node --check` under github-script async-wrap).

## 🧪 How to test

A fix-bot commit on a failing pipeline PR re-triggers CI (enabling attempts 2 and 3); guard rails (`claude/issue-*` scope, attempt cap, `packages/` stop) unchanged.

Closes #626

Part of epic #336. Initiative #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9TREWe57VVL6xs68ayyQV)_