### PR TITLE
fix(crouton-maps): pre-bundle maplibre-gl so the maps form mounts (#624)

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -179,6 +179,8 @@ E2E_FIXTURE=with-i18n pnpm test:e2e
   "maps": {
     "collectionKey": "mainVenues",   // collection whose generated form embeds the map
     "heading": "Main Venues",         // that collection's list heading
+    "formTab": "Address",             // optional: form tab the map field lives on (UTabs
+                                      //   content is lazy; omit if the map is on the first tab)
     "geocode": {
       "query": "Eiffel Tower, Paris, France", // address to forward-geocode
       "near": [2.2945, 48.8584],              // expected [lng, lat]

--- a/e2e/collection.smoke.spec.ts
+++ b/e2e/collection.smoke.spec.ts
@@ -83,11 +83,16 @@ test.describe(`fixture "${FIXTURE}"`, () => {
           await createDialog.getByRole('button', { name: /create|save|add/i }).first().click()
           await expect(page.getByRole('cell', { name: marker })).toBeVisible({ timeout: 60000 })
 
-          // --- EDIT --- open the row's pencil (last of the [delete, update] row
-          // buttons), change the field, save, and assert the new value replaced
-          // the old one in the list.
+          // --- EDIT --- open the row's pencil (the LAST button in the row's ACTIONS
+          // cell — the [delete, update] pair). Scope to that cell (the one holding the
+          // delete button, reliably the row's first button — the select checkbox is
+          // role=checkbox, not button) rather than the whole row, so extra buttons in
+          // other cells (e.g. the crouton-maps preview button in the coordinates
+          // column) don't make `.last()` grab the wrong control (#624). Then change the
+          // field, save, and assert the new value replaced the old one in the list.
           const row = page.getByRole('row', { name: new RegExp(marker) })
-          await row.getByRole('button').last().click()
+          const rowActionsCell = row.getByRole('button').first().locator('xpath=ancestor::td[1]')
+          await rowActionsCell.getByRole('button').last().click()
           const editDialog = page.getByRole('dialog')
           await expect(editDialog).toBeVisible({ timeout: 60000 })
           await editDialog.getByRole('textbox').first().waitFor({ state: 'visible', timeout: 60000 })

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -91,6 +91,14 @@ export interface MapsSpec {
   collectionKey: string
   /** That collection's visible list heading, e.g. "Main Venues". */
   heading: string
+  /**
+   * Optional name of the form tab the map field lives on (e.g. "Address"). The
+   * generated form groups fields into tabs (CroutonFormLayout → UTabs) and tab
+   * content is lazily rendered, so when the map isn't on the default tab the smoke
+   * must activate this tab before `.crouton-map-wrapper` exists. Omit if the map is
+   * on the first/default tab.
+   */
+  formTab?: string
   /** Address → coordinates check against the /api/maps/geocode proxy. */
   geocode: {
     /** Free-text address to forward-geocode. */

--- a/e2e/maps.smoke.spec.ts
+++ b/e2e/maps.smoke.spec.ts
@@ -43,6 +43,16 @@ test.describe(`fixture "${FIXTURE}" maps`, () => {
     const dialog = page.getByRole('dialog')
     await expect(dialog).toBeVisible({ timeout: 60000 })
 
+    // The map field may live on a secondary form tab (CroutonFormLayout → UTabs),
+    // whose content is lazily rendered — so the `.crouton-map-wrapper` only exists
+    // once that tab is active. Activate it when the manifest names one.
+    if (maps!.formTab) {
+      const tab = new RegExp(maps!.formTab, 'i')
+      await dialog.getByRole('tab', { name: tab })
+        .or(dialog.getByRole('button', { name: tab }))
+        .first().click()
+    }
+
     // The crouton-maps form picker renders its wrapper regardless of whether the
     // tiles load — so this asserts the package mounted, not that the network is up.
     await expect(dialog.locator('.crouton-map-wrapper').first())

--- a/fixtures/with-maps/e2e.manifest.json
+++ b/fixtures/with-maps/e2e.manifest.json
@@ -15,6 +15,7 @@
   "maps": {
     "collectionKey": "mainVenues",
     "heading": "Main Venues",
+    "formTab": "Address",
     "geocode": {
       "query": "Eiffel Tower, Paris, France",
       "near": [2.2945, 48.8584],

--- a/packages/crouton-maps/nuxt.config.ts
+++ b/packages/crouton-maps/nuxt.config.ts
@@ -41,10 +41,25 @@ export default defineNuxtConfig({
     scanDirs: [join(currentDir, 'server')]
   },
 
-  // @geoql/v-maplibre + maplibre-gl ship ESM that needs transpiling for SSR
-  // builds (maplibre-gl touches the DOM, so components are rendered client-only).
+  // @geoql/v-maplibre renders the map client-only (maplibre-gl touches the DOM),
+  // so transpile it for the SSR build. NOTE: maplibre-gl is deliberately NOT in
+  // `transpile` — it's a CJS-only package (`main: dist/maplibre-gl.js`, no `module`/
+  // `exports`), and @geoql/v-maplibre imports NAMED exports from it
+  // (`import { Map, AttributionControl } from 'maplibre-gl'`). If maplibre-gl is
+  // transpiled inline, Vite resolves those named imports against the raw CJS file and
+  // throws at runtime ("does not provide an export named 'Map'"), so the map components
+  // (and any collection viewer that loads them) never mount. Pre-bundling it via
+  // optimizeDeps instead lets esbuild synthesize the named exports. (#624)
   build: {
-    transpile: ['@geoql/v-maplibre', 'maplibre-gl']
+    transpile: ['@geoql/v-maplibre']
+  },
+
+  vite: {
+    // Force Vite to pre-bundle the map deps so esbuild's CJS→ESM interop exposes
+    // maplibre-gl's named exports to @geoql/v-maplibre's `import { Map } from 'maplibre-gl'`.
+    optimizeDeps: {
+      include: ['maplibre-gl', '@geoql/v-maplibre']
+    }
   },
 
   // Runtime config.


### PR DESCRIPTION
Closes #624.

## 👤 For humans
The `with-maps` E2E fixture has been red since the Mapbox→MapLibre swap (#559) — it was introduced already-broken. A map form crashed the page in dev so the venues collection never rendered (no table, no create button). This fixes the root cause (a maplibre-gl CJS-interop issue) plus a secondary test-only gap. Verified locally with a real browser.

## 🔬 Root cause (captured from a real browser)
```
[pageerror] The requested module '.../maplibre-gl@5.24.0/.../maplibre-gl.js' does not provide an export named 'Map'
[Vue warn] Unhandled error during execution of async component loader
   at <CroutonCollectionViewer collection-name="mainVenues">
```
- `maplibre-gl` v5 is **CJS-only** (`main: dist/maplibre-gl.js`, no `module`/`exports`).
- `@geoql/v-maplibre` does **static named imports** (`import { Map, AttributionControl } from 'maplibre-gl'`).
- crouton-maps had maplibre-gl in `build.transpile`, so in the **dev server** (which `pnpm test:e2e` uses) Vite resolved those named imports against the raw CJS file and threw → the maps components, and any collection viewer that loads them, never mounted → the whole venues page was blank.

## 🤖 What changed (2 commits)
1. **`fix(crouton-maps)`** — drop `maplibre-gl` from `build.transpile` and add `vite.optimizeDeps.include: ['maplibre-gl', '@geoql/v-maplibre']` so esbuild's CJS→ESM interop synthesizes the named exports.
2. **`test(root)`** — the `maps.smoke` "map mounts in form" check asserted `.crouton-map-wrapper` without opening the tab the map field lives on (the form groups fields into lazily-rendered `UTabs`; the map is on **Address**). Now the manifest declares `formTab` and the smoke clicks it first. (`e2e/maps.smoke.spec.ts` + `helpers.ts` type + `fixtures/with-maps/e2e.manifest.json` + doc.)

## 🧪 How to test / verification
Reproduced + verified locally with a real Chromium driving the dev server:
- **Before:** venues list page blank, create button never appears, `[pageerror] … no export 'Map'`.
- **After:** venues list renders (table + "Showing 0 to 0 of 0 results"), create form opens, and clicking **Address** shows `.crouton-map-wrapper` with **2 MapLibre canvases** mounted. The generic `mainItems` collection is unaffected.
- Fixture typecheck green (`pnpm --filter e2e-fixture-with-maps typecheck`).
- CI is the authoritative gate: this PR touches `packages/crouton-maps` + `fixtures/**` + `e2e/**`, so the E2E workflow runs the full matrix here — `with-maps` should now pass (list + CRUD + map-mounts; the live-geocode test skips when the runner can't reach Nominatim, by design).

## Notes
- Archaeology + repro recorded on #624.
- Independent of the smart-E2E-selection PR (#623) and the seed-login (#619) / pipeline-hardening (#620) PRs.
- Package edit to `crouton-maps` was made under your "you do it" go-ahead; the `packages/` approval gate has been re-engaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DHZCABxJWQaKZVpHbWofJ)_