### PR TITLE
docs(root): blocked agents leave a self-contained handoff, not just a question

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -98,6 +98,23 @@ confirmed high/criticals) `security`/`sec:*` GitHub issues.
   GitHub/app notification), apply `status:blocked`, and stop — the human answers by
   replying on the issue. Small ambiguities are decided with a default + a noted
   assumption (no ping). Change the handle in this file and in the task-decompose skill.
+- **A block comment is a HANDOFF, not just a question (#639).** The owner's reply spawns a
+  **brand-new session** (`resume-on-comment.yml`) that has **zero memory** of your reasoning
+  and checks out `main` — not your worktree, which is gone. So the blocking comment must be
+  self-contained enough for a cold agent to resume from. Post this structured block (it
+  doubles as the question *and* the resume brief):
+  ```
+  ## 🔀 Blocked — need a decision (handoff)
+  **Question for @pmcp:** <the one thing only you can decide>
+  **Why it blocks:** <what cannot proceed until answered>
+  **State so far:** <what's done · branch name + pushed? · what's NOT done>
+  **After you answer:** a NEW session resumes from THIS ticket —
+    Option A → <next steps> · Option B → <next steps>
+  **Don't lose:** <decisions/assumptions already made the next agent must keep>
+  ```
+  And **push before you block**: if you've written anything, `git push -u origin <branch>`
+  first and name that branch under *State so far* — an unpushed worktree is lost on stop, a
+  pushed branch is recoverable by the resuming session.
 - **An @mention is a request for action, not a broadcast.** Only @mention `NOTIFY_HANDLE`
   when you need the human to *do* something: answer a blocking question, give a sign-off,
   or unblock you. **Pure progress/status updates** ("spawning the worker for #NN", "wave 2

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -289,8 +289,28 @@ package edit isn't covered by the epic's approval, that's a blocker — comment 
 
 You may be running headless — do NOT use `AskUserQuestion` (it times out). On a **real
 blocker** (the `packages/` gate, a missing decision, a failing approach you can't resolve
-on your own): `add_issue_comment` on the issue with a tight description of what's blocking
-+ what you need, **@mention the notify handle (`@pmcp` — `NOTIFY_HANDLE` in the
-task-decompose skill)** so they get a notification, apply `status:blocked`, and **stop**
-(leave the branch as-is for resuming). Do not silently guess past a blocker. Small
-implementation choices don't need a ping — make them and note them in the PR body.
+on your own): `add_issue_comment` on the issue, **@mention the notify handle (`@pmcp` —
+`NOTIFY_HANDLE` in the task-decompose skill)** so they get a notification, apply
+`status:blocked`, and **stop**. Do not silently guess past a blocker. Small implementation
+choices don't need a ping — make them and note them in the PR body.
+
+**The comment is a HANDOFF, not just a question (#639).** The owner's reply spawns a
+**brand-new session** (`resume-on-comment.yml`) with **zero memory** of your reasoning — it
+checks out `main`, not this worktree (which is gone on stop). So the comment must let a cold
+agent resume without re-deriving or diverging. Use the canonical handoff block (see
+`.claude/agents/CLAUDE.md` → "A block comment is a HANDOFF"):
+
+```
+## 🔀 Blocked — need a decision (handoff)
+**Question for @pmcp:** <the one thing only you can decide>
+**Why it blocks:** <what cannot proceed until answered>
+**State so far:** <what's done · branch name + pushed? · what's NOT done>
+**After you answer:** a NEW session resumes from THIS ticket —
+  Option A → <next steps> · Option B → <next steps>
+**Don't lose:** <decisions/assumptions already made the next agent must keep>
+```
+
+**Push before you block.** If you've written *any* code before hitting the blocker,
+`git push -u origin <branch>` **first**, then name that branch under *State so far*. An
+unpushed worktree is lost when you stop; a pushed branch is what the resuming session picks
+up. (This extends the step-8 "push immediately" checkpoint to the block path.)


### PR DESCRIPTION
## 👤 For humans

When a pipeline agent gets stuck it comments on the ticket, @mentions you, and stops — and your reply spawns a **brand-new session** (`resume-on-comment.yml`) to continue. The gap: that blocking comment was written for *you to answer*, not as a brief the *next agent* can boot from. The resuming session has zero memory of the blocked agent's reasoning and checks out `main` (the worker's worktree is gone), so a bare "Option A or B?" forces it to reconstruct what's done — which is where it redoes work or diverges.

This makes the blocking comment double as a **handoff**: question + state-so-far + what-happens-after-you-answer + don't-lose, plus a "push your branch before you block" rule so partial work is recoverable.

## 🤖 For agents

- `.claude/agents/CLAUDE.md` — new **"A block comment is a HANDOFF"** contract bullet (shared by orchestrator/decomposer/worker) carrying the canonical handoff-block template + the push-before-block rule.
- `.claude/agents/task-worker.md` — the **"Asking the human"** section now requires the handoff block (refs the canonical template) and push-before-block, extending the step-8 "push immediately" checkpoint to the block path.
- Mechanism unchanged: no `AskUserQuestion`, @mention `NOTIFY_HANDLE`, `status:blocked`, stop; small choices still decided with a noted default. This only changes **what the blocking comment must contain**.

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019FkvDa811qzWNGiYyv93tb)_