### PR TITLE
chore(root): auto-strip status:* labels when an issue closes (#641)

### DIFF
--- a/.github/workflows/strip-status-on-close.yml
+++ b/.github/workflows/strip-status-on-close.yml
@@ -1,0 +1,49 @@
+name: Strip status labels on close
+
+# (#641) When an issue closes, remove any `status:*` label it still carries.
+#
+# Why: project-status.yml moves the board card to Done on close, but it never
+# removes the `status:in-progress` / `status:blocked` LABEL — so closed issues
+# linger wearing a stale status (all 5 closed children of #336 did). This is the
+# missing other half: the label is repo data, the board column is Projects data;
+# this workflow owns the label, project-status.yml owns the column.
+#
+# Auth: plain GITHUB_TOKEN with `issues: write` is enough — removing a label on
+# this repo's own issue is a repo-scoped op (no Projects v2 / Harness App needed).
+# Idempotent: a 404 ("label not present") is swallowed, so a re-run is a clean no-op.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  strip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.issue.number
+
+            // Match by the `status:` prefix so new status labels are covered
+            // automatically — don't hard-code the full set.
+            const toRemove = (context.payload.issue.labels || [])
+              .map(l => l.name)
+              .filter(n => (n || '').toLowerCase().startsWith('status:'))
+
+            if (toRemove.length === 0) { core.info('No status:* label to strip.'); return }
+
+            for (const name of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name })
+                core.info(`Removed "${name}" from #${issue_number}`)
+              } catch (e) {
+                // 404 = label already gone (race / re-run) — ignore; rethrow anything else.
+                if (e.status === 404) core.info(`"${name}" already absent on #${issue_number}`)
+                else throw e
+              }
+            }


### PR DESCRIPTION
Closes #641. Carried over from the #336 postmortem.

## What

When an issue closes, remove any `status:*` label it still carries. `project-status.yml` moves the board card to Done on close but never removes the `status:in-progress` / `status:blocked` **label** — so closed issues linger wearing a stale status (all 5 closed children of #336 did). This owns the label half; `project-status.yml` keeps owning the board column.

## How

- New `.github/workflows/strip-status-on-close.yml`: trigger `issues: [closed]`, `permissions: issues: write`.
- Plain `GITHUB_TOKEN` is enough — removing a label on the repo's own issue is repo-scoped (no Projects v2 / Harness App needed, unlike the board automation).
- Prefix-driven (`status:`), so new status labels are covered automatically — no hard-coded set.
- Swallows a 404 ("label already gone") → a re-run is a clean no-op.

Validated: YAML parses; embedded github-script parses (async-wrapped).

## 🧪 We'll know by

Closing any issue carrying `status:in-progress` → the label is auto-removed, board card still lands in Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQvhwgDsGptDTx1yRvoPHa)_