### PR TITLE
fix(root): surface the real preview URL on deploys (#293 part 2)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -186,8 +186,21 @@ jobs:
           else
             pnpm run cf:staging | tee deploy.log
           fi
-          # Surface the deployed *.workers.dev URL (best-effort) for the PR comment.
-          URL=$(grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' deploy.log | tail -1 || true)
+          # Surface the deployed URL for the PR comment, seed-login + review steps.
+          # Prefer the configured custom-domain URL (staging-url/production-url input):
+          # the workflow already knows it, and it's the actual deploy target (the route
+          # in wrangler.jsonc env.staging). The log-grep only matches *.workers.dev,
+          # which a custom-domain deploy NEVER emits — so grepping left the URL empty,
+          # which in turn skipped the seed-login + PR-comment steps (gated on url != '').
+          # Fall back to the log-grep only when no URL was configured (#293).
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            URL="${{ inputs['production-url'] }}"
+          else
+            URL="${{ inputs['staging-url'] }}"
+          fi
+          if [ -z "$URL" ]; then
+            URL=$(grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' deploy.log | tail -1 || true)
+          fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "Deployed: ${URL:-<url not parsed>}"
 


### PR DESCRIPTION
## 👤 For humans

Preview deploys to a **custom domain** (e.g. `blog.pmcp.dev`, `velo.pmcp.dev`) were posting an **empty link** on the PR and **silently skipping the throwaway test-login seed** — so a reviewer opened the PR to no URL and no credentials, then had to go dig for the deploy. This makes the deploy report the URL it *actually* deployed to, so the "open link, paste creds, you're in" flow (#609 goals #3 + #4) works on every preview.

## 🤖 For agents

The `Deploy` step in `deploy-app.yml` set `steps.deploy.outputs.url` by grepping `deploy.log` for a `*.workers.dev` URL. **Custom-domain deploys never emit one**, so `url` came back empty — which gated OUT two downstream steps, both `if: ... steps.deploy.outputs.url != ''`:
- **Seed review login** (the disposable test account, #608)
- **Comment staging URL on PR** (the clickable preview + creds, #607/#488)

The fix prefers the configured `production-url` / `staging-url` input (the actual deploy target = the `route` in `wrangler.jsonc` `env.staging`), falling back to the log-grep only when no URL was configured. Validated: `deploy-app.yml` parses as valid YAML.

This is **part 2 of 2 of #293** (reliable URL surfacing). **Part 1** — a Playwright `login → CRUD → public-read` smoke against the deployed URL, with a screenshot to `screenshots/` — remains open on #293 (it needs CF creds, so it only runs in CI).

Refs #293. Part of the #609 "set up the flow" hardening (audit traced this as the top zero-babysitting blocker in the live-preview gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA3uRc3rXWE6STByAVHvC2)_