### PR TITLE
fix(root): artifact-gate names the real failure cause (#661)

### DIFF
--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -42,6 +42,7 @@ jobs:
       # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
       # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        id: claude
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: "/task-decompose #${{ github.event.issue.number }}"
@@ -63,6 +64,11 @@ jobs:
       - name: Artifact-gate — fail if the agent produced nothing
         if: always()
         uses: actions/github-script@v7
+        env:
+          # #661: let the gate read WHY the agent produced nothing (billing / underspecified /
+          # genuine no-op) so the failure comment is actionable instead of a generic message.
+          CLAUDE_EXEC_FILE: ${{ steps.claude.outputs.execution_file }}
+          CLAUDE_CONCLUSION: ${{ steps.claude.outputs.conclusion }}
         with:
           script: |
             const issue_number = context.payload.issue.number
@@ -120,15 +126,60 @@ jobs:
               return
             }
 
+            // ── Classify WHY there was no deliverable, for an ACTIONABLE comment (#661) ──
+            // The old message always read "narrate-the-plan-then-stop no-op" — which sent us
+            // chasing the wrong thing when the real cause was a billing_error (#660). Read the
+            // agent's execution log + step conclusion and name the actual cause + the fix.
+            const fs = require('fs')
+            let why = ''      // human-readable cause
+            let action = ''   // what to do about it
+            try {
+              const execFile = process.env.CLAUDE_EXEC_FILE
+              if (execFile && fs.existsSync(execFile)) {
+                const events = JSON.parse(fs.readFileSync(execFile, 'utf8'))
+                const result = [...events].reverse().find(e => e && e.type === 'result')
+                const text = result ? String(result.result || '') : ''
+                if (result && result.is_error) {
+                  if (/credit balance|billing/i.test(text)) {
+                    why = `the Claude API call failed — **${text}**`
+                    action = 'The Anthropic account behind the `ANTHROPIC_API_KEY` secret is out of credit. '
+                      + 'Top it up (Console → Billing; enable auto-reload), then re-apply `delegate`.'
+                  } else {
+                    why = `the agent run errored — **${text || 'see the run log'}**`
+                    action = 'Check the run log for the SDK/tooling error, fix the cause, then re-apply `delegate`.'
+                  }
+                } else if (result) {
+                  // Ran to completion but produced nothing on the issue — usually an underspecified
+                  // task: the agent asked for clarification instead of building.
+                  const snippet = text.length > 600 ? text.slice(0, 600) + '…' : text
+                  why = 'the agent finished its turn without opening a PR, creating sub-issues, or holding for sign-off'
+                  action = 'This usually means the issue is underspecified — add a concrete description + '
+                    + 'acceptance criteria so there is something to build, then re-apply `delegate`.'
+                  if (snippet) why += `. Its final message was:\n\n> ${snippet.replace(/\n/g, '\n> ')}`
+                }
+              }
+            } catch (e) { core.warning(`artifact-gate: could not parse execution log: ${e.message}`) }
+
+            // Fallback when the log is unreadable but the agent step itself failed (e.g. a hard
+            // billing/API error that aborts before writing the log) — still point at the likely cause.
+            if (!why && process.env.CLAUDE_CONCLUSION === 'failure') {
+              why = 'the agent step **failed before producing anything** (often a billing/credit, API, or tooling error)'
+              action = 'Open the run log. If it says "Credit balance is too low", top up the Anthropic account '
+                + 'behind `ANTHROPIC_API_KEY` (enable auto-reload). Otherwise fix the logged error, then re-apply `delegate`.'
+            }
+
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            await github.rest.issues.createComment({
-              ...context.repo, issue_number,
-              body: '⚠️ **Artifact-gate failed (#461).** @pmcp — this run produced no real deliverable on '
+            const body = why
+              ? `⚠️ **Artifact-gate failed (#461).** @pmcp — this run produced no deliverable: ${why}\n\n`
+                + `**What to do:** ${action}\n\n`
+                + `🔗 **Run log:** ${runUrl}`
+              : '⚠️ **Artifact-gate failed (#461).** @pmcp — this run produced no real deliverable on '
                 + 'this issue: no PR was opened, and it is not held for sign-off (`status:blocked` + a review). '
                 + 'A bare progress comment ("spawning the worker…") does not count — the '
                 + '"narrate-the-plan-then-stop" no-op. The run is marked **failed** so it is not mistaken '
                 + 'for done.\n\n'
                 + `🔗 **Run log:** ${runUrl}\n`
-                + '↻ Re-apply the `delegate` label to retry.',
-            })
+                + '↻ Re-apply the `delegate` label to retry.'
+
+            await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no PR, not held for sign-off).`)


### PR DESCRIPTION
Closes #661.

## 👤 For humans

When a delegated run produces no PR, the artifact-gate failure comment now says **why** in plain terms instead of always printing the same generic "narrate-the-plan-then-stop no-op" text. That generic message is what sent us chasing a phantom pipeline bug on #660 when the real cause was a `billing_error` (the API key was out of credit).

Now the comment reads, e.g.:

> ⚠️ **Artifact-gate failed (#461).** @pmcp — this run produced no deliverable: the Claude API call failed — **Credit balance is too low**
> **What to do:** The Anthropic account behind the `ANTHROPIC_API_KEY` secret is out of credit. Top it up (Console → Billing; enable auto-reload), then re-apply `delegate`.

…or, for an empty/underspecified issue, it quotes the agent's own clarifying question and tells you to add a description.

## 🤖 For agents

- `decompose-on-issue.yml`: gave the `claude-code-action` step `id: claude`; pass its `execution_file` + `conclusion` outputs into the artifact-gate step via `env`.
- The gate parses the agent's execution log and classifies the final `type: result` event:
  - `is_error` + `/credit balance|billing/i` → **billing** message (top up the key).
  - `is_error` (other) → surface the SDK error text + "see run log".
  - ran to completion, no artifact → **underspecified** hint + quote the agent's final message (truncated).
- Falls back to step `conclusion == 'failure'` (covers a hard billing abort that writes no log), and to the **original generic message** when nothing is readable — so it never regresses.
- Deterministic, no LLM; still uses `GITHUB_TOKEN` (never trips the bot-actor guard).
- Scope: the decompose gate only. The same treatment for `resume-on-comment.yml`'s gate is a noted follow-up.

## 🧪 How to test

- Re-check against the #660 billing run `27969381130` — the comment should name billing + the top-up action.
- An empty-body issue run posts the "underspecified — add a description" hint, quoting the agent's question.
- A genuine no-op still posts the existing message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJVcEeSK2sgx1fTCEjBR5P)_