### PR TITLE
chore(root): route agent workflows via AGENT_RUNNER toggle (#655)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,7 +14,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
     # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to

--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -29,7 +29,7 @@ jobs:
        github.event.comment.author_association == 'COLLABORATOR') &&
       (contains(github.event.comment.body, '/delegate') ||
        contains(github.event.comment.body, '/deploy'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     steps:
       # Mint a Nuxt Harness App installation token so the `delegate` label is applied by
       # `nuxt-harness[bot]`. That makes the dispatched decompose run App-actored, which passes

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -16,7 +16,7 @@ jobs:
     if: |
       (github.event.action == 'labeled' && github.event.label.name == 'delegate') ||
       (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
     # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to

--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -28,7 +28,7 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'failure' &&
       startsWith(github.event.workflow_run.head_branch, 'claude/issue-')
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     # NOTE: permissions MUST live at the job level — GitHub job-level `permissions` fully
     # OVERRIDES a workflow-level block, so id-token: write has to be here or

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   red-team-daily:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     # Job-level permissions (see red-team.yml for why id-token MUST be here). No issues/PR
     # write — this workflow does NOT post to GitHub; disclosure is by private email only.

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -26,7 +26,7 @@ jobs:
     if: >
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
     # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -19,7 +19,7 @@ jobs:
       !github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot' &&
       contains(github.event.issue.labels.*.name, 'status:blocked')
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     permissions:
       contents: write

--- a/.github/workflows/schedule-waves.yml
+++ b/.github/workflows/schedule-waves.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     steps:
       # Mint a Nuxt Harness App installation token so the released `delegate` label is applied by
       # `nuxt-harness[bot]` → the dispatched decompose run passes the bot-actor guard via

--- a/.github/workflows/sync-changelogs.yml
+++ b/.github/workflows/sync-changelogs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: apps/docs


### PR DESCRIPTION
Closes #655. Part of epic #610 (WS3 — run the agent loop on the Mac mini).

## 👤 For humans

The nine Claude-consuming agent workflows now read their runner from a single repo variable. Set `AGENT_RUNNER=mac-mini` and the whole agent loop moves to the Mac mini self-hosted runner; unset it and everything falls back to GitHub-hosted in seconds — one variable, no per-workflow edits, no risky big-bang cutover.

Behaviour is **unchanged** while `AGENT_RUNNER` is unset (the `||` default resolves to `ubuntu-latest`), so this is safe to land before the runner exists.

## 🤖 For agents

- `runs-on: ubuntu-latest` → `runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}` in: `claude`, `decompose-on-issue`, `resume-on-comment`, `schedule-waves`, `fix-ci-on-failure`, `comment-dispatch`, `red-team`, `red-team-daily`, `sync-changelogs`.
- Deliberately **not** touched: `ci.yml` / `e2e.yml` / deploy workflows (fork-exposed or trusted-but-separate — see the security policy #656).
- ⚠️ Note for #656: `red-team.yml` is `pull_request`-triggered (fork-exposable) yet is in this issue's explicit nine. The toggle is inert until `AGENT_RUNNER` is set; once it points at `mac-mini`, the #656 policy ("require approval for fork PRs" in Actions settings) is what keeps a fork PR off the box — a settings-side guard, not code-side.

## 🧪 How to test

1. `AGENT_RUNNER` unset → workflows run on `ubuntu-latest` (provable now).
2. `AGENT_RUNNER=mac-mini` (after the runner exists, #653) → the same workflows execute on the Mac mini.
3. Unset → instant fallback to GitHub-hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJVcEeSK2sgx1fTCEjBR5P)_