### PR TITLE
fix(crouton-auth): resolve schema export to built dist, not raw .ts (#678)

### DIFF
--- a/packages/crouton-auth/package.json
+++ b/packages/crouton-auth/package.json
@@ -27,9 +27,9 @@
       "types": "./server/utils/team-auth.ts"
     },
     "./server/database/schema/auth": {
-      "types": "./server/database/schema/auth.ts",
-      "import": "./server/database/schema/auth.ts",
-      "default": "./server/database/schema/auth.ts"
+      "types": "./dist/schema/auth.d.mts",
+      "import": "./dist/schema/auth.mjs",
+      "default": "./dist/schema/auth.mjs"
     },
     "./server/utils/useServerAuth": {
       "import": "./server/utils/useServerAuth.ts",


### PR DESCRIPTION
## What

Points `@fyit/crouton-auth`'s `./server/database/schema/auth` export at the **built** `dist/schema/auth.{mjs,d.mts}` instead of the raw `.ts` source.

Closes #678.

## Why

A freshly built app (`pocs/links` — the first app built under **NuxtHub 0.10**) crashed on boot:

```
Unknown file extension ".ts" for …/packages/crouton-auth/server/database/schema/auth.ts
```

NuxtHub 0.10 builds the DB schema barrel with **`tsdown` + `skipNodeModulesBundle: true`**, which leaves `export * from "@fyit/crouton-auth/server/database/schema/auth"` **external**. At runtime that specifier resolved (via the package's `exports` map) to raw TypeScript, which Node's ESM loader can't load.

Existing apps (velo/fanfare) only *appear* fine because their `.nuxt/hub/db/schema.mjs` is a **stale 0.7-era artifact** that inlined the schema; rebuilding them reproduces the break. `dist/schema/auth.mjs` is already produced by `unbuild`, so this just retargets the export to it — the same pattern `./module` already uses.

## Risk / note

The export now resolves to `dist`, so crouton-auth must be **built before consumption**. The guarded `postinstall` (`nuxt prepare … || true`) + the package build pipeline cover this; flagging it explicitly since it's the one behavioral dependency.

## Verified locally

- `import('@fyit/crouton-auth/server/database/schema/auth')` loads via Node's native ESM (the exact externalized path) → all auth tables exported.
- `pocs/links` boots: no `.ts` error, `/api/auth/get-session` → 200, login page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
