### PR TITLE
fix(crouton-core): smooth collection viewer load with a Suspense skeleton

### DIFF
--- a/packages/crouton-core/CLAUDE.md
+++ b/packages/crouton-core/CLAUDE.md
@@ -57,6 +57,7 @@ export default defineNuxtConfig({
 | `app/composables/useCollectionImport.ts` | CSV/JSON import with column mapping, validation, and batched POST |
 | `app/composables/useDisplayConfig.ts` | Resolves display config (title/subtitle/image/badge/description) with auto-inference |
 | `app/components/Collection.vue` | Multi-layout display (table, list, grid, tree, kanban) |
+| `app/components/CollectionSkeleton.vue` | `CroutonCollectionSkeleton` — layout-aware shimmer (table/list/grid) used as the `<Suspense>` fallback in `CollectionViewer` so the viewer reveals the populated result at once instead of flashing a loader + filling in row-by-row |
 | `app/components/Form.vue` | Main CRUD form handler with nested modal support |
 | `app/components/Detail.vue` | `CroutonDetail` — Generic detail view using display config and runtime field metadata |
 | `app/components/DefaultCard.vue` | `CroutonDefaultCard` — Display-aware card (title/image/badge from display config) |

--- a/packages/crouton-core/app/components/CollectionSkeleton.vue
+++ b/packages/crouton-core/app/components/CollectionSkeleton.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+/**
+ * CroutonCollectionSkeleton
+ *
+ * Layout-aware loading placeholder for the collection viewer. Rendered as the
+ * <Suspense> fallback while the async generated List component resolves its
+ * data, so the viewer shows one calm, centered shimmer (sized to match the real
+ * layout, avoiding a jump) and then reveals the fully-populated result at once —
+ * instead of an empty table that fills in row-by-row.
+ *
+ * `layout` is a plain string (not LayoutType) so it accepts the viewer's wider
+ * set, including the 'cards' grid-size alias.
+ */
+const props = withDefaults(defineProps<{
+  layout?: string
+  rows?: number
+}>(), {
+  layout: 'table',
+  rows: 6
+})
+
+// Grid/card layouts share a card-grid skeleton; everything else falls back to rows.
+const isGrid = computed(() => props.layout === 'grid' || props.layout === 'cards')
+</script>
+
+<template>
+  <div
+    class="h-full w-full p-4"
+    role="status"
+    aria-busy="true"
+    :aria-label="'Loading'"
+  >
+    <!-- Toolbar (search + actions) to match the real table header height -->
+    <div class="flex items-center gap-2 mb-4">
+      <USkeleton class="h-9 flex-1 min-w-0 rounded-md" />
+      <USkeleton class="h-9 w-9 rounded-md shrink-0" />
+    </div>
+
+    <!-- Grid / cards layout -->
+    <div
+      v-if="isGrid"
+      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+    >
+      <div
+        v-for="i in rows"
+        :key="i"
+        class="flex flex-col gap-3 p-4 border border-default rounded-lg"
+      >
+        <USkeleton class="h-32 w-full rounded-md" />
+        <USkeleton class="h-5 w-3/4 rounded" />
+        <USkeleton class="h-4 w-1/2 rounded" />
+      </div>
+    </div>
+
+    <!-- Table / list layout -->
+    <div
+      v-else
+      class="flex flex-col gap-1"
+    >
+      <!-- Header row -->
+      <div class="flex items-center gap-4 px-2 py-3 border-b border-default">
+        <USkeleton class="h-4 w-4 rounded shrink-0" />
+        <USkeleton class="h-4 w-1/4 rounded" />
+        <USkeleton class="h-4 w-1/3 rounded" />
+        <USkeleton class="h-4 w-1/5 rounded ml-auto" />
+      </div>
+
+      <!-- Body rows -->
+      <div
+        v-for="i in rows"
+        :key="i"
+        class="flex items-center gap-4 px-2 py-4 border-b border-default/60"
+      >
+        <USkeleton class="h-4 w-4 rounded shrink-0" />
+        <USkeleton class="h-4 w-1/4 rounded" />
+        <USkeleton class="h-4 w-1/3 rounded" />
+        <USkeleton class="h-7 w-16 rounded-md ml-auto" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/crouton-core/app/components/CollectionViewer.vue
+++ b/packages/crouton-core/app/components/CollectionViewer.vue
@@ -40,12 +40,18 @@
           class="h-full"
         />
 
-        <component
-          :is="componentName"
-          v-else-if="componentName"
-          :layout="currentLayout"
-          class="h-full"
-        />
+        <!-- Async generated List component — boundaried by Suspense so the
+             skeleton holds until its data resolves, then reveals at once -->
+        <Suspense v-else-if="componentName">
+          <component
+            :is="componentName"
+            :layout="currentLayout"
+            class="h-full"
+          />
+          <template #fallback>
+            <CroutonCollectionSkeleton :layout="currentLayout" />
+          </template>
+        </Suspense>
 
         <div
           v-else

--- a/packages/crouton-core/app/pages/admin/[team]/crouton/[collection].vue
+++ b/packages/crouton-core/app/pages/admin/[team]/crouton/[collection].vue
@@ -13,30 +13,24 @@ definePageMeta({
 })
 
 const route = useRoute()
-const { t } = useT()
 const { getConfig } = useCollections()
 const { collectionWithCapital } = useFormatCollections()
 
 const collectionName = computed(() => route.params.collection as string)
 
-const loading = ref(true)
-const error = ref<string | null>(null)
-
 // Get collection config for display
 const collectionConfig = computed(() => getConfig(collectionName.value))
+
+// Verify collection exists in registry (reactive — no loading flash; the
+// viewer's own Suspense skeleton covers the data-loading phase)
+const error = computed(() =>
+  collectionConfig.value ? null : `Collection not found: ${collectionName.value}`
+)
 
 // Format collection name for display
 const collectionTitle = computed(() => {
   const config = collectionConfig.value
   return config?.adminNav?.label || config?.displayName || collectionWithCapital(collectionName.value)
-})
-
-// Verify collection exists in registry
-onMounted(() => {
-  if (!collectionConfig.value) {
-    error.value = `Collection not found: ${collectionName.value}`
-  }
-  loading.value = false
 })
 </script>
 
@@ -55,18 +49,7 @@ onMounted(() => {
 
     <!-- Use default slot instead of body for full-height content without auto-scroll -->
     <div
-      v-if="loading"
-      class="italic opacity-50 flex items-center gap-2 p-4"
-    >
-      <UIcon
-        name="i-lucide-loader-circle"
-        class="animate-spin"
-      />
-      {{ t('common.loading') }}
-    </div>
-
-    <div
-      v-else-if="error"
+      v-if="error"
       class="text-red-600 p-4"
     >
       {{ error }}


### PR DESCRIPTION
Closes #687

## 👤 What & why

Opening a collection viewer no longer flashes an ugly "Loading" in the **top-left corner** and then fills the table in **row-by-row**. Instead you get one calm, centered shimmer that matches the layout, and the **fully-populated table appears at once** when the data is ready.

## The bug — two stacked, mismatched loading phases

1. **Cosmetic page-level loader** — `pages/admin/[team]/crouton/[collection].vue` set `loading = ref(true)` and flipped it off synchronously in `onMounted` after a *local config-registry lookup*. It was never tied to a data fetch — it just flashed an italic, 50%-opacity, left-aligned (`p-4`) spinner for one render tick.
2. **Real async load** — the generated `List.vue` does a top-level `await useCollectionQuery(...)` (a Suspense trigger) with **no explicit `<Suspense>` boundary + fallback**, so the empty table mounted and populated reactively.

There was no table/collection skeleton (only `Loading.vue`, which is a *form* skeleton).

## The fix

- **New `CroutonCollectionSkeleton`** (`app/components/CollectionSkeleton.vue`) — layout-aware (table/list/grid) `USkeleton` shimmer, full-height, sized to avoid layout jump.
- **`CollectionViewer.vue`** — wrap the async generated `<component :is>` List in an explicit `<Suspense>` with the skeleton as `#fallback`. The boundary holds until `await useCollectionQuery` resolves, then reveals at once. Covers **every collection/layout** — no generator change, no regeneration.
- **`[collection].vue`** — drop the cosmetic `loading` ref + flash; the "not found" guard is now a reactive `computed`. Removed the now-unused `t`.

Switching layouts and paginating after load don't re-trigger the skeleton (the component instance is reused, so setup doesn't re-suspend).

## Verify

- [x] `pnpm typecheck` green across all three apps (velo, triage, fanfare) — no ripple from the `crouton-core` change.
- [ ] Load a collection viewer (fixture `minimal` or a staging app): one centered skeleton, no top-left flash, table reveals fully populated.
- [ ] Switch layouts / paginate after load → no skeleton re-flash.

Scope: `packages/crouton-core` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011MeLeB1AoNNLbiRZiXEDy4)_