### PR TITLE
fix(crouton-i18n): graceful-degrade translations read when the table is absent (#680)

### DIFF
--- a/packages/crouton-i18n/server/utils/translationsQueries.ts
+++ b/packages/crouton-i18n/server/utils/translationsQueries.ts
@@ -45,37 +45,52 @@ export async function getTeamBySlugForTranslations(slugOrId: string) {
 export async function getSystemTranslationsWithTeamOverrides(teamId: string, locale?: string) {
   const db = useDB()
 
-  // First, get all overrideable system translations
-  const systemTranslations = await db
-    .select({
-      keyPath: translationsUi.keyPath,
-      category: translationsUi.category,
-      namespace: translationsUi.namespace,
-      systemValues: translationsUi.values,
-      systemId: translationsUi.id,
-      isOverrideable: translationsUi.isOverrideable
-    })
-    .from(translationsUi)
-    .where(
-      and(
-        isNull(translationsUi.teamId), // Only system translations
-        eq(translationsUi.isOverrideable, true) // Only overrideable ones
+  // Graceful degradation (#680): `translations_ui` is owned by crouton-i18n and only
+  // holds team OVERRIDES — the UI defaults come from the bundled locale JSON via useT().
+  // A fresh app that never created the table (e.g. one that gets i18n transitively via
+  // crouton-core but has no override storage yet) must NOT hard-500 here; return empty
+  // so the caller falls back to the file-based defaults.
+  let systemTranslations: any[] = []
+  let teamOverrides: any[] = []
+  try {
+    // First, get all overrideable system translations
+    systemTranslations = await db
+      .select({
+        keyPath: translationsUi.keyPath,
+        category: translationsUi.category,
+        namespace: translationsUi.namespace,
+        systemValues: translationsUi.values,
+        systemId: translationsUi.id,
+        isOverrideable: translationsUi.isOverrideable
+      })
+      .from(translationsUi)
+      .where(
+        and(
+          isNull(translationsUi.teamId), // Only system translations
+          eq(translationsUi.isOverrideable, true) // Only overrideable ones
+        )
       )
-    )
-    .orderBy(translationsUi.keyPath)
+      .orderBy(translationsUi.keyPath)
 
-  // Then, get all team overrides for this team
-  const teamOverrides = await db
-    .select({
-      keyPath: translationsUi.keyPath,
-      namespace: translationsUi.namespace,
-      teamValues: translationsUi.values,
-      overrideId: translationsUi.id,
-      overrideDescription: translationsUi.description,
-      overrideUpdatedAt: translationsUi.updatedAt
-    })
-    .from(translationsUi)
-    .where(eq(translationsUi.teamId, teamId))
+    // Then, get all team overrides for this team
+    teamOverrides = await db
+      .select({
+        keyPath: translationsUi.keyPath,
+        namespace: translationsUi.namespace,
+        teamValues: translationsUi.values,
+        overrideId: translationsUi.id,
+        overrideDescription: translationsUi.description,
+        overrideUpdatedAt: translationsUi.updatedAt
+      })
+      .from(translationsUi)
+      .where(eq(translationsUi.teamId, teamId))
+  } catch (error: any) {
+    // Missing table → no overrides; defaults resolve from the bundled locale files.
+    if (/no such table|translations_ui/i.test(String(error?.message ?? error))) {
+      return []
+    }
+    throw error
+  }
 
   // Create a lookup map for team overrides
   const overrideMap = new Map()

--- a/packages/crouton-i18n/server/utils/translationsQueries.ts
+++ b/packages/crouton-i18n/server/utils/translationsQueries.ts
@@ -49,12 +49,11 @@ export async function getSystemTranslationsWithTeamOverrides(teamId: string, loc
   // holds team OVERRIDES — the UI defaults come from the bundled locale JSON via useT().
   // A fresh app that never created the table (e.g. one that gets i18n transitively via
   // crouton-core but has no override storage yet) must NOT hard-500 here; return empty
-  // so the caller falls back to the file-based defaults.
-  let systemTranslations: any[] = []
-  let teamOverrides: any[] = []
+  // so the caller falls back to the file-based defaults. The whole body is wrapped so
+  // the queries stay `const` (preserving their drizzle-inferred row types for callers).
   try {
     // First, get all overrideable system translations
-    systemTranslations = await db
+    const systemTranslations = await db
       .select({
         keyPath: translationsUi.keyPath,
         category: translationsUi.category,
@@ -73,7 +72,7 @@ export async function getSystemTranslationsWithTeamOverrides(teamId: string, loc
       .orderBy(translationsUi.keyPath)
 
     // Then, get all team overrides for this team
-    teamOverrides = await db
+    const teamOverrides = await db
       .select({
         keyPath: translationsUi.keyPath,
         namespace: translationsUi.namespace,
@@ -84,6 +83,42 @@ export async function getSystemTranslationsWithTeamOverrides(teamId: string, loc
       })
       .from(translationsUi)
       .where(eq(translationsUi.teamId, teamId))
+
+    // Create a lookup map for team overrides
+    const overrideMap = new Map()
+    for (const override of teamOverrides) {
+      const key = `${override.keyPath}:${override.namespace}`
+      overrideMap.set(key, override)
+    }
+
+    // Combine system translations with team overrides
+    const enhancedTranslations = systemTranslations.map((systemTranslation: any) => {
+      const key = `${systemTranslation.keyPath}:${systemTranslation.namespace}`
+      const override = overrideMap.get(key)
+
+      return {
+        keyPath: systemTranslation.keyPath,
+        category: systemTranslation.category,
+        namespace: systemTranslation.namespace,
+        systemValues: systemTranslation.systemValues,
+        systemId: systemTranslation.systemId,
+        isOverrideable: systemTranslation.isOverrideable,
+        teamValues: override?.teamValues || null,
+        hasOverride: override !== undefined,
+        overrideId: override?.overrideId || null,
+        overrideDescription: override?.overrideDescription || null,
+        overrideUpdatedAt: override?.overrideUpdatedAt || null
+      }
+    })
+
+    // Filter by locale if provided
+    if (locale) {
+      return enhancedTranslations.filter((t: any) =>
+        t.systemValues && typeof t.systemValues === 'object' && t.systemValues !== null && locale in t.systemValues
+      )
+    }
+
+    return enhancedTranslations
   } catch (error: any) {
     // Missing table → no overrides; defaults resolve from the bundled locale files.
     if (/no such table|translations_ui/i.test(String(error?.message ?? error))) {
@@ -91,42 +126,6 @@ export async function getSystemTranslationsWithTeamOverrides(teamId: string, loc
     }
     throw error
   }
-
-  // Create a lookup map for team overrides
-  const overrideMap = new Map()
-  for (const override of teamOverrides) {
-    const key = `${override.keyPath}:${override.namespace}`
-    overrideMap.set(key, override)
-  }
-
-  // Combine system translations with team overrides
-  const enhancedTranslations = systemTranslations.map((systemTranslation: any) => {
-    const key = `${systemTranslation.keyPath}:${systemTranslation.namespace}`
-    const override = overrideMap.get(key)
-
-    return {
-      keyPath: systemTranslation.keyPath,
-      category: systemTranslation.category,
-      namespace: systemTranslation.namespace,
-      systemValues: systemTranslation.systemValues,
-      systemId: systemTranslation.systemId,
-      isOverrideable: systemTranslation.isOverrideable,
-      teamValues: override?.teamValues || null,
-      hasOverride: override !== undefined,
-      overrideId: override?.overrideId || null,
-      overrideDescription: override?.overrideDescription || null,
-      overrideUpdatedAt: override?.overrideUpdatedAt || null
-    }
-  })
-
-  // Filter by locale if provided
-  if (locale) {
-    return enhancedTranslations.filter((t: any) =>
-      t.systemValues && typeof t.systemValues === 'object' && t.systemValues !== null && locale in t.systemValues
-    )
-  }
-
-  return enhancedTranslations
 }
 
 /**


### PR DESCRIPTION
Closes #680. Replaces #685 (closed — see below).

## 👤 For humans

A fresh app that gets i18n transitively (via `crouton-core`) but never created the `translations_ui` table 500'd on every admin load (`no such table: translations_ui`). But UI **defaults come from the bundled locale files** — the table only holds **team overrides** — so a missing table should mean *"no overrides, use file defaults,"* not a crash. This makes the read degrade gracefully.

## 🤖 For agents

- `getSystemTranslationsWithTeamOverrides`: wrap the two `translations_ui` reads in `try/catch`; a `no such table` error returns `[]` → `useT()` falls back to the bundled locale JSON. **Other DB errors still throw** (no masking real failures).
- One-file change, `packages/crouton-i18n/server/utils/translationsQueries.ts`.

## Why this replaces #685 (package-shipped migration)

#685 tried to have `crouton-i18n` ship a `translations_ui` migration. CI proved that **structurally can't work**: NuxtHub applies every package/layer's `server/db/migrations` **before** the app's own dir (directory order, *not* filename order — confirmed: even renamed `9999_…` it still applied first). So the package migration **always** ran before each existing app's own non-idempotent `translations_ui` migration → `table already exists` on every app's node-server build and 4/5 E2E fixtures. No rename/ordering trick fixes it. Graceful degradation fixes the original symptom with **no migration and no collision**.

## 🧪 How to test

- Fresh app with no `translations_ui` (e.g. `pocs/links`): admin loads, `…/translations-ui/with-system` → 200 (empty), defaults render from files — no 500.
- Existing apps (have the table): unchanged behaviour.
- node-server build + E2E fixtures green (no package migration to collide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJVcEeSK2sgx1fTCEjBR5P)_