### PR TITLE
chore(root): wire epic-digest email via Resend; share RESEND_FROM (#551)

### DIFF
--- a/.claude/skills/epic-digest/SKILL.md
+++ b/.claude/skills/epic-digest/SKILL.md
@@ -165,6 +165,10 @@ GH_TOKEN=… DIGEST_BODY_FILE=epic-digest-<date>.md bash .claude/skills/epic-dig
 - **`post-comment.sh`** posts the Markdown as a comment on the single standing
   **"📊 Daily epic digest"** issue (creating it if missing) via `gh` + the built-in
   `GITHUB_TOKEN`. No email provider, no secret to provision (#408).
+- **Optional email rail (#551):** the scheduled workflow also emails the rendered
+  HTML (+ text mirror) via Resend when `secrets.RESEND_API_KEY`, `vars.RESEND_FROM`
+  (shared with the red-team daily) and `vars.DIGEST_REPORT_EMAIL` are set. Unset ⇒ the
+  step warns and skips, so the standing-issue comment stays the baseline delivery.
 - The render is the same `render.mjs`, so the hand-run and the cron stay in lockstep.
 
 ## Step 5 — Hand off

--- a/.github/workflows/epic-digest.yml
+++ b/.github/workflows/epic-digest.yml
@@ -48,6 +48,45 @@ jobs:
           DIGEST_BODY_FILE: digest.md
         run: bash .claude/skills/epic-digest/post-comment.sh
 
+      # Optional second rail (#551): also DM the digest by email via Resend. Render-only
+      # (no LLM); reuses the same render.mjs output as email-safe HTML + a plain-text mirror.
+      # Shares the sender var (RESEND_FROM) with red-team-daily.yml; recipient is its own
+      # (DIGEST_REPORT_EMAIL). When the secret/vars are unset the step warns and skips —
+      # the job stays green so the standing-issue comment remains the baseline delivery.
+      - name: Render HTML for email
+        run: node .claude/skills/epic-digest/render.mjs digest.data.json --out-dir .
+
+      - name: Email the digest (Resend)
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          EMAIL_FROM: ${{ vars.RESEND_FROM }}
+          EMAIL_TO: ${{ vars.DIGEST_REPORT_EMAIL }}
+        run: |
+          HTML=$(ls -t epic-digest-*.html 2>/dev/null | head -1 || true)
+          TXT=$(ls -t epic-digest-*.txt 2>/dev/null | head -1 || true)
+          if [ -z "$HTML" ] || [ -z "$TXT" ]; then
+            echo "::warning::No rendered digest HTML/text found — nothing to email."
+            exit 0
+          fi
+          if [ -z "$RESEND_API_KEY" ] || [ -z "$EMAIL_FROM" ] || [ -z "$EMAIL_TO" ]; then
+            echo "::warning::RESEND_API_KEY / RESEND_FROM / DIGEST_REPORT_EMAIL not set — skipping email. The digest was still posted to the standing issue."
+            exit 0
+          fi
+          SUBJECT="📊 Daily epic digest — $(date -u +%F)"
+          echo "Emailing $HTML → $EMAIL_TO"
+          # Build the JSON payload with jq so the HTML/text bodies are safely escaped.
+          jq -n \
+            --arg from "$EMAIL_FROM" \
+            --arg to "$EMAIL_TO" \
+            --arg subject "$SUBJECT" \
+            --rawfile html "$HTML" \
+            --rawfile text "$TXT" \
+            '{from:$from, to:[$to], subject:$subject, html:$html, text:$text}' \
+          | curl -sS -X POST https://api.resend.com/emails \
+              -H "Authorization: Bearer $RESEND_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d @- -w '\nHTTP %{http_code}\n'
+
       - name: Upload digest artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -56,4 +95,6 @@ jobs:
           path: |
             digest.data.json
             epic-digest-*.md
+            epic-digest-*.html
+            epic-digest-*.txt
           if-no-files-found: ignore

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -11,7 +11,8 @@ name: Red-Team (daily deep sweep)
 # Required repo config:
 #   secrets.RESEND_API_KEY        — Resend API key (https://resend.com)
 #   secrets.ANTHROPIC_API_KEY     — already present (shared with the other claude workflows)
-#   vars.RED_TEAM_EMAIL_FROM      — verified Resend sender, e.g. "red-team@your-domain"
+#   vars.RESEND_FROM              — verified Resend sender, e.g. "reports@friendlyinter.net"
+#                                   (shared with the epic-digest email; see #551)
 #   vars.RED_TEAM_REPORT_EMAIL    — recipient (your inbox)
 # If RESEND_API_KEY / the vars are unset the email step warns and skips (the job stays green).
 
@@ -75,7 +76,7 @@ jobs:
         if: always()
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          EMAIL_FROM: ${{ vars.RED_TEAM_EMAIL_FROM }}
+          EMAIL_FROM: ${{ vars.RESEND_FROM }}
           EMAIL_TO: ${{ vars.RED_TEAM_REPORT_EMAIL }}
         run: |
           REPORT=$(ls -t writeups/reports/red-team-repo-*.md 2>/dev/null | head -1 || true)
@@ -84,7 +85,7 @@ jobs:
             exit 0
           fi
           if [ -z "$RESEND_API_KEY" ] || [ -z "$EMAIL_FROM" ] || [ -z "$EMAIL_TO" ]; then
-            echo "::warning::RESEND_API_KEY / RED_TEAM_EMAIL_FROM / RED_TEAM_REPORT_EMAIL not set — skipping email. Report at $REPORT (in this run's workspace only)."
+            echo "::warning::RESEND_API_KEY / RESEND_FROM / RED_TEAM_REPORT_EMAIL not set — skipping email. Report at $REPORT (in this run's workspace only)."
             exit 0
           fi
           SUBJECT="🔴 Red-team daily report — $(date -u +%F)"


### PR DESCRIPTION
Closes #551.

## 👤 For humans

The morning **epic digest** can now also land in your inbox, not just on the standing GitHub issue. Both daily emails (digest + red-team) share one verified Resend sender, so there's a single thing to keep configured. Until the Resend key/vars are set, both jobs stay green and just skip the email — verified live: the digest emailed successfully end-to-end (subject, sender, HTML render all confirmed).

The Resend domain (`messages.friendlyinter.net`) was already verified, so this was mostly the small agent wiring on top of the human secret/var setup.

## 🤖 For agents

- **`epic-digest.yml`** — after posting to the standing issue, render HTML + text (`render.mjs` default `--format all`) and a guarded **"Email the digest (Resend)"** step (jq + curl, mirrors `red-team-daily.yml`). Reads `secrets.RESEND_API_KEY`, `vars.RESEND_FROM`, `vars.DIGEST_REPORT_EMAIL`; warns + `exit 0` when unset so the standing-issue comment stays the baseline delivery. Artifact upload now also includes `.html`/`.txt`.
- **`red-team-daily.yml`** — sender var renamed `RED_TEAM_EMAIL_FROM` → shared **`RESEND_FROM`** (recipient stays `RED_TEAM_REPORT_EMAIL`); header doc + skip-warning text updated to match.
- **`.claude/skills/epic-digest/SKILL.md`** — documented the optional email rail + required config.

### Required repo config (already provisioned by @pmcp)

| Kind | Name | Used by |
|---|---|---|
| Secret | `RESEND_API_KEY` | both |
| Variable | `RESEND_FROM` (e.g. `reports@messages.friendlyinter.net`) | both |
| Variable | `RED_TEAM_REPORT_EMAIL` | red-team |
| Variable | `DIGEST_REPORT_EMAIL` | epic-digest |

## 🧪 How to test

- **What changed**: the scheduled epic-digest now also emails the rendered digest via Resend.
- **Steps**: Actions → epic-digest → Run workflow → the **"Email the digest (Resend)"** step prints `HTTP 200` and the digest arrives by email (still also posted to the standing issue #410). Unset any of the secret/vars → the step warns and skips, job stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK1Sobib8baxv5Z37Ru1BL)_