### PR TITLE
chore(root): announce the pre-installed headless browser; TodoWrite optional

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -20,6 +20,26 @@ cat <<'REMINDER'
   failing build: stop and create it.
 REMINDER
 
+# Headless-browser announcement — surfaces in EVERY session so no agent has to
+# rediscover it (the recurring trap: the Playwright browser DOWNLOAD is
+# egress-blocked, so `npx playwright install` fails and a session wrongly
+# concludes "no browser" — when a chromium is ALREADY installed under
+# /opt/pw-browsers). You CAN screenshot/preview UI locally. Use
+# `node scripts/app-shots.mjs <url> <path[:name]>` (it auto-resolves the build).
+_chromium=""
+for _c in /opt/pw-browsers/chromium_headless_shell-*/chrome-linux/headless_shell \
+          /opt/pw-browsers/chromium-*/chrome-linux/chrome; do
+  [ -x "$_c" ] && _chromium="$_c"
+done
+if [ -n "$_chromium" ]; then
+  cat <<BROWSER
+[session-start] 📸 HEADLESS BROWSER AVAILABLE — you can render/screenshot UI locally.
+  chromium: $_chromium  (the download host is egress-blocked; use this pre-installed one)
+  Easiest: node scripts/app-shots.mjs <baseUrl> <path[:name]>  → screenshots/<name>.png
+  Do NOT conclude "no browser" from a failed \`playwright install\` — verify, don't assume.
+BROWSER
+fi
+
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,26 @@ Whenever you need to perform multiple independent operations, invoke all relevan
 When improving code, use multiple focused passes:
 1. Functionality → Performance → Quality → Testing → Documentation
 
-### 4. Task Management with TodoWrite (MANDATORY)
+### 4. Task Management with TodoWrite (when available)
 
-**CRITICAL**: Use the TodoWrite tool proactively for ALL complex tasks.
+**Use the TodoWrite tool proactively for complex tasks — *when the harness exposes it*.**
+
+> ⚠️ **TodoWrite is not available on every harness** (notably Claude Code on the
+> web, where the tool errors with *"not enabled in this context"*). It's a
+> **capability, not a guarantee** — don't assume it, and don't waste turns
+> retrying it after it errors. When it's absent, **fall back** to:
+> 1. a short inline checklist in your reply (the breakdown lives in chat), and
+> 2. the **GitHub issue's own acceptance-criteria checkboxes** as the durable,
+>    coarse tracker — tick them as you satisfy each criterion.
+>
+> Do **not** push ephemeral per-step micro-todos onto the GitHub issue (comment
+> spam / body churn) — the issue tracks the *unit of work* (epic + sub-issues +
+> acceptance criteria), the inline checklist tracks *this session's steps*.
 
 **When to use:** Any task with 3+ steps, multi-file changes, debugging, feature implementations.
 **When NOT to use:** Single straightforward tasks, trivial changes, purely conversational queries.
 
-**Critical Rules:**
+**Critical Rules (when using TodoWrite):**
 - Exactly ONE task must be `in_progress` at any time
 - Mark tasks `completed` IMMEDIATELY after finishing
 - ONLY mark complete when FULLY accomplished — never if tests fail or work is partial
@@ -373,6 +385,28 @@ import { useDrizzle } from '#server/utils/drizzle'
 
 When delegating: template scout first → parallel tasks → clear boundaries → smell check after.
 Agent definitions live in `.claude/agents/*.md` (the recursive `task-orchestrator` / `task-decomposer` / `task-worker` pipeline). When an agent defines a custom persona, include it in the Task prompt when invoking.
+
+## You HAVE a headless browser (verify capabilities, don't assume)
+
+**This environment has a working headless browser** — Playwright + a chromium
+pre-installed under `/opt/pw-browsers/`. You **can** render pages, screenshot UI,
+and drive a live preview locally. The recurring trap: the Playwright browser
+**download host is egress-blocked**, so `npx playwright install` fails — and a
+session wrongly concludes "no Chromium / no browser" and plans around a
+limitation that **doesn't exist**. Don't. Use the already-installed browser:
+
+```bash
+# Easiest — screenshot a running app (auto-resolves the chromium build):
+node scripts/app-shots.mjs <baseUrl> <path[:name]> [more...]   # → screenshots/<name>.png
+# In Playwright code, point launch() at the installed binary (build number varies):
+#   chromium.launch({ executablePath: <…/opt/pw-browsers/chromium-*/chrome-linux/chrome> })
+```
+
+The `SessionStart` hook announces the browser + its path every session. **General
+rule:** a prior session's (or a task brief's) claimed limitation is a
+*hypothesis* — verify it with a 5-second check before designing around it. The
+same applies to any "X isn't available here" (TodoWrite, a CLI, a binary): probe,
+don't trust a stale assertion.
 
 ## UI Sign-Off (deploy a live preview before you build) — epic #307
 

--- a/scripts/app-shots.mjs
+++ b/scripts/app-shots.mjs
@@ -15,8 +15,33 @@
 // Output: screenshots/<name>.png (name defaults to a slug of the path).
 // All screenshots go in screenshots/ (repo HARD GATE) unless --out overrides.
 
-import { existsSync, mkdirSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
+
+// Resolve an already-installed chromium WITHOUT pinning a build number. The
+// browsers live at /opt/pw-browsers/chromium-<build>/… and the build bumps with
+// Playwright; a hardcoded path silently breaks after a bump and looks like "no
+// browser" (the trap that's fooled past sessions — there IS always a browser).
+// So we glob the newest matching build instead. Override with
+// PLAYWRIGHT_CHROMIUM_PATH.
+export function findChromium() {
+  const envPath = process.env.PLAYWRIGHT_CHROMIUM_PATH
+  if (envPath && existsSync(envPath)) return envPath
+  const root = '/opt/pw-browsers'
+  if (!existsSync(root)) return undefined
+  const dirs = readdirSync(root)
+  const pick = (prefix, rel) =>
+    dirs
+      .filter(d => d.startsWith(prefix))
+      .map(d => `${root}/${d}/${rel}`)
+      .filter(existsSync)
+      .sort() // build numbers sort lexically; newest wins
+      .pop()
+  return (
+    pick('chromium-', 'chrome-linux/chrome')
+    || pick('chromium_headless_shell-', 'chrome-linux/headless_shell')
+  )
+}
 
 const argv = process.argv.slice(2)
 let outDir = 'screenshots'


### PR DESCRIPTION
Closes #719.

Stops two recurring "the environment doesn't match what CLAUDE.md assumes" traps that have bitten multiple web sessions.

## The problem
1. **"No browser."** Playwright's browser *download* host is egress-blocked, so `npx playwright install` fails — but a chromium is **already installed** at `/opt/pw-browsers/chromium-<build>/…`. Sessions either burn turns rediscovering it or wrongly conclude "no Chromium" and design around a limitation that doesn't exist (one stale "can't screenshot" note even leaked into a later session's task brief as fact).
2. **TodoWrite errors.** `CLAUDE.md` mandated TodoWrite as a HARD requirement, but it isn't exposed on the web harness, so agents call it and get "not enabled in this context" every session.

## The fix
- **`.claude/hooks/session-start.sh`** — detect + announce a chromium under `/opt/pw-browsers` every session (`📸 HEADLESS BROWSER AVAILABLE …`), prefers full chrome over headless_shell, and states plainly that the *download* is blocked but the installed browser works.
- **`scripts/app-shots.mjs`** — `findChromium()` now **globs** `/opt/pw-browsers/chromium-*/chrome-linux/chrome` (newest build wins) instead of the hardcoded `chromium-1194` that silently broke after a Playwright build bump — the exact failure that *looks* like "no browser".
- **`CLAUDE.md`** — new **"You HAVE a headless browser (verify capabilities, don't assume)"** section (use `scripts/app-shots.mjs`; *a claimed limitation is a hypothesis — verify with a 5-second check*), and §4 TodoWrite reframed from MANDATORY → **"when available"**, with a fallback (inline checklist + the issue's acceptance-criteria checkboxes — no per-step micro-todo spam on the issue).

## Test
1. `bash .claude/hooks/session-start.sh` → prints the `📸 HEADLESS BROWSER AVAILABLE` line with a real path. ✅ (verified locally)
2. `node scripts/app-shots.mjs <url> <path>` → writes `screenshots/<name>.png` with no `playwright install`.

Surfaced while working #706 (Sprint 3 of #703), whose brief claimed the container couldn't screenshot — it can; that's how this PR's own UI sign-off will be done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T61rKSFs9mMiEp4U5s5Deg)_