### PR TITLE
chore(root): add Nuxt UI MCP server to project mcpServers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,9 @@
     },
     "thinkgraph": {
       "url": "http://localhost:3004/mcp"
+    },
+    "nuxt-ui": {
+      "url": "https://ui.nuxt.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## 👤 For humans

Wires the **Nuxt UI remote MCP server** into the project config so the AI assistant can pull up-to-date Nuxt UI v4 component docs, examples, and source while building UI.

## 🤖 For agents

- `.claude/settings.json`: add `mcpServers.nuxt-ui` → `https://ui.nuxt.com/mcp` (streamable-HTTP remote, same url-field style as the existing `thinkgraph` entry).

## ⚠️ Heads up — won't connect from web sessions yet

This web harness's network policy **blocks egress to `ui.nuxt.com`** (verified: proxy `connect_rejected` 403, `curl` → `HTTP 000`). The config is correct and will work in envs that allow the egress (e.g. local Claude Code), but using it from web sessions needs a network-policy change — tracked separately in #737 (a human action item, done in the web-environment config, not in this repo).

This PR does **not** close #737; merging it only lands the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKYxNZDK3J4DYMScviotzD)_