### PR TITLE
feat(root): run axe-core a11y assertions in the e2e harness (#728)

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -16,6 +16,7 @@ e2e/                         # the harness (Playwright) — NOT a workspace pack
   surface.smoke.spec.ts      # generic, manifest-driven package-surface checks (optional)
   i18n.smoke.spec.ts         # generic, manifest-driven locale-switch check (optional)
   maps.smoke.spec.ts         # generic, manifest-driven maps mount + live geocode check (optional)
+  a11y.smoke.spec.ts         # generic, manifest-driven axe-core accessibility scan (per surface)
   .auth/                     # generated storageState + team slug (gitignored)
 
 fixtures/                    # the apps under test — real crouton apps, one per config
@@ -169,7 +170,8 @@ When you add a fixture, set its `packages` (step 3) **and** add it to `ALL` in t
       "heading": "Main Items",      // visible list heading to assert
       "create": { "name": "e2e item" },  // text field label/name -> value; omit to skip CRUD
       "update": { "name": "renamed" },   // optional edit values; default = first field + " edited"
-      "requiredField": "name"            // optional: clear this field to assert validation blocks submit; omit to skip
+      "requiredField": "name",           // optional: clear this field to assert validation blocks submit; omit to skip
+      "a11y": false                      // optional: opt this list page OUT of the axe-core scan (quarantine; default = scan)
     }
   ],
   // Optional: package-specific UI a generic items CRUD doesn't reach. Omit when a
@@ -181,8 +183,13 @@ When you add a fixture, set its `packages` (step 3) **and** add it to `ALL` in t
       "path": "/admin/{team}/workspace",          // route; {team} -> active team slug
       "expect": { "visible": "[id$='-panel-pages-sidebar']" }  // CSS selector that must be visible
       // or: "expect": { "heading": "Workspace" } // a role=heading name (case-insensitive)
+      // add "a11y": false inside "expect" to opt this surface OUT of the axe-core scan
     }
   ],
+  // Optional: opt the WHOLE fixture out of the axe-core a11y scan (a11y.smoke.spec.ts).
+  // Prefer the per-collection / per-surface "a11y": false over this blanket switch.
+  // Omit (default) to scan. See "Accessibility scan (axe-core)" below.
+  "a11y": false,
   // Optional: a locale-switch check (crouton-i18n). A `surface` can only assert a
   // static element renders; this one *interacts* — flips locale via the
   // package-owned LanguageSwitcher and asserts a known UI string changes
@@ -249,6 +256,40 @@ Locally, `pnpm test:e2e` writes the same HTML report to `playwright-report/`
 (`npx playwright show-report` to open). Out of scope for now: `toHaveScreenshot()`
 pixel-diff baselines (flake-prone, separate follow-up) and screenshotting the live
 staging deploys.
+
+## Accessibility scan (axe-core — epic #726 WS2)
+
+`a11y.smoke.spec.ts` runs **`@axe-core/playwright`** against each rendered surface —
+the runtime half of the a11y story (the static half is the warn-first eslint-a11y
+rules, #727). It's manifest-driven like the other specs: for every `collection`
+(its list page) and every declared `surface`, it waits for the page to render, then
+runs axe on the **live DOM** and **fails on any critical/serious violation**.
+
+- **Why runtime, not just lint:** axe scans the *actually-rendered* page (generated
+  templates and computed ARIA included), so it catches what static lint can't —
+  computed roles, focus order, names that only exist after hydration.
+- **Lenient by design (start):** only `critical`/`serious` impacts go red
+  (`A11Y_BLOCKING_IMPACTS` in `helpers.ts`). `moderate`/`minor` are attached as
+  `a11y-advisory` annotations (visible in the HTML report / trace) and `console.log`ged,
+  **not** failed — so the gate landed without walling existing fixtures red. Tighten by
+  adding `moderate` to that set once the backlog is clear.
+- **Theme-owned rules are excluded:** `color-contrast` is **disabled**
+  (`A11Y_EXCLUDED_RULES`) — it's determined by the active theme's colour tokens
+  (Nuxt UI 4 / crouton-themes), identical across every template, so gating each
+  fixture on it would re-fail the same theme-level finding on every PR. Contrast is
+  tracked as a theme/Unlighthouse concern (#731), not per-template. Every
+  **structural** rule a template controls (names, labels, roles, `image-alt`,
+  keyboard) stays a hard fail. The scan is scoped to WCAG 2.0/2.1 A+AA tags so
+  best-practice noise (e.g. `region`) doesn't gate either.
+- **Opt-out** (to quarantine a known-bad surface while a fix is tracked — leave a
+  manifest note pointing at the issue):
+  - whole fixture → `"a11y": false` at the manifest root
+  - one collection → `"a11y": false` on the collection entry
+  - one surface → `"expect": { "a11y": false }` on the surface entry
+- **No new fixtures or CI matrix change needed:** the spec is generic and runs under
+  the existing `chromium` project (any `*.smoke.spec.ts`), so it covers every fixture
+  the matrix already selects; `@axe-core/playwright` is a root devDependency picked up
+  by CI's `pnpm install`. Findings show up in the same Playwright HTML report / trace.
 
 ## Gotchas
 - **Module format:** repo root is CommonJS, and Playwright 1.57 transpiles

--- a/e2e/a11y.smoke.spec.ts
+++ b/e2e/a11y.smoke.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Generic accessibility smoke — runs axe-core against each rendered surface.
+ *
+ * The runtime a11y check (epic #726 WS2). Fixture-agnostic, same contract as the
+ * other manifest-driven specs: for every collection list page and every declared
+ * `surface`, it waits for the page to render, then runs axe-core on the live DOM
+ * and FAILS on any critical/serious violation. Moderate/minor are recorded as
+ * advisory annotations (visible in the Playwright report/trace), not failures —
+ * we start lenient so the gate lands without walling existing generated templates
+ * red (see A11Y_BLOCKING_IMPACTS in helpers.ts).
+ *
+ * This catches what the static eslint-a11y layer (#727) can't: computed ARIA
+ * roles, colour contrast, focus order — because it scans the actually-rendered
+ * page (generated templates included), reusing the fixture the smoke already
+ * boots + authenticates.
+ *
+ * Opt-out (to quarantine a known-bad surface while a fix is tracked):
+ *   - whole fixture:   manifest `"a11y": false`
+ *   - one collection:  collection `"a11y": false`
+ *   - one surface:     surface `"expect": { "a11y": false }`
+ *
+ * Uses the saved auth state (see auth.setup.ts).
+ */
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import {
+  collectionUrl,
+  surfaceUrl,
+  ensureAuthed,
+  fixtureManifest,
+  scanA11y,
+  classifyA11y,
+  formatA11yViolations,
+  TEAM_FILE,
+  FIXTURE
+} from './helpers'
+
+const manifest = fixtureManifest()
+const fixtureEnabled = manifest.a11y !== false
+const collections = manifest.collections.filter(c => c.a11y !== false)
+const surfaces = (manifest.surfaces ?? []).filter(s => s.expect.a11y !== false)
+
+test.describe(`fixture "${FIXTURE}" a11y (axe-core)`, () => {
+  test.skip(!fixtureEnabled, 'fixture opts out of a11y (manifest a11y=false)')
+  test.skip(
+    collections.length === 0 && surfaces.length === 0,
+    'fixture has no collections/surfaces to scan (all opted out)'
+  )
+
+  let slug: string
+  test.beforeAll(() => {
+    slug = JSON.parse(readFileSync(TEAM_FILE, 'utf8')).slug
+  })
+
+  /** Scan a rendered page: fail on blocking violations, annotate the advisory ones. */
+  async function assertNoBlockingViolations(page: import('@playwright/test').Page, label: string) {
+    const { blocking, advisory } = classifyA11y(await scanA11y(page))
+
+    // Surface advisory findings (moderate/minor + baselined shell rules) in the
+    // report without failing — they're tracked, not gated.
+    if (advisory.length) {
+      const summary = formatA11yViolations(advisory)
+      test.info().annotations.push({ type: 'a11y-advisory', description: `${label}\n${summary}` })
+      console.log(`[a11y advisory] ${label}:\n${summary}`)
+    }
+
+    expect(
+      blocking,
+      `Critical/serious a11y violations on ${label}:\n${formatA11yViolations(blocking)}`
+    ).toEqual([])
+  }
+
+  for (const collection of collections) {
+    test(`collection "${collection.key}" list is accessible`, async ({ page, baseURL }) => {
+      const base = baseURL || 'http://localhost:3000'
+      // The reused storageState session may have been invalidated by the auth
+      // smoke specs; re-establish it before hitting a protected route.
+      await ensureAuthed(page, base)
+      await page.goto(collectionUrl(base, slug, collection.key), { waitUntil: 'domcontentloaded' })
+      await page.waitForLoadState('networkidle').catch(() => {})
+      // Wait for real content (the list heading) so axe scans the page, not a
+      // cold-compile spinner. Generous: the dev server compiles on first hit.
+      await expect(page.getByRole('heading', { name: new RegExp(collection.heading, 'i') }))
+        .toBeVisible({ timeout: 180000 })
+
+      await assertNoBlockingViolations(page, `collection list "${collection.key}"`)
+    })
+  }
+
+  for (const surface of surfaces) {
+    test(`surface "${surface.name}" is accessible`, async ({ page, baseURL }) => {
+      const base = baseURL || 'http://localhost:3000'
+      await ensureAuthed(page, base)
+      await page.goto(surfaceUrl(base, slug, surface.path), { waitUntil: 'domcontentloaded' })
+      await page.waitForLoadState('networkidle').catch(() => {})
+
+      // Wait for the surface's declared element/heading before scanning.
+      const { visible, heading } = surface.expect
+      if (visible) {
+        await expect(page.locator(visible).first()).toBeVisible({ timeout: 180000 })
+      } else if (heading) {
+        await expect(page.getByRole('heading', { name: new RegExp(heading, 'i') }).first())
+          .toBeVisible({ timeout: 180000 })
+      }
+
+      await assertNoBlockingViolations(page, `surface "${surface.name}"`)
+    })
+  }
+})

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -8,6 +8,7 @@
  * Target: fixtures/minimal (pkg "e2e-fixture-minimal").
  */
 import type { Page } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -38,6 +39,13 @@ export interface CollectionSpec {
    * omit to skip that check for this collection.
    */
   requiredField?: string
+  /**
+   * Opt this collection's list page OUT of the axe-core a11y scan
+   * (a11y.smoke.spec.ts). Set `false` to quarantine a known-bad surface while a
+   * fix is tracked — leave a note in the manifest pointing at the issue. Omit
+   * (default) to scan it.
+   */
+  a11y?: boolean
 }
 
 /**
@@ -56,6 +64,12 @@ export interface SurfaceSpec {
     visible?: string
     /** Visible heading (role=heading) name, matched case-insensitively. */
     heading?: string
+    /**
+     * Opt this surface OUT of the axe-core a11y scan (a11y.smoke.spec.ts). Set
+     * `false` to quarantine a known-bad surface while a fix is tracked (leave a
+     * note pointing at the issue). Omit (default) to scan it.
+     */
+    a11y?: boolean
   }
 }
 
@@ -118,6 +132,13 @@ export interface FixtureManifest {
   i18n?: I18nSpec
   /** Optional maps + geocoding check; omit for fixtures without crouton-maps. */
   maps?: MapsSpec
+  /**
+   * Opt the WHOLE fixture out of the axe-core a11y scan (a11y.smoke.spec.ts).
+   * Set `false` to skip every collection/surface scan for this fixture. Omit
+   * (default) to scan. Prefer the per-collection / per-surface `a11y: false`
+   * over this blanket switch so coverage stays as wide as possible.
+   */
+  a11y?: boolean
 }
 
 /** Read the active fixture's e2e manifest (what to smoke). */
@@ -314,4 +335,116 @@ export async function fillField(scope: Page | ReturnType<Page['getByRole']>, fie
     return
   }
   throw new Error(`Could not find form field "${field}"`)
+}
+
+/**
+ * axe-core impacts that FAIL the a11y smoke. We start lenient (epic #726 WS2):
+ * only `critical`/`serious` go red — these block a screen-reader / keyboard user
+ * (missing names, keyboard traps, contrast). `moderate`/`minor` are reported as
+ * advisory annotations, not failures, so the gate lands without walling existing
+ * generated templates red. Tighten by adding `moderate` here once the backlog is
+ * clear.
+ */
+export const A11Y_BLOCKING_IMPACTS: ReadonlySet<string> = new Set(['critical', 'serious'])
+
+/**
+ * axe rules excluded from the gate because they're owned by the DESIGN SYSTEM, not
+ * the per-template markup this harness scans.
+ *
+ * - `color-contrast` — determined by the active theme's colour tokens (Nuxt UI 4 /
+ *   crouton-themes), identical across every generated template, so gating each
+ *   fixture on it would just re-fail the same theme-level finding on every PR and
+ *   wall the whole suite red. Contrast is a theme concern, tracked separately
+ *   (epic #726 follow-up / the Unlighthouse sweep, #731). The gate keeps every
+ *   STRUCTURAL rule a template actually controls — names, labels, roles,
+ *   `image-alt`, keyboard operability — as hard fails.
+ */
+export const A11Y_EXCLUDED_RULES: readonly string[] = ['color-contrast']
+
+/**
+ * Critical/serious rules currently violated by the SHARED admin shell (crouton-core
+ * layout) and Nuxt UI 4 / reka-ui chrome — so they appear identically on EVERY
+ * fixture and are fixable only in `packages/` (out of this harness's scope). They're
+ * downgraded from blocking to ADVISORY so the gate could land green on today's code;
+ * tracked in #735 to drive to zero. As each is fixed in the shell, delete it here so
+ * the gate starts failing on any regression of it.
+ *
+ * This is a baseline by RULE, not a blanket disable: a NEW violation of any OTHER
+ * rule (e.g. `image-alt`, `label`, `link-name`, `select-name`) on a scanned page
+ * still fails the gate — so a template that ships an inaccessible element is caught.
+ *
+ *   button-name      — icon-only shell buttons (pagination, menu toggles) with no name
+ *   aria-allowed-attr — `aria-controls` on reka-ui collapsible nav trailing icons
+ */
+export const A11Y_KNOWN_SHELL_RULES: readonly string[] = ['aria-allowed-attr', 'button-name']
+
+/** A flattened axe violation — enough to fail a test with an actionable message. */
+export interface A11yViolation {
+  /** axe rule id, e.g. "image-alt", "color-contrast", "label". */
+  id: string
+  /** axe impact: "critical" | "serious" | "moderate" | "minor" (may be null). */
+  impact: string
+  /** Human description of the rule. */
+  help: string
+  /** Deep link to the axe rule docs. */
+  helpUrl: string
+  /** How many DOM nodes violated it. */
+  nodes: number
+  /** Up to 5 offending CSS selectors (the rest are elided). */
+  targets: string[]
+}
+
+/**
+ * Run axe-core against the current page DOM and return the violations, flattened.
+ *
+ * Injects axe-core (via @axe-core/playwright) into the live page and analyses the
+ * rendered DOM — so it catches what static lint can't (computed roles, contrast,
+ * focus order). Scoped to the standard WCAG 2.0/2.1 A+AA rule set so best-practice
+ * noise (e.g. `region`) doesn't fail the gate; the caller decides which impacts
+ * are blocking (see A11Y_BLOCKING_IMPACTS).
+ *
+ * Call it only AFTER the page has rendered (await a heading/element first) so axe
+ * scans real content, not a cold-compile spinner.
+ */
+export async function scanA11y(page: Page): Promise<A11yViolation[]> {
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .disableRules([...A11Y_EXCLUDED_RULES])
+    .analyze()
+  return results.violations.map(v => ({
+    id: v.id,
+    impact: v.impact ?? 'unknown',
+    help: v.help,
+    helpUrl: v.helpUrl,
+    nodes: v.nodes.length,
+    targets: v.nodes.flatMap(n => n.target.map(String)).slice(0, 5)
+  }))
+}
+
+/**
+ * Split a scan's violations into what FAILS the gate vs what's only ADVISORY.
+ *
+ * Blocking = `critical`/`serious` impact AND not a known shared-shell baseline rule
+ * (`A11Y_KNOWN_SHELL_RULES`). Everything else — `moderate`/`minor`, plus the
+ * baselined shell rules — is advisory: reported in the run, not failed. See the
+ * `A11Y_*` constants above for the rationale behind each bucket.
+ */
+export function classifyA11y(
+  violations: A11yViolation[]
+): { blocking: A11yViolation[], advisory: A11yViolation[] } {
+  const blocking = violations.filter(
+    v => A11Y_BLOCKING_IMPACTS.has(v.impact) && !A11Y_KNOWN_SHELL_RULES.includes(v.id)
+  )
+  const advisory = violations.filter(v => !blocking.includes(v))
+  return { blocking, advisory }
+}
+
+/** Format violations into a readable multi-line block for a test message / annotation. */
+export function formatA11yViolations(violations: A11yViolation[]): string {
+  if (!violations.length) return 'no violations'
+  return violations
+    .map(v => `  [${v.impact}] ${v.id} (${v.nodes} node${v.nodes === 1 ? '' : 's'}) — ${v.help}\n`
+      + `    ${v.helpUrl}\n`
+      + `    ${v.targets.join(' , ')}`)
+    .join('\n')
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
+    "@axe-core/playwright": "^4.10.2",
     "@changesets/cli": "^2.30.0",
     "@nuxt/eslint-config": "^1.2.0",
     "@nuxt/test-utils": "^3.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
         version: 0.18.2
+      '@axe-core/playwright':
+        specifier: ^4.10.2
+        version: 4.12.1(playwright-core@1.57.0)
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@22.19.7)
@@ -1977,6 +1980,11 @@ packages:
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -8358,6 +8366,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -16037,6 +16049,11 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.57.0)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.57.0
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -24699,6 +24716,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
 
   b4a@1.7.3: {}
 


### PR DESCRIPTION
Closes #728 (epic #726, WS2).

## 👤 For humans
The **runtime** half of the accessibility story (the static half — warn-first eslint-a11y — landed in [#727](https://github.com/FriendlyInternet/nuxt-crouton/pull/727)). `pnpm test:e2e` now scans every rendered surface with **axe-core** and fails on critical/serious violations — so a generated app that ships an inaccessible page goes red, not just lint. It reuses the fixture the smoke already boots + authenticates, so we get coverage of the *actually-rendered* pages (generated templates included) almost for free.

## 🤖 For agents
Mirrors the existing manifest-driven specs (each concern gets its own `*.smoke.spec.ts`):

- **`e2e/a11y.smoke.spec.ts`** (new) — for each collection list page + declared `surface`, waits for render then runs `new AxeBuilder({ page }).analyze()` on the live DOM. **Fails on blocking violations**; advisory ones (moderate/minor + baselined shell rules) attach as `a11y-advisory` annotations + `console.log` (visible in the Playwright HTML report / trace).
- **`e2e/helpers.ts`** — `scanA11y()` (scoped to WCAG 2.0/2.1 A+AA), `classifyA11y()` (blocking vs advisory), and `a11y` opt-out fields on the manifest/collection/surface interfaces. Policy constants:
  - `A11Y_BLOCKING_IMPACTS` = `critical`/`serious` (start lenient; `moderate`/`minor` advisory).
  - `A11Y_EXCLUDED_RULES` = `color-contrast` — theme-token level (Nuxt UI 4 / crouton-themes), identical across templates; tracked via Unlighthouse ([#731](https://github.com/FriendlyInternet/nuxt-crouton/issues/731)).
  - `A11Y_KNOWN_SHELL_RULES` = `aria-allowed-attr`, `button-name` — currently violated by the **shared admin shell** (crouton-core layout + reka-ui chrome), identical on every fixture, fixable only in `packages/`. Baselined to advisory and tracked in **[#735](https://github.com/FriendlyInternet/nuxt-crouton/issues/735)**. This is a baseline by *rule* — a new violation of any **other** rule (e.g. `image-alt`, `label`) still fails the gate.
- **`package.json` + `pnpm-lock.yaml`** — adds `@axe-core/playwright@4.12.1` (MPL-2.0). The lockfile was edited **surgically** (only the 4 axe entries, +19/-0) to avoid dragging in unrelated pre-existing peer-resolution drift that `pnpm install` wanted to apply; **`pnpm install --frozen-lockfile` passes**, so package.json ↔ lockfile are in sync (#614).
- **`e2e/CLAUDE.md`** — documents the scan, the lenient/baseline policy, and the opt-out.

No new fixtures or CI-matrix change needed: the spec is generic and runs under the existing `chromium` project, so it covers every fixture the matrix already selects.

## 🧪 How to test
Verified locally against `fixtures/minimal`:
1. First run **failed** on real shell violations — `button-name` (7 icon buttons), `aria-allowed-attr` (reka-ui collapsible), `color-contrast` — proving the gate **detects and fails** on genuine issues.
2. After excluding theme-owned `color-contrast` and baselining the two shell rules to [#735](https://github.com/FriendlyInternet/nuxt-crouton/issues/735), the run is **green** (`2 passed`), with both shell rules logged as `a11y-advisory`.
3. A new violation of any non-baselined rule (the acceptance's `<img>`-without-`alt` → `image-alt`) still goes to blocking → fails.

```
E2E_FIXTURE=minimal pnpm test:e2e --grep a11y
```

> Note for reviewers: CI runs `e2e.yml` across all fixtures here (this PR touches `e2e/**` + the lockfile → universal trigger). The shared-shell baseline is global, but a heavier fixture (with-pages/with-bookings) *could* surface a new package-specific rule. If so I'll extend the baseline (if shell/library) or quarantine that surface with a tracked note — the designed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQeHi7E3jayqo6VY1AZYWR)_