### PR TITLE
feat(root): wire the a11y CI gate (per-PR) + daily sweep (#730)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -47,6 +47,25 @@ It's steered by the **`/red-team` skill** (on demand) and run by
 `red-team-daily.yml` (daily `deep`). Findings → a report under `writeups/reports/` + (for
 confirmed high/criticals) `security`/`sec:*` GitHub issues.
 
+## The a11y agent (standalone — the accessibility analog of red-team)
+
+`a11y.md` is an **accessibility prober** (epic #726), the code-cleaning analog of
+`red-team`. Given `{ scope, depth, fix }` it reads `.vue` templates as a screen-reader /
+keyboard user would — ARIA-without-keyboard, missing `alt`/labels, positive `tabindex`,
+bad roles — and **returns structured severity-rated findings**. Static-first via
+`eslint-plugin-vuejs-accessibility`; at `depth=deep` it runs `@axe-core/playwright`
+against a fixture. It reports; it patches the safe set (`alt`/`aria-label`/label-for/
+`role`+`tabindex`) only under `fix:true`.
+
+| Agent | File | Recurses? | Writes code? | Model |
+|-------|------|-----------|--------------|-------|
+| `a11y` | `a11y.md` | no | only under `fix:true` (safe set) | `sonnet` |
+
+It's steered by the **`/a11y` skill** (on demand) and run by
+`.github/workflows/a11y.yml` (per-PR `quick`, fails the check on 🔴 critical/serious) and
+`a11y-daily.yml` (daily `deep`, posts a public standing issue + files `a11y` issues for new
+criticals). Severity maps axe critical/serious → 🔴, moderate → 🟡, minor → 🔵.
+
 ### The agent contract
 
 - **Input is passed in the prompt** as a small JSON-ish object — e.g.

--- a/.claude/skills/a11y/SKILL.md
+++ b/.claude/skills/a11y/SKILL.md
@@ -187,6 +187,10 @@ called out as "needs a human decision" with the reason.
   **`/simplify`** (the code-cleaning family), and **`/red-team`** (security) — same
   spawn-and-collate shape, different lens. Reach for `/a11y` when you specifically want
   accessibility, with the option to comment or fix.
-- A future CI gate could run the subagent at `depth=quick` on a PR diff (like
-  `red-team.yml`); for now `pnpm lint`'s warn-first rules are the CI signal and `/a11y`
-  is the human/agent entry point.
+- **CI runs the same engines automatically** (#730, mirroring the red-team workflows):
+  `.github/workflows/a11y.yml` runs the subagent at `depth=quick` on a PR diff — posts a
+  sticky `<!-- a11y -->` comment and **fails the check on a 🔴 critical/serious finding**
+  (diff-scoped, so never on the pre-existing backlog). `.github/workflows/a11y-daily.yml`
+  runs `/a11y` at `depth=deep` daily — writes a report (`writeups/reports/a11y-repo-*.md`),
+  updates a public standing issue, and files `a11y` issues for new confirmed criticals.
+  `/a11y` is the **on-demand** brain and human entry point for the same machinery.

--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -1,0 +1,120 @@
+name: A11y (daily sweep)
+
+# Scheduled whole-repo accessibility sweep (epic #726, WS4). Runs the /a11y skill at
+# depth=deep — static eslint-a11y across every package, plus best-effort runtime axe via
+# the e2e fixture harness — then POSTS the report to a public standing issue and files
+# `a11y`-labelled issues for new confirmed criticals.
+#
+# PUBLIC POSTING (unlike red-team-daily, which emails privately): accessibility findings
+# are NOT a security disclosure — they're safe and useful to track in the open. So the
+# report lands on a rolling standing issue and new criticals become their own `a11y` issues.
+#
+# Required repo config: secrets.ANTHROPIC_API_KEY (shared with the other claude workflows).
+
+on:
+  schedule:
+    - cron: '42 6 * * *'   # 06:42 UTC daily (offset from red-team's 06:17 to avoid pile-up)
+  workflow_dispatch:        # manual run
+
+concurrency:
+  group: a11y-daily
+  cancel-in-progress: false
+
+jobs:
+  a11y-daily:
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 45
+    # Job-level permissions (see a11y.yml for why id-token MUST be here). `issues: write`
+    # because — unlike the security sweep — this workflow DOES post to GitHub (standing
+    # issue + new-finding issues); a11y findings are safe to disclose publicly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # The deep pass runs eslint-a11y (needs deps) and may boot a fixture for axe.
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
+      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
+          claude_args: "--max-turns 60"
+          prompt: |
+            Run the **`/a11y`** skill (`.claude/skills/a11y/SKILL.md`) at
+            **depth=deep, scope=repo**. Sweep the `vuejs-accessibility/*` eslint rules across
+            every `packages/*` `.vue`, and attempt best-effort runtime axe via the e2e fixture
+            harness (the `a11y.smoke.spec.ts` path, epic #726 WS2) — if booting a fixture is too
+            heavy or unavailable, degrade gracefully to the static deep sweep and say so. Only
+            probe this repo's own local fixtures — never any external or production host.
+
+            Collate ONE whole-repo report to
+            `writeups/reports/a11y-repo-$(date -u +%Y%m%d).md` following
+            `writeups/reports/a11y-TEMPLATE.md`. Always write the report, even on a clean sweep.
+
+            Then **file `a11y` GitHub issues for NEW confirmed critical findings only**
+            (🔴, engine-confirmed). Dedupe FIRST: search open issues with the `a11y` label and
+            skip any whose title/location already matches — note "already filed" in the report
+            instead. Label each new issue `a11y` + the owning `pkg:<name>`/`app:<name>` +
+            `type:fix`. Title in plain language naming the impact (e.g. "Icon-only delete button
+            has no accessible name in crouton-sales"). Body in `github-tasks` style (👤 what an
+            AT user can't do & why it matters, 🤖 `location`/`rule`/`fix`, 🧪 how to test).
+            Warnings/notes stay in the report only — don't file them (noise).
+
+            Do NOT edit any `apps/`/`packages/` product code. The report file + any new `a11y`
+            issues are the whole job — a later step posts the report to the standing issue.
+
+      - name: Post report to the standing issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          REPORT=$(ls -t writeups/reports/a11y-repo-*.md 2>/dev/null | head -1 || true)
+          if [ -z "$REPORT" ]; then
+            echo "::warning::No a11y report file was produced — nothing to post."
+            exit 0
+          fi
+          echo "Report: $REPORT"
+          TITLE="♿ A11y — daily accessibility sweep"
+          MARKER="<!-- a11y-daily -->"
+          DATE=$(date -u +%F)
+
+          # Build the issue body: provenance header (autonomous CI bot — name the source, no
+          # @pmcp disclaimer per CLAUDE.md) + marker + the report, trimmed to fit the field.
+          BODY_FILE=$(mktemp)
+          {
+            echo "$MARKER"
+            echo "> 🤖 **Claude Code** · agent pipeline (CI) · _daily a11y deep sweep, updated ${DATE}_"
+            echo ""
+            echo "_Last run: [$DATE]($RUN_URL) · this issue is updated in place each day._"
+            echo ""
+            head -c 60000 "$REPORT"
+          } > "$BODY_FILE"
+
+          # Find-or-create the rolling standing issue. Key off the EXACT title among open
+          # a11y issues — deterministic (individual finding-issues also carry the `a11y`
+          # label, so a loose search could edit the wrong one; the title is unique).
+          NUM=$(gh issue list --repo "$REPO" --state open --label a11y --limit 200 --json number,title \
+                  --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty" || true)
+
+          if [ -z "$NUM" ]; then
+            echo "Creating the standing a11y issue…"
+            gh issue create --repo "$REPO" --title "$TITLE" --label a11y --body-file "$BODY_FILE"
+          else
+            echo "Updating standing a11y issue #$NUM…"
+            gh issue edit "$NUM" --repo "$REPO" --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,116 @@
+name: A11y (PR)
+
+# Per-PR accessibility scan (epic #726, WS4). Runs the a11y subagent at depth=quick
+# over the PR diff (eslint-a11y on changed .vue + static ARIA/keyboard smells), posts
+# an advisory sticky comment, and FAILS the check on any critical/serious (🔴) finding,
+# blocking merge. Diff-scoped, so it never fails on the pre-existing repo backlog — only
+# on what THIS PR introduces. Mirrors red-team.yml.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      # a11y lives in templates — only scan PRs that touch .vue files.
+      - '**/*.vue'
+
+concurrency:
+  group: a11y-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  a11y:
+    # Skip drafts and bot-authored PRs (no point scanning Dependabot/agent noise here).
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot'
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
+    # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to
+    # be here or the claude-code-action OIDC token request fails ("Could not fetch an OIDC
+    # token"). A workflow-level block would be silently shadowed.
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the agent can diff the PR against its base branch.
+          fetch-depth: 0
+
+      # a11y's engine is eslint-plugin-vuejs-accessibility (already wired into the root
+      # eslint.config.mjs, warn-first) — so unlike red-team's pure static read, the subagent
+      # needs node_modules to actually run `npx eslint`. Install before invoking it.
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
+      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
+        # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found
+        # nothing critical/serious, which would turn every PR red on a flake (mirrors the
+        # red-team #499/#602/#603 fix). `continue-on-error` makes the gate step below the sole
+        # decider: no verdict ⇒ inconclusive pass; a 🔴 finding in the verdict ⇒ fail.
+        continue-on-error: true
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
+          claude_args: "--max-turns 30"
+          prompt: |
+            Act as the **a11y subagent** defined in `.claude/agents/a11y.md`.
+            Input: { scope: "diff", depth: "quick", fix: false }.
+
+            The PR diff is this branch vs its base. The base branch is
+            `origin/${{ github.event.pull_request.base.ref }}` — diff against it
+            (`git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD`),
+            keep only the changed `.vue` files, and scan ONLY those through the engines in the
+            agent definition (run `npx eslint <changed.vue> --format json` for the
+            `vuejs-accessibility/*` rules, then read the templates for the ARIA-without-keyboard
+            / missing-name / missing-label smells). Be precise and avoid false positives — a red
+            CI check on a wrong call is worse than a comment. Do NOT boot a fixture (that's the
+            deep/daily path); quick is static only.
+
+            Then do exactly two outputs:
+
+            1. **Post a single PR comment** summarising the findings using the review skill's
+               3-level format (🔴 Critical / 🟡 Warning / 🔵 Note) — a severity table + each
+               finding's `file:line`, rule id, and one-line fix. Make it a sticky comment
+               containing the literal marker `<!-- a11y -->` on its own line, and EDIT that
+               comment in place if it already exists rather than posting a new one. If there
+               are no findings, post/update the comment saying the quick scan found nothing.
+
+            2. **Write `a11y-verdict.json`** at the repo root, exactly:
+               `{"highest":"<none|note|warning|critical>","critical":N,"warning":N,"note":N}`
+               where `highest` is the most severe finding's level (🔴→critical, 🟡→warning,
+               🔵→note, or `none`) per the skill's severity map (axe critical/serious +
+               structural eslint rules → 🔴). This file is the machine signal the gate step
+               reads — always write it, even for a clean scan.
+
+            Do NOT edit any `apps/`/`packages/` code (quick scan is report-only; `--fix` is a
+            separate, human-invoked path). Do NOT file GitHub issues (the daily sweep owns that).
+            Reporting + the verdict file is all.
+
+      - name: Gate on critical/serious
+        if: always()
+        run: |
+          if [ ! -f a11y-verdict.json ]; then
+            echo "::warning::a11y produced no verdict file — treating as inconclusive (not blocking)."
+            exit 0
+          fi
+          echo "Verdict: $(cat a11y-verdict.json)"
+          HIGHEST=$(node -e "process.stdout.write((require('./a11y-verdict.json').highest||'none').toLowerCase())")
+          case "$HIGHEST" in
+            critical)
+              echo "::error::a11y found a critical/serious accessibility issue in this PR's diff — see the a11y PR comment. Blocking merge."
+              exit 1
+              ;;
+            *)
+              echo "a11y highest severity: ${HIGHEST}. No critical/serious — check passes."
+              ;;
+          esac

--- a/writeups/reports/a11y-TEMPLATE.md
+++ b/writeups/reports/a11y-TEMPLATE.md
@@ -1,0 +1,63 @@
+<!--
+  A11y report template (epic #726, WS4). The a11y-daily.yml sweep (and the /a11y
+  skill on a deep run) writes one report per run to:
+      writeups/reports/a11y-<scope-slug>-YYYYMMDD.md
+  Copy this structure. <scope-slug> is "repo" for a whole-repo sweep, else a
+  path-derived slug (e.g. "apps-velo", "pkg-crouton-sales").
+  This file is the format reference — it is NOT itself a report. Keep it.
+-->
+
+# ♿ A11y report — `<scope>`
+
+- **Scope:** `<repo | path>`
+- **Depth:** `<quick | standard | deep>`
+- **Date:** `YYYY-MM-DD`
+- **Commit:** `<short SHA>`
+- **Run by:** `<interactive /a11y | CI a11y.yml | daily a11y-daily.yml>`
+- **Engines:** `eslint-plugin-vuejs-accessibility` (static) · `@axe-core/playwright` (runtime, deep)
+
+## Summary
+
+| Severity | Confirmed | Suspected |
+|----------|-----------|-----------|
+| 🔴 Critical | 0 | 0 |
+| 🟡 Warning | 0 | 0 |
+| 🔵 Note | 0 | 0 |
+
+> One-line verdict: `<e.g. "No critical findings — 3 warnings on hand-rolled ARIA in crouton-sales." >`
+> **Filed:** `<links to any a11y issues opened for confirmed criticals, or "none">`
+
+<!--
+  Per-finding sections follow, grouped by severity (highest first). Drop any empty
+  group. "confidence: confirmed" means an engine flagged it (eslint rule fired, or
+  axe reported it against a live DOM); "suspected" means reasoned from the template
+  but not engine-confirmed. ONLY confirmed criticals become issues.
+-->
+
+## 🔴 Critical
+
+### `<short finding title>`
+- **Severity:** critical
+- **Confidence:** `<confirmed | suspected>`
+- **Location:** `path/to/Component.vue:NN`
+- **Rule:** `<vuejs-accessibility/… | axe rule id>`
+- **Who it hurts:** `<screen-reader / keyboard / low-vision user — and how>`
+- **Fix:** `<the exact attribute/element to add — e.g. "add aria-label to the icon-only delete button">`
+
+## 🟡 Warning
+
+### `<short finding title>`
+- **Severity:** warning
+- **Confidence:** `<confirmed | suspected>`
+- **Location:** `path/to/Component.vue:NN`
+- **Rule:** `<…>`
+- **Who it hurts:** `<…>`
+- **Fix:** `<…>`
+
+## 🔵 Note
+
+- `<one-line polish note>` — `path/to/Component.vue:NN` (`<rule>`)
+
+## Out of scope / not checked
+
+- `<anything the depth/scope deliberately skipped — e.g. color-contrast (theme-level, tracked separately), the shared-shell baseline (#735), so the next run knows>`


### PR DESCRIPTION
Closes #730 (epic #726, WS4).

## 👤 For humans
Accessibility becomes automatic, exactly like security: every PR that touches a `.vue` gets a **quick a11y check** that comments its findings and **blocks merge on a critical/serious one**, and a **daily deep sweep** posts a rolling report and opens issues for anything new. Both reuse the `a11y` subagent + `/a11y` skill that landed in [#729](https://github.com/FriendlyInternet/nuxt-crouton/pull/734).

## 🤖 For agents
Mirrors `red-team.yml` / `red-team-daily.yml` and carries the full claude-action standard on both (job-level `id-token: write`, `anthropic_api_key` from `ANTHROPIC_API_KEY`, `show_full_output: true`, pinned action SHA `c26cb64…`).

- **`.github/workflows/a11y.yml`** — `pull_request` (paths: `**/*.vue`). Runs the **a11y subagent at `depth=quick`** over the diff (eslint-a11y on changed `.vue` + static ARIA/keyboard smells). Installs deps first — unlike red-team's pure static read, a11y's engine *is* eslint. Posts a sticky `<!-- a11y -->` comment (review skill's 🔴/🟡/🔵 format) and writes `a11y-verdict.json`. A separate **gate step fails on `highest=critical` (🔴)** — the verdict file is the gate, not the agent's exit code (`continue-on-error`, mirroring the red-team #499/#602 flake fix). **Diff-scoped**, so it never fails on the pre-existing repo backlog — only on what the PR introduces.
- **`.github/workflows/a11y-daily.yml`** — `cron` 06:42 UTC (offset from red-team's 06:17) + `workflow_dispatch`. Runs **`/a11y` at `depth=deep`**, writes `writeups/reports/a11y-repo-<date>.md`, and files `a11y` issues for **new confirmed criticals** (dedup first). A deterministic step posts/updates a **public rolling standing issue** via `gh` — a11y findings are safe to disclose, so this posts publicly (unlike `red-team-daily`, which emails privately). Standing issue keyed off its exact title.
- **`writeups/reports/a11y-TEMPLATE.md`** — report format (mirrors `red-team-TEMPLATE.md`).
- **`.claude/skills/a11y/SKILL.md`** + **`.claude/agents/CLAUDE.md`** — the CI gate now *exists* (was documented as "future"); added the a11y agent + its workflows to the agents guide.

### Severity → gate mapping
axe critical/serious + structural eslint rules → 🔴 **critical** (blocks) · axe moderate / redundant role / positive tabindex → 🟡 warning · axe minor → 🔵 note. Only 🔴 fails the PR check.

## 🧪 How to test
- **Per-PR:** open a throwaway PR adding ``'&lt;img src="x"&gt;'`` (no `alt`) to a `.vue` → the `A11y (PR)` check posts a `<!-- a11y -->` comment flagging `image-alt` 🔴 and the job **fails**; remove it → passes. A PR with only 🟡/🔵 findings comments but passes.
- **Daily:** `workflow_dispatch` `A11y (daily sweep)` → produces `writeups/reports/a11y-repo-<date>.md`, creates/updates the “♿ A11y — daily accessibility sweep” standing issue, and files `a11y` issues for new criticals.

Validated locally: both workflows parse as YAML and their embedded bash passes `bash -n`; they mirror the proven red-team workflows. (`actionlint` wasn't available in the sandbox.)

> Depends only on the merged a11y subagent + `a11y` label — independent of [#728](https://github.com/FriendlyInternet/nuxt-crouton/pull/739) (axe-in-e2e). When #728 lands, the daily's best-effort runtime axe gains the `a11y.smoke.spec.ts` path; until then it degrades to the static deep sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQeHi7E3jayqo6VY1AZYWR)_