### PR TITLE
feat(root): opt-in @nuxt/a11y dev module + scheduled Unlighthouse sweep (#731)

### DIFF
--- a/.github/workflows/unlighthouse.yml
+++ b/.github/workflows/unlighthouse.yml
@@ -1,0 +1,77 @@
+name: Unlighthouse (a11y staging sweep)
+
+# Scheduled whole-site accessibility (+ perf/SEO/best-practices) sweep of a STAGING deploy
+# (epic #726, WS5). Unlighthouse (MIT, self-hosted, axe + Lighthouse under the hood) crawls
+# the site and produces a route-by-route static report. This is a REPORT-ONLY monitor — it
+# uploads the static report as a build artifact; it does NOT gate merges (the per-PR a11y.yml
+# is the gate). Complements the daily a11y subagent sweep (#730) with a real-browser,
+# whole-route view of the running app.
+#
+# No SaaS, no lockfile impact: run via `npx`, scanning a public staging URL.
+#
+# Required repo config:
+#   vars.UNLIGHTHOUSE_SITE — the staging URL to scan, e.g. "https://triage.pmcp.dev"
+# If it's unset the job warns and skips (stays green) — so this lands safely before a URL
+# is chosen. Set it in repo Settings → Secrets and variables → Actions → Variables.
+
+on:
+  schedule:
+    - cron: '23 7 * * 1'   # 07:23 UTC every Monday (weekly; a full crawl is heavier than the daily subagent sweep)
+  workflow_dispatch:
+    inputs:
+      site:
+        description: 'Staging URL to scan (overrides vars.UNLIGHTHOUSE_SITE)'
+        required: false
+        type: string
+
+concurrency:
+  group: unlighthouse
+  cancel-in-progress: false
+
+jobs:
+  unlighthouse:
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve target site
+        id: site
+        env:
+          INPUT_SITE: ${{ inputs.site }}
+          VAR_SITE: ${{ vars.UNLIGHTHOUSE_SITE }}
+        run: |
+          SITE="${INPUT_SITE:-$VAR_SITE}"
+          if [ -z "$SITE" ]; then
+            echo "::warning::Neither the workflow_dispatch site input nor vars.UNLIGHTHOUSE_SITE is set — skipping the Unlighthouse sweep. Set vars.UNLIGHTHOUSE_SITE to a staging URL (e.g. https://triage.pmcp.dev) to enable it."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Scanning: $SITE"
+            echo "site=$SITE" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.site.outputs.skip == 'false'
+        with:
+          node-version: 22
+
+      - name: Run Unlighthouse (static report)
+        if: steps.site.outputs.skip == 'false'
+        # Report-only: never fail the job on a low score (no --budget). `|| true` guards
+        # transient crawl/headless hiccups so a flake can't turn the scheduled run red.
+        run: |
+          npx --yes unlighthouse-ci@^0.17 \
+            --site "${{ steps.site.outputs.site }}" \
+            --build-static \
+            || echo "::warning::Unlighthouse exited non-zero — see logs; uploading whatever report was produced."
+
+      - name: Upload static report
+        if: steps.site.outputs.skip == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unlighthouse-report
+          # Unlighthouse writes the static client to .unlighthouse/ by default.
+          path: .unlighthouse/
+          if-no-files-found: warn
+          retention-days: 14

--- a/writeups/guides/a11y-devtools-guide.md
+++ b/writeups/guides/a11y-devtools-guide.md
@@ -1,0 +1,119 @@
+# Live a11y while you develop — `@nuxt/a11y` (opt-in) + Unlighthouse sweep
+
+Two **opt-in** accessibility layers on top of the always-on ones (the warn-first
+eslint-a11y rules, #727; the axe e2e gate, #728; the `/a11y` skill + CI gate, #729/#730).
+Epic #726, WS5.
+
+| Layer | When it runs | What it gives you |
+|-------|--------------|-------------------|
+| **`@nuxt/a11y`** | live, in `pnpm dev` | an axe-core panel in Nuxt DevTools that flags violations on the page you're looking at, as you navigate |
+| **Unlighthouse** | scheduled (CI) / on demand | a route-by-route Lighthouse + axe report of a **deployed staging** site |
+
+Both are OSS / self-hostable, no SaaS.
+
+---
+
+## 1. `@nuxt/a11y` — live DevTools feedback (opt-in)
+
+[`@nuxt/a11y`](https://github.com/nuxt/a11y) is the official Nuxt accessibility module: it
+runs axe-core in the browser during `nuxt dev` and surfaces violations in a **Nuxt DevTools**
+tab, so you see a problem the moment you render the page — the same axe engine the e2e gate
+and `/a11y --deep` use, just live.
+
+> ⚠️ **It's `1.0.0-alpha.1`.** That's why it is **opt-in per app** and **NOT** wired into the
+> crouton generator or any shared config — we don't want an alpha module in every generated
+> app's lockfile yet. Add it to the one app you're actively hardening; remove it when done.
+> Revisit promoting it to a generator default once it ships a **stable (non-alpha)** release
+> (see §3).
+
+### Enable it in an app (≈2 minutes)
+
+From the app dir (`apps/<name>`, `pocs/<name>`, or a fixture — **not** `packages/`):
+
+```bash
+pnpm add -D @nuxt/a11y@^1.0.0-alpha.1
+```
+
+Then add an **env-guarded** module entry to that app's `nuxt.config.ts` so it only loads when
+you ask for it (zero impact on normal `pnpm dev`, builds, and CI):
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: [
+    // …existing modules…
+    // Opt-in: only load the alpha a11y module when NUXT_A11Y is set.
+    ...(process.env.NUXT_A11Y ? ['@nuxt/a11y'] : [])
+  ]
+})
+```
+
+Run dev with the flag and open DevTools:
+
+```bash
+NUXT_A11Y=1 pnpm --filter <app> dev
+# → open the app, press Shift+Option+D (Nuxt DevTools), pick the "Accessibility" tab.
+# Navigate the app; axe violations for the current page list live, with the offending element.
+```
+
+The module is **dev-only** — it never ships to a production build even if the guard is on.
+Leaving the `process.env.NUXT_A11Y` guard in is harmless; drop the devDependency + the module
+line when you're done hardening that app.
+
+### Fixing what it finds
+
+The DevTools panel reports the same axe rules the rest of the stack uses, so the fixes are the
+same: run **`/a11y --fix`** on the diff for the safe, mechanical ones (`alt`, `aria-label`,
+label-for, `role`+`tabindex`), and hand-fix the judgement calls (heading order, contrast,
+interaction model). The shared admin-shell findings are tracked in
+[#735](https://github.com/FriendlyInternet/nuxt-crouton/issues/735).
+
+---
+
+## 2. Unlighthouse — scheduled whole-site staging sweep
+
+[Unlighthouse](https://unlighthouse.dev) (MIT, self-hosted) crawls a **deployed** site and
+produces a route-by-route report (Lighthouse accessibility — axe-based — plus perf / SEO /
+best-practices). It's the "whole running app, every route" view that complements the per-PR
+diff gate and the daily subagent sweep.
+
+### Scheduled (CI)
+
+`.github/workflows/unlighthouse.yml` runs it **weekly** (and on `workflow_dispatch`) against a
+staging URL and uploads the static report as a build artifact. It's **report-only** — it never
+gates a merge (that's `a11y.yml`'s job).
+
+**To enable it:** set the repo variable `UNLIGHTHOUSE_SITE` to a staging URL — Settings →
+Secrets and variables → Actions → **Variables**:
+
+```
+UNLIGHTHOUSE_SITE = https://triage.pmcp.dev
+```
+
+Staging URLs follow the two-domain topology (`<app>.pmcp.dev`). Until the var is set the job
+**warns and skips** (stays green), so it lands safely before a target is chosen. To review a
+run: Actions → the Unlighthouse run → **Artifacts** → download `unlighthouse-report` → open
+`index.html`.
+
+> **Auth note:** Unlighthouse crawls what's reachable without logging in, so for a crouton app
+> it covers the **public** surfaces (login, marketing/home, error pages). Auditing the
+> authenticated `/admin/**` routes needs cookie injection (Unlighthouse `cookies`/`extraHeaders`
+> config) — a follow-up if we want the admin shell swept this way too; for now the axe e2e gate
+> (#728) covers the authenticated surfaces.
+
+### Locally
+
+```bash
+npx unlighthouse --site https://triage.pmcp.dev   # interactive UI on localhost
+npx unlighthouse-ci --site https://triage.pmcp.dev --build-static   # static report → .unlighthouse/
+```
+
+---
+
+## 3. Revisit: promote `@nuxt/a11y` to a generator default?
+
+When `@nuxt/a11y` ships a **stable (≥ `1.0.0`, non-alpha)** release, reconsider baking the
+env-guarded module entry into the crouton CLI generator (`packages/crouton-cli` app template)
+so every new app gets the live DevTools panel for free. Until then it stays opt-in per the
+guidance above. Track via the epic #726 close-out / a new `workflow` issue when the stable
+release lands.


### PR DESCRIPTION
Closes #731 (epic #726, WS5 — the final workstream).

## 👤 For humans
Two **opt-in** accessibility layers on top of the always-on ones (eslint-a11y #727, axe e2e #728, `/a11y` skill + CI #729/#730):
- **`@nuxt/a11y`** — live axe-core feedback in **Nuxt DevTools** while you `pnpm dev`, so you catch a violation the moment you render the page.
- **Unlighthouse** — a scheduled, route-by-route Lighthouse + axe report of a **deployed staging** site.

## 🤖 For agents
- **`.github/workflows/unlighthouse.yml`** — weekly (Mon 07:23 UTC) + `workflow_dispatch` sweep via `npx unlighthouse-ci --site <url> --build-static`. **Report-only** (uploads the static report as the `unlighthouse-report` artifact; never gates a merge — that's `a11y.yml`'s job). Target from `vars.UNLIGHTHOUSE_SITE`; **warns + skips green if unset**, so it lands safely before a URL is chosen. No lockfile impact (npx), no SaaS.
- **`writeups/guides/a11y-devtools-guide.md`** — the opt-in playbook: exact `@nuxt/a11y` devDep + **env-guarded** (`NUXT_A11Y`) `nuxt.config.ts` module entry, DevTools usage, the Unlighthouse var + local commands, and the **"revisit as a generator default once it ships stable (non-alpha)"** trigger.

### Deliberate decision (flagging the judgement call)
`@nuxt/a11y` is **`1.0.0-alpha.1`**, and the issue explicitly wants it *opt-in / not a generator default*. So rather than force an alpha dep into the **shared** lockfile (every generated app's, with the same churn risk [#728](https://github.com/FriendlyInternet/nuxt-crouton/pull/739) hit), I shipped a **turnkey documented opt-in** — a 2-minute, copy-paste enable per app. If you'd prefer it *pre-wired* into a specific app or POC (behind the `NUXT_A11Y` guard), say which and I'll add the devDep + module line there.

## 🧪 How to test
- **@nuxt/a11y:** follow the guide in an app → `NUXT_A11Y=1 pnpm --filter <app> dev` → DevTools → Accessibility tab lists axe violations as you navigate. (Dev-only; never ships to a production build.)
- **Unlighthouse:** set `vars.UNLIGHTHOUSE_SITE` (e.g. `https://triage.pmcp.dev`), then run the workflow via `workflow_dispatch` → it produces `.unlighthouse/` and uploads the `unlighthouse-report` artifact. Without the var set, a dispatch run **skips green** (verified by the guard logic).

Validated locally: the workflow parses as YAML and its embedded bash passes `bash -n`; `unlighthouse-ci@^0.17` and `@nuxt/a11y@1.0.0-alpha.1` confirmed on npm. (`actionlint` wasn't available in the sandbox.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQeHi7E3jayqo6VY1AZYWR)_