### PR TITLE
feat(booking-demo): loading state on the layout page

### DIFF
--- a/pocs/booking-demo/app/pages/admin/[team]/layout.vue
+++ b/pocs/booking-demo/app/pages/admin/[team]/layout.vue
@@ -19,15 +19,20 @@ definePageMeta({ layout: 'admin', middleware: ['auth'] })
 
 const LAYOUT_ID = 'default'
 const tree = ref<LayoutTree | null>(null)
+const loading = ref(true)
 const { load, save, saving } = useCroutonLayoutStore()
 
 // Persist every edit (debounced in the store).
 watch(tree, (v) => { if (v) save(LAYOUT_ID, v) })
 
 onMounted(async () => {
-  const persisted = await load(LAYOUT_ID)
-  // Fall back to the generated default so the preview is never a blank canvas.
-  tree.value = persisted ?? (generatedDefault.tree as LayoutTree)
+  try {
+    const persisted = await load(LAYOUT_ID)
+    // Fall back to the generated default so the preview is never a blank canvas.
+    tree.value = persisted ?? (generatedDefault.tree as LayoutTree)
+  } finally {
+    loading.value = false
+  }
 })
 </script>
 
@@ -45,7 +50,14 @@ onMounted(async () => {
     </template>
 
     <template #body>
-      <div class="h-full w-full">
+      <div class="relative h-full w-full">
+        <div
+          v-if="loading"
+          class="absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 bg-default/70 backdrop-blur-sm"
+        >
+          <UIcon name="i-lucide-loader-2" class="size-6 animate-spin text-primary" />
+          <span class="text-sm text-muted">Loading layout…</span>
+        </div>
         <CroutonLayout v-model="tree" />
       </div>
     </template>


### PR DESCRIPTION
Part of #740 (booking-demo POC). Adds a loading state to the POC's `/admin/[team]/layout` page so opening it no longer flashes a blank canvas while the saved layout tree loads.

## What
- `pocs/booking-demo/app/pages/admin/[team]/layout.vue`: a `loading` ref (true → false in `onMounted`'s `finally` after `store.load`), and an overlay (`absolute inset-0`, `backdrop-blur`, `UIcon i-lucide-loader-2 animate-spin` + "Loading layout…") gated on it.

## Verified
On a 390px viewport with the `crouton-layouts` GET artificially delayed, the overlay shows mid-load and clears when the tree resolves.

## Note
POC-local for now. The core `/admin/[team]/layout` page should get the same treatment as part of the `@fyit/crouton-layout` extraction (see the extraction epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5Szz8RiW8kVMcT4WLEf82)_