### PR TITLE
fix(root): always build crouton-devtools dist on deploy (#745)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -129,29 +129,48 @@ jobs:
       # The dist-consumed framework packages (inputs.layer-packages) must be built
       # before the app build. Pure source layers (crouton-editor/pages/charts) have
       # no build script and are skipped.
+
+      # The layer cache is shared across ALL callers (one runner cache), but the set
+      # of dists a deploy needs varies per app (different layer-packages, + devtools
+      # below). Keying on source alone (`hashFiles('packages/**/*.ts')`) meant the
+      # first app to populate the cache decided which dists every later app got — a
+      # cache HIT could restore a set MISSING a package the current app needs, and
+      # the build step (gated on cache-miss) would skip it → `nuxt prepare` failing
+      # to load it. That's the #745 devtools crash, but it's a general cross-app
+      # collision class (e.g. an i18n-needing app hitting an i18n-less cache). So we
+      # fold the resolved build set into the cache key: different sets → different
+      # entries → no collision.
+      - name: Compute layer build-set key
+        id: layer-set
+        env:
+          LAYER_PACKAGES: ${{ inputs['layer-packages'] }}
+        run: |
+          # The EXACT set built below: caller's layer-packages + devtools (always),
+          # sorted + de-duped so key is order-independent. crouton-devtools is in the
+          # set unconditionally — scaffolded apps declare it in nuxt.config `modules`
+          # (scaffold-app.ts), so `nuxt prepare` needs its dist on every deploy (there
+          # is no review flag to gate on; building it for apps that don't list it is
+          # cheap and inert). (#745)
+          set_str=$(printf '%s\n' $LAYER_PACKAGES @fyit/crouton-devtools | sort -u | tr '\n' ' ')
+          echo "Layer build set: $set_str"
+          echo "hash=$(printf '%s' "$set_str" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
       - name: Cache layer builds
         id: layer-cache
         uses: actions/cache@v4
         with:
           path: |
             packages/*/dist
-          # v2: crouton-devtools is now ALWAYS built (below), so every entry carries
-          # its dist. The bump abandons stale v1 caches that were populated by apps
-          # which didn't build devtools and would otherwise satisfy a hit without it
-          # → `nuxt prepare` failing to load the module on a scaffolded app (#745).
-          key: layer-builds-v2-${{ hashFiles('packages/**/*.ts') }}
+          key: layer-builds-${{ steps.layer-set.outputs.hash }}-${{ hashFiles('packages/**/*.ts') }}
 
       - name: Build layer packages
         if: steps.layer-cache.outputs.cache-hit != 'true'
         env:
           LAYER_PACKAGES: ${{ inputs['layer-packages'] }}
         run: |
-          # crouton-devtools is appended unconditionally: scaffolded apps declare it
-          # in their nuxt.config `modules` (scaffold-app.ts), so `nuxt prepare` needs
-          # its dist on every deploy — not just review ones (there is no review flag
-          # to gate on). Building it for apps that don't list it is cheap and inert.
-          # Keeping the set constant across all callers also keeps the shared cache
-          # above valid (no per-caller divergence to hide a missing dist). (#745)
+          # Same set the cache key was computed from (layer-set step). de-dupe is by
+          # "dist already built this run" so an explicit devtools in layer-packages
+          # isn't built twice.
           for pkg in $LAYER_PACKAGES @fyit/crouton-devtools; do
             dir="packages/${pkg#@fyit/}"
             # de-dupe: skip if this dist was already built earlier in the loop

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -135,15 +135,30 @@ jobs:
         with:
           path: |
             packages/*/dist
-          key: layer-builds-${{ hashFiles('packages/**/*.ts') }}
+          # v2: crouton-devtools is now ALWAYS built (below), so every entry carries
+          # its dist. The bump abandons stale v1 caches that were populated by apps
+          # which didn't build devtools and would otherwise satisfy a hit without it
+          # → `nuxt prepare` failing to load the module on a scaffolded app (#745).
+          key: layer-builds-v2-${{ hashFiles('packages/**/*.ts') }}
 
       - name: Build layer packages
         if: steps.layer-cache.outputs.cache-hit != 'true'
         env:
           LAYER_PACKAGES: ${{ inputs['layer-packages'] }}
         run: |
-          for pkg in $LAYER_PACKAGES; do
+          # crouton-devtools is appended unconditionally: scaffolded apps declare it
+          # in their nuxt.config `modules` (scaffold-app.ts), so `nuxt prepare` needs
+          # its dist on every deploy — not just review ones (there is no review flag
+          # to gate on). Building it for apps that don't list it is cheap and inert.
+          # Keeping the set constant across all callers also keeps the shared cache
+          # above valid (no per-caller divergence to hide a missing dist). (#745)
+          for pkg in $LAYER_PACKAGES @fyit/crouton-devtools; do
             dir="packages/${pkg#@fyit/}"
+            # de-dupe: skip if this dist was already built earlier in the loop
+            if [ -d "$dir/dist" ] && [ -n "$(ls -A "$dir/dist" 2>/dev/null)" ]; then
+              echo "Skipping $pkg (already built this run)"
+              continue
+            fi
             if node -e "process.exit(require('./$dir/package.json').scripts?.build ? 0 : 1)" 2>/dev/null; then
               echo "Building $pkg"
               pnpm --filter "$pkg" build

--- a/scripts/scaffold-poc-deploy.mjs
+++ b/scripts/scaffold-poc-deploy.mjs
@@ -18,10 +18,13 @@
 // route + id-less D1) is produced by the app scaffold; this script only writes the
 // deploy config and sanity-checks the wrangler.
 //
-// Review overlay (#590/#596): deploy-pocs.yml passes enable-review: true to deploy-app.yml
-// for every POC staging deploy, so the @fyit/crouton-devtools overlay is always active on
-// previews — every preview URL is review-ready. The NUXT_CROUTON_REVIEW_GITHUB_APP_*
-// repo secrets enable the /api/_review bridge (GitHub App-based PR commenting).
+// Review overlay (#590/#596): scaffolded apps declare @fyit/crouton-devtools in their
+// nuxt.config `modules` (scaffold-app.ts), so the overlay is active on every POC staging
+// preview — every preview URL is review-ready. deploy-app.yml always builds the devtools
+// dist before `nuxt prepare` (#745), so it loads regardless of this script's layerPackages
+// default. A PR-tied deploy also gets the /api/_review bridge wired (deploy-app.yml's
+// review-pr input + the NUXT_CROUTON_REVIEW_GITHUB_APP_* repo secrets → GitHub App PR
+// commenting as nuxt-harness[bot]).
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'


### PR DESCRIPTION
Closes #745

## 👤 For humans

A freshly-scaffolded app declares the `@fyit/crouton-devtools` review overlay in its `modules` (and sets `NUXT_PUBLIC_CROUTON_REVIEW=true` in its `cf:staging` script), but the deploy pipeline never built that package's `dist` — so `nuxt prepare` failed to load it. The first POC to deploy via `deploy-pocs.yml` (#743) hit exactly this. This makes every deploy build the devtools dist, so scaffolded apps deploy with the **review overlay live**, with no manual surgery — restoring the #596 "overlay always on for POC previews" promise.

## 🤖 For agents

The bug was two-part (both addressed), pure CI fix in `deploy-app.yml`:

1. **Layer-build omission** — `@fyit/crouton-devtools` was in no app's `layerPackages`, so `deploy-app.yml`'s "Build layer packages" step never built its (gitignored) dist. The build loop now appends `@fyit/crouton-devtools` **unconditionally** (de-duped against dists already built this run). There's no review flag to gate on — the module is declared statically in `scaffold-app.ts`'s nuxt.config, so `prepare` needs its dist on every deploy.

2. **Shared cache hid it (general fix)** — the layer cache was keyed only on `hashFiles('packages/**/*.ts')`, shared across all callers. The first app to populate it decided which dists every later app got; a cache **hit** could restore a set *missing* a package the current app needs, and the build step (gated on cache-miss) would skip it. That's the #745 devtools crash, but it's a general cross-app collision class (e.g. an i18n-needing app hitting an i18n-less cache). Fixed by folding the **resolved build set** into the cache key: a new "Compute layer build-set key" step hashes the sorted+deduped set (caller `layer-packages` + devtools) into a 12-char digest → `layer-builds-${set-hash}-${hashFiles('packages/**/*.ts')}`. Different sets → different entries → no collision.

Also: `scaffold-poc-deploy.mjs` — corrected the stale comment that referenced a nonexistent `enable-review` input.

**Rejected alternatives:** #3 (load module only if dist exists) makes the overlay silently OFF — breaks the #596 promise. #1 (build only when review on) needs a new `enable-review` input threaded through to gate something that's already always-on. #4 (scaffold no longer declares the module) is a larger behavioral change than warranted.

> ⚠️ **Note for the reviewer:** this PR's own CI does **not** exercise the fix — its `deploy` jobs skip (it touches only workflow/script files, not app paths). The real proof is re-adding `@fyit/crouton-devtools` to `pocs/booking-demo`'s modules (dropped as the #743 workaround) and confirming its staging deploy renders the overlay without `nuxt prepare` throwing. First deploy after this lands is a cache miss (expected) — confirm it then populates a `layer-builds-<set-hash>-` entry *with* the devtools dist.

## 🧪 We'll know by

A scaffolded app's staging deploy renders the click-to-comment overlay at its preview URL, and `nuxt prepare` no longer throws on `@fyit/crouton-devtools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iAGcTSgnAH6MC3a5zDXv3