### PR TITLE
feat(crouton-cli): generator emits a schema-smoke test per collection (#785)

### DIFF
--- a/.claude/skills/crouton.md
+++ b/.claude/skills/crouton.md
@@ -92,6 +92,7 @@ Use this skill when the user mentions:
 | `--hierarchy` | Enable tree structure |
 | `--seed` | Generate seed data file |
 | `--count <n>` | Seed record count (default: 25) |
+| `--no-tests` | Skip the per-collection schema-smoke test (emitted by default, #785) |
 | `--dry-run` | Preview without writing |
 
 ### Field Types
@@ -346,10 +347,16 @@ layers/{layer}/collections/{collection}/
 │       ├── schema.ts         # Drizzle ORM schema
 │       ├── queries.ts        # Database operations
 │       └── seed.ts           # Seed data (with --seed flag)
+├── {Layer}{Collection}s.test.ts  # Zod schema-smoke test (#785) — skip with --no-tests
 ├── types.ts                  # TypeScript interfaces
 ├── nuxt.config.ts           # Layer configuration
 └── README.md                # Collection documentation
 ```
+
+A **schema-smoke test** is emitted per collection by default (#785): runtime-free
+(zod only), it asserts the generated Zod schema accepts a valid record and rejects
+an invalid one. `crouton init`/`scaffold-app` wire a `vitest.config.ts` + `test`
+script so `pnpm test` runs them. The e2e fixture smoke still owns boot + CRUD.
 
 ### Running Seed Files
 

--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -272,6 +272,7 @@ crouton db-pull --config ./custom-wrangler.jsonc
 | `--count <number>` | Number of seed records (default: 25) |
 | `--force` | Overwrite existing files |
 | `--no-translations` | Skip i18n fields |
+| `--no-tests` | Skip the per-collection schema-smoke test (emitted by default, #785) |
 | `--dry-run` | Preview without writing |
 
 ## Key Files
@@ -284,7 +285,8 @@ crouton db-pull --config ./custom-wrangler.jsonc
 | `lib/compose-layout.ts` | **Deterministic default-layout step** (#709) — after generation, runs `@fyit/crouton-layout`'s `composeDefaultLayout` (moved out of crouton-core, #751) over the generated collections and writes `crouton.layout.json` (a `layout_configs` tree the POC boots with). `registryKeyFor(layer, collection)` mirrors the generated registry key; mirrors the core + bookings block sizing contracts (no live `app.config` at generate time) |
 | `lib/generate-collection.ts` | Main orchestrator (~74KB) |
 | `lib/init-app.ts` | Init pipeline (scaffold → generate → doctor) |
-| `lib/generators/*.ts` | Template generators (14 files) |
+| `lib/generators/*.ts` | Template generators (15 files) |
+| `lib/generators/collection-test.ts` | Emits `<Layer><Collections>.test.ts` — a runtime-free Zod schema smoke (valid parses / invalid rejected). Sample derived from each field's `zod`. On by default; `--no-tests` skips (#785) |
 | `lib/db-pull.ts` | Remote D1 → local dev pull |
 | `lib/module-registry.ts` | Module definitions for `crouton add` |
 | `lib/add-module.ts` | Module installation implementation |
@@ -310,7 +312,8 @@ lib/generators/
 ├── types.ts               → TypeScript interfaces
 ├── nuxt-config.ts         → Layer config
 ├── field-components.ts    → Dependent field components
-└── query-registry.ts      → Server-side query registry (lazy imports)
+├── query-registry.ts      → Server-side query registry (lazy imports)
+└── collection-test.ts     → <Layer><Collections>.test.ts (Zod schema smoke, #785)
 ```
 
 ## Schema Format
@@ -508,6 +511,7 @@ layers/[layer]/collections/[collection]/
 │       ├── queries.ts
 │       └── seed.ts          # Only with --seed flag
 ├── seed.json                # Editable auto-derived sample rows (#298)
+├── [Layer][Collections].test.ts  # Zod schema-smoke test (#785) — skip with --no-tests
 ├── types.ts
 └── nuxt.config.ts
 
@@ -515,6 +519,26 @@ layers/[layer]/collections/[collection]/
 server/utils/crouton-query-registry.ts   # Lazy-loaded query function registry
 crouton.layout.json                       # Deterministic default layout tree (#709) — seeded into layout_configs
 ```
+
+## Generated Tests (#785)
+
+Every generated collection ships a **schema-smoke test** next to it
+(`<Layer><Collections>.test.ts`) — on by default, suppressed with `--no-tests`
+(or `tests: false` on a collection). It imports the collection's generated Zod
+schema from the composable and asserts the deterministic surface: a valid record
+parses, an invalid one is rejected. It is **runtime-free** (zod only, no Nuxt/DB,
+no mocks), so it stays green for any schema — the unit-level complement to the
+**e2e fixture smoke**, which owns boot + CRUD (this does NOT duplicate it).
+
+- The valid sample is derived at generation time from each field's `zod` (the
+  same source the schema embeds), so it matches the schema whether or not the
+  type manifest resolved. Two overrides mirror `fieldsSchema` in
+  `generate-collection.ts`: `date` → `z.coerce.date()` (ISO string), dependent
+  fields → non-empty `z.array(z.string()).min(1)`. Auto/system + hierarchy
+  fields are excluded; output is deterministic (no `Date.now()`/`Math.random()`).
+- `scaffold-app`/`crouton init` emit a `vitest.config.ts` + `test` script + the
+  `vitest` devDep, so `pnpm test` runs these out of the box (#789).
+- API route auth/error-path tests are a tracked follow-up (#791), not emitted yet.
 
 ## Default Layout (generate → POC, #709)
 
@@ -652,6 +676,7 @@ features: {
 | `formComponent` | string | Use a custom form component instead of generating Form.vue |
 | `kind` | string | Collection kind: `'data'` (default), `'content'`, or `'media'`. Affects admin sidebar grouping |
 | `publishable` | boolean | Auto-register as page type in crouton-pages (requires crouton-pages) |
+| `tests` | boolean | Emit the schema-smoke test for this collection (default `true`; set `false` to skip, like `--no-tests`) (#785) |
 
 ### formComponent Option
 
@@ -853,6 +878,7 @@ npx nuxt typecheck
 | `lib/utils/helpers.ts` | Case conversion, type mapping, seed generators |
 | `lib/generators/types.ts` | TypeScript type generation (snapshot) |
 | `lib/generators/composable.ts` | Composable generation (snapshot) |
+| `lib/generators/collection-test.ts` | Schema-smoke test emission — import path, per-type sample derivation, valid/invalid cases (#785) |
 
 ## Seed Data Generation
 

--- a/packages/crouton-cli/README.md
+++ b/packages/crouton-cli/README.md
@@ -8,6 +8,7 @@ A powerful CLI tool for generating complete CRUD collections in Nuxt Crouton app
 - 🗄️ **Multi-Database Support** - PostgreSQL and SQLite
 - 🎯 **Type-Safe** - Full TypeScript support with Zod validation
 - 🌱 **Seed Data** - Generate realistic test data with drizzle-seed
+- ✅ **Tests by Default** - Emits a runtime-free Zod schema-smoke test per collection (`--no-tests` to skip)
 - 🔧 **Customizable** - Modify generated code to fit your needs
 - 📦 **Zero Config** - Works out of the box with sensible defaults
 
@@ -141,6 +142,7 @@ crouton-generate <layer> <collection> [options]
 - `--seed` - Generate seed data file with realistic test data
 - `--count <number>` - Number of seed records to generate (default: 25)
 - `--no-translations` - Skip translation fields
+- `--no-tests` - Skip the per-collection schema-smoke test (emitted by default)
 - `--force` - Force generation even if files exist
 - `--no-db` - Skip database table creation
 - `--dry-run` - Preview what will be generated

--- a/packages/crouton-cli/bin/crouton-generate.js
+++ b/packages/crouton-cli/bin/crouton-generate.js
@@ -55,6 +55,7 @@ const generate = defineCommand({
     hierarchy: { type: 'boolean', description: 'Enable hierarchy support (parentId, path, depth, order)' },
     seed: { type: 'boolean', description: 'Generate seed data file using drizzle-seed' },
     count: { type: 'string', description: 'Number of seed records (default: 25)', default: '25' },
+    tests: { type: 'boolean', description: 'Generate a per-collection schema-smoke test (use --no-tests to skip)', default: true },
     noAutoMerge: { type: 'boolean', description: 'Skip auto-merging package collections from manifests' },
   },
   async run({ args }) {
@@ -65,6 +66,7 @@ const generate = defineCommand({
         configPath: args.config,
         force: args.force,
         dryRun: args.dryRun,
+        noTests: args.tests === false,
         noAutoMerge: args.noAutoMerge,
       })
       return
@@ -79,6 +81,7 @@ const generate = defineCommand({
           configPath,
           force: args.force,
           dryRun: args.dryRun,
+          noTests: args.tests === false,
           noAutoMerge: args.noAutoMerge,
         })
         return
@@ -112,6 +115,7 @@ const generate = defineCommand({
       hierarchy: args.hierarchy,
       seed: args.seed,
       seedCount: parseInt(args.count || '25', 10),
+      noTests: args.tests === false,
     })
   }
 })
@@ -125,6 +129,7 @@ const configCmd = defineCommand({
     only: { type: 'string', description: 'Generate only a specific collection' },
     dryRun: { type: 'boolean', description: 'Preview without writing' },
     force: { type: 'boolean', description: 'Force generation' },
+    tests: { type: 'boolean', description: 'Generate per-collection schema-smoke tests (use --no-tests to skip)', default: true },
     noAutoMerge: { type: 'boolean', description: 'Skip auto-merging package collections' },
   },
   async run({ args }) {
@@ -140,6 +145,7 @@ const configCmd = defineCommand({
       force: args.force,
       dryRun: args.dryRun,
       only: args.only,
+      noTests: args.tests === false,
       noAutoMerge: args.noAutoMerge,
     })
   }

--- a/packages/crouton-cli/examples/crouton.config.example.js
+++ b/packages/crouton-cli/examples/crouton.config.example.js
@@ -76,7 +76,9 @@ export default {
     // Basic collection
     {
       name: 'products', // Collection name (plural, kebab-case recommended)
-      fieldsFile: './schemas/products.json' // Path to JSON schema file
+      fieldsFile: './schemas/products.json', // Path to JSON schema file
+      // tests: false // Skip the schema-smoke test for this collection (emitted by
+      //              // default, #785; equivalent to the global --no-tests flag)
     },
 
     // Collection with hierarchy support (tree structure)

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -39,6 +39,7 @@ import { generateQueries } from './generators/database-queries.ts'
 import { generateSchema } from './generators/database-schema.ts'
 import { generateTypes } from './generators/types.ts'
 import { generateNuxtConfig } from './generators/nuxt-config.ts'
+import { generateCollectionTest } from './generators/collection-test.ts'
 import { generateRepeaterItemComponent } from './generators/repeater-item-component.ts'
 import { generateFieldComponents } from './generators/field-components.ts'
 import { generateSeedFile } from './generators/seed-data.ts'
@@ -120,6 +121,7 @@ interface WriteScaffoldOptions {
   hierarchy?: boolean
   seed?: boolean
   seedCount?: number
+  noTests?: boolean
 }
 
 interface RunConfigOptions {
@@ -128,6 +130,7 @@ interface RunConfigOptions {
   dryRun?: boolean
   only?: string
   noAutoMerge?: boolean
+  noTests?: boolean
 }
 
 interface RunGenerateOptions {
@@ -143,6 +146,7 @@ interface RunGenerateOptions {
   hierarchy?: boolean
   seed?: boolean
   seedCount?: number
+  noTests?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -627,7 +631,7 @@ ${translationsFieldSchema}
   }
 }
 
-async function writeScaffold({ layer, collection, fields, dialect, autoRelations, dryRun, noDb, force = false, noTranslations = false, config = null, collectionConfig = null, hierarchy: hierarchyFlag = false, seed = false, seedCount = 25 }: WriteScaffoldOptions): Promise<void> {
+async function writeScaffold({ layer, collection, fields, dialect, autoRelations, dryRun, noDb, force = false, noTranslations = false, config = null, collectionConfig = null, hierarchy: hierarchyFlag = false, seed = false, seedCount = 25, noTests = false }: WriteScaffoldOptions): Promise<void> {
   const cases = toCase(collection)
   const base = path.resolve('layers', layer, 'collections', cases.plural)
 
@@ -849,6 +853,9 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
       console.log(`• ${base}/server/database/seed.ts (${seedCount} records)`)
     }
     console.log(`• ${base}/types.ts`)
+    if (!noTests) {
+      console.log(`• ${base}/${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
+    }
     console.log(`• ${base}/nuxt.config.ts`)
     console.log(`• layers/${layer}/nuxt.config.ts (layer root config)`)
     console.log(`• nuxt.config.ts (root config - add layer to extends)`)
@@ -1037,6 +1044,18 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
       content: `${JSON.stringify(seedFixture, null, 2)}\n`,
     })
     console.log(`  Generating seed.json (${seedFixture.rows.length} sample rows)`)
+  }
+
+  // Emit a schema-smoke test next to the collection (#785) — on by default,
+  // suppressed by --no-tests. Runtime-free (zod only): asserts the generated
+  // Zod schema accepts a valid record and rejects an invalid one. The e2e
+  // fixture smoke owns boot + CRUD; this is the unit-level complement.
+  if (!noTests) {
+    files.push({
+      path: path.join(base, `${layerPascalCase}${cases.pascalCasePlural}.test.ts`),
+      content: generateCollectionTest(data, config),
+    })
+    console.log(`  Generating ${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
   }
 
   // Write all files
@@ -1299,6 +1318,7 @@ export async function runConfig(options: RunConfigOptions = {}): Promise<void> {
     if (!config.flags) config.flags = {}
     if (options.force) config.flags.force = true
     if (options.dryRun) config.flags.dryRun = true
+    if (options.noTests) config.flags.noTests = true
 
     // Single-collection filter
     const onlyCollection = options.only || null
@@ -1461,7 +1481,8 @@ export async function runConfig(options: RunConfigOptions = {}): Promise<void> {
               config: config,
               collectionConfig: collectionConfig, // Pass individual collection config for hierarchy detection
               seed: !!collectionSeed,
-              seedCount: collectionSeed?.count || config?.seed?.defaultCount || 25
+              seedCount: collectionSeed?.count || config?.seed?.defaultCount || 25,
+              noTests: config.flags?.noTests || collectionConfig?.tests === false || false
             })
 
             allCollections.push({ name: collectionName, layer: target.layer, fields })
@@ -1502,7 +1523,8 @@ export async function runConfig(options: RunConfigOptions = {}): Promise<void> {
               noTranslations: config.flags?.noTranslations || false,
               config: config,
               seed: globalSeed,
-              seedCount: config?.seed?.defaultCount || 25
+              seedCount: config?.seed?.defaultCount || 25,
+              noTests: config.flags?.noTests || false
             })
 
             allCollections.push({ name: collection, layer: target.layer, fields })
@@ -1547,7 +1569,8 @@ export async function runGenerate(options: RunGenerateOptions = {}): Promise<voi
       noTranslations: options.noTranslations || false,
       hierarchy: options.hierarchy || false,
       seed: options.seed || false,
-      seedCount: options.seedCount || 25
+      seedCount: options.seedCount || 25,
+      noTests: options.noTests || false
     }
 
     // Validate CLI arguments

--- a/packages/crouton-cli/lib/generators/collection-test.ts
+++ b/packages/crouton-cli/lib/generators/collection-test.ts
@@ -1,0 +1,141 @@
+// Generator for a per-collection schema-smoke test (<Collection>.test.ts).
+//
+// Emitted next to each generated collection (#785/#788). It imports the
+// collection's generated Zod schema (from the composable) and asserts the
+// deterministic, runtime-free surface: a schema-valid record parses, and an
+// invalid one is rejected. This is the unit-level complement to the e2e fixture
+// smoke (which owns boot + CRUD) — no Nuxt/DB runtime, no mocks, just zod, so it
+// stays green for any schema. On by default; suppressed by `--no-tests`.
+//
+// The sample is derived at generation time from the same field metadata the
+// schema is built from, so it must mirror the schema's required-field rules
+// (see fieldsSchema in generate-collection.ts): required string/text uses
+// `.min(1)` (so the value must be non-empty), required dependent fields use
+// `.min(1)` on an array, dates are `z.coerce.date()` (accept an ISO string),
+// and translatable fields are validated under `translations.<defaultLocale>`.
+
+// Auto-generated / system columns and hierarchy columns are injected by the
+// runtime, not part of the create/validate schema — never sampled here.
+const AUTO_FIELDS = new Set([
+  'id', 'teamId', 'owner',
+  'createdAt', 'updatedAt', 'createdBy', 'updatedBy',
+  'parentId', 'path', 'depth', 'order',
+])
+
+function isDependentField(field: Record<string, any>): boolean {
+  return Boolean((field.meta?.dependsOn && field.meta?.dependsOnCollection) || field.meta?.displayAs === 'slotButtonGroup')
+}
+
+/**
+ * A schema-valid literal for a field. Derived from the field's `zod` expression
+ * — the same source the generated schema embeds — so the sample matches the
+ * schema whether or not the type manifest resolved (a manifest-less run degrades
+ * every field to `z.string()`, and so does the sample). Two overrides mirror
+ * the schema generator (see fieldsSchema in generate-collection.ts): dates are
+ * forced to `z.coerce.date()` (accept an ISO string) and dependent fields to a
+ * non-empty `z.array(z.string()).min(1)`.
+ */
+function sampleLiteral(field: Record<string, any>): string {
+  if (isDependentField(field)) return "['sample']"
+  if (field.type === 'date') return "'2024-01-01T00:00:00.000Z'"
+
+  const zod = String(field.zod || '')
+  // enum (defensive — current generator keeps option fields as z.string())
+  const enumMatch = zod.match(/z\.enum\(\[\s*'([^']*)'/)
+  if (enumMatch) return `'${enumMatch[1]}'`
+  if (/z\.coerce\.date|z\.date/.test(zod)) return "'2024-01-01T00:00:00.000Z'"
+  if (/z\.number/.test(zod)) return '1'
+  if (/z\.boolean/.test(zod)) return 'true'
+  if (/z\.array/.test(zod)) return '[]'
+  if (/z\.record|z\.object/.test(zod)) return '{}'
+  // strings, text, image/file, option fields, and the manifest-less fallback —
+  // required string/text is `.min(1)`, so the value must be non-empty.
+  return "'sample'"
+}
+
+function objectLiteral(entries: string[], indent = '      '): string {
+  if (entries.length === 0) return '{}'
+  return `{\n${entries.map(e => `${indent}${e}`).join(',\n')},\n${indent.slice(2)}}`
+}
+
+/**
+ * Generate the source of a `<Collection>.test.ts` schema-smoke test.
+ * Returns the file content as a string (the orchestrator decides whether to
+ * write it, honouring `--no-tests`).
+ */
+export function generateCollectionTest(data: Record<string, any>, config: Record<string, any> | null = null): string {
+  const { layer, plural, pascalCase, pascalCasePlural, layerPascalCase, layerCamelCase, fields } = data
+
+  const schemaName = `${layerCamelCase}${pascalCase}Schema`
+  const composableName = `use${layerPascalCase}${pascalCasePlural}`
+  const importPath = `./app/composables/${composableName}`
+
+  // Translatable fields are validated under `translations` (config-driven, mirrors fieldsSchema).
+  const translatableFieldNames: string[] = config?.translations?.collections?.[plural] || []
+  const defaultLocale: string = config?.defaultLocale || 'en'
+
+  const schemaFields = fields.filter((f: Record<string, any>) => !AUTO_FIELDS.has(f.name))
+  const plainFields = schemaFields.filter((f: Record<string, any>) => !translatableFieldNames.includes(f.name))
+  const requiredPlain = plainFields.filter((f: Record<string, any>) => f.meta?.required)
+  const translatableFields = schemaFields.filter((f: Record<string, any>) => translatableFieldNames.includes(f.name))
+  const requiredTranslatable = translatableFields.filter((f: Record<string, any>) => f.meta?.required)
+
+  // Build the valid sample: every required plain field with a type-correct value
+  // (optional fields are omitted — they're `.optional()`/`.nullish()`).
+  const validEntries: string[] = requiredPlain.map((f: Record<string, any>) => `${f.name}: ${sampleLiteral(f)}`)
+
+  // When the schema has translatable fields it carries a (required) `translations`
+  // record; populate the default locale for any required translatable fields.
+  if (translatableFieldNames.length > 0) {
+    if (requiredTranslatable.length > 0) {
+      const inner = requiredTranslatable.map((f: Record<string, any>) => `${f.name}: 'sample'`).join(', ')
+      validEntries.push(`translations: { ${defaultLocale}: { ${inner} } }`)
+    } else {
+      validEntries.push('translations: {}')
+    }
+  }
+
+  const validLiteral = objectLiteral(validEntries)
+
+  // Build the invalid sample so there's always a meaningful red case:
+  //  - omit a required plain field (most common), else
+  //  - blank the required translations, else
+  //  - assert a non-object is rejected (collection has no required fields).
+  let invalidBody: string
+  if (requiredPlain.length > 0) {
+    const omit = requiredPlain[0].name
+    const invalidEntries = validEntries.filter(e => !e.startsWith(`${omit}:`))
+    invalidBody = `    const invalid = ${objectLiteral(invalidEntries)}\n    expect(${schemaName}.safeParse(invalid).success).toBe(false)`
+  } else if (requiredTranslatable.length > 0) {
+    const invalidEntries = validEntries.map(e => e.startsWith('translations:') ? 'translations: {}' : e)
+    invalidBody = `    const invalid = ${objectLiteral(invalidEntries)}\n    expect(${schemaName}.safeParse(invalid).success).toBe(false)`
+  } else {
+    invalidBody = `    // no required fields — a non-object must still be rejected\n    expect(${schemaName}.safeParse(null).success).toBe(false)`
+  }
+
+  const header = `/**
+ * @crouton-generated
+ * @collection ${plural}
+ * @layer ${layer}
+ *
+ * Schema-smoke test (#785): asserts the generated Zod schema accepts a valid
+ * record and rejects an invalid one. Runtime-free (zod only) — the e2e fixture
+ * smoke owns boot + CRUD. Regenerate with --force; suppress with --no-tests.
+ */
+`
+
+  return `${header}import { describe, it, expect } from 'vitest'
+import { ${schemaName} } from '${importPath}'
+
+describe('${layer}/${plural} schema (generated)', () => {
+  it('accepts a valid record', () => {
+    const valid = ${validLiteral}
+    expect(${schemaName}.safeParse(valid).success).toBe(true)
+  })
+
+  it('rejects an invalid record', () => {
+${invalidBody}
+  })
+})
+`
+}

--- a/packages/crouton-cli/lib/scaffold-app.ts
+++ b/packages/crouton-cli/lib/scaffold-app.ts
@@ -118,7 +118,10 @@ function tmplPackageJson(vars: ScaffoldVars): string {
   const devDeps = {
     '@fyit/crouton-cli': 'workspace:*',
     '@fyit/crouton-devtools': 'workspace:*',
-    'drizzle-kit': '^0.31.0'
+    'drizzle-kit': '^0.31.0',
+    // Runs the schema-smoke tests the generator emits next to each collection
+    // (#785). Not cataloged by design (#141); matches @fyit/crouton-cli.
+    'vitest': '^2.1.0'
   }
   if (vars.cf) {
     devDeps['wrangler'] = '^4.64.0'
@@ -129,6 +132,8 @@ function tmplPackageJson(vars: ScaffoldVars): string {
     dev: 'nuxt dev',
     generate: 'nuxt generate',
     preview: 'nuxt preview',
+    // Runs the per-collection schema-smoke tests the generator emits (#785).
+    test: 'vitest run',
     // Guarded: a whole-monorepo `pnpm install` (e.g. on Cloudflare) runs every
     // workspace's postinstall before the dist-consumed @fyit/* packages are built;
     // a bare `nuxt prepare` would error and abort the entire install. The guard
@@ -344,6 +349,21 @@ export default defineConfig({
   dialect: 'sqlite',
   schema,
   out: 'server/db/migrations/sqlite',
+})
+`
+}
+
+function tmplVitestConfig(): string {
+  // Runs the per-collection schema-smoke tests the generator emits (#785). They
+  // import only the generated Zod schema (no Nuxt runtime), so a plain node
+  // environment is enough — the e2e fixture smoke owns boot + CRUD.
+  return `import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['layers/**/*.test.ts', 'tests/**/*.test.ts'],
+    environment: 'node',
+  },
 })
 `
 }
@@ -603,6 +623,7 @@ export async function scaffoldApp(
     { path: 'app/assets/css/main.css', content: tmplMainCss() },
     { path: 'server/db/schema.ts', content: tmplSchemaTs() },
     { path: 'server/db/translations-ui.ts', content: tmplTranslationsUi(vars) },
+    { path: 'vitest.config.ts', content: tmplVitestConfig() },
     { path: 'schemas/.gitkeep', content: '' }
   ]
 

--- a/packages/crouton-cli/tests/unit/generators/collection-test.test.ts
+++ b/packages/crouton-cli/tests/unit/generators/collection-test.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { generateCollectionTest } from '../../../lib/generators/collection-test.ts'
+
+// Minimal `data` shape the orchestrator passes to generators (see generate-collection.ts).
+const baseData = {
+  layer: 'shop',
+  singular: 'product',
+  plural: 'products',
+  pascalCase: 'Product',
+  pascalCasePlural: 'Products',
+  layerPascalCase: 'Shop',
+  layerCamelCase: 'shop',
+  // `zod`/`default`/`tsType` are what loadFields attaches once the type manifest
+  // resolves — the sample is derived from `zod`, so the fixtures carry it.
+  fields: [
+    { name: 'id', type: 'string', zod: 'z.string()', meta: { primaryKey: true } },
+    { name: 'name', type: 'string', zod: 'z.string()', meta: { required: true } },
+    { name: 'price', type: 'decimal', zod: 'z.number()', meta: { required: true } },
+    { name: 'inStock', type: 'boolean', zod: 'z.boolean()', meta: {} },
+    { name: 'releasedAt', type: 'date', zod: 'z.date()', meta: {} },
+  ],
+}
+
+describe('generateCollectionTest (#788)', () => {
+  const code = generateCollectionTest(baseData, null)
+
+  it('imports the generated Zod schema by exact name + composable path', () => {
+    expect(code).toContain("import { shopProductSchema } from './app/composables/useShopProducts'")
+  })
+
+  it('accepts a valid sample whose required string is non-empty (schema is .min(1))', () => {
+    // required string must be present AND non-empty — z.string().min(1) rejects ''
+    expect(code).toMatch(/name:\s*'[^']+'/)
+    expect(code).not.toMatch(/name:\s*''/)
+    expect(code).toContain('.safeParse(')
+    expect(code).toMatch(/success\)\.toBe\(true\)/)
+  })
+
+  it('samples a numeric field as a number, not a string (matches z.number())', () => {
+    // the sample is derived from field.zod, so a decimal/number field is 1, not 'sample'
+    expect(code).toMatch(/price:\s*1\b/)
+    expect(code).not.toMatch(/price:\s*'/)
+  })
+
+  it('rejects an invalid sample', () => {
+    expect(code).toMatch(/success\)\.toBe\(false\)/)
+  })
+
+  it('omits auto/system fields from the sample', () => {
+    expect(code).not.toMatch(/\bteamId:/)
+    expect(code).not.toMatch(/\bcreatedAt:/)
+    expect(code).not.toMatch(/^\s*id:/m)
+  })
+
+  it('still emits a reject case when the collection has no required fields', () => {
+    const c = generateCollectionTest({
+      ...baseData,
+      fields: [
+        { name: 'id', type: 'string', meta: { primaryKey: true } },
+        { name: 'note', type: 'text', meta: {} },
+      ],
+    }, null)
+    expect(c).toMatch(/success\)\.toBe\(false\)/)
+  })
+
+  it('emits no nondeterministic calls', () => {
+    expect(code).not.toContain('Date.now(')
+    expect(code).not.toContain('Math.random(')
+  })
+})


### PR DESCRIPTION
Epic #785 — the deferred Level 3 from #774's postmortem: make the **generator** emit tests so "tests-first" scales to the place most runtime logic actually lives — generated code.

## What landed

| Sub-issue | Commit | What |
|---|---|---|
| Closes #788 | `cefac9f` | Generator emits `<Layer><Collections>.test.ts` per collection — on by default, `--no-tests` (or `tests: false`) to skip |
| Closes #789 | `b8e6400` | `scaffold-app`/`crouton init` emit `vitest.config.ts` + `test` script + `vitest` devDep so `pnpm test` runs them |
| Closes #790 | `80b28ee` | Doc sync — `crouton-cli/CLAUDE.md`, `/crouton` skill, example config, README |

`#791` (API route auth/error-path tests) stays **open** as the tracked follow-up — deferred at decomposition so the schema-smoke (guaranteed-green) ships first and the runner + mocking pattern are proven before the meatier handler tests.

## How it works

The emitted test imports the collection's generated **Zod schema** from the composable and asserts the deterministic surface: a valid record parses, an invalid one is rejected. It's **runtime-free** (zod only — no Nuxt/DB, no mocks), so it stays green for any schema and is the unit-level complement to the **e2e fixture smoke** (which still owns boot + CRUD — no duplication).

The valid sample is derived at generation time from each field's `zod` (the same source the schema embeds), so it matches the schema whether or not the type manifest resolved. Two overrides mirror `fieldsSchema` in `generate-collection.ts`: `date` → `z.coerce.date()` (ISO string), dependent fields → non-empty `z.array(z.string()).min(1)`. Auto/system + hierarchy fields are excluded; output is deterministic (no `Date.now()`/`Math.random()`).

## Decisions (from decomposition)

- **On by default** (`--no-tests` opt-out) — matches the epic hypothesis that test-first becomes the default.
- **Schema-smoke only for v1** — pure and guaranteed-green; API-handler depth → #791.
- **Scaffold a per-app vitest runner** — makes "a freshly generated collection ships a passing test" literally true.

## Verification

- **Test-first (#774):** `tests/unit/generators/collection-test.test.ts` was written as the agreed contract (red), then the generator implemented to green.
- **End-to-end:** generated a varied collection (`string`/`number`/`decimal`/`boolean`/`date`/`json`) into `fixtures/minimal` (manifest resolves) → emitted test ran **green** (`qty` sampled as `1`, not `'sample'`); fixture artifacts fully restored.
- `--no-tests` confirmed to suppress; scaffolded an app and confirmed the vitest wiring lands.
- Full crouton-cli suite green (274 tests); field-types + skills-doc sync checks pass.

## Merge note

Commits are atomic and single-concern (one per sub-issue) — please **merge or rebase, don't squash** (repo merge policy: keep granular history for archaeology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q5Gj2ni5xBnfRReGm6QMi

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q5Gj2ni5xBnfRReGm6QMi)_