### PR TITLE
fix(crouton-devtools): restore review overlay on booking-demo — verifies #745

### DIFF
--- a/pocs/booking-demo/nuxt.config.ts
+++ b/pocs/booking-demo/nuxt.config.ts
@@ -6,7 +6,7 @@ const cfStubs = resolve(__dirname, 'server/utils/_cf-stubs')
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  modules: ['@fyit/crouton'],
+  modules: ['@fyit/crouton', '@fyit/crouton-devtools'],
   css: ['~/assets/css/main.css'],
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },


### PR DESCRIPTION
## 👤 For humans

Re-adds the `@fyit/crouton-devtools` click-to-comment review overlay to the **booking-demo** POC. It was dropped as the [#743](https://github.com/FriendlyInternet/nuxt-crouton/pull/743) workaround because the deploy pipeline never built the devtools `dist`, so `nuxt prepare` crashed on deploy.

[#745](https://github.com/FriendlyInternet/nuxt-crouton/issues/745) is now fixed (merged via [#792](https://github.com/FriendlyInternet/nuxt-crouton/pull/792)) — `deploy-app.yml` builds the devtools dist on every deploy and keys the layer cache on the resolved build set. **This PR is the end-to-end proof:** opening it triggers `deploy-pocs.yml` → a staging deploy of booking-demo. We watch that the deploy (a) builds the devtools dist, (b) `nuxt prepare` no longer throws, and (c) the overlay renders at https://booking-demo.pmcp.dev — closing the loop on #745's "we'll know by".

This does **not** carry `Closes #745` — #745 is already closed by #792. This PR verifies it (and is the correct end state: a scaffolded POC keeps its review overlay).

## 🤖 For agents

- `pocs/booking-demo/nuxt.config.ts`: `modules += '@fyit/crouton-devtools'` (reverts the #743 removal). `@fyit/crouton-devtools` is a declared devDependency.
- `deploy.config.json` `layerPackages` still omits devtools **on purpose** — the fixed `deploy-app.yml` appends it unconditionally and folds the sorted/deduped build set into the layer cache key.
- **Expected on first deploy:** a layer cache **miss** (the key bumped to `layer-builds-<set-hash>-…`), slower, then it populates a fresh entry **with** the devtools dist.

## 🧪 We'll know by

booking-demo's staging deploy succeeds (no `Could not load @fyit/crouton-devtools` from `nuxt prepare`), and the review overlay renders at the preview URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iAGcTSgnAH6MC3a5zDXv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQbcN1sjpnf6KJyhLyHC2f)_