### PR TITLE
test(root): re-enable devtools overlay on booking-demo to verify #745 fix

### DIFF
--- a/pocs/booking-demo/nuxt.config.ts
+++ b/pocs/booking-demo/nuxt.config.ts
@@ -6,7 +6,7 @@ const cfStubs = resolve(__dirname, 'server/utils/_cf-stubs')
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  modules: ['@fyit/crouton'],
+  modules: ['@fyit/crouton', '@fyit/crouton-devtools'],
   css: ['~/assets/css/main.css'],
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },


### PR DESCRIPTION
Verifies #745 (fix landed via #792 — do **not** re-open).

## 👤 For humans

This is the live proof for the #745 deploy fix. #792 made every deploy build the `@fyit/crouton-devtools` dist; this PR re-adds the review-overlay module to `pocs/booking-demo`'s `nuxt.config` modules (it had been dropped as the #743 workaround when the deploy couldn't load it). The expected result: booking-demo deploys to staging with the **click-to-comment overlay live** at `booking-demo.pmcp.dev`, and `nuxt prepare` no longer throws.

## 🤖 For agents

- `pocs/booking-demo/nuxt.config.ts`: `modules: ['@fyit/crouton']` → `['@fyit/crouton', '@fyit/crouton-devtools']` (restores the scaffold default).
- `@fyit/crouton-devtools` is still a `workspace:*` dependency in `package.json` (only the module entry had been removed), so no dependency change is needed.
- **Local check:** `npx nuxt prepare` in `pocs/booking-demo` now exits `0` with the module loaded — the exact step that threw `Could not load \`@fyit/crouton-devtools\`` in #743.
- **CI proof (this PR):** touching `pocs/booking-demo/**` triggers `deploy-pocs.yml` → `deploy-app.yml`, which now runs #792's logic. The first deploy is a cache **MISS** (expected) and should populate a `layer-builds-<set-hash>-` entry that includes `crouton-devtools/dist`. Confirm on the run: build step builds devtools, `nuxt prepare` survives, and the staging preview renders the overlay.

## 🧪 We'll know by

booking-demo's staging deploy renders the click-to-comment overlay at its preview URL, and `nuxt prepare` no longer throws on `@fyit/crouton-devtools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6JMHUHdajD7UiurC3HBuE

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6JMHUHdajD7UiurC3HBuE)_