### PR TITLE
feat(crouton-cli): generator emits API route handler tests (#791)

### DIFF
--- a/.claude/skills/crouton.md
+++ b/.claude/skills/crouton.md
@@ -92,7 +92,7 @@ Use this skill when the user mentions:
 | `--hierarchy` | Enable tree structure |
 | `--seed` | Generate seed data file |
 | `--count <n>` | Seed record count (default: 25) |
-| `--no-tests` | Skip the per-collection schema-smoke test (emitted by default, #785) |
+| `--no-tests` | Skip the per-collection tests — schema-smoke (#785) + API route handler test (#791); both emitted by default |
 | `--dry-run` | Preview without writing |
 
 ### Field Types
@@ -347,16 +347,25 @@ layers/{layer}/collections/{collection}/
 │       ├── schema.ts         # Drizzle ORM schema
 │       ├── queries.ts        # Database operations
 │       └── seed.ts           # Seed data (with --seed flag)
-├── {Layer}{Collection}s.test.ts  # Zod schema-smoke test (#785) — skip with --no-tests
+├── {Layer}{Collection}s.test.ts      # Zod schema-smoke test (#785) — skip with --no-tests
+├── {Layer}{Collection}s.api.test.ts  # API route handler test (#791) — skip with --no-tests
 ├── types.ts                  # TypeScript interfaces
 ├── nuxt.config.ts           # Layer configuration
 └── README.md                # Collection documentation
 ```
 
-A **schema-smoke test** is emitted per collection by default (#785): runtime-free
-(zod only), it asserts the generated Zod schema accepts a valid record and rejects
-an invalid one. `crouton init`/`scaffold-app` wire a `vitest.config.ts` + `test`
-script so `pnpm test` runs them. The e2e fixture smoke still owns boot + CRUD.
+Two tests are emitted per collection by default (skip both with `--no-tests`):
+
+- A **schema-smoke test** (#785): runtime-free (zod only), it asserts the generated
+  Zod schema accepts a valid record and rejects an invalid one.
+- An **API route handler test** (#791): drives the generated endpoint handlers
+  (`get`/`post`/`[id].patch`/`[id].delete`, plus `move`/`reorder` for hierarchy) with
+  a mocked team-auth util + queries module and a fake H3 event — covering team-scoping
+  (unauthenticated → rejected; queries called with the resolved team id) and error
+  paths (invalid body → rejected, missing id → 400, not-found → 404).
+
+`crouton init`/`scaffold-app` wire a `vitest.config.ts` + `test` script so `pnpm test`
+runs them. The e2e fixture smoke still owns real boot + CRUD.
 
 ### Running Seed Files
 

--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -272,7 +272,7 @@ crouton db-pull --config ./custom-wrangler.jsonc
 | `--count <number>` | Number of seed records (default: 25) |
 | `--force` | Overwrite existing files |
 | `--no-translations` | Skip i18n fields |
-| `--no-tests` | Skip the per-collection schema-smoke test (emitted by default, #785) |
+| `--no-tests` | Skip the per-collection tests — schema-smoke (#785) + API route handler test (#791); both emitted by default |
 | `--dry-run` | Preview without writing |
 
 ## Key Files
@@ -285,8 +285,9 @@ crouton db-pull --config ./custom-wrangler.jsonc
 | `lib/compose-layout.ts` | **Deterministic default-layout step** (#709) — after generation, runs `@fyit/crouton-layout`'s `composeDefaultLayout` (moved out of crouton-core, #751) over the generated collections and writes `crouton.layout.json` (a `layout_configs` tree the POC boots with). `registryKeyFor(layer, collection)` mirrors the generated registry key; mirrors the core + bookings block sizing contracts (no live `app.config` at generate time) |
 | `lib/generate-collection.ts` | Main orchestrator (~74KB) |
 | `lib/init-app.ts` | Init pipeline (scaffold → generate → doctor) |
-| `lib/generators/*.ts` | Template generators (15 files) |
-| `lib/generators/collection-test.ts` | Emits `<Layer><Collections>.test.ts` — a runtime-free Zod schema smoke (valid parses / invalid rejected). Sample derived from each field's `zod`. On by default; `--no-tests` skips (#785) |
+| `lib/generators/*.ts` | Template generators (16 files) |
+| `lib/generators/collection-test.ts` | Emits `<Layer><Collections>.test.ts` — a runtime-free Zod schema smoke (valid parses / invalid rejected). Sample derived from each field's `zod`. On by default; `--no-tests` skips (#785). Also exports the shared sample derivation (`buildCollectionSample`) reused by the API test |
+| `lib/generators/api-test.ts` | Emits `<Layer><Collections>.api.test.ts` — drives the generated route handlers (get/post/[id].patch/[id].delete + move/reorder) with a mocked team-auth util + queries module and a fake H3 event; covers team-scoping + 400/403/404 error paths. Same `--no-tests` gate (#791) |
 | `lib/db-pull.ts` | Remote D1 → local dev pull |
 | `lib/module-registry.ts` | Module definitions for `crouton add` |
 | `lib/add-module.ts` | Module installation implementation |
@@ -313,7 +314,8 @@ lib/generators/
 ├── nuxt-config.ts         → Layer config
 ├── field-components.ts    → Dependent field components
 ├── query-registry.ts      → Server-side query registry (lazy imports)
-└── collection-test.ts     → <Layer><Collections>.test.ts (Zod schema smoke, #785)
+├── collection-test.ts     → <Layer><Collections>.test.ts (Zod schema smoke, #785)
+└── api-test.ts            → <Layer><Collections>.api.test.ts (route handler tests, #791)
 ```
 
 ## Schema Format
@@ -511,7 +513,8 @@ layers/[layer]/collections/[collection]/
 │       ├── queries.ts
 │       └── seed.ts          # Only with --seed flag
 ├── seed.json                # Editable auto-derived sample rows (#298)
-├── [Layer][Collections].test.ts  # Zod schema-smoke test (#785) — skip with --no-tests
+├── [Layer][Collections].test.ts      # Zod schema-smoke test (#785) — skip with --no-tests
+├── [Layer][Collections].api.test.ts  # API route handler test (#791) — skip with --no-tests
 ├── types.ts
 └── nuxt.config.ts
 
@@ -538,7 +541,36 @@ no mocks), so it stays green for any schema — the unit-level complement to the
   fields are excluded; output is deterministic (no `Date.now()`/`Math.random()`).
 - `scaffold-app`/`crouton init` emit a `vitest.config.ts` + `test` script + the
   `vitest` devDep, so `pnpm test` runs these out of the box (#789).
-- API route auth/error-path tests are a tracked follow-up (#791), not emitted yet.
+
+### API route handler test (#791)
+
+Each collection also ships `<Layer><Collections>.api.test.ts` next to the
+schema-smoke — the depth deferred from #788. It drives the **generated endpoint
+handlers** (`index.get`/`index.post`/`[id].patch`/`[id].delete`, plus
+`move.patch`/`reorder.patch` for hierarchy/sortable collections) to cover the
+runtime logic the schema-smoke can't: **team-scoping** (an unauthenticated
+request is rejected and never writes; the happy path calls the query with the
+*resolved team's* id — flip `teamId: team.id` in a handler and the test goes red)
+and **error paths** (invalid body → rejected before any write, missing id param →
+400, a not-found surfaced by the query → 404).
+
+- **Runtime-free-ish:** the team-auth util (`@fyit/crouton-auth/server/utils/team`)
+  and the generated `./server/database/queries` module are `vi.mock`ed; the H3/Nitro
+  auto-imports the handlers call (`defineEventHandler`, `getQuery`,
+  `getRouterParams`, `readBody`, `readValidatedBody`, `createError`,
+  `useServerTiming`) are provided as globals via `vi.hoisted` (so the route's
+  `export default defineEventHandler(...)` evaluates at import); each handler runs
+  against a plain fake H3 event. No Nuxt server, no DB, no network.
+- **Same `--no-tests` gate** as the schema-smoke — it rides the one `tests` flag
+  (on by default). The assertions are engineered to be schema-shape-independent
+  (mock/control-flow driven); the one body-shape-dependent case (invalid-body →
+  rejected) is emitted only when an invalid sample is derivable, degrading
+  gracefully. The happy-path body reuses the schema-smoke's single-sourced sample
+  derivation (`buildCollectionSample` in `collection-test.ts`).
+- The emitted file carries `// @ts-nocheck` — it relies on untyped Nitro globals
+  and runs under vitest, not the app's `nuxt typecheck`.
+- The **e2e fixture smoke** still owns real boot + CRUD; this is the unit-level
+  complement (no duplication).
 
 ## Default Layout (generate → POC, #709)
 
@@ -676,7 +708,7 @@ features: {
 | `formComponent` | string | Use a custom form component instead of generating Form.vue |
 | `kind` | string | Collection kind: `'data'` (default), `'content'`, or `'media'`. Affects admin sidebar grouping |
 | `publishable` | boolean | Auto-register as page type in crouton-pages (requires crouton-pages) |
-| `tests` | boolean | Emit the schema-smoke test for this collection (default `true`; set `false` to skip, like `--no-tests`) (#785) |
+| `tests` | boolean | Emit the per-collection tests — schema-smoke (#785) + API route handler test (#791) — for this collection (default `true`; set `false` to skip, like `--no-tests`) |
 
 ### formComponent Option
 
@@ -879,6 +911,7 @@ npx nuxt typecheck
 | `lib/generators/types.ts` | TypeScript type generation (snapshot) |
 | `lib/generators/composable.ts` | Composable generation (snapshot) |
 | `lib/generators/collection-test.ts` | Schema-smoke test emission — import path, per-type sample derivation, valid/invalid cases (#785) |
+| `lib/generators/api-test.ts` | API route handler test emission — handler import paths, query-mock factory, auth/team-scope + 400/403/404 cases, hierarchy move/reorder (#791) |
 
 ## Seed Data Generation
 

--- a/packages/crouton-cli/README.md
+++ b/packages/crouton-cli/README.md
@@ -8,7 +8,7 @@ A powerful CLI tool for generating complete CRUD collections in Nuxt Crouton app
 - 🗄️ **Multi-Database Support** - PostgreSQL and SQLite
 - 🎯 **Type-Safe** - Full TypeScript support with Zod validation
 - 🌱 **Seed Data** - Generate realistic test data with drizzle-seed
-- ✅ **Tests by Default** - Emits a runtime-free Zod schema-smoke test per collection (`--no-tests` to skip)
+- ✅ **Tests by Default** - Emits a Zod schema-smoke test + an API route handler test (auth/team-scope + 400/403/404 paths) per collection (`--no-tests` to skip)
 - 🔧 **Customizable** - Modify generated code to fit your needs
 - 📦 **Zero Config** - Works out of the box with sensible defaults
 
@@ -142,7 +142,7 @@ crouton-generate <layer> <collection> [options]
 - `--seed` - Generate seed data file with realistic test data
 - `--count <number>` - Number of seed records to generate (default: 25)
 - `--no-translations` - Skip translation fields
-- `--no-tests` - Skip the per-collection schema-smoke test (emitted by default)
+- `--no-tests` - Skip the per-collection tests — schema-smoke + API route handler test (both emitted by default)
 - `--force` - Force generation even if files exist
 - `--no-db` - Skip database table creation
 - `--dry-run` - Preview what will be generated

--- a/packages/crouton-cli/examples/crouton.config.example.js
+++ b/packages/crouton-cli/examples/crouton.config.example.js
@@ -77,8 +77,9 @@ export default {
     {
       name: 'products', // Collection name (plural, kebab-case recommended)
       fieldsFile: './schemas/products.json', // Path to JSON schema file
-      // tests: false // Skip the schema-smoke test for this collection (emitted by
-      //              // default, #785; equivalent to the global --no-tests flag)
+      // tests: false // Skip the per-collection tests for this collection — the
+      //              // schema-smoke (#785) + the API route handler test (#791);
+      //              // both emitted by default, equivalent to the global --no-tests flag
     },
 
     // Collection with hierarchy support (tree structure)

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -40,6 +40,7 @@ import { generateSchema } from './generators/database-schema.ts'
 import { generateTypes } from './generators/types.ts'
 import { generateNuxtConfig } from './generators/nuxt-config.ts'
 import { generateCollectionTest } from './generators/collection-test.ts'
+import { generateApiTest } from './generators/api-test.ts'
 import { generateRepeaterItemComponent } from './generators/repeater-item-component.ts'
 import { generateFieldComponents } from './generators/field-components.ts'
 import { generateSeedFile } from './generators/seed-data.ts'
@@ -855,6 +856,7 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     console.log(`• ${base}/types.ts`)
     if (!noTests) {
       console.log(`• ${base}/${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
+      console.log(`• ${base}/${layerPascalCase}${cases.pascalCasePlural}.api.test.ts (route handlers)`)
     }
     console.log(`• ${base}/nuxt.config.ts`)
     console.log(`• layers/${layer}/nuxt.config.ts (layer root config)`)
@@ -1056,6 +1058,17 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
       content: generateCollectionTest(data, config),
     })
     console.log(`  Generating ${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
+
+    // Emit the API route handler test (#791) — the depth deferred from #788.
+    // Drives the generated handlers with mocked team-auth + queries and a fake
+    // H3 event to cover team-scoping (unauth → rejected; queries called with the
+    // resolved team id) and error paths (invalid body → rejected, missing id →
+    // 400, not-found → 404). Same --no-tests gate.
+    files.push({
+      path: path.join(base, `${layerPascalCase}${cases.pascalCasePlural}.api.test.ts`),
+      content: generateApiTest(data, config),
+    })
+    console.log(`  Generating ${layerPascalCase}${cases.pascalCasePlural}.api.test.ts (route handlers)`)
   }
 
   // Write all files

--- a/packages/crouton-cli/lib/generators/api-test.ts
+++ b/packages/crouton-cli/lib/generators/api-test.ts
@@ -1,0 +1,291 @@
+// Generator for a per-collection API route handler test (<Collection>.api.test.ts).
+//
+// Emitted next to each generated collection (#785/#791) alongside the schema-smoke
+// test (#788). Where the schema-smoke proves the Zod schema, this proves the
+// generated endpoint *handlers* — the runtime logic most likely to regress:
+//
+//   • team-scoping — an unauthenticated request is rejected and never writes;
+//     the happy path calls the query with the resolved team's id (flip the
+//     `teamId: team.id` in a handler and this turns red).
+//   • error paths — an invalid body is rejected before any write, a missing id
+//     param 400s, and a not-found surfaced by the query becomes a 404.
+//
+// It is runtime-free-ish: no Nuxt server, no DB, no network. The team-auth util
+// and the generated queries module are `vi.mock`ed, the H3/Nitro auto-imports the
+// handlers rely on are provided as globals via `vi.hoisted` (so the route's
+// `export default defineEventHandler(...)` evaluates at import), and each handler
+// is driven with a plain fake H3 event. The e2e fixture smoke still owns the real
+// boot + CRUD; this is the unit-level complement.
+//
+// On by default; suppressed by `--no-tests` (same gate as the schema-smoke). The
+// assertions are engineered to be schema-shape-independent (mock/control-flow
+// driven); the only body-shape-dependent case (invalid-body → rejected) is
+// emitted only when an invalid sample is derivable, degrading gracefully.
+
+import { toSnakeCase } from '../utils/helpers.ts'
+import { buildCollectionSample, objectLiteral } from './collection-test.ts'
+
+/** Mirror the API directory naming from generate-collection.ts (`${layer}-${plural}`,
+ *  or the `crouton-<collection>` form for system layers). */
+function apiPathFor(layer: string, plural: string, collection: string): string {
+  if (layer.startsWith('crouton-')) {
+    return toSnakeCase(`crouton_${collection}`).replace(/_/g, '-')
+  }
+  return `${layer}-${plural}`
+}
+
+/**
+ * Generate the source of a `<Collection>.api.test.ts` handler test.
+ * Returns the file content as a string (the orchestrator decides whether to
+ * write it, honouring `--no-tests`).
+ */
+export function generateApiTest(data: Record<string, any>, config: Record<string, any> | null = null): string {
+  const { layer, plural, singular, camelCase, pascalCase, pascalCasePlural, layerPascalCase, originalCollectionName } = data
+
+  const S = `${layerPascalCase}${pascalCase}`        // ShopProduct      — singular query suffix
+  const P = `${layerPascalCase}${pascalCasePlural}`  // ShopProducts     — plural query suffix
+  const apiPath = apiPathFor(layer, plural, originalCollectionName || singular || plural)
+  const idParam = `${camelCase}Id`                   // productId        — router param + filename
+  const routeBase = `./server/api/teams/[id]/${apiPath}`
+
+  const hierarchy = data.hierarchy?.enabled === true
+  const sortable = !hierarchy && data.sortable?.enabled === true
+  const hasReorder = hierarchy || sortable
+  const orderField = hierarchy
+    ? (data.hierarchy.orderField || 'order')
+    : (sortable ? (data.sortable.orderField || 'order') : 'order')
+
+  // --- mock factory: every query name the routes import must be present, else the
+  // route gets `undefined` for it and throws on call. Extra exports are harmless.
+  const queryExports = [
+    `getAll${P}: vi.fn()`,
+    `get${P}ByIds: vi.fn()`,
+    `create${S}: vi.fn()`,
+    `update${S}: vi.fn()`,
+    `delete${S}: vi.fn()`,
+  ]
+  if (hierarchy) queryExports.push(`updatePosition${S}: vi.fn()`)
+  if (hasReorder) queryExports.push(`reorderSiblings${P}: vi.fn()`)
+
+  // Named imports we assert against.
+  const queryImports = [`getAll${P}`, `create${S}`, `update${S}`, `delete${S}`]
+  if (hierarchy) queryImports.push(`updatePosition${S}`)
+  if (hasReorder) queryImports.push(`reorderSiblings${P}`)
+
+  // Handler imports.
+  const handlerImports = [
+    `import getHandler from '${routeBase}/index.get.ts'`,
+    `import postHandler from '${routeBase}/index.post.ts'`,
+    `import patchHandler from '${routeBase}/[${idParam}].patch.ts'`,
+    `import deleteHandler from '${routeBase}/[${idParam}].delete.ts'`,
+  ]
+  if (hierarchy) handlerImports.push(`import moveHandler from '${routeBase}/[${idParam}]/move.patch.ts'`)
+  if (hasReorder) handlerImports.push(`import reorderHandler from '${routeBase}/reorder.patch.ts'`)
+
+  // --- POST happy/invalid bodies, reusing the single-sourced sample derivation (#788).
+  const { validEntries, requiredPlain } = buildCollectionSample(data, config)
+  const validBodyLiteral = objectLiteral(validEntries, '  ')
+  let invalidConst = ''
+  let invalidPostCase = ''
+  if (requiredPlain.length > 0) {
+    const omit = requiredPlain[0].name
+    const invalidEntries = validEntries.filter((e: string) => !e.startsWith(`${omit}:`))
+    invalidConst = `\nconst INVALID_BODY = ${objectLiteral(invalidEntries, '  ')}`
+    invalidPostCase = `
+
+    it('rejects an invalid body before writing', async () => {
+      // required \`${omit}\` omitted → readValidatedBody throws → no write happens
+      await expect(postHandler({ __body: INVALID_BODY } as any)).rejects.toBeTruthy()
+      expect(create${S}).not.toHaveBeenCalled()
+    })`
+  }
+
+  // --- describe blocks
+  const getBlock = `
+  describe('index.get', () => {
+    it('rejects an unauthenticated request', async () => {
+      unauth()
+      await expect(getHandler({ __query: {} } as any)).rejects.toBeTruthy()
+      expect(getAll${P}).not.toHaveBeenCalled()
+    })
+
+    it('lists scoped to the resolved team', async () => {
+      ;(getAll${P} as any).mockResolvedValue([])
+      await getHandler({ __query: {} } as any)
+      expect(getAll${P}).toHaveBeenCalled()
+      // first positional arg is always the resolved team id (FK filters ride in opts)
+      expect((getAll${P} as any).mock.calls[0][0]).toBe(TEAM.id)
+    })
+  })`
+
+  const postBlock = `
+  describe('index.post', () => {
+    it('rejects an unauthenticated request and never writes', async () => {
+      unauth()
+      await expect(postHandler({ __body: VALID_BODY } as any)).rejects.toBeTruthy()
+      expect(create${S}).not.toHaveBeenCalled()
+    })
+
+    it('creates scoped to the resolved team', async () => {
+      ;(create${S} as any).mockResolvedValue({ id: 'rec_1' })
+      const result = await postHandler({ __body: VALID_BODY } as any)
+      expect(create${S}).toHaveBeenCalledWith(expect.objectContaining({ teamId: TEAM.id, owner: USER.id }))
+      expect(result).toMatchObject({ id: 'rec_1' })
+    })${invalidPostCase}
+  })`
+
+  const patchBlock = `
+  describe('[${idParam}].patch', () => {
+    it('400s when the id param is missing', async () => {
+      await expect(patchHandler({ __params: {}, __body: {} } as any)).rejects.toMatchObject({ status: 400 })
+    })
+
+    it('rejects an unauthenticated request and never writes', async () => {
+      unauth()
+      await expect(patchHandler({ __params: { ${idParam}: 'rec_1' }, __body: {} } as any)).rejects.toBeTruthy()
+      expect(update${S}).not.toHaveBeenCalled()
+    })
+
+    it('updates scoped to the resolved team', async () => {
+      ;(update${S} as any).mockResolvedValue({ id: 'rec_1' })
+      await patchHandler({ __params: { ${idParam}: 'rec_1' }, __body: {} } as any)
+      expect(update${S}).toHaveBeenCalledWith('rec_1', TEAM.id, USER.id, expect.anything(), expect.anything())
+    })
+
+    it('propagates a not-found from the query as a 404', async () => {
+      ;(update${S} as any).mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }))
+      await expect(patchHandler({ __params: { ${idParam}: 'missing' }, __body: {} } as any)).rejects.toMatchObject({ status: 404 })
+    })
+  })`
+
+  const deleteBlock = `
+  describe('[${idParam}].delete', () => {
+    it('400s when the id param is missing', async () => {
+      await expect(deleteHandler({ __params: {} } as any)).rejects.toMatchObject({ status: 400 })
+    })
+
+    it('rejects an unauthenticated request and never writes', async () => {
+      unauth()
+      await expect(deleteHandler({ __params: { ${idParam}: 'rec_1' } } as any)).rejects.toBeTruthy()
+      expect(delete${S}).not.toHaveBeenCalled()
+    })
+
+    it('deletes scoped to the resolved team', async () => {
+      ;(delete${S} as any).mockResolvedValue({ success: true })
+      await deleteHandler({ __params: { ${idParam}: 'rec_1' } } as any)
+      expect(delete${S}).toHaveBeenCalledWith('rec_1', TEAM.id, USER.id, expect.anything())
+    })
+
+    it('propagates a not-found from the query as a 404', async () => {
+      ;(delete${S} as any).mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }))
+      await expect(deleteHandler({ __params: { ${idParam}: 'missing' } } as any)).rejects.toMatchObject({ status: 404 })
+    })
+  })`
+
+  const moveBlock = hierarchy ? `
+  describe('[${idParam}]/move.patch', () => {
+    it('400s when the id param is missing', async () => {
+      await expect(moveHandler({ __params: {}, __body: { order: 0 } } as any)).rejects.toMatchObject({ status: 400 })
+    })
+
+    it('rejects an unauthenticated request', async () => {
+      unauth()
+      await expect(moveHandler({ __params: { ${idParam}: 'rec_1' }, __body: { order: 0 } } as any)).rejects.toBeTruthy()
+      expect(updatePosition${S}).not.toHaveBeenCalled()
+    })
+
+    it('400s on an invalid order', async () => {
+      await expect(moveHandler({ __params: { ${idParam}: 'rec_1' }, __body: {} } as any)).rejects.toMatchObject({ status: 400 })
+    })
+
+    it('moves scoped to the resolved team', async () => {
+      ;(updatePosition${S} as any).mockResolvedValue({ id: 'rec_1' })
+      await moveHandler({ __params: { ${idParam}: 'rec_1' }, __body: { order: 0 } } as any)
+      expect(updatePosition${S}).toHaveBeenCalledWith(TEAM.id, 'rec_1', null, 0)
+    })
+  })` : ''
+
+  const reorderBlock = hasReorder ? `
+  describe('reorder.patch', () => {
+    it('rejects an unauthenticated request', async () => {
+      unauth()
+      await expect(reorderHandler({ __body: { updates: [] } } as any)).rejects.toBeTruthy()
+      expect(reorderSiblings${P}).not.toHaveBeenCalled()
+    })
+
+    it('400s when updates is not an array', async () => {
+      await expect(reorderHandler({ __body: {} } as any)).rejects.toMatchObject({ status: 400 })
+    })
+
+    it('reorders scoped to the resolved team', async () => {
+      ;(reorderSiblings${P} as any).mockResolvedValue([])
+      await reorderHandler({ __body: { updates: [{ id: 'a', ${orderField}: 0 }] } } as any)
+      expect((reorderSiblings${P} as any).mock.calls[0][0]).toBe(TEAM.id)
+    })
+  })` : ''
+
+  const blocks = [getBlock, postBlock, patchBlock, deleteBlock, moveBlock, reorderBlock].filter(Boolean).join('\n')
+
+  const header = `// @ts-nocheck
+/**
+ * @crouton-generated
+ * @collection ${plural}
+ * @layer ${layer}
+ *
+ * API route handler test (#791): drives the generated endpoint handlers with a
+ * mocked team-auth util + queries module and a fake H3 event. Covers what the
+ * schema-smoke can't — team-scoping (unauthenticated → rejected; queries called
+ * with the resolved team id) and error paths (invalid body → rejected, missing
+ * id → 400, not-found → 404). Runtime-free: no Nuxt/DB, no network.
+ * Regenerate with --force; suppress with --no-tests.
+ */
+`
+
+  return `${header}import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// The generated handlers reference Nitro/H3 auto-imports as globals. Define them
+// BEFORE the route modules import (vi.hoisted runs first) so that the route's
+// \`export default defineEventHandler(...)\` evaluates. \`createError\` attaches its
+// fields to the thrown Error so status codes stay assertable.
+vi.hoisted(() => {
+  const g = globalThis as any
+  g.defineEventHandler = (fn: any) => fn
+  g.useServerTiming = () => ({ start: () => ({ end: () => {} }) })
+  g.getQuery = (event: any) => event?.__query ?? {}
+  g.getRouterParams = (event: any) => event?.__params ?? {}
+  g.readBody = async (event: any) => event?.__body
+  g.readValidatedBody = async (event: any, validate: any) => validate(event?.__body)
+  g.createError = (err: any) => Object.assign(new Error(err?.statusText || err?.message || 'error'), err)
+})
+
+vi.mock('@fyit/crouton-auth/server/utils/team', () => ({
+  resolveTeamAndCheckMembership: vi.fn(),
+}))
+vi.mock('./server/database/queries', () => ({
+  ${queryExports.join(',\n  ')},
+}))
+
+import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import {
+  ${queryImports.join(',\n  ')},
+} from './server/database/queries'
+${handlerImports.join('\n')}
+
+const TEAM = { id: 'team_1' }
+const USER = { id: 'user_1' }
+const MEMBERSHIP = { role: 'member' }
+const VALID_BODY = ${validBodyLiteral}${invalidConst}
+
+const authed = () => (resolveTeamAndCheckMembership as any).mockResolvedValue({ team: TEAM, user: USER, membership: MEMBERSHIP })
+const unauth = () => (resolveTeamAndCheckMembership as any).mockRejectedValueOnce(Object.assign(new Error('Not a team member'), { status: 403 }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authed()
+})
+
+describe('${layer}/${plural} API handlers (generated)', () => {
+${blocks}
+})
+`
+}

--- a/packages/crouton-cli/lib/generators/collection-test.ts
+++ b/packages/crouton-cli/lib/generators/collection-test.ts
@@ -16,7 +16,7 @@
 
 // Auto-generated / system columns and hierarchy columns are injected by the
 // runtime, not part of the create/validate schema — never sampled here.
-const AUTO_FIELDS = new Set([
+export const AUTO_FIELDS = new Set([
   'id', 'teamId', 'owner',
   'createdAt', 'updatedAt', 'createdBy', 'updatedBy',
   'parentId', 'path', 'depth', 'order',
@@ -53,22 +53,33 @@ function sampleLiteral(field: Record<string, any>): string {
   return "'sample'"
 }
 
-function objectLiteral(entries: string[], indent = '      '): string {
+export function objectLiteral(entries: string[], indent = '      '): string {
   if (entries.length === 0) return '{}'
   return `{\n${entries.map(e => `${indent}${e}`).join(',\n')},\n${indent.slice(2)}}`
 }
 
-/**
- * Generate the source of a `<Collection>.test.ts` schema-smoke test.
- * Returns the file content as a string (the orchestrator decides whether to
- * write it, honouring `--no-tests`).
- */
-export function generateCollectionTest(data: Record<string, any>, config: Record<string, any> | null = null): string {
-  const { layer, plural, pascalCase, pascalCasePlural, layerPascalCase, layerCamelCase, fields } = data
+export { sampleLiteral }
 
-  const schemaName = `${layerCamelCase}${pascalCase}Schema`
-  const composableName = `use${layerPascalCase}${pascalCasePlural}`
-  const importPath = `./app/composables/${composableName}`
+export interface CollectionSample {
+  /** Source-string entries (`name: 'sample'`) for the valid create body. */
+  validEntries: string[]
+  /** Required, non-translatable fields — the ones safe to omit for an invalid body. */
+  requiredPlain: Record<string, any>[]
+  /** Required translatable fields (validated under `translations.<locale>`). */
+  requiredTranslatable: Record<string, any>[]
+  /** Whether the collection declares any translatable fields. */
+  hasTranslations: boolean
+}
+
+/**
+ * Derive a schema-valid create sample from a collection's field metadata.
+ * Single-sourced here so both the schema-smoke test (#788) and the API handler
+ * test (#791) build the same `valid` body — it mirrors the required-field rules
+ * of `fieldsSchema`/the composable schema (same `data.fieldsSchema` source), so
+ * the sample parses whether or not the type manifest resolved.
+ */
+export function buildCollectionSample(data: Record<string, any>, config: Record<string, any> | null = null): CollectionSample {
+  const { plural, fields } = data
 
   // Translatable fields are validated under `translations` (config-driven, mirrors fieldsSchema).
   const translatableFieldNames: string[] = config?.translations?.collections?.[plural] || []
@@ -94,6 +105,23 @@ export function generateCollectionTest(data: Record<string, any>, config: Record
       validEntries.push('translations: {}')
     }
   }
+
+  return { validEntries, requiredPlain, requiredTranslatable, hasTranslations: translatableFieldNames.length > 0 }
+}
+
+/**
+ * Generate the source of a `<Collection>.test.ts` schema-smoke test.
+ * Returns the file content as a string (the orchestrator decides whether to
+ * write it, honouring `--no-tests`).
+ */
+export function generateCollectionTest(data: Record<string, any>, config: Record<string, any> | null = null): string {
+  const { layer, plural, pascalCase, pascalCasePlural, layerPascalCase, layerCamelCase } = data
+
+  const schemaName = `${layerCamelCase}${pascalCase}Schema`
+  const composableName = `use${layerPascalCase}${pascalCasePlural}`
+  const importPath = `./app/composables/${composableName}`
+
+  const { validEntries, requiredPlain, requiredTranslatable } = buildCollectionSample(data, config)
 
   const validLiteral = objectLiteral(validEntries)
 

--- a/packages/crouton-cli/tests/unit/generators/api-test.test.ts
+++ b/packages/crouton-cli/tests/unit/generators/api-test.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { generateApiTest } from '../../../lib/generators/api-test.ts'
+
+// Minimal `data` shape the orchestrator passes to generators (see buildGeneratorData
+// in generate-collection.ts). The API test imports the generated route handlers and
+// the queries module by relative path, so the fixtures carry the case variants +
+// hierarchy/sortable flags the path/name derivation needs.
+const baseData = {
+  layer: 'shop',
+  singular: 'product',
+  plural: 'products',
+  camelCase: 'product',
+  camelCasePlural: 'products',
+  pascalCase: 'Product',
+  pascalCasePlural: 'Products',
+  layerPascalCase: 'Shop',
+  layerCamelCase: 'shop',
+  hierarchy: { enabled: false },
+  sortable: { enabled: false },
+  fields: [
+    { name: 'id', type: 'string', zod: 'z.string()', meta: { primaryKey: true } },
+    { name: 'name', type: 'string', zod: 'z.string()', meta: { required: true } },
+    { name: 'price', type: 'decimal', zod: 'z.number()', meta: { required: true } },
+    { name: 'inStock', type: 'boolean', zod: 'z.boolean()', meta: {} },
+  ],
+}
+
+describe('generateApiTest (#791)', () => {
+  const code = generateApiTest(baseData, null)
+
+  it('mocks the team-auth util and the generated queries module', () => {
+    expect(code).toContain("vi.mock('@fyit/crouton-auth/server/utils/team'")
+    expect(code).toContain("vi.mock('./server/database/queries'")
+  })
+
+  it('provides the H3/Nitro auto-imports before the route modules load (vi.hoisted)', () => {
+    expect(code).toContain('vi.hoisted(')
+    expect(code).toContain('defineEventHandler')
+    expect(code).toContain('readValidatedBody')
+  })
+
+  it('imports the four CRUD handlers by their exact generated paths', () => {
+    expect(code).toContain("from './server/api/teams/[id]/shop-products/index.get.ts'")
+    expect(code).toContain("from './server/api/teams/[id]/shop-products/index.post.ts'")
+    expect(code).toContain("from './server/api/teams/[id]/shop-products/[productId].patch.ts'")
+    expect(code).toContain("from './server/api/teams/[id]/shop-products/[productId].delete.ts'")
+  })
+
+  it('exports the query functions the routes import from the mock factory', () => {
+    expect(code).toMatch(/createShopProduct:\s*vi\.fn\(\)/)
+    expect(code).toMatch(/getAllShopProducts:\s*vi\.fn\(\)/)
+    expect(code).toMatch(/updateShopProduct:\s*vi\.fn\(\)/)
+    expect(code).toMatch(/deleteShopProduct:\s*vi\.fn\(\)/)
+  })
+
+  it('asserts an unauthenticated request is rejected and never writes', () => {
+    // resolveTeamAndCheckMembership is made to reject; the create query must not run
+    expect(code).toMatch(/mockRejected/)
+    expect(code).toContain('expect(createShopProduct).not.toHaveBeenCalled()')
+  })
+
+  it('asserts the create is scoped to the resolved team (flipping team-scope turns it red)', () => {
+    expect(code).toMatch(/toHaveBeenCalledWith\(expect\.objectContaining\(\{ teamId: TEAM\.id/)
+  })
+
+  it('asserts the list query receives the resolved team id', () => {
+    expect(code).toContain('getAllShopProducts')
+    expect(code).toMatch(/toBe\(TEAM\.id\)/)
+  })
+
+  it('asserts a missing id param 400s on patch/delete', () => {
+    expect(code).toMatch(/status:\s*400/)
+  })
+
+  it('asserts a not-found from the query surfaces as a 404', () => {
+    expect(code).toMatch(/status:\s*404/)
+    expect(code).toMatch(/toMatchObject\(\{ status: 404 \}\)/)
+  })
+
+  it('rejects an invalid body before writing (collection has a required field)', () => {
+    // required `name` omitted → readValidatedBody throws → create never runs
+    expect(code).toMatch(/invalid body|before writing/i)
+  })
+
+  it('omits move/reorder cases for a non-hierarchy, non-sortable collection', () => {
+    expect(code).not.toContain('move.patch.ts')
+    expect(code).not.toContain('reorder.patch.ts')
+    expect(code).not.toContain('updatePositionShopProduct')
+    expect(code).not.toContain('reorderSiblingsShopProducts')
+  })
+
+  it('emits move + reorder cases when hierarchy is enabled', () => {
+    const h = generateApiTest({
+      ...baseData,
+      hierarchy: { enabled: true, parentField: 'parentId', orderField: 'order', pathField: 'path', depthField: 'depth' },
+    }, null)
+    expect(h).toContain("from './server/api/teams/[id]/shop-products/[productId]/move.patch.ts'")
+    expect(h).toContain("from './server/api/teams/[id]/shop-products/reorder.patch.ts'")
+    expect(h).toMatch(/updatePositionShopProduct:\s*vi\.fn\(\)/)
+    expect(h).toMatch(/reorderSiblingsShopProducts:\s*vi\.fn\(\)/)
+  })
+
+  it('emits a reorder case (no move) for a sortable-only collection', () => {
+    const s = generateApiTest({
+      ...baseData,
+      sortable: { enabled: true, orderField: 'order' },
+    }, null)
+    expect(s).toContain('reorder.patch.ts')
+    expect(s).not.toContain('move.patch.ts')
+    expect(s).toMatch(/reorderSiblingsShopProducts:\s*vi\.fn\(\)/)
+  })
+
+  it('emits no nondeterministic calls', () => {
+    expect(code).not.toContain('Date.now(')
+    expect(code).not.toContain('Math.random(')
+  })
+})


### PR DESCRIPTION
Closes #791. Completes epic #785 (generator emits tests) — the **Level-3 depth** deferred from #788 because it needed a mocking pattern proven first. Builds directly on #793.

## What landed

| Sub-issue | Commit | What |
|---|---|---|
| Closes #791 | `280b6e6` | Generator emits `<Layer><Collections>.api.test.ts` per collection — drives the generated route handlers; same `--no-tests` gate |
| (docs) | `9d6cdb2` | Doc sync — `crouton-cli/CLAUDE.md`, `/crouton` skill, README, example config |

## How it works

Next to the schema-smoke (#788), each collection now ships an **API route handler test** that imports the generated handlers and runs them against a **fake H3 event**, covering the runtime logic the schema-smoke can't:

- **Team-scoping** — an unauthenticated request is rejected and **never writes**; the happy path calls the query with the **resolved team's id** (`expect.objectContaining({ teamId: TEAM.id, owner: USER.id })`). Flip `teamId: team.id` in a handler and the test goes red.
- **Error paths** — invalid body → rejected before any write, missing id param → **400**, a not-found surfaced by the query → **404**.

Routes covered: `index.get`, `index.post`, `[id].patch`, `[id].delete`, plus `move.patch`/`reorder.patch` for hierarchy/sortable collections.

**Mocking strategy (decision 1):** runtime-free-ish and deterministic —
- `vi.mock` the team-auth util (`@fyit/crouton-auth/server/utils/team`) and the generated `./server/database/queries` module, so no better-auth, no drizzle, no DB load — the route file is the only real code under test.
- The H3/Nitro auto-imports the handlers call (`defineEventHandler`, `getQuery`, `getRouterParams`, `readBody`, `readValidatedBody`, `createError`, `useServerTiming`) are provided as globals via `vi.hoisted` (runs **before** the route imports, so `export default defineEventHandler(...)` evaluates).
- `vi.mock` resolves both the test's `./server/database/queries` and the route's `../../../../database/queries` to the same module id → one factory mocks all of them.
- Proven on **one route (POST)** first, then templated to the rest.

## Decisions

- **On by default, same `tests` flag (decision 2)** — honours #791's "covered by default" hypothesis. Justified because every assertion is **schema-shape-independent** (mock/control-flow driven): auth rejection, team-scoping, not-found propagation, missing-id 400, and move/reorder input-validation 400. The one body-shape-dependent case (invalid-body → rejected) is emitted **only** when an invalid sample is derivable (≥1 required field), degrading gracefully — same pattern as #788. The happy-path body reuses #788's single-sourced sample derivation (`buildCollectionSample`, same `data.fieldsSchema` as the composable schema).
- **Same vitest runner (decision 3)** — the emitted file matches #789's existing `layers/**/*.test.ts` include glob under `environment: 'node'`. No separate project, no `scaffold-app` change.
- The emitted file carries `// @ts-nocheck` — it relies on untyped Nitro globals and runs under vitest, not the app's `nuxt typecheck`.

## Verification

- **Test-first (#774):** `tests/unit/generators/api-test.test.ts` written as the agreed contract (red — module absent), then `api-test.ts` implemented to green.
- **End-to-end (mirrors #793):** generated into `fixtures/minimal` via `crouton config --force` → the **13 emitted handler tests ran green** against the real generated handlers; deliberately breaking `teamId: team.id` turned exactly one test red (the team-scope assertion has teeth, per #791's success criterion); `--no-tests` confirmed to suppress both tests; fixture artifacts fully restored (`git checkout` + `git clean`).
- Full crouton-cli suite **288 green** (was 274 + 14 new); schema-smoke output unchanged by the `collection-test.ts` refactor; field-types + skills-doc sync checks pass.

## Merge note

Two atomic, single-concern commits — please **merge or rebase, don't squash** (repo merge policy: keep granular history for archaeology).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiYhmVZ7Bjz8bTTzL79FPN)_