### PR TITLE
feat(crouton-sales): config LWW conflict-resolution policy (#813)

### DIFF
--- a/packages/crouton-sales/server/utils/config-lww.ts
+++ b/packages/crouton-sales/server/utils/config-lww.ts
@@ -1,0 +1,121 @@
+/**
+ * @crouton-package crouton-sales
+ * @description Config last-write-wins + conflict-resolution policy (WS1.C, #813,
+ * epic #801 — bidirectional config sync).
+ *
+ * The single **pure** brain both sync directions consume:
+ *   - device→cloud apply (`incomingSource: 'device'`) — the cloud ingest (#814)
+ *   - cloud→device apply (`incomingSource: 'cloud'`)   — the device pull (#815)
+ *
+ * Given the row currently in the target store (`local`, possibly absent) and the
+ * row arriving from the other side (`incoming`), it decides who wins:
+ *   - **last-write-wins** by per-row `updatedAt` (every config table already
+ *     stamps `updatedAt.$onUpdate`)
+ *   - **device wins while the row's event is live** — overrides a newer cloud
+ *     write, because the till is authoritative during service
+ *   - **equal `updatedAt` → device wins** the tiebreak, so BOTH machines (each
+ *     running this same function) converge on the device's row instead of
+ *     permanently disagreeing
+ *
+ * It performs no I/O: callers read `local`, apply the winner, and persist
+ * `result.audit` whenever it is non-null. An audit record is emitted for every
+ * discarded write — overwrite OR rejection — so a losing config edit is never
+ * silently dropped (the epic's hard requirement; surfaced by Leaf D #816).
+ */
+
+/** The columns the policy needs; every other column is opaque and carried through. */
+export interface ConfigRow {
+  id: string
+  /** Per-row write clock. A `Date` (timestamp-mode column) or epoch ms. */
+  updatedAt: Date | number
+  [key: string]: unknown
+}
+
+/** Which side produced `incoming` — i.e. which machine is applying the write. */
+export type SyncSource = 'device' | 'cloud'
+
+export interface ResolveInput {
+  /** The row currently in the target store, or null when absent. */
+  local: ConfigRow | null
+  /** The row arriving from the other side. */
+  incoming: ConfigRow
+  /** Who sent `incoming`: 'device' on the cloud ingest, 'cloud' on the device pull. */
+  incomingSource: SyncSource
+  /** Is the row's event currently live? Device wins outright while true. */
+  eventLive: boolean
+}
+
+export type ResolveReason =
+  | 'absent' // no local row — incoming adopted, nothing overwritten
+  | 'newer' // incoming.updatedAt > local.updatedAt
+  | 'older' // incoming.updatedAt < local.updatedAt — rejected
+  | 'tie-break' // equal updatedAt — device wins the tiebreak
+  | 'event-live-device-wins' // event live — device row wins regardless of clocks
+
+/** A discarded write, recorded so it is never silently lost (persisted by Leaf D). */
+export interface ConfigAuditRecord {
+  entityId: string
+  winner: 'local' | 'incoming'
+  reason: ResolveReason
+  /** The full value that lost — the device-or-cloud row that was discarded. */
+  loser: ConfigRow
+  /** Which side the losing row came from, for the human reading the trail. */
+  loserSource: SyncSource
+}
+
+export interface ResolveResult {
+  winner: 'local' | 'incoming'
+  reason: ResolveReason
+  /** Non-null whenever a write was overwritten or rejected. */
+  audit: ConfigAuditRecord | null
+}
+
+function ms(at: Date | number): number {
+  return at instanceof Date ? at.getTime() : Number(at)
+}
+
+/**
+ * The side `incoming` came from is `incomingSource`; the opposite side produced
+ * `local`. Used to know which row is "the device's" for the device-wins rules.
+ */
+function localSource(incomingSource: SyncSource): SyncSource {
+  return incomingSource === 'device' ? 'cloud' : 'device'
+}
+
+export function resolveConfigWrite(input: ResolveInput): ResolveResult {
+  const { local, incoming, incomingSource, eventLive } = input
+
+  // No local row → adopt incoming; nothing is overwritten, so no audit.
+  if (local == null) {
+    return { winner: 'incoming', reason: 'absent', audit: null }
+  }
+
+  const incomingIsDevice = incomingSource === 'device'
+  const localIsDevice = localSource(incomingSource) === 'device'
+
+  // Build the result + an audit record for the discarded side.
+  const decide = (winner: 'local' | 'incoming', reason: ResolveReason): ResolveResult => {
+    const loser = winner === 'incoming' ? local : incoming
+    const loserSource = winner === 'incoming' ? localSource(incomingSource) : incomingSource
+    return {
+      winner,
+      reason,
+      audit: { entityId: incoming.id, winner, reason, loser, loserSource },
+    }
+  }
+
+  // Event live → the device row wins outright, whichever side is applying.
+  if (eventLive) {
+    const winner = incomingIsDevice ? 'incoming' : 'local'
+    return decide(winner, 'event-live-device-wins')
+  }
+
+  const a = ms(incoming.updatedAt)
+  const b = ms(local.updatedAt)
+
+  if (a > b) return decide('incoming', 'newer')
+  if (a < b) return decide('local', 'older')
+
+  // Tie → the device row wins so both machines converge on it.
+  return decide(localIsDevice ? 'local' : 'incoming', 'tie-break')
+}

--- a/packages/crouton-sales/test/config-lww.test.ts
+++ b/packages/crouton-sales/test/config-lww.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { resolveConfigWrite } from '../server/utils/config-lww'
+
+/**
+ * WS1.C (#813) — the pure config LWW + conflict-resolution policy.
+ *
+ * One deterministic brain both sync directions consume:
+ *  - device→cloud apply (incomingSource: 'device')  ← Leaf A (#814)
+ *  - cloud→device apply (incomingSource: 'cloud')    ← Leaf B (#815)
+ *
+ * Rules (recorded on epic #801):
+ *  - last-write-wins by per-row `updatedAt`
+ *  - DEVICE WINS while the row's event is live (overrides a newer cloud write)
+ *  - equal timestamps → deterministic tiebreak (device wins → both sides converge)
+ *  - every overwritten / rejected write yields an audit record (no silent drop)
+ *
+ * No I/O — `resolveConfigWrite` is given the two rows + flags and returns the
+ * decision; the callers do the DB read/write and persist `result.audit`.
+ */
+
+const t = (ms: number) => new Date(ms)
+
+// Minimal config-row shape the policy needs; other columns are opaque to it.
+const row = (over: Partial<{ id: string, updatedAt: Date }> = {}) => ({
+  id: 'prod-1',
+  title: 'Pils',
+  updatedAt: t(1_000),
+  ...over,
+})
+
+describe('resolveConfigWrite — absent local', () => {
+  it('incoming wins when there is no local row (no audit — nothing overwritten)', () => {
+    const r = resolveConfigWrite({
+      local: null,
+      incoming: row(),
+      incomingSource: 'device',
+      eventLive: false,
+    })
+    expect(r.winner).toBe('incoming')
+    expect(r.reason).toBe('absent')
+    expect(r.audit).toBeNull()
+  })
+})
+
+describe('resolveConfigWrite — last-write-wins by updatedAt', () => {
+  it('newer incoming overwrites local (both directions); audit records the loser', () => {
+    for (const incomingSource of ['device', 'cloud'] as const) {
+      const r = resolveConfigWrite({
+        local: row({ updatedAt: t(1_000), title: 'Pils' } as any),
+        incoming: row({ updatedAt: t(2_000), title: 'Pils 0.0' } as any),
+        incomingSource,
+        eventLive: false,
+      })
+      expect(r.winner).toBe('incoming')
+      expect(r.reason).toBe('newer')
+      // The overwritten local value is captured, not silently dropped.
+      expect(r.audit).not.toBeNull()
+      expect(r.audit!.entityId).toBe('prod-1')
+      expect(r.audit!.winner).toBe('incoming')
+      expect((r.audit!.loser as any).title).toBe('Pils')
+    }
+  })
+
+  it('older incoming is rejected; the dropped write is still audited', () => {
+    const r = resolveConfigWrite({
+      local: row({ updatedAt: t(2_000) } as any),
+      incoming: row({ updatedAt: t(1_000), title: 'stale' } as any),
+      incomingSource: 'cloud',
+      eventLive: false,
+    })
+    expect(r.winner).toBe('local')
+    expect(r.reason).toBe('older')
+    expect(r.audit).not.toBeNull()
+    expect((r.audit!.loser as any).title).toBe('stale')
+  })
+})
+
+describe('resolveConfigWrite — device-wins-while-event-live', () => {
+  it('device row wins over a NEWER cloud row when the event is live (cloud→device apply)', () => {
+    // Applying on the device: incoming is the cloud row, local is the device row.
+    const r = resolveConfigWrite({
+      local: row({ updatedAt: t(1_000) } as any), // device, older
+      incoming: row({ updatedAt: t(5_000) } as any), // cloud, newer
+      incomingSource: 'cloud',
+      eventLive: true,
+    })
+    expect(r.winner).toBe('local') // the device row
+    expect(r.reason).toBe('event-live-device-wins')
+    expect(r.audit).not.toBeNull() // the rejected (newer) cloud write is recorded
+  })
+
+  it('device row wins on the cloud side too (device→cloud apply): a newer cloud row is overwritten', () => {
+    // Applying on the cloud: incoming is the device row, local is the cloud row.
+    const r = resolveConfigWrite({
+      local: row({ updatedAt: t(5_000) } as any), // cloud, newer
+      incoming: row({ updatedAt: t(1_000) } as any), // device, older
+      incomingSource: 'device',
+      eventLive: true,
+    })
+    expect(r.winner).toBe('incoming') // the device row
+    expect(r.reason).toBe('event-live-device-wins')
+    expect(r.audit).not.toBeNull()
+  })
+})
+
+describe('resolveConfigWrite — deterministic tiebreak on equal updatedAt', () => {
+  it('equal timestamps converge to the device row from BOTH sides', () => {
+    const onCloud = resolveConfigWrite({
+      local: row({ updatedAt: t(3_000) } as any), // cloud
+      incoming: row({ updatedAt: t(3_000) } as any), // device
+      incomingSource: 'device',
+      eventLive: false,
+    })
+    const onDevice = resolveConfigWrite({
+      local: row({ updatedAt: t(3_000) } as any), // device
+      incoming: row({ updatedAt: t(3_000) } as any), // cloud
+      incomingSource: 'cloud',
+      eventLive: false,
+    })
+    expect(onCloud.reason).toBe('tie-break')
+    expect(onDevice.reason).toBe('tie-break')
+    // Cloud side: device is `incoming` → incoming wins. Device side: device is
+    // `local` → local wins. Both keep the device row ⇒ deterministic convergence.
+    expect(onCloud.winner).toBe('incoming')
+    expect(onDevice.winner).toBe('local')
+  })
+})


### PR DESCRIPTION
Closes #813.

## 👤 For humans
The decision-maker for two-way config sync: when the same menu/price/printer row was edited **both** online and on the till, which version wins? Newer edit wins by timestamp; the **till wins while an event is live** (the operator on-site is authoritative during service); and **every discarded edit is recorded** so an online change is never silently lost. Pure logic with no database — both sync directions (the up-mirror #814 and the down-pull #815) call this one function so they can never permanently disagree.

## 🤖 For agents
- New `packages/crouton-sales/server/utils/config-lww.ts` — `resolveConfigWrite({ local, incoming, incomingSource, eventLive }) → { winner, reason, audit }`. No I/O; callers read `local`, apply the winner, persist `audit` when non-null.
- **LWW** by per-row `updatedAt` (`'newer'`/`'older'`); **`event-live-device-wins`** override (device row wins regardless of clocks, both apply directions); equal `updatedAt` → `'tie-break'` resolves to the **device** row so both machines converge.
- `ConfigAuditRecord` emitted for every overwrite **or rejection** (loser snapshot + reason + source) — the epic's "no silent dropped writes". Surfaced by Leaf D (#816).
- **Test-first (#774):** `test/config-lww.test.ts` (6 cases) written and signed off **before** the impl. `pnpm test` → 12 passed; `tsc` clean.

## 🧪 How to test
```
pnpm --filter @fyit/crouton-sales test
```
6 `config-lww` cases: absent-local · newer-overwrites (both directions) · older-rejected-but-audited · event-live device-wins (cloud→device and device→cloud) · equal-timestamp converges to the device from both sides.

Part of #802 (WS1) · epic #801.
