### PR TITLE
chore(fanfare): make the local-first Pi venue rig reproducible (node-server + systemd + persistent net + health check)

### DIFF
--- a/apps/fanfare/deploy/pi/README.md
+++ b/apps/fanfare/deploy/pi/README.md
@@ -1,0 +1,103 @@
+# fanfare local-first venue Pi rig (#798)
+
+Makes the **phone POS → order → in-process ESC/POS drainer → thermal printer**
+loop (proven on real hardware in #63) **reproducible and reboot-survivable**. A
+Pi reboot brings fanfare back up — LAN-reachable, drainer on, both printers
+reachable — with **zero manual steps**.
+
+This replaces the ephemeral bench rig (a manual `tmux` dev server + a hand-typed
+`ip addr add` alias that vanished on every link-down) with:
+
+| Piece | What it gives you |
+|-------|-------------------|
+| `NITRO_PRESET=node-server` build | a real production server (`.output/server/index.mjs`), not `nuxt dev` |
+| `fanfare.service` (systemd) | auto-start on boot, `Restart=always`, binds `HOST=0.0.0.0 PORT=3007`, `CROUTON_PRINTING_DRAINER=1` |
+| `configure-network.sh` (NetworkManager) | a **persistent** `192.168.1.51/24` route to the printer subnet (no more `ip addr add`) |
+| `fanfare-healthcheck.{service,timer}` | boot + 5-min reachability check of the RUT + both printers, logged to the journal |
+
+## Topology (why the network bits matter)
+
+```
+ phone (home/venue wifi) ──▶ Pi wlan0  192.168.0.180:3007   ← the POS URL
+                                  │
+                                  ▼  fanfare (node-server) + ESC/POS drainer
+ Pi eth0  192.168.1.51/24 ──▶ RUT956 LAN ──▶ kitchen 192.168.1.70:9100
+   (static, NetworkManager)                  bar     192.168.1.72:9100
+```
+
+- The printers are **wifi clients of the RUT956** on its `192.168.1.0/24` LAN. The
+  Pi reaches them **only** over the wired `eth0` (in a RUT LAN port) holding a
+  static `192.168.1.51/24`. **Home wifi (wlan0) cannot reach them.**
+- ⚠️ **The RUT must be powered.** If it powers down, `eth0` goes `NO-CARRIER` and
+  **all** printing fails with the drainer error *"printer not responding — paper
+  out, cover open"* — which looks like a printer fault but is really the network
+  path being dead. The health check calls this out explicitly (`eth0 NO-CARRIER`).
+
+## First-time setup (fresh Pi or after a code update)
+
+```bash
+ssh pmcp@192.168.0.180
+cd ~/nuxt-crouton/apps/fanfare/deploy/pi
+./setup.sh --build      # build node-server, then install + enable everything
+```
+
+`setup.sh` is idempotent — re-run it any time (e.g. after `git pull`); it
+rebuilds (with `--build`), re-renders the unit, and restarts the service.
+
+Then, **once**, create the venue data (persists across reboots in
+`.data/db/sqlite.db`):
+
+1. On a phone on the **same wifi as the Pi**, open `http://192.168.0.180:3007`,
+   register an account + team.
+2. Build the event in the **admin UI**: create an event (set its helper PIN),
+   add locations (e.g. *Keuken*, *Bar*), products, and one `network-escpos`
+   printer per location pointed at its IP (kitchen `192.168.1.70`, bar
+   `192.168.1.72`). Give each product a `locationId` so tickets route per
+   station — a product with **no** location prints a "default" ticket on *every*
+   kitchen printer.
+
+   > The dev-only `_seed` route (`import.meta.dev`-gated, so it does **not**
+   > exist in this production build) can do the above in one shot when running
+   > `pnpm dev` for a bench test. A production-safe seed runner is #797.
+
+This DB **persists across reboots** — you only set the venue up once.
+
+## Day-to-day ops
+
+```bash
+systemctl status fanfare                 # is it up?
+journalctl -u fanfare -f                 # app + drainer logs
+journalctl -u fanfare-healthcheck -e     # last reachability verdicts
+./healthcheck.sh                         # run the check by hand (RUT + both printers)
+sudo systemctl restart fanfare           # restart after a manual rebuild
+```
+
+**Verify reboot-survival:** `sudo reboot`, wait ~1 min, then from a phone load
+`http://192.168.0.180:3007` and ring up an order — kitchen + bar tickets print,
+nothing touched by hand.
+
+## Gotchas (learned the hard way)
+
+- **Bind with `HOST`/`PORT` env, never `nuxt dev --host/--port`** — the CLI flags
+  mangle the port (drifts to 3000/3001). The systemd unit uses env vars.
+- **`drizzle-orm/libsql` trace fix** — the node-server build needs
+  `nitro.externals.traceInclude: ['drizzle-orm/libsql']` (in `nuxt.config.ts`)
+  or `node .output/server` dies with *"Cannot find module .../drizzle-orm/libsql"*.
+  Scoped to the non-Cloudflare target.
+- **`BETTER_AUTH_SECRET` must be stable** across reboots or every session is
+  invalidated on restart. It lives in `/etc/fanfare/fanfare.env` (not committed).
+- **Re-add nothing after a RUT power-cycle** — the static route is a real
+  NetworkManager profile now, so it comes back on its own. If `eth0` ever lacks
+  `192.168.1.51`, re-run `configure-network.sh`.
+- **Printer IPs can drift** (`.72`→`.70` has happened). If a station goes quiet,
+  sweep `192.168.1.0/24` for `:9100` and update the printer row + healthcheck IPs.
+
+## Files
+
+| File | Role |
+|------|------|
+| `setup.sh` | idempotent orchestrator (build + install + enable) |
+| `fanfare.service` | systemd unit **template** (`setup.sh` renders the paths) |
+| `fanfare.env.example` | secrets template → copy to `/etc/fanfare/fanfare.env` |
+| `configure-network.sh` | persistent NetworkManager printer-subnet route |
+| `healthcheck.sh` | RUT + printer reachability check (exit ≠ 0 when degraded) |

--- a/apps/fanfare/deploy/pi/README.md
+++ b/apps/fanfare/deploy/pi/README.md
@@ -11,14 +11,15 @@ This replaces the ephemeral bench rig (a manual `tmux` dev server + a hand-typed
 | Piece | What it gives you |
 |-------|-------------------|
 | `NITRO_PRESET=node-server` build | a real production server (`.output/server/index.mjs`), not `nuxt dev` |
-| `fanfare.service` (systemd) | auto-start on boot, `Restart=always`, binds `HOST=0.0.0.0 PORT=3007`, `CROUTON_PRINTING_DRAINER=1` |
+| `fanfare.service` (systemd) | auto-start on boot, `Restart=always`, binds `HOST=0.0.0.0 PORT=80`, `CROUTON_PRINTING_DRAINER=1` |
+| `avahi-alias@kassa.local` (mDNS) | the till answers to **`http://kassa.local`** (per-interface CNAME), not `IP:3007` |
 | `configure-network.sh` (NetworkManager) | a **persistent** `192.168.1.51/24` route to the printer subnet (no more `ip addr add`) |
 | `fanfare-healthcheck.{service,timer}` | boot + 5-min reachability check of the RUT + both printers, logged to the journal |
 
 ## Topology (why the network bits matter)
 
 ```
- phone (home/venue wifi) ──▶ Pi wlan0  192.168.0.180:3007   ← the POS URL
+ phone (venue/home wifi) ──▶ http://kassa.local  (mDNS → Pi :80)  ← the POS URL
                                   │
                                   ▼  fanfare (node-server) + ESC/POS drainer
  Pi eth0  192.168.1.51/24 ──▶ RUT956 LAN ──▶ kitchen 192.168.1.70:9100
@@ -47,8 +48,8 @@ rebuilds (with `--build`), re-renders the unit, and restarts the service.
 Then, **once**, create the venue data (persists across reboots in
 `.data/db/sqlite.db`):
 
-1. On a phone on the **same wifi as the Pi**, open `http://192.168.0.180:3007`,
-   register an account + team.
+1. On a phone on the **same wifi as the Pi**, open **`http://kassa.local`**
+   (iOS/macOS resolve it via mDNS, no setup), register an account + team.
 2. Build the event in the **admin UI**: create an event (set its helper PIN),
    add locations (e.g. *Keuken*, *Bar*), products, and one `network-escpos`
    printer per location pointed at its IP (kitchen `192.168.1.70`, bar
@@ -73,8 +74,23 @@ sudo systemctl restart fanfare           # restart after a manual rebuild
 ```
 
 **Verify reboot-survival:** `sudo reboot`, wait ~1 min, then from a phone load
-`http://192.168.0.180:3007` and ring up an order — kitchen + bar tickets print,
+`http://kassa.local` and ring up an order — kitchen + bar tickets print,
 nothing touched by hand.
+
+## The friendly URL
+
+Staff reach the till at **`http://kassa.local`** — no IP, no `:3007`:
+- The app binds **port 80** (`fanfare.service` grants the non-root process
+  `CAP_NET_BIND_SERVICE`), so the URL drops the port.
+- `avahi-alias@kassa.local` publishes an **mDNS CNAME** to this host, resolved
+  **per-interface** — a phone on the RUT wifi gets the wired `.51`, a bench phone
+  on home wifi gets `.180`, with no per-network config. `BETTER_AUTH_URL` is set
+  to match so session cookies line up.
+- **iOS/macOS** resolve `.local` natively. **Android/Windows don't** — for an
+  all-device venue, add one line to the venue router / RUT DNS (dnsmasq):
+  `address=/kassa/<the till's IP on that network>` → staff use `http://kassa`.
+  (`setup.sh` prints this line for you.)
+- Change the name by passing `ALIAS=till.local ./setup.sh`.
 
 ## Gotchas (learned the hard way)
 
@@ -101,3 +117,5 @@ nothing touched by hand.
 | `fanfare.env.example` | secrets template → copy to `/etc/fanfare/fanfare.env` |
 | `configure-network.sh` | persistent NetworkManager printer-subnet route |
 | `healthcheck.sh` | RUT + printer reachability check (exit ≠ 0 when degraded) |
+| `avahi-alias` | mDNS CNAME publisher — `<name>.local` → this host (per-interface) |
+| `avahi-alias@.service` | systemd template running the publisher (`avahi-alias@kassa.local`) |

--- a/apps/fanfare/deploy/pi/avahi-alias
+++ b/apps/fanfare/deploy/pi/avahi-alias
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Publish extra mDNS names as CNAMEs pointing at this host's own `.local` record
+(#798/#804) — so the till is reachable at e.g. `kassa.local` instead of an IP.
+
+A CNAME-to-host (not a fixed-IP A record) is deliberate: the host's own
+`<hostname>.local` is published per-interface by avahi, so the alias resolves to
+whichever address the querying client can actually reach — the wired RUT IP for a
+phone on the venue wifi, the home-wifi IP at the bench — with no per-network config.
+
+Runs in the foreground holding the registration; on SIGTERM it withdraws the
+record cleanly (so `systemctl stop` removes it). Needs only python3-dbus +
+avahi-daemon (no avahi-utils). Usage: avahi-alias kassa.local [more.local ...]
+"""
+import sys
+import signal
+import dbus
+
+DBUS_NAME = 'org.freedesktop.Avahi'
+SERVER_IFACE = 'org.freedesktop.Avahi.Server'
+GROUP_IFACE = 'org.freedesktop.Avahi.EntryGroup'
+IF_UNSPEC = dbus.Int32(-1)
+PROTO_UNSPEC = dbus.Int32(-1)
+CLASS_IN = dbus.UInt16(0x01)
+TYPE_CNAME = dbus.UInt16(0x05)
+TTL = dbus.UInt32(60)
+
+
+def encode_dns_name(name):
+    """Wire-format a domain name: length-prefixed labels + null terminator."""
+    out = bytearray()
+    for label in name.rstrip('.').split('.'):
+        b = label.encode('ascii')
+        out.append(len(b))
+        out += b
+    out.append(0)
+    return [dbus.Byte(x) for x in out]
+
+
+def main(aliases):
+    if not aliases:
+        print('usage: avahi-alias <name.local> [name2.local ...]', file=sys.stderr)
+        return 2
+    bus = dbus.SystemBus()
+    server = dbus.Interface(bus.get_object(DBUS_NAME, '/'), SERVER_IFACE)
+    fqdn = str(server.GetHostNameFqdn())          # e.g. "pmcpi.local"
+    rdata = encode_dns_name(fqdn)
+    group = dbus.Interface(bus.get_object(DBUS_NAME, server.EntryGroupNew()), GROUP_IFACE)
+    for cname in aliases:
+        # AddRecord(interface, protocol, flags, name, class, type, ttl, rdata)
+        group.AddRecord(IF_UNSPEC, PROTO_UNSPEC, dbus.UInt32(0),
+                        cname, CLASS_IN, TYPE_CNAME, TTL, rdata)
+    group.Commit()
+    print(f'published {", ".join(aliases)} -> {fqdn} (CNAME, per-interface)')
+
+    def stop(*_):
+        try:
+            group.Reset()
+        finally:
+            sys.exit(0)
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    signal.pause()
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/apps/fanfare/deploy/pi/avahi-alias@.service
+++ b/apps/fanfare/deploy/pi/avahi-alias@.service
@@ -1,0 +1,16 @@
+[Unit]
+# Publishes an mDNS CNAME alias (the instance name, e.g. kassa.local) pointing at
+# this host's own .local record, so the till is reachable by name (#798/#804).
+# setup.sh renders __ALIAS_BIN__ to the installed avahi-alias path.
+Description=mDNS alias %i -> this host (for the friendly venue URL)
+Requires=avahi-daemon.service
+After=avahi-daemon.service
+
+[Service]
+Type=simple
+ExecStart=__ALIAS_BIN__ %i
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/fanfare/deploy/pi/configure-network.sh
+++ b/apps/fanfare/deploy/pi/configure-network.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Persistent printer-subnet route for the fanfare venue Pi (#798).
+#
+# The thermal printers (kitchen 192.168.1.70 / bar 192.168.1.72) are wifi clients
+# of the RUT956 and live on its 192.168.1.0/24 LAN. The Pi reaches them over the
+# WIRED eth0 (plugged into a RUT LAN port) by holding a static address in that
+# subnet. Home wifi (wlan0) CANNOT reach them.
+#
+# Previously this was a hand-typed `sudo ip addr add 192.168.1.51/24 dev eth0`,
+# which is flushed on every link-down/reboot. This makes it a real, autoconnecting
+# NetworkManager profile so it survives reboots with zero manual steps.
+#
+# Idempotent: safe to re-run. Requires sudo (nmcli writes need root).
+set -euo pipefail
+
+CONN="${ETH_CONN:-eth0}"              # NM connection name bound to the eth0 device
+ADDR="${ETH_ADDR:-192.168.1.51/24}"   # static IP on the RUT printer subnet
+COMPETING="${COMPETING_CONN:-netplan-eth0}"  # DHCP profile that else grabs eth0 at boot
+
+run() { echo "+ $*"; sudo "$@"; }
+
+echo "[configure-network] pinning $CONN -> $ADDR (autoconnect, no default route)"
+
+# Make the printer-LAN profile static, autoconnecting, and the winner for eth0.
+# ipv4.never-default = the printer subnet must NEVER become the default route
+# (internet/default stays on wlan0 home wifi). No gateway on this profile.
+run nmcli con mod "$CONN" \
+  ipv4.method manual \
+  ipv4.addresses "$ADDR" \
+  ipv4.gateway "" \
+  ipv4.never-default yes \
+  connection.autoconnect yes \
+  connection.autoconnect-priority 100
+
+# Stop the DHCP sibling profile from claiming the device on boot.
+if nmcli -t -f NAME con show | grep -qx "$COMPETING"; then
+  echo "[configure-network] disabling autoconnect on competing profile: $COMPETING"
+  run nmcli con mod "$COMPETING" connection.autoconnect no || true
+fi
+
+# Apply now (idempotent — re-activates the profile).
+run nmcli con up "$CONN"
+
+echo "[configure-network] result:"
+ip -4 addr show eth0 | sed 's/^/    /'
+echo "[configure-network] done — 192.168.1.x route is now persistent across reboots."

--- a/apps/fanfare/deploy/pi/fanfare.env.example
+++ b/apps/fanfare/deploy/pi/fanfare.env.example
@@ -6,9 +6,10 @@
 # changing secret logs everyone out on restart.
 BETTER_AUTH_SECRET=change-me-to-a-long-random-string
 
-# The URL the venue reaches the Pi on — the home/venue-wifi IP (wlan0), port 3007.
-# Must match how phones load the POS. Ideally a DHCP reservation so it never drifts.
-BETTER_AUTH_URL=http://192.168.0.180:3007
+# The URL staff reach the till on — the friendly mDNS name (setup.sh publishes it
+# and sets this for you). Must match how phones actually load the POS so session
+# cookies line up. The till serves on port 80, so no :port.
+BETTER_AUTH_URL=http://kassa.local
 
 # --- Optional overrides (the unit already sets sane defaults) ---
 # HOST=0.0.0.0

--- a/apps/fanfare/deploy/pi/fanfare.env.example
+++ b/apps/fanfare/deploy/pi/fanfare.env.example
@@ -1,0 +1,19 @@
+# fanfare venue-rig secrets — copy to /etc/fanfare/fanfare.env on the Pi and fill in.
+# This file is read by the systemd unit (EnvironmentFile). It is NOT committed; only
+# this .example is. setup.sh seeds the real file from the app's .env if one exists.
+#
+# better-auth needs a STABLE secret across reboots (it signs session cookies); a
+# changing secret logs everyone out on restart.
+BETTER_AUTH_SECRET=change-me-to-a-long-random-string
+
+# The URL the venue reaches the Pi on — the home/venue-wifi IP (wlan0), port 3007.
+# Must match how phones load the POS. Ideally a DHCP reservation so it never drifts.
+BETTER_AUTH_URL=http://192.168.0.180:3007
+
+# --- Optional overrides (the unit already sets sane defaults) ---
+# HOST=0.0.0.0
+# PORT=3007
+# CROUTON_PRINTING_DRAINER=1
+# CROUTON_PRINTING_DRAINER_POLL_MS=2000
+# Restrict the drainer to one event id (default: drain all events):
+# CROUTON_PRINTING_DRAINER_EVENT=

--- a/apps/fanfare/deploy/pi/fanfare.service
+++ b/apps/fanfare/deploy/pi/fanfare.service
@@ -18,10 +18,13 @@ WorkingDirectory=__APP_DIR__
 # Nitro server plugin gated on this flag, so it runs in the production build too.
 Environment=NODE_ENV=production
 Environment=HOST=0.0.0.0
-Environment=PORT=3007
+Environment=PORT=80
 Environment=CROUTON_PRINTING_DRAINER=1
 # Secrets (BETTER_AUTH_SECRET, BETTER_AUTH_URL) live outside the repo.
 EnvironmentFile=/etc/fanfare/fanfare.env
+# Bind port 80 (the friendly URL drops the :3007) as the non-root User above —
+# the only privileged capability the app needs.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=__NODE_BIN__ __APP_DIR__/.output/server/index.mjs
 Restart=always
 RestartSec=3

--- a/apps/fanfare/deploy/pi/fanfare.service
+++ b/apps/fanfare/deploy/pi/fanfare.service
@@ -1,0 +1,31 @@
+[Unit]
+# fanfare — local-first venue POS (node-server) + in-process ESC/POS print drainer.
+# This is a TEMPLATE: setup.sh renders __APP_DIR__ / __NODE_BIN__ / __USER__ to the
+# real paths and installs the result as /etc/systemd/system/fanfare.service.
+Description=fanfare local-first venue POS (node-server + ESC/POS drainer)
+Documentation=https://github.com/FriendlyInternet/nuxt-crouton/issues/798
+# Needs the LAN up. NetworkManager brings up both wlan0 (home, the access URL)
+# and the eth0 static 192.168.1.51/24 printer-subnet route before this target.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__USER__
+WorkingDirectory=__APP_DIR__
+# Rig defaults (non-secret). Bind to the LAN with HOST/PORT *env* — never the
+# `nuxt dev --host/--port` flags, which mangle the port (#798). The drainer is a
+# Nitro server plugin gated on this flag, so it runs in the production build too.
+Environment=NODE_ENV=production
+Environment=HOST=0.0.0.0
+Environment=PORT=3007
+Environment=CROUTON_PRINTING_DRAINER=1
+# Secrets (BETTER_AUTH_SECRET, BETTER_AUTH_URL) live outside the repo.
+EnvironmentFile=/etc/fanfare/fanfare.env
+ExecStart=__NODE_BIN__ __APP_DIR__/.output/server/index.mjs
+Restart=always
+RestartSec=3
+TimeoutStartSec=90
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/fanfare/deploy/pi/healthcheck.sh
+++ b/apps/fanfare/deploy/pi/healthcheck.sh
@@ -17,7 +17,7 @@ KITCHEN="${KITCHEN_IP:-192.168.1.70}"
 BAR="${BAR_IP:-192.168.1.72}"
 PORT="${PRINTER_PORT:-9100}"
 ETH_ADDR="${ETH_ADDR:-192.168.1.51/24}"
-APP_URL="${APP_HEALTH_URL:-http://127.0.0.1:3007/}"
+APP_URL="${APP_HEALTH_URL:-http://127.0.0.1/}"   # the till serves on port 80
 
 fail=0
 log() { echo "[fanfare-health] $*"; }

--- a/apps/fanfare/deploy/pi/healthcheck.sh
+++ b/apps/fanfare/deploy/pi/healthcheck.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Boot-time + periodic reachability check for the fanfare venue rig (#798).
+#
+# Distinguishes the two failure modes that look identical from the app
+# ("printer not responding — paper out, cover open"):
+#   1. a real printer fault, vs
+#   2. the RUT (the printers' wifi AP) being powered down → eth0 NO-CARRIER →
+#      the whole printer subnet is gone.
+#
+# Run at boot and every few minutes (systemd timer). Logs a clear verdict to the
+# journal; exits non-zero when degraded so `systemctl status` shows it red.
+set -u
+
+RUT="${RUT_IP:-192.168.1.1}"
+KITCHEN="${KITCHEN_IP:-192.168.1.70}"
+BAR="${BAR_IP:-192.168.1.72}"
+PORT="${PRINTER_PORT:-9100}"
+ETH_ADDR="${ETH_ADDR:-192.168.1.51/24}"
+APP_URL="${APP_HEALTH_URL:-http://127.0.0.1:3007/}"
+
+fail=0
+log() { echo "[fanfare-health] $*"; }
+tcp_open() { timeout 2 bash -c "cat < /dev/null > /dev/tcp/$1/$2" 2>/dev/null; }
+
+# 1. eth0 physical link (RUT LAN). carrier 0 == RUT/link down.
+carrier="$(cat /sys/class/net/eth0/carrier 2>/dev/null || echo 0)"
+if [ "$carrier" = "1" ]; then
+  log "OK   eth0 carrier up"
+else
+  log "FAIL eth0 NO-CARRIER — RUT or cable down; ALL printing will fail until restored"
+  fail=1
+fi
+
+# 2. static printer-subnet IP present
+if ip -4 addr show eth0 2>/dev/null | grep -q "${ETH_ADDR%/*}/"; then
+  log "OK   eth0 has $ETH_ADDR (printer-subnet route)"
+else
+  log "FAIL eth0 missing $ETH_ADDR — run configure-network.sh"
+  fail=1
+fi
+
+# 3. RUT gateway reachable
+if ping -c1 -W1 "$RUT" >/dev/null 2>&1; then
+  log "OK   RUT gateway $RUT reachable"
+else
+  log "FAIL RUT gateway $RUT unreachable"
+  fail=1
+fi
+
+# 4. both station printers listening on :9100
+for kv in "kitchen=$KITCHEN" "bar=$BAR"; do
+  name="${kv%%=*}"; ip="${kv#*=}"
+  if tcp_open "$ip" "$PORT"; then
+    log "OK   $name printer $ip:$PORT open"
+  else
+    log "FAIL $name printer $ip:$PORT unreachable"
+    fail=1
+  fi
+done
+
+# 5. fanfare app responding locally. Informational, NOT a hard gate — the network
+#    reachability above is the #798 signal, and the drainer tolerates the app
+#    lagging. Retry for ~15s: on a fresh boot the node cold-start lags the
+#    boot-time check (OnBootSec) by a few seconds, and we don't want a spurious
+#    WARN every reboot.
+app_ok=0
+for _ in 1 2 3 4 5; do
+  if curl -fsS -o /dev/null --max-time 4 "$APP_URL" 2>/dev/null; then app_ok=1; break; fi
+  sleep 3
+done
+if [ "$app_ok" -eq 1 ]; then
+  log "OK   fanfare app responding at $APP_URL"
+else
+  log "WARN fanfare app not responding at $APP_URL (still cold-starting, or down — check: journalctl -u fanfare)"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  log "VERDICT: DEGRADED — see FAIL lines above"
+  exit 1
+fi
+if [ "$app_ok" -eq 1 ]; then
+  log "VERDICT: healthy — LAN up, RUT + both printers reachable, app up"
+else
+  log "VERDICT: network healthy (LAN + RUT + both printers); app not responding yet — re-run in a few seconds"
+fi

--- a/apps/fanfare/deploy/pi/setup.sh
+++ b/apps/fanfare/deploy/pi/setup.sh
@@ -20,6 +20,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_DIR="$(cd "$HERE/../.." && pwd)"          # apps/fanfare
 RUN_USER="${SUDO_USER:-$(id -un)}"
 ENV_FILE="/etc/fanfare/fanfare.env"
+ALIAS="${ALIAS:-kassa.local}"   # friendly mDNS name — the till is reached by name, not IP:port
 
 log() { echo "[setup] $*"; }
 
@@ -61,6 +62,15 @@ else
   log "$ENV_FILE already exists — leaving it"
 fi
 
+# Point auth at the friendly URL (the till is reached by name, not IP:port), so
+# session cookies match what staff type. Idempotent.
+log "pointing BETTER_AUTH_URL at http://$ALIAS"
+if sudo grep -q '^BETTER_AUTH_URL=' "$ENV_FILE" 2>/dev/null; then
+  sudo sed -i "s#^BETTER_AUTH_URL=.*#BETTER_AUTH_URL=http://$ALIAS#" "$ENV_FILE"
+else
+  echo "BETTER_AUTH_URL=http://$ALIAS" | sudo tee -a "$ENV_FILE" >/dev/null
+fi
+
 # --- 3. render + install the systemd unit -------------------------------------
 log "installing /etc/systemd/system/fanfare.service"
 sed -e "s|__USER__|$RUN_USER|g" \
@@ -98,15 +108,30 @@ Unit=fanfare-healthcheck.service
 WantedBy=timers.target
 UNIT
 
+# --- 5b. friendly mDNS URL ($ALIAS) -------------------------------------------
+# Publish a per-interface CNAME alias so the till answers to a name, not IP:port.
+log "installing the mDNS alias $ALIAS"
+if ! python3 -c 'import dbus' 2>/dev/null; then
+  log "  installing python3-dbus"
+  sudo apt-get update -qq && sudo apt-get install -y -qq python3-dbus
+fi
+sudo install -m 755 "$HERE/avahi-alias" /usr/local/bin/avahi-alias
+sed "s|__ALIAS_BIN__|/usr/local/bin/avahi-alias|g" "$HERE/avahi-alias@.service" \
+  | sudo tee /etc/systemd/system/avahi-alias@.service >/dev/null
+
 # --- 6. enable + (re)start ----------------------------------------------------
 log "enabling + starting units"
 sudo systemctl daemon-reload
 sudo systemctl enable --now fanfare.service
 sudo systemctl enable --now fanfare-healthcheck.timer
+sudo systemctl enable --now "avahi-alias@${ALIAS}.service"
 sudo systemctl restart fanfare.service   # pick up a fresh build if re-run
 
 log "done. status:"
 sudo systemctl --no-pager --lines=0 status fanfare.service || true
 echo
-log "next: register an account + team at the venue URL, then seed the event (see README)."
+log "the till is reachable at  http://$ALIAS  (iOS/macOS resolve it with zero config)."
+log "for Android/Windows, add a name on the venue router/RUT DNS (dnsmasq), e.g.:"
+log "    address=/kassa/<the till's IP on that network>   -> staff then use http://kassa"
+log "next: register an account + team at http://$ALIAS, then set up the event (see README)."
 log "verify the rig with: $HERE/healthcheck.sh"

--- a/apps/fanfare/deploy/pi/setup.sh
+++ b/apps/fanfare/deploy/pi/setup.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# One-command, idempotent setup for the fanfare local-first venue Pi (#798).
+#
+# Turns the ephemeral bench rig (manual tmux dev server + hand-added IP alias)
+# into a reboot-survivable box:
+#   * node-server production build  (with --build)
+#   * systemd unit                  -> fanfare auto-starts on boot, Restart=always
+#   * persistent printer-subnet route (NetworkManager, survives reboots)
+#   * boot + periodic reachability health check (RUT + both printers)
+#
+# Safe to re-run. Needs sudo for the system-level bits (systemd, nmcli, /etc).
+#
+# Usage:
+#   ./setup.sh            # wire everything against an existing .output build
+#   ./setup.sh --build    # build the node-server bundle first, then wire
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$HERE/../.." && pwd)"          # apps/fanfare
+RUN_USER="${SUDO_USER:-$(id -un)}"
+ENV_FILE="/etc/fanfare/fanfare.env"
+
+log() { echo "[setup] $*"; }
+
+# --- resolve the node binary (nvm installs aren't on the non-interactive PATH) ---
+NODE_BIN="${NODE_BIN:-$(command -v node || true)}"
+if [ -z "$NODE_BIN" ]; then
+  NODE_BIN="$(ls -1 "$HOME"/.nvm/versions/node/*/bin/node 2>/dev/null | sort -V | tail -1 || true)"
+fi
+[ -n "$NODE_BIN" ] && [ -x "$NODE_BIN" ] || { echo "[setup] ERROR: could not find a node binary; set NODE_BIN=" >&2; exit 1; }
+log "app dir : $APP_DIR"
+log "user    : $RUN_USER"
+log "node    : $NODE_BIN ($("$NODE_BIN" -v))"
+
+# --- 1. (optional) build the node-server bundle -------------------------------
+if [ "${1:-}" = "--build" ]; then
+  log "building node-server bundle (NITRO_PRESET=node-server)..."
+  ( cd "$APP_DIR" && PATH="$(dirname "$NODE_BIN"):$PATH" \
+      NITRO_PRESET=node-server NODE_OPTIONS=--max-old-space-size=6144 pnpm build )
+fi
+if [ ! -f "$APP_DIR/.output/server/index.mjs" ]; then
+  echo "[setup] ERROR: $APP_DIR/.output/server/index.mjs missing — run: ./setup.sh --build" >&2
+  exit 1
+fi
+
+# --- 2. secrets env file ------------------------------------------------------
+if [ ! -f "$ENV_FILE" ]; then
+  log "creating $ENV_FILE"
+  sudo mkdir -p "$(dirname "$ENV_FILE")"
+  if [ -f "$APP_DIR/.env" ] && grep -q BETTER_AUTH_SECRET "$APP_DIR/.env"; then
+    log "  seeding BETTER_AUTH_* from $APP_DIR/.env"
+    sudo install -m 600 /dev/null "$ENV_FILE"
+    grep -E '^BETTER_AUTH_(SECRET|URL)=' "$APP_DIR/.env" | sudo tee "$ENV_FILE" >/dev/null
+  else
+    log "  no app .env found — copying the example; EDIT $ENV_FILE before going live"
+    sudo install -m 600 "$HERE/fanfare.env.example" "$ENV_FILE"
+  fi
+  sudo chmod 600 "$ENV_FILE"
+else
+  log "$ENV_FILE already exists — leaving it"
+fi
+
+# --- 3. render + install the systemd unit -------------------------------------
+log "installing /etc/systemd/system/fanfare.service"
+sed -e "s|__USER__|$RUN_USER|g" \
+    -e "s|__APP_DIR__|$APP_DIR|g" \
+    -e "s|__NODE_BIN__|$NODE_BIN|g" \
+    "$HERE/fanfare.service" | sudo tee /etc/systemd/system/fanfare.service >/dev/null
+
+# --- 4. persistent printer-subnet route ---------------------------------------
+log "configuring persistent printer-subnet route (NetworkManager)"
+bash "$HERE/configure-network.sh"
+
+# --- 5. boot + periodic health check ------------------------------------------
+log "installing fanfare-healthcheck.service + .timer"
+sudo tee /etc/systemd/system/fanfare-healthcheck.service >/dev/null <<UNIT
+[Unit]
+Description=fanfare venue rig reachability check (RUT + both printers)
+After=network-online.target fanfare.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$HERE/healthcheck.sh
+UNIT
+
+sudo tee /etc/systemd/system/fanfare-healthcheck.timer >/dev/null <<'UNIT'
+[Unit]
+Description=Run the fanfare venue rig health check at boot and every 5 minutes
+
+[Timer]
+OnBootSec=45s
+OnUnitActiveSec=5min
+Unit=fanfare-healthcheck.service
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+# --- 6. enable + (re)start ----------------------------------------------------
+log "enabling + starting units"
+sudo systemctl daemon-reload
+sudo systemctl enable --now fanfare.service
+sudo systemctl enable --now fanfare-healthcheck.timer
+sudo systemctl restart fanfare.service   # pick up a fresh build if re-run
+
+log "done. status:"
+sudo systemctl --no-pager --lines=0 status fanfare.service || true
+echo
+log "next: register an account + team at the venue URL, then seed the event (see README)."
+log "verify the rig with: $HERE/healthcheck.sh"

--- a/apps/fanfare/nuxt.config.ts
+++ b/apps/fanfare/nuxt.config.ts
@@ -89,6 +89,15 @@ export default defineNuxtConfig({
           '@simplewebauthn/server': cfStubs,
           'papaparse': cfStubs
         }
-      : {}
+      : {},
+    // node-server (venue/Pi) target: Nitro's externalizer mangles drizzle-orm in
+    // this pnpm monorepo — it misses the `drizzle-orm/libsql` driver subpath and
+    // emits broken absolute pnpm-store paths for drizzle's internal cross-imports,
+    // so `node .output/server` dies with ERR_MODULE_NOT_FOUND. Inline the whole of
+    // drizzle-orm so Rollup bundles it self-contained into the server chunk (only
+    // the imported subpaths — core + libsql — are pulled in; the unused mysql/pg
+    // drivers are not). @libsql/client stays external and traces fine. The
+    // Cloudflare build uses D1 (no libsql) so it's scoped out by isCloudflare. (#798)
+    externals: isCloudflare ? {} : { inline: ['drizzle-orm'] }
   }
 })


### PR DESCRIPTION
Closes #798.

## Hypothesis — confirmed ✅
We thought that if we scripted the Pi venue rig (persistent printer route + node-server build + systemd + a boot health check), **then** fanfare-on-the-Pi would survive reboots and "just run". **It does** — verified by rebooting `pmcpi` and ringing up a mixed order that printed to both stations, untouched.

## 👤 For humans
Today's #63 hardware proof (phone POS → order → in-process ESC/POS drainer → thermal printer, no cloud, no Mac) worked but was ephemeral: a manual `tmux` dev server, a hand-typed `192.168.1.51` IP alias (gone on every link-down), and no autostart. This turns it into a real always-on box — power-cycle the Pi and fanfare comes back on its own.

No `packages/` were touched — everything is app-land (`apps/fanfare/`).

## 🤖 For agents
Two commits:
1. **`fix(fanfare): inline drizzle-orm …`** — the node-server build wouldn't boot (`ERR_MODULE_NOT_FOUND: drizzle-orm/libsql`). Nitro's externalizer mishandles drizzle-orm in this pnpm monorepo (misses the libsql driver subpath; emits broken absolute pnpm-store paths for drizzle's internal cross-imports). Fix: `nitro.externals = { inline: ['drizzle-orm'] }` on the non-Cloudflare target only (the CF build uses D1, scoped out by the existing `isCloudflare` guard). Bundles drizzle self-contained; `@libsql/client` stays external and traces fine.
2. **`chore(fanfare): make the … Pi venue rig reproducible`** — new `apps/fanfare/deploy/pi/`:
   - `setup.sh` — idempotent orchestrator (build → render+install unit → configure net → install health timer → enable+start).
   - `fanfare.service` — systemd unit template. `node .output/server/index.mjs`, `HOST=0.0.0.0 PORT=3007 CROUTON_PRINTING_DRAINER=1` (env, **not** `nuxt dev --host/--port` which mangles the port), `Restart=always`, `After=network-online.target`; secrets via `EnvironmentFile=/etc/fanfare/fanfare.env`.
   - `configure-network.sh` — persistent printer-subnet route via **NetworkManager** (eth0 static `192.168.1.51/24`, autoconnect + priority, `never-default`; disables the competing netplan DHCP profile). Replaces the throwaway `ip addr add` alias.
   - `healthcheck.sh` — boot + 5-min reachability check (eth0 carrier, the `.51` route, RUT gateway, both printers `:9100`, app), naming the "RUT powered down → eth0 NO-CARRIER → all prints fail" trap; exits non-zero when degraded. Wired as a `oneshot` + `timer`.
   - `fanfare.env.example` + `README.md` (runbook, topology, gotchas).

## 🧪 Verify (done on `pmcpi`, 2026-06-24)
- `setup.sh` → `fanfare.service` **enabled + active**, health check green at boot.
- **`sudo reboot`** → fresh boot: the `192.168.1.51/24` route came back via NetworkManager (no manual alias), `fanfare.service` auto-started and was **listening in ~5 s** with the drainer ON, LAN serving.
- Boot health check ran automatically (boot+45 s) and passed every line.
- **Mixed order** (Hamburger → kitchen `192.168.1.70`, Pils → bar `192.168.1.72`): both print jobs drained `0 → 1 → 2`, printer-confirmed via DLE-EOT, zero errors → **both stations printed**.

> Depends on PR #714 (the `print_jobs` migration), already on `main`. The dev-only `_seed` route is `import.meta.dev`-gated so it's absent from this production build; #797 owns a production-safe seed runner. The Pi build verified here is the merged #714 state + this PR's changes (it predates `@fyit/crouton-layout` in fanfare's extends, which is orthogonal to the rig).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
