### PR TITLE
fix(crouton-devtools): boot cleanly when devtools is on but events package is absent

### DIFF
--- a/packages/crouton-devtools/src/module.ts
+++ b/packages/crouton-devtools/src/module.ts
@@ -148,16 +148,25 @@ export default defineNuxtModule<ModuleOptions>({
       method: 'post'
     })
 
-    // Add events-specific RPC handlers (when events package detected)
-    addServerHandler({
-      route: '/__nuxt_crouton_devtools/api/events',
-      handler: resolver.resolve('./runtime/server-rpc/events')
-    })
+    // Add events-specific RPC handlers — ONLY when the events package is present.
+    // These handlers statically `import('~~/.../schema')` event-table paths that
+    // don't exist in a standard generated app (its schema lives at
+    // `server/db/schema`). nitro dev eagerly resolves those literal specifiers at
+    // build time, so registering them unconditionally hard-fails `pnpm dev` with
+    // ENOENT for any devtools-enabled, events-free app (#799). The runtime handler
+    // already no-ops when `!hasEventsPackage`, so gating registration here loses
+    // nothing and keeps the broken import out of the bundle entirely.
+    if (hasEventsPackage) {
+      addServerHandler({
+        route: '/__nuxt_crouton_devtools/api/events',
+        handler: resolver.resolve('./runtime/server-rpc/events')
+      })
 
-    addServerHandler({
-      route: '/__nuxt_crouton_devtools/api/events/health',
-      handler: resolver.resolve('./runtime/server-rpc/eventsHealth')
-    })
+      addServerHandler({
+        route: '/__nuxt_crouton_devtools/api/events/health',
+        handler: resolver.resolve('./runtime/server-rpc/eventsHealth')
+      })
+    }
 
     // Add system operations RPC handlers (D1: System Ops tab)
     addServerHandler({


### PR DESCRIPTION
Closes #799

## 👤 For humans

A crouton app that enabled the **dev-tools** module but didn't have the **events** package would crash on `pnpm dev` with an `ENOENT`. This makes the dev-tools wire up the events panel **only when the events package is actually installed**, so a normal app boots cleanly.

This is the leading blocker for epic #808 (the consolidated dev-tools menu) — "show dev-tools by default everywhere" only works if a devtools-enabled app boots in the first place.

## 🤖 For agents

**Root cause (archaeology in #799):** `runtime/server-rpc/eventsHealth.ts` statically does `import('~~/server/database/schema')` (plus two other event-table paths). nitro dev **eagerly resolves those literal specifiers at build time**, so it hard-fails with `ENOENT` for any standard generated app — whose schema lives at `server/db/schema`, not `server/database/schema`. The runtime `try/catch` never runs because the failure is at build.

**Fix:** `module.ts` now wraps the two events handlers (`/api/events`, `/api/events/health`) in `if (hasEventsPackage)`. The handler already early-returns *"Events package not installed"* when `!hasEventsPackage`, so gating its **registration** loses nothing and keeps the broken import out of the bundle entirely (issue candidate #3).

**Verification:**
- `pocs/booking-demo` (devtools on, no events, schema at `server/db/schema`) — previously failed to build; now boots Nitro (`Nuxt Nitro server built`, serving on `:3000`) with **zero** `ENOENT`/`server/database/schema` errors. Remaining log errors are font-provider 403s (egress-blocked in CI), unrelated.
- `pnpm build` for the package emits `.d.ts` clean.
- `apps/velo typecheck` clean.

**Note / follow-up:** the events-present path still hardcodes `~~/server/database/schema` as one of three schema fallbacks (should be `~~/server/db/schema`). No app currently ships devtools+events, so it's latent; worth aligning when the events panel is next touched (tracked in epic #808 context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018n6Jb6999toagFCqCSC8TK)_