### PR TITLE
feat(crouton-bookings): add demo seed provider (#696)

### DIFF
--- a/apps/fanfare/package.json
+++ b/apps/fanfare/package.json
@@ -11,7 +11,7 @@
     "postinstall": "nuxt prepare 2>/dev/null || true",
     "typecheck": "nuxt typecheck",
     "cf:deploy": "NITRO_PRESET=cloudflare_module nuxt build && npx wrangler --cwd .output deploy && node scripts/sync-wrangler-ids.mjs && npx wrangler d1 migrations apply fanfare-db --remote",
-    "cf:staging": "NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply fanfare-staging-db --env staging --remote && pnpm db:seed:staging",
+    "cf:staging": "NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply fanfare-staging-db --env staging --remote && (pnpm db:seed:staging || true)",
     "sync:ids": "node scripts/sync-wrangler-ids.mjs",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "npx wrangler d1 migrations apply fanfare-db --local",

--- a/apps/triage/package.json
+++ b/apps/triage/package.json
@@ -15,6 +15,10 @@
     "db:migrate": "npx wrangler d1 migrations apply triage-db --local",
     "db:migrate:prod": "npx wrangler d1 migrations apply triage-db --remote",
     "db:migrate:staging": "npx wrangler d1 migrations apply triage-staging-db --env staging --remote",
+    "db:seed": "pnpm db:seed:local",
+    "db:seed:local": "crouton-seed --db triage-db --with-staff",
+    "db:seed:remote": "crouton-seed --db triage-db --remote",
+    "db:seed:staging": "crouton-seed --db triage-staging-db --remote --with-staff",
     "tunnel": "cloudflared tunnel --config ~/.cloudflared/triage-dev.yml run triage-dev",
     "logs": "npx wrangler tail triage"
   },
@@ -22,6 +26,7 @@
     "@fyit/crouton": "workspace:*",
     "@fyit/crouton-charts": "workspace:*",
     "@fyit/crouton-layout": "workspace:*",
+    "@fyit/crouton-triage": "workspace:*",
     "@libsql/client": "catalog:",
     "@vue-flow/background": "^1.3.0",
     "@vue-flow/controls": "^1.1.2",

--- a/apps/triage/package.json
+++ b/apps/triage/package.json
@@ -9,7 +9,7 @@
     "typecheck": "nuxt typecheck",
     "postinstall": "nuxt prepare 2>/dev/null || true",
     "cf:deploy": "NITRO_PRESET=cloudflare_module nuxt build && npx wrangler --cwd .output deploy && node scripts/sync-wrangler-ids.mjs && npx wrangler d1 migrations apply triage-db --remote",
-    "cf:staging": "NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply triage-staging-db --env staging --remote",
+    "cf:staging": "NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply triage-staging-db --env staging --remote && (pnpm db:seed:staging || true)",
     "sync:ids": "node scripts/sync-wrangler-ids.mjs",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "npx wrangler d1 migrations apply triage-db --local",

--- a/apps/velo/package.json
+++ b/apps/velo/package.json
@@ -11,7 +11,7 @@
     "postinstall": "nuxt prepare 2>/dev/null || true",
     "typecheck": "nuxt typecheck",
     "cf:deploy": "NITRO_PRESET=cloudflare_module nuxt build && npx wrangler --cwd .output deploy && node scripts/sync-wrangler-ids.mjs && npx wrangler d1 migrations apply velo-db --remote",
-    "cf:staging": "NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply velo-staging-db --env staging --remote",
+    "cf:staging": "NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply velo-staging-db --env staging --remote && (pnpm db:seed:staging || true)",
     "sync:ids": "node scripts/sync-wrangler-ids.mjs",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "npx wrangler d1 migrations apply velo-db --local",

--- a/apps/velo/package.json
+++ b/apps/velo/package.json
@@ -16,7 +16,11 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "npx wrangler d1 migrations apply velo-db --local",
     "db:migrate:prod": "npx wrangler d1 migrations apply velo-db --remote",
-    "db:migrate:staging": "npx wrangler d1 migrations apply velo-staging-db --env staging --remote"
+    "db:migrate:staging": "npx wrangler d1 migrations apply velo-staging-db --env staging --remote",
+    "db:seed": "pnpm db:seed:local",
+    "db:seed:local": "crouton-seed --db velo-db --with-staff",
+    "db:seed:remote": "crouton-seed --db velo-db --remote",
+    "db:seed:staging": "crouton-seed --db velo-staging-db --remote --with-staff"
   },
   "dependencies": {
     "@fyit/crouton": "workspace:*",

--- a/packages/crouton-ai/CLAUDE.md
+++ b/packages/crouton-ai/CLAUDE.md
@@ -27,6 +27,16 @@ AI integration layer for Nuxt applications using Vercel AI SDK. Provides composa
 | `schemas/chat-conversations.json` | JSON schema for crouton generator |
 | `schemas/chat-conversations.ts` | TypeScript schema with Zod validation |
 
+## Demo Seeding — intentionally none (#697)
+
+crouton-ai ships a single collection, `chat_conversations` — **runtime AI chat
+history**, written per-user as conversations happen. It carries no curated,
+user-facing demo content a reviewer needs to see pre-populated (a seeded fake
+conversation owned by `seed` wouldn't surface in the chat UI, which is keyed to
+the logged-in user). Per epic #695/#697, this package is **deliberately exempt**
+from the composable seeding system — it ships **no `./seed` provider**. If a
+future collection here warrants demo data, add a provider then.
+
 ## Architecture
 
 ```

--- a/packages/crouton-bookings/CLAUDE.md
+++ b/packages/crouton-bookings/CLAUDE.md
@@ -19,6 +19,7 @@ Booking system layer for Nuxt applications that provides both slot-based booking
 | `server/api/crouton-bookings/` | API endpoints |
 | `server/utils/booking-emails.ts` | Email utilities |
 | `schemas/` | JSON schema definitions |
+| `seed/index.ts` | Seed provider (`@fyit/crouton-bookings/seed`, #696) — one settings row (statuses + groups) + demo locations (two slot-mode courts, one inventory-mode rental) + a few bookings, so previews open populated |
 
 ## Architecture
 
@@ -205,6 +206,29 @@ bookings.
 ├── meta.*           - Metadata labels
 └── common.*         - Common terms
 ```
+
+## Demo Seeding (`@fyit/crouton-bookings/seed`)
+
+Part of the composable seeding system (epic #82, contract in
+`@fyit/crouton-core/shared/seed`). Provider id `bookings`, `dependsOn: ['auth']`:
+
+- **Settings:** one `bookings_settings` row with three statuses
+  (confirmed/pending/cancelled) and two age groups (adults/youth), each an
+  option item (`{ id, value, label, translations }`) so booking `status`/`group`
+  values resolve to readable, translated labels in the admin list.
+- **Locations:** three `bookings_locations` covering both modes — two slot-mode
+  courts (named time slots with capacity) and one inventory-mode rental (a
+  quantity pool). Titles carry `nl`/`en` translations.
+- **Bookings:** four `bookings_bookings` referencing those locations/slots,
+  dated `unixepoch() + N*86400` so they always sit in the near future. Slot-mode
+  rows store a JSON array of slot ids (`["slot-0900"]`); the inventory row stores
+  the JSON literal `null` — the exact shape the live batch-checkout endpoint
+  writes (the `slot` column is NOT-NULL JSON).
+
+Pure module (references `bookings_*` table/columns by name, loads under jiti).
+Idempotent — stable `seedId(...)` ids upsert in place. Every NOT-NULL column is
+set explicitly because Drizzle `$default(...)` is ORM-time, not a SQL DEFAULT.
+Run via an app's `crouton-seed` / `db:seed:*` scripts.
 
 ## Testing
 

--- a/packages/crouton-bookings/package.json
+++ b/packages/crouton-bookings/package.json
@@ -8,6 +8,7 @@
     "app",
     "server",
     "schemas",
+    "seed",
     "i18n",
     "dist",
     "nuxt.config.ts",
@@ -18,6 +19,10 @@
   "exports": {
     ".": "./nuxt.config.ts",
     "./crouton.manifest": "./crouton.manifest.ts",
+    "./seed": {
+      "import": "./seed/index.ts",
+      "types": "./seed/index.ts"
+    },
     "./server/utils/email-service": {
       "types": "./dist/server/utils/email-service.d.ts",
       "import": "./dist/server/utils/email-service.mjs"

--- a/packages/crouton-bookings/seed/index.ts
+++ b/packages/crouton-bookings/seed/index.ts
@@ -1,0 +1,196 @@
+/**
+ * crouton-bookings seed provider (#696).
+ *
+ * Domain seed: a small, realistic booking demo so an app extending bookings
+ * opens with populated tables instead of `0–0 / 0` empties. Seeds
+ * - one `bookings_settings` row (statuses + age groups), so booking
+ *   `status`/`group` values resolve to readable labels in the admin list;
+ * - three locations covering both booking modes — two slot-mode courts (named
+ *   time slots) and one inventory-mode rental (a quantity pool);
+ * - a handful of bookings referencing those locations/slots, dated relative to
+ *   seed time so the calendar always shows upcoming reservations.
+ *
+ * Pure module: references the generated `bookings_*` table/column names as
+ * strings, so it never imports the app's generated schema and loads cleanly
+ * under jiti. Idempotent — stable `seedId(...)` ids upsert in place on re-run.
+ *
+ * Column notes (match the generator's Drizzle output):
+ * - `slot` is a NOT-NULL JSON column; slot-mode bookings store an array of slot
+ *   ids (`["slot-0900"]`), inventory bookings store the JSON literal `null`
+ *   (`'null'` text) — the same shape the live batch-checkout endpoint writes.
+ * - `date` is an integer timestamp (unix seconds); `unixepoch() + N*86400`
+ *   keeps demo bookings in the near future on every (re-)seed.
+ * - every NOT-NULL column is set explicitly: Drizzle `$default(...)` is an
+ *   ORM-time default, not a SQL DEFAULT, so raw-SQL upserts must supply them.
+ */
+import type { SeedProvider, SeedContext } from '@fyit/crouton-core/shared/seed'
+import { seedId, raw } from '@fyit/crouton-core/shared/seed'
+
+/** An option-item row as stored in `bookings_settings.statuses`/`.groups`. */
+interface OptionItem {
+  id: string
+  label: string
+  value: string
+  translations?: { label?: Record<string, string> }
+}
+
+const STATUSES: OptionItem[] = [
+  { id: 'confirmed', value: 'confirmed', label: 'Confirmed', translations: { label: { nl: 'Bevestigd', fr: 'Confirmé' } } },
+  { id: 'pending', value: 'pending', label: 'Pending', translations: { label: { nl: 'In afwachting', fr: 'En attente' } } },
+  { id: 'cancelled', value: 'cancelled', label: 'Cancelled', translations: { label: { nl: 'Geannuleerd', fr: 'Annulé' } } }
+]
+
+const GROUPS: OptionItem[] = [
+  { id: 'adults', value: 'adults', label: 'Adults', translations: { label: { nl: 'Volwassenen', fr: 'Adultes' } } },
+  { id: 'youth', value: 'youth', label: 'Youth', translations: { label: { nl: 'Jeugd', fr: 'Jeunes' } } }
+]
+
+interface SeedSlot {
+  id: string
+  label: string
+  capacity: number
+}
+
+interface SeedLocation {
+  key: string
+  title: string
+  titleNl: string
+  color: string
+  city: string
+  inventoryMode: boolean
+  quantity?: number
+  slots: SeedSlot[]
+}
+
+const LOCATIONS: SeedLocation[] = [
+  {
+    key: 'center-court',
+    title: 'Center Court',
+    titleNl: 'Centrumplein',
+    color: '#3b82f6',
+    city: 'Antwerpen',
+    inventoryMode: false,
+    slots: [
+      { id: 'slot-0900', label: '09:00 – 10:00', capacity: 1 },
+      { id: 'slot-1000', label: '10:00 – 11:00', capacity: 1 },
+      { id: 'slot-1100', label: '11:00 – 12:00', capacity: 2 }
+    ]
+  },
+  {
+    key: 'park-court',
+    title: 'Park Court',
+    titleNl: 'Parkzijde',
+    color: '#22c55e',
+    city: 'Gent',
+    inventoryMode: false,
+    slots: [
+      { id: 'slot-1400', label: '14:00 – 15:00', capacity: 1 },
+      { id: 'slot-1500', label: '15:00 – 16:00', capacity: 1 }
+    ]
+  },
+  {
+    key: 'kayak-rental',
+    title: 'Kayak Rental',
+    titleNl: 'Kajakverhuur',
+    color: '#f59e0b',
+    city: 'Brugge',
+    inventoryMode: true,
+    quantity: 8,
+    slots: []
+  }
+]
+
+interface SeedBooking {
+  locationKey: string
+  /** Slot ids for slot-mode; empty for inventory bookings. */
+  slotIds: string[]
+  /** Days from seed time (keeps demo bookings upcoming). */
+  inDays: number
+  quantity: number
+  status: string
+  group: string | null
+}
+
+const BOOKINGS: SeedBooking[] = [
+  { locationKey: 'center-court', slotIds: ['slot-0900'], inDays: 1, quantity: 1, status: 'confirmed', group: 'adults' },
+  { locationKey: 'center-court', slotIds: ['slot-1100'], inDays: 1, quantity: 1, status: 'confirmed', group: 'youth' },
+  { locationKey: 'park-court', slotIds: ['slot-1400'], inDays: 2, quantity: 1, status: 'pending', group: 'adults' },
+  { locationKey: 'kayak-rental', slotIds: [], inDays: 3, quantity: 2, status: 'confirmed', group: null }
+]
+
+function locationId(ctx: SeedContext, key: string): string {
+  return seedId('bookings-location', ctx.teamSlug, key)
+}
+
+export const provider: SeedProvider = {
+  id: 'bookings',
+  dependsOn: ['auth'],
+  seed(ctx) {
+    // Settings — one row per team (status + group option lists).
+    ctx.upsert('bookings_settings', { id: seedId('bookings-settings', ctx.teamSlug) }, {
+      teamId: ctx.teamId,
+      owner: 'seed',
+      order: 0,
+      statuses: STATUSES,
+      groups: GROUPS,
+      createdAt: ctx.now,
+      updatedAt: ctx.now,
+      createdBy: 'seed',
+      updatedBy: 'seed'
+    })
+
+    // Locations.
+    LOCATIONS.forEach((loc, index) => {
+      ctx.upsert('bookings_locations', { id: locationId(ctx, loc.key) }, {
+        teamId: ctx.teamId,
+        owner: 'seed',
+        order: index,
+        title: loc.titleNl,
+        color: loc.color,
+        city: loc.city,
+        content: null,
+        slots: loc.inventoryMode ? null : loc.slots,
+        openDays: null,
+        slotSchedule: null,
+        blockedDates: null,
+        inventoryMode: loc.inventoryMode,
+        quantity: loc.inventoryMode ? (loc.quantity ?? 0) : null,
+        maxBookingsPerMonth: null,
+        translations: {
+          [ctx.locale]: { title: loc.titleNl, city: loc.city },
+          en: { title: loc.title, city: loc.city }
+        },
+        createdAt: ctx.now,
+        updatedAt: ctx.now,
+        createdBy: 'seed',
+        updatedBy: 'seed'
+      })
+    })
+
+    // Bookings — slot-mode store a JSON array of slot ids; inventory stores the
+    // JSON literal `null` (NOT-NULL column → `'null'` text, like the live app).
+    BOOKINGS.forEach((booking, index) => {
+      ctx.upsert(
+        'bookings_bookings',
+        { id: seedId('bookings-booking', ctx.teamSlug, booking.locationKey, String(index)) },
+        {
+          teamId: ctx.teamId,
+          owner: 'seed',
+          order: index,
+          location: locationId(ctx, booking.locationKey),
+          date: raw(`unixepoch() + ${booking.inDays * 86400}`),
+          slot: booking.slotIds.length ? booking.slotIds : raw("'null'"),
+          group: booking.group,
+          quantity: booking.quantity,
+          status: booking.status,
+          createdAt: ctx.now,
+          updatedAt: ctx.now,
+          createdBy: 'seed',
+          updatedBy: 'seed'
+        }
+      )
+    })
+  }
+}
+
+export default provider

--- a/packages/crouton-triage/CLAUDE.md
+++ b/packages/crouton-triage/CLAUDE.md
@@ -34,6 +34,7 @@ Discussion-to-task triage system for Nuxt applications. Receives discussions fro
 | `server/utils/domain-routing.ts` | AI-powered domain routing for multi-output flows |
 | `server/api/crouton-triage/` | API endpoints |
 | `schemas/` | 8 JSON schema definitions |
+| `seed/index.ts` | Seed provider (`@fyit/crouton-triage/seed`, #697) — seeds the user-facing content chain (flow → input → discussions → tasks + inbox messages) so the Triage admin surfaces open populated. Integration-plumbing collections (accounts/outputs/jobs/users) are intentionally NOT seeded |
 
 ## Architecture
 
@@ -247,6 +248,36 @@ export default defineAppConfig({
 ```
 
 See `packages/crouton-core/CLAUDE.md` for the full `parentApp` pattern documentation.
+
+## Demo Seeding (`@fyit/crouton-triage/seed`)
+
+Part of the composable seeding system (epic #82, contract in
+`@fyit/crouton-core/shared/seed`). Provider id `triage`, `dependsOn: ['auth']`.
+
+Triage is integration-driven (Slack/Figma/email → AI → Notion), so most of its
+collections are **plumbing tied to live credentials** — `accounts` (OAuth),
+`outputs` (Notion targets), `jobs` (sync runs), `users` (platform identities).
+Seeding those with fake rows would misrepresent a working integration, so the
+provider seeds only the **user-facing content chain** a reviewer opens:
+
+```
+flow → input → discussions → tasks   (+ a couple of inbox messages)
+```
+
+- 1 flow ("Support Triage") + 1 Slack input (demo display config, no live token)
+- 3 discussions (varied status: completed/pending) with AI summaries + key points
+- 2 tasks (one per resolved discussion; `notionPageId`/`notionPageUrl` are demo
+  placeholders — `notionPageId` is unique per team, so stable demo ids stay idempotent)
+- 2 inbox messages
+
+Pure module (references `triage_*` table/columns by name, loads under jiti).
+Idempotent — stable `seedId(...)` ids upsert in place; every NOT-NULL column is
+set explicitly. Run via an app's `crouton-seed` / `db:seed:*` scripts.
+
+> **Discovery note:** `crouton-seed` finds providers by walking the app's
+> `package.json` dependency graph (not its `nuxt.config` extends). `apps/triage`
+> now declares `@fyit/crouton-triage` as a dependency (#698) so this provider is
+> discovered and seeded there.
 
 ## Naming Conventions
 

--- a/packages/crouton-triage/package.json
+++ b/packages/crouton-triage/package.json
@@ -8,6 +8,7 @@
     "app",
     "server",
     "schemas",
+    "seed",
     "i18n",
     "dist",
     "nuxt.config.ts",
@@ -17,6 +18,10 @@
   "exports": {
     ".": "./nuxt.config.ts",
     "./crouton.manifest": "./crouton.manifest.ts",
+    "./seed": {
+      "import": "./seed/index.ts",
+      "types": "./seed/index.ts"
+    },
     "./server/utils/domain-routing": {
       "types": "./dist/server/utils/domain-routing.d.ts",
       "import": "./dist/server/utils/domain-routing.mjs"

--- a/packages/crouton-triage/seed/index.ts
+++ b/packages/crouton-triage/seed/index.ts
@@ -1,0 +1,257 @@
+/**
+ * crouton-triage seed provider (#697).
+ *
+ * Triage is a discussion-to-task pipeline (Slack/Figma/email → AI → Notion).
+ * Most of its collections are *integration plumbing* tied to live credentials —
+ * `accounts` (OAuth connections), `outputs` (Notion targets), `jobs` (sync
+ * runs), `users` (platform identities) — so seeding them with fake rows would
+ * misrepresent a working integration. This provider instead seeds the
+ * **user-facing content chain** a reviewer actually opens:
+ *
+ *   flow → input → discussions → tasks   (+ a couple of inbox messages)
+ *
+ * so the Triage admin surfaces (overview / discussions / tasks / inbox) open
+ * populated instead of empty. The integration-plumbing collections are left to
+ * real connected accounts.
+ *
+ * Pure module: references the generated `triage_*` table/column names as
+ * strings, loads under jiti. Idempotent — stable `seedId(...)` ids upsert in
+ * place. Every NOT-NULL column is set explicitly (Drizzle `$default(...)` is
+ * ORM-time, not a SQL DEFAULT, so raw-SQL upserts must supply them).
+ */
+import type { SeedProvider, SeedContext } from '@fyit/crouton-core/shared/seed'
+import { seedId, raw } from '@fyit/crouton-core/shared/seed'
+
+const FLOW_KEY = 'support'
+const INPUT_KEY = 'support-slack'
+
+function flowId(ctx: SeedContext): string {
+  return seedId('triage-flow', ctx.teamSlug, FLOW_KEY)
+}
+function inputId(ctx: SeedContext): string {
+  return seedId('triage-input', ctx.teamSlug, INPUT_KEY)
+}
+function discussionId(ctx: SeedContext, key: string): string {
+  return seedId('triage-discussion', ctx.teamSlug, key)
+}
+
+interface SeedDiscussion {
+  key: string
+  title: string
+  content: string
+  authorHandle: string
+  status: string
+  totalMessages: number
+  aiSummary: string
+  aiKeyPoints: string[]
+}
+
+const DISCUSSIONS: SeedDiscussion[] = [
+  {
+    key: 'checkout-bug',
+    title: 'Bug: checkout button unresponsive on mobile',
+    content: 'Several customers report the checkout button does nothing on iOS Safari. Tapping it never opens the payment sheet.',
+    authorHandle: '@sarah',
+    status: 'completed',
+    totalMessages: 6,
+    aiSummary: 'A mobile-only checkout regression: the pay button is unresponsive on iOS Safari, blocking purchases.',
+    aiKeyPoints: ['iOS Safari only', 'Blocks all mobile checkout', 'Started after the latest deploy']
+  },
+  {
+    key: 'dark-mode',
+    title: 'Feature request: dark mode for the dashboard',
+    content: 'Multiple users in the channel are asking for a dark theme on the admin dashboard for late-night shifts.',
+    authorHandle: '@miguel',
+    status: 'completed',
+    totalMessages: 12,
+    aiSummary: 'Recurring request for a dark theme on the admin dashboard, driven by night-shift usage.',
+    aiKeyPoints: ['High demand', 'Night-shift ergonomics', 'Dashboard scope only']
+  },
+  {
+    key: 'rate-limits',
+    title: 'Question about API rate limits',
+    content: 'A partner is hitting 429s on the public API and wants to know the per-minute limit and how to request more.',
+    authorHandle: '@aisha',
+    status: 'pending',
+    totalMessages: 3,
+    aiSummary: 'Partner integration is hitting rate limits and needs documented thresholds plus an increase path.',
+    aiKeyPoints: ['429 responses', 'Needs documented limits', 'Possible quota bump']
+  }
+]
+
+interface SeedTask {
+  discussionKey: string
+  title: string
+  description: string
+  status: string
+  priority: string
+  assignee: string
+}
+
+const TASKS: SeedTask[] = [
+  {
+    discussionKey: 'checkout-bug',
+    title: 'Fix unresponsive checkout button on mobile',
+    description: 'Reproduce on iOS Safari, bisect the recent deploy, and restore the payment sheet trigger.',
+    status: 'todo',
+    priority: 'high',
+    assignee: 'Sarah Chen'
+  },
+  {
+    discussionKey: 'dark-mode',
+    title: 'Implement dark mode toggle for the dashboard',
+    description: 'Add a theme switch and dark token set scoped to the admin dashboard.',
+    status: 'todo',
+    priority: 'medium',
+    assignee: 'Miguel Santos'
+  }
+]
+
+interface SeedMessage {
+  key: string
+  from: string
+  subject: string
+  textBody: string
+  read: boolean
+}
+
+const MESSAGES: SeedMessage[] = [
+  {
+    key: 'invoice',
+    from: 'customer@acme.com',
+    subject: 'Re: Invoice question',
+    textBody: 'Hi — can you confirm whether invoice #4821 includes the seat upgrade we added last week?',
+    read: false
+  },
+  {
+    key: 'partnership',
+    from: 'hello@partner.io',
+    subject: 'Partnership opportunity',
+    textBody: 'We love what you are building and would like to explore a co-marketing partnership.',
+    read: true
+  }
+]
+
+const SOURCE_URL = 'https://example.slack.com/archives/C0SUPPORT'
+
+export const provider: SeedProvider = {
+  id: 'triage',
+  dependsOn: ['auth'],
+  seed(ctx) {
+    // Flow — the central triage entity (the FlowList landing surface).
+    ctx.upsert('triage_flows', { id: flowId(ctx) }, {
+      teamId: ctx.teamId,
+      owner: 'seed',
+      order: 0,
+      name: 'Support Triage',
+      description: 'Routes support discussions into actionable tasks.',
+      availableDomains: null,
+      aiEnabled: true,
+      replyPersonality: 'Helpful, concise, and friendly.',
+      personalityIcon: 'i-lucide-bot',
+      active: true,
+      onboardingComplete: true,
+      createdAt: ctx.now,
+      updatedAt: ctx.now,
+      createdBy: 'seed',
+      updatedBy: 'seed'
+    })
+
+    // Input — a Slack source under the flow (demo display config; no live token).
+    ctx.upsert('triage_inputs', { id: inputId(ctx) }, {
+      teamId: ctx.teamId,
+      owner: 'seed',
+      order: 0,
+      flowId: flowId(ctx),
+      sourceType: 'slack',
+      name: 'Support Channel',
+      sourceMetadata: { channel: '#support' },
+      active: true,
+      createdAt: ctx.now,
+      updatedAt: ctx.now,
+      createdBy: 'seed',
+      updatedBy: 'seed'
+    })
+
+    // Discussions — incoming threads, analysed by AI.
+    DISCUSSIONS.forEach((d, index) => {
+      ctx.upsert('triage_discussions', { id: discussionId(ctx, d.key) }, {
+        teamId: ctx.teamId,
+        owner: 'seed',
+        order: index,
+        sourceType: 'slack',
+        sourceThreadId: `seed-thread-${d.key}`,
+        sourceUrl: `${SOURCE_URL}/p${index + 1}`,
+        flowInputId: inputId(ctx),
+        title: d.title,
+        content: d.content,
+        authorHandle: d.authorHandle,
+        participants: [d.authorHandle, '@support'],
+        status: d.status,
+        threadData: {},
+        totalMessages: d.totalMessages,
+        aiSummary: d.aiSummary,
+        aiKeyPoints: d.aiKeyPoints,
+        aiTasks: {},
+        isMultiTask: false,
+        metadata: {},
+        processedAt: ctx.now,
+        createdAt: ctx.now,
+        updatedAt: ctx.now,
+        createdBy: 'seed',
+        updatedBy: 'seed'
+      })
+    })
+
+    // Tasks — the actionable output, one per resolved discussion. The Notion
+    // ids/urls are demo placeholders (no live Notion sync); `notionPageId` is
+    // unique per team, so stable demo ids keep re-runs idempotent.
+    TASKS.forEach((t, index) => {
+      ctx.upsert('triage_tasks', { id: seedId('triage-task', ctx.teamSlug, t.discussionKey) }, {
+        teamId: ctx.teamId,
+        owner: 'seed',
+        order: index,
+        discussionId: discussionId(ctx, t.discussionKey),
+        syncJobId: seedId('triage-job', ctx.teamSlug, t.discussionKey),
+        notionPageId: `seed-notion-${t.discussionKey}`,
+        notionPageUrl: `https://www.notion.so/seed-${t.discussionKey}`,
+        title: t.title,
+        description: t.description,
+        status: t.status,
+        priority: t.priority,
+        assignee: t.assignee,
+        summary: t.description,
+        sourceUrl: `${SOURCE_URL}/p${index + 1}`,
+        isMultiTaskChild: false,
+        metadata: {},
+        createdAt: ctx.now,
+        updatedAt: ctx.now,
+        createdBy: 'seed',
+        updatedBy: 'seed'
+      })
+    })
+
+    // Messages — a small inbox so the Inbox surface isn't empty.
+    MESSAGES.forEach((m, index) => {
+      ctx.upsert('triage_messages', { id: seedId('triage-message', ctx.teamSlug, m.key) }, {
+        teamId: ctx.teamId,
+        owner: 'seed',
+        order: index,
+        flowInputId: inputId(ctx),
+        messageType: 'email',
+        from: m.from,
+        to: 'support@example.com',
+        subject: m.subject,
+        textBody: m.textBody,
+        receivedAt: raw(`unixepoch() - ${(index + 1) * 3600}`),
+        read: m.read,
+        createdAt: ctx.now,
+        updatedAt: ctx.now,
+        createdBy: 'seed',
+        updatedBy: 'seed'
+      })
+    })
+  }
+}
+
+export default provider

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@fyit/crouton-layout':
         specifier: workspace:*
         version: link:../../packages/crouton-layout
+      '@fyit/crouton-triage':
+        specifier: workspace:*
+        version: link:../../packages/crouton-triage
       '@libsql/client':
         specifier: 'catalog:'
         version: 0.17.4


### PR DESCRIPTION
👤 For humans
Apps that use bookings now deploy with realistic demo data instead of
empty tables — a couple of courts with time slots, an equipment rental,
and a few upcoming reservations — so previews look alive.

🤖 For agents
- New seed/index.ts exports a SeedProvider (id 'bookings', dependsOn ['auth'])
  + ./seed package export. Seeds bookings_settings (statuses/groups),
  three bookings_locations (two slot-mode, one inventory-mode), four
  bookings_bookings.
- Matches the generated Drizzle columns: slot-mode bookings store a JSON
  array of slot ids, inventory stores the JSON literal 'null' (slot is a
  NOT-NULL JSON column); dates are unixepoch()+N*86400 so they stay upcoming.
- Every NOT-NULL column set explicitly (Drizzle $default is ORM-time, not a
  SQL DEFAULT). Idempotent via stable seedId ids. Verified: SQL executes +
  is idempotent against a SQLite mirror of the schema.