### PR TITLE
feat(crouton-devtools): unified glasses launcher + tool registry (#809)

### DIFF
--- a/packages/crouton-devtools/CLAUDE.md
+++ b/packages/crouton-devtools/CLAUDE.md
@@ -9,6 +9,9 @@ DevTools integration for Nuxt Crouton. Provides visual inspection and management
 | File | Purpose |
 |------|---------|
 | `src/module.ts` | Nuxt module entry point |
+| `src/runtime/composables/useCroutonDevTools.ts` | Dev-tools **tool registry** — `registerTool()` + reactive `tools`/`toggle` the launcher reads (#809) |
+| `src/runtime/components/CroutonDevTools.vue` | Unified **glasses launcher** → Nuxt UI dropdown of toggleable tools (#809) |
+| `src/runtime/plugins/crouton-devtools.client.ts` | Mounts the launcher into the host app's context (appContext) so global Nuxt UI components resolve (#809) |
 | `src/runtime/transform/croutonSrc.ts` | Build-time `data-crouton-src` stamper (preview-review overlay, #490) |
 | `src/runtime/plugins/review-overlay.client.ts` | In-page preview-review overlay: click element → comment → payload (#489) |
 | `src/runtime/overlay/capture.ts` | Pure capture helpers + `formatReviewComment` (selector / source-file / annotation / Markdown), unit-tested (#489, #491) |
@@ -111,6 +114,45 @@ When `nuxt-crouton-events` is installed, the Activity tab appears automatically:
 - **Event ↔ Operation Correlation** - Link HTTP operations to events via itemId
 
 The module auto-detects the events package via layer inspection.
+
+## Unified dev-tools launcher + tool registry (epic #808, #809)
+
+One neutral **glasses** button (bottom-right) → a Nuxt UI 4 dropdown of toggleable
+tools. The launcher only renders the registry; it owns no tool logic, so adding
+the next tool is one `registerTool()` call, not another floating button. Console
+(eruda) + Annotate fold in as the first two tools in #810.
+
+```ts
+// A tool registers itself from its own client plugin:
+const { registerTool } = useCroutonDevTools()
+registerTool({
+  id: 'console',
+  label: 'Console',
+  icon: 'i-lucide-terminal',
+  order: 1,
+  isAvailable: () => true,        // hide/disable in the current context
+  activate: async () => { /* lazy-import + show */ },
+  deactivate: () => { /* hide */ },
+  badge: () => unread || null     // optional row badge
+})
+```
+
+- **Registry** (`useCroutonDevTools`) — a module-singleton reactive store
+  (`registerTool` / `unregisterTool` / reactive `tools` filtered by `isAvailable`
+  + sorted by `order` / `isActive` / `toggle`). Pure Vue reactivity, unit-tested
+  in `test/useCroutonDevTools.test.ts` (no Nuxt needed). `resetCroutonDevTools()`
+  for HMR/tests.
+- **Launcher** (`CroutonDevTools.vue`) — `UPopover` + `UButton` (glasses) +
+  `USwitch` rows + `UIcon`. Built on Nuxt UI 4 (every crouton app ships it);
+  hidden when no tool is available.
+- **Mount** (`crouton-devtools.client.ts`) — appends the launcher to `<body>` on
+  `app:mounted` and renders it with `nuxtApp.vueApp._context` as `appContext`, so
+  global U* components resolve without the host app placing anything in its layout.
+- **Gating** — the module adds the plugin + auto-imports `useCroutonDevTools`
+  only in local dev, or when a build sets `NUXT_PUBLIC_CROUTON_DEVTOOLS=true`
+  (→ `runtimeConfig.public.croutonDevtools`); the plugin double-checks at runtime,
+  so production ships nothing. Registered **before** the dev-only early return so a
+  flagged staging build gets it. Folder-based auto-on for pocs/fixtures is #811.
 
 ## Preview-review source stamping — `data-crouton-src` (epic #488, #490)
 

--- a/packages/crouton-devtools/build.config.ts
+++ b/packages/crouton-devtools/build.config.ts
@@ -26,13 +26,29 @@ export default defineBuildConfig({
       pattern: ['**/*.ts'],
       loaders: ['js']
     },
-    // Client review-overlay plugin (#489)
+    // Client plugins: review-overlay (#489) + dev-tools launcher mount (#809)
     {
       input: 'src/runtime/plugins',
       outDir: 'dist/runtime/plugins',
       builder: 'mkdist',
       pattern: ['**/*.ts'],
       loaders: ['js']
+    },
+    // Dev-tools registry composable (#809)
+    {
+      input: 'src/runtime/composables',
+      outDir: 'dist/runtime/composables',
+      builder: 'mkdist',
+      pattern: ['**/*.ts'],
+      loaders: ['js']
+    },
+    // Dev-tools launcher SFC (#809) — mkdist compiles the .vue to .mjs (+ .css)
+    {
+      input: 'src/runtime/components',
+      outDir: 'dist/runtime/components',
+      builder: 'mkdist',
+      pattern: ['**/*.vue'],
+      loaders: ['vue', 'js']
     },
     // Pure capture helpers shared by the overlay (#489)
     {

--- a/packages/crouton-devtools/src/module.ts
+++ b/packages/crouton-devtools/src/module.ts
@@ -1,4 +1,4 @@
-import { defineNuxtModule, createResolver, addServerHandler, addPlugin } from '@nuxt/kit'
+import { defineNuxtModule, createResolver, addServerHandler, addPlugin, addImports } from '@nuxt/kit'
 import { addCustomTab } from '@nuxt/devtools-kit'
 import { createCroutonSrcTransform } from './runtime/transform/croutonSrc'
 
@@ -66,6 +66,31 @@ export default defineNuxtModule<ModuleOptions>({
         route: '/api/_review',
         handler: reviewResolver.resolve('./runtime/server/api/review.post'),
         method: 'post'
+      })
+    }
+
+    // --- Unified dev-tools launcher + tool registry (#809) ------------------
+    // One neutral glasses launcher → a Nuxt UI dropdown of pluggable tools.
+    // Tools register themselves via useCroutonDevTools().registerTool(); the
+    // launcher only renders the registry, so adding the next tool is one call,
+    // not another floating button. Console + Annotate fold in as the first two
+    // tools (#810).
+    //
+    // Enabled in local dev, or when a build opts in via
+    // NUXT_PUBLIC_CROUTON_DEVTOOLS=true (folder-based auto-on for pocs/fixtures
+    // is #811). Registered BEFORE the dev-only early return so a flagged staging
+    // build gets it too; runtime-gated as well, so production ships nothing.
+    if (nuxt.options.dev || process.env.NUXT_PUBLIC_CROUTON_DEVTOOLS === 'true') {
+      const devtoolsResolver = createResolver(import.meta.url)
+      nuxt.options.runtimeConfig.public ||= {}
+      ;(nuxt.options.runtimeConfig.public as Record<string, any>).croutonDevtools = true
+      addImports({
+        name: 'useCroutonDevTools',
+        from: devtoolsResolver.resolve('./runtime/composables/useCroutonDevTools')
+      })
+      addPlugin({
+        src: devtoolsResolver.resolve('./runtime/plugins/crouton-devtools.client'),
+        mode: 'client'
       })
     }
 

--- a/packages/crouton-devtools/src/runtime/components/CroutonDevTools.vue
+++ b/packages/crouton-devtools/src/runtime/components/CroutonDevTools.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useCroutonDevTools } from '../composables/useCroutonDevTools'
+
+/**
+ * The unified dev-tools launcher (#809).
+ *
+ * One neutral glasses button (bottom-right) → a Nuxt UI dropdown of the
+ * registered tools, each a toggle row. The launcher only renders the registry
+ * (`useCroutonDevTools`); it owns no tool logic. Hidden when no tool is
+ * available in the current context. Console + Annotate register in #810.
+ *
+ * Built entirely on Nuxt UI 4 (UPopover / UButton / USwitch / UIcon). It is
+ * mounted into the host app's context by `crouton-devtools.client.ts`, so the
+ * global U* components resolve.
+ */
+const { tools, isActive, toggle } = useCroutonDevTools()
+
+const hasTools = computed(() => tools.value.length > 0)
+</script>
+
+<template>
+  <UPopover
+    v-if="hasTools"
+    :content="{ side: 'top', align: 'end', sideOffset: 8 }"
+  >
+    <UButton
+      icon="i-lucide-glasses"
+      color="neutral"
+      variant="outline"
+      size="lg"
+      square
+      aria-label="Crouton dev tools"
+      class="fixed bottom-4 right-4 z-[99999] rounded-xl bg-default shadow-lg"
+    />
+
+    <template #content>
+      <div class="w-64 p-1">
+        <p class="px-2.5 py-1.5 text-[11px] font-medium tracking-wide text-muted">
+          Crouton tools
+        </p>
+
+        <div
+          v-for="tool in tools"
+          :key="tool.id"
+          class="flex items-center gap-2.5 rounded-md px-2.5 py-2 transition-colors hover:bg-elevated/50"
+        >
+          <UIcon :name="tool.icon" class="size-4 shrink-0 text-dimmed" />
+          <span class="flex-1 truncate text-sm">{{ tool.label }}</span>
+          <UBadge
+            v-if="tool.badge?.() != null"
+            color="neutral"
+            variant="soft"
+            size="sm"
+          >
+            {{ tool.badge() }}
+          </UBadge>
+          <USwitch
+            :model-value="isActive(tool.id)"
+            size="sm"
+            :aria-label="`Toggle ${tool.label}`"
+            @update:model-value="toggle(tool)"
+          />
+        </div>
+      </div>
+    </template>
+  </UPopover>
+</template>

--- a/packages/crouton-devtools/src/runtime/composables/useCroutonDevTools.ts
+++ b/packages/crouton-devtools/src/runtime/composables/useCroutonDevTools.ts
@@ -1,0 +1,91 @@
+import { reactive, computed } from 'vue'
+
+/**
+ * A single entry in the Crouton dev-tools menu (#809).
+ *
+ * Tools register themselves (from their own client plugin) via
+ * `useCroutonDevTools().registerTool(...)`; the launcher renders the registry,
+ * so adding the next tool is one `registerTool` call — not another floating
+ * button. Console + Annotate fold in as the first two tools in #810.
+ */
+export interface CroutonDevTool {
+  /** Stable unique id (e.g. `'console'`, `'annotate'`). */
+  id: string
+  /** Human label shown in the menu row. */
+  label: string
+  /** `UIcon` name, e.g. `'i-lucide-terminal'`. */
+  icon: string
+  /** Lower sorts first; defaults to 0. */
+  order?: number
+  /** Return false to hide/disable the tool in the current context. */
+  isAvailable?: () => boolean
+  /** Turn the tool on. Awaited, so it may lazy-import (e.g. eruda). */
+  activate?: () => void | Promise<void>
+  /** Turn the tool off. */
+  deactivate?: () => void
+  /** Optional badge (e.g. an unread count) shown on the row. */
+  badge?: () => string | number | null
+}
+
+interface DevToolsState {
+  tools: Map<string, CroutonDevTool>
+  active: Set<string>
+}
+
+// Module-singleton, client-only UI state. Reactive Map/Set so the launcher
+// re-renders as tools register and toggle.
+const state: DevToolsState = reactive({
+  tools: new Map<string, CroutonDevTool>(),
+  active: new Set<string>()
+})
+
+/**
+ * The dev-tools registry. Returns the registration + toggle API plus a reactive
+ * `tools` list (filtered by `isAvailable`, sorted by `order`) the launcher reads.
+ */
+export function useCroutonDevTools() {
+  function registerTool(tool: CroutonDevTool): void {
+    if (!tool?.id) return
+    state.tools.set(tool.id, tool)
+  }
+
+  function unregisterTool(id: string): void {
+    state.tools.delete(id)
+    state.active.delete(id)
+  }
+
+  const tools = computed<CroutonDevTool[]>(() =>
+    [...state.tools.values()]
+      .filter(tool => (tool.isAvailable ? !!tool.isAvailable() : true))
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  )
+
+  function isActive(id: string): boolean {
+    return state.active.has(id)
+  }
+
+  async function activate(tool: CroutonDevTool): Promise<void> {
+    if (state.active.has(tool.id)) return
+    await tool.activate?.()
+    state.active.add(tool.id)
+  }
+
+  function deactivate(tool: CroutonDevTool): void {
+    if (!state.active.has(tool.id)) return
+    tool.deactivate?.()
+    state.active.delete(tool.id)
+  }
+
+  async function toggle(tool: CroutonDevTool): Promise<void> {
+    if (state.active.has(tool.id)) deactivate(tool)
+    else await activate(tool)
+  }
+
+  return { registerTool, unregisterTool, tools, isActive, activate, deactivate, toggle }
+}
+
+/** Clear all tools + active state (HMR / test isolation). */
+export function resetCroutonDevTools(): void {
+  state.tools.clear()
+  state.active.clear()
+}

--- a/packages/crouton-devtools/src/runtime/plugins/crouton-devtools.client.ts
+++ b/packages/crouton-devtools/src/runtime/plugins/crouton-devtools.client.ts
@@ -1,0 +1,36 @@
+import { createVNode, render } from 'vue'
+import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
+import CroutonDevTools from '../components/CroutonDevTools.vue'
+
+/**
+ * Mounts the unified dev-tools launcher (#809).
+ *
+ * The module only adds this plugin when dev-tools are enabled for the build
+ * (local dev, or `NUXT_PUBLIC_CROUTON_DEVTOOLS=true`); we double-check at
+ * runtime so production ships nothing. Folder-based auto-on (pocs/fixtures) is
+ * #811.
+ *
+ * The launcher is appended to `<body>` after mount and rendered with the host
+ * app's context (`appContext`), so the global Nuxt UI components inside the SFC
+ * resolve — without the host app having to place anything in its layout.
+ */
+const ROOT_ID = '__crouton_devtools_root'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  if (!import.meta.client) return
+
+  const enabled = import.meta.dev || useRuntimeConfig().public.croutonDevtools
+  if (!enabled) return
+
+  nuxtApp.hook('app:mounted', () => {
+    if (document.getElementById(ROOT_ID)) return
+
+    const container = document.createElement('div')
+    container.id = ROOT_ID
+    document.body.appendChild(container)
+
+    const vnode = createVNode(CroutonDevTools)
+    vnode.appContext = nuxtApp.vueApp._context
+    render(vnode, container)
+  })
+})

--- a/packages/crouton-devtools/test/useCroutonDevTools.test.ts
+++ b/packages/crouton-devtools/test/useCroutonDevTools.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  useCroutonDevTools,
+  resetCroutonDevTools,
+  type CroutonDevTool
+} from '../src/runtime/composables/useCroutonDevTools'
+
+const tool = (over: Partial<CroutonDevTool> = {}): CroutonDevTool => ({
+  id: 'demo',
+  label: 'Demo',
+  icon: 'i-lucide-bug',
+  ...over
+})
+
+describe('useCroutonDevTools registry', () => {
+  beforeEach(() => resetCroutonDevTools())
+
+  it('registers a tool and exposes it in the reactive list', () => {
+    const { registerTool, tools } = useCroutonDevTools()
+    expect(tools.value).toHaveLength(0)
+    registerTool(tool({ id: 'console', label: 'Console' }))
+    expect(tools.value.map(t => t.id)).toEqual(['console'])
+  })
+
+  it('ignores a tool without an id', () => {
+    const { registerTool, tools } = useCroutonDevTools()
+    registerTool({ id: '', label: 'x', icon: 'i' })
+    expect(tools.value).toHaveLength(0)
+  })
+
+  it('re-registering the same id replaces, not duplicates', () => {
+    const { registerTool, tools } = useCroutonDevTools()
+    registerTool(tool({ id: 'a', label: 'First' }))
+    registerTool(tool({ id: 'a', label: 'Second' }))
+    expect(tools.value).toHaveLength(1)
+    expect(tools.value[0].label).toBe('Second')
+  })
+
+  it('sorts available tools by order', () => {
+    const { registerTool, tools } = useCroutonDevTools()
+    registerTool(tool({ id: 'b', order: 2 }))
+    registerTool(tool({ id: 'a', order: 1 }))
+    registerTool(tool({ id: 'c' })) // order undefined → 0
+    expect(tools.value.map(t => t.id)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('hides tools whose isAvailable() is false', () => {
+    const { registerTool, tools } = useCroutonDevTools()
+    registerTool(tool({ id: 'on', isAvailable: () => true }))
+    registerTool(tool({ id: 'off', isAvailable: () => false }))
+    expect(tools.value.map(t => t.id)).toEqual(['on'])
+  })
+
+  it('toggle activates (awaiting activate) then deactivates', async () => {
+    const { registerTool, toggle, isActive } = useCroutonDevTools()
+    const activate = vi.fn()
+    const deactivate = vi.fn()
+    const t = tool({ id: 'console', activate, deactivate })
+    registerTool(t)
+
+    expect(isActive('console')).toBe(false)
+    await toggle(t)
+    expect(activate).toHaveBeenCalledOnce()
+    expect(isActive('console')).toBe(true)
+
+    await toggle(t)
+    expect(deactivate).toHaveBeenCalledOnce()
+    expect(isActive('console')).toBe(false)
+  })
+
+  it('unregisterTool removes the tool and clears its active state', async () => {
+    const { registerTool, unregisterTool, toggle, isActive, tools } = useCroutonDevTools()
+    const t = tool({ id: 'gone', activate: vi.fn() })
+    registerTool(t)
+    await toggle(t)
+    expect(isActive('gone')).toBe(true)
+
+    unregisterTool('gone')
+    expect(tools.value).toHaveLength(0)
+    expect(isActive('gone')).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #809. Part of epic #808 (one consolidated Crouton dev-tools menu).

## 👤 For humans

The foundation for **one** dev-tools menu: a single neutral **glasses** button in the bottom-right that opens a light Nuxt UI dropdown of toggleable tools — instead of scattered, separate floating overlays. The launcher only renders a **registry**, so adding the next tool is one `registerTool()` call, not another button.

This PR is just the **shell** (launcher + registry). The first real tools — **Console** (eruda) and **Annotate** — fold in next (#810); folder-based auto-on for pocs/fixtures is #811.

Verified live in an isolated Nuxt UI app — the glasses button opens the menu and the toggles flip:

| Open | Toggled |
|---|---|
| Console + Annotate (badge `3`), each a `USwitch` | Console switched on (reactive state) |

## 🤖 For agents

- **`src/runtime/composables/useCroutonDevTools.ts`** — module-singleton reactive registry: `registerTool` / `unregisterTool`, reactive `tools` (filtered by `isAvailable`, sorted by `order`), `isActive` / `activate` / `deactivate` / `toggle`, `resetCroutonDevTools` (HMR/tests). `CroutonDevTool` interface: `id/label/icon/order/isAvailable/activate/deactivate/badge`. Pure Vue reactivity — no Nuxt dependency.
- **`src/runtime/components/CroutonDevTools.vue`** — `UPopover` + `UButton` (`i-lucide-glasses`) + `USwitch` rows + `UIcon`. Built on Nuxt UI 4; hidden when no tool is available.
- **`src/runtime/plugins/crouton-devtools.client.ts`** — appends the launcher to `<body>` on `app:mounted`, renders with `nuxtApp.vueApp._context` as `appContext` so global U* components resolve without a host-layout edit.
- **`src/module.ts`** — when `dev || NUXT_PUBLIC_CROUTON_DEVTOOLS=true`: set `runtimeConfig.public.croutonDevtools`, `addImports(useCroutonDevTools)`, `addPlugin(launcher)`. Registered **before** the dev-only early return so a flagged staging build gets it; runtime-gated too → production ships nothing.
- **`build.config.ts`** — mkdist entries for `runtime/composables` (js) + `runtime/components` (vue) so they emit to `dist`.
- **`CLAUDE.md`** — documents the launcher, registry, and gating.

### Considered & rejected
- Keep the vanilla-DOM overlay → ❌ every crouton app ships Nuxt UI 4; building on it gets theming + a11y + consistency for free.
- A separate FAB per tool → ❌ doesn't scale; the registry is the whole point.

## 🧪 How to test

- **What changed:** there's now a single glasses button (bottom-right) that opens a dropdown of dev tools. No menu appears yet in a plain app because no tools are registered until #810 — register a tool and it shows up.
- **Where:** bottom-right corner, in local `pnpm dev` or a build with `NUXT_PUBLIC_CROUTON_DEVTOOLS=true`.
- **Steps:** in an app with the devtools module, `useCroutonDevTools().registerTool({...})` → the glasses button appears → click it → the tool shows as a row with a switch → toggling flips its active state.
- **Automated:** `pnpm vitest run test/useCroutonDevTools.test.ts` (7/7). Apps typecheck (velo/fanfare/triage) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018n6Jb6999toagFCqCSC8TK)_