### PR TITLE
feat(crouton-auth): prefill login fields from URL params

### DIFF
--- a/packages/crouton-auth/app/components/Auth/RouteModal.vue
+++ b/packages/crouton-auth/app/components/Auth/RouteModal.vue
@@ -172,6 +172,17 @@ const loginSubmitButton = computed(() => ({
   block: true
 }))
 
+// Prefill credentials from a shared link (e.g. /auth/login?email=…&password=…)
+// when the login form mounts. Fills the fields only — the user still clicks
+// Sign in (we never auto-submit). Re-applies if the form remounts (e.g. magic-
+// link toggle) while still in login mode.
+const loginFormRef = useTemplateRef('loginForm')
+watch(loginFormRef, (form) => {
+  if (!form?.state) return
+  if (state.value.prefillEmail) form.state.email = state.value.prefillEmail
+  if (state.value.prefillPassword) form.state.password = state.value.prefillPassword
+})
+
 async function onLoginSubmit(event: FormSubmitEvent<{ email: string, password?: string, rememberMe?: boolean }>) {
   formError.value = null
   submitting.value = true
@@ -359,6 +370,7 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
           <!-- Login form -->
           <template v-else>
             <UAuthForm
+              ref="loginForm"
               :fields="loginFields"
               :providers="hasPassword ? oauthButtons : []"
               :submit="loginSubmitButton"

--- a/packages/crouton-auth/app/composables/useAuthModal.ts
+++ b/packages/crouton-auth/app/composables/useAuthModal.ts
@@ -14,6 +14,13 @@ interface AuthModalState {
   previousPath: string
   prefillEmail?: string
   /**
+   * Pre-fills the login/register password field (e.g. from a `?password=`
+   * link shared for a demo/preview). The form is filled but NOT submitted —
+   * the user still clicks Sign in. Convenience only; see the security note on
+   * `open()` before sharing such links.
+   */
+  prefillPassword?: string
+  /**
    * When true, the modal can be dismissed (X / Esc / outside-click) and
    * restores `previousPath`. Used by the "staff door" on pages that have their
    * own gate behind them (e.g. a scoped kassa page falls back to the PIN gate),
@@ -32,8 +39,17 @@ export function useAuthModal() {
     previousPath: '/'
   }))
 
-  function open(mode: AuthModalMode, redirectTo: string, previousPath: string, prefillEmail?: string, dismissible = false) {
-    state.value = { open: true, mode, redirectTo, previousPath, prefillEmail, dismissible }
+  /**
+   * Open the auth modal.
+   *
+   * `prefillEmail` / `prefillPassword` pre-fill the credential fields without
+   * submitting — handy for handing someone a ready-to-go demo/preview link
+   * (`/auth/login?email=…&password=…`). SECURITY: a password in a URL lands in
+   * browser history, server/proxy access logs and any `Referer` header, so only
+   * use this for throwaway demo credentials — never a real account's password.
+   */
+  function open(mode: AuthModalMode, redirectTo: string, previousPath: string, prefillEmail?: string, dismissible = false, prefillPassword?: string) {
+    state.value = { open: true, mode, redirectTo, previousPath, prefillEmail, prefillPassword, dismissible }
   }
 
   /**

--- a/packages/crouton-auth/app/pages/auth/login.vue
+++ b/packages/crouton-auth/app/pages/auth/login.vue
@@ -14,8 +14,12 @@ const authModal = useAuthModal()
 
 onMounted(async () => {
   const redirectTo = (route.query.redirect as string) || '/'
+  // Optional credential prefill from the link (e.g. a shared demo/preview URL
+  // like /auth/login?email=…&password=…). Fills the fields only — never submits.
+  const prefillEmail = (route.query.email as string) || undefined
+  const prefillPassword = (route.query.password as string) || undefined
   await navigateTo('/', { replace: true })
-  authModal.open('login', redirectTo, '/')
+  authModal.open('login', redirectTo, '/', prefillEmail, false, prefillPassword)
 })
 </script>
 

--- a/packages/crouton-auth/app/plugins/auth-modal-router.client.ts
+++ b/packages/crouton-auth/app/plugins/auth-modal-router.client.ts
@@ -29,6 +29,10 @@ export default defineNuxtPlugin(() => {
 
     const redirectTo = (to.query.redirect as string) || '/'
     const prefillEmail = (to.query.email as string) || undefined
+    // Convenience prefill for shared demo/preview links — fills the field but
+    // never auto-submits. Only for throwaway demo credentials (a password in a
+    // URL is logged in history / proxies / Referer).
+    const prefillPassword = (to.query.password as string) || undefined
     // A "staff door" link (e.g. on a scoped kassa page) passes ?dismissible=1
     // so the modal can be closed back to the page behind it (which re-asserts
     // its own gate). Hard auth redirects omit it and stay non-dismissable.
@@ -38,7 +42,7 @@ export default defineNuxtPlugin(() => {
     window.history.pushState(null, '', to.fullPath)
 
     // Open the auth modal
-    useAuthModal().open(mode, redirectTo, from.fullPath, prefillEmail, dismissible)
+    useAuthModal().open(mode, redirectTo, from.fullPath, prefillEmail, dismissible, prefillPassword)
 
     // Cancel the router navigation
     return false


### PR DESCRIPTION
👤 For humans
You can now hand someone a ready-to-go login link for a demo/preview —
e.g. /auth/login?email=demo@acme.com&password=letmein — and the email
and password fields fill in automatically. It never logs in for you:
the user still clicks "Sign in". Handy when delivering a previewed app
or book that sits behind auth. Note: a password in a URL is visible in
browser history and server logs, so only use throwaway demo creds.

🤖 For agents
- useAuthModal.open() gains an optional `prefillPassword` arg; state
  carries prefillEmail + prefillPassword.
- auth-modal-router.client.ts (in-app nav) and pages/auth/login.vue
  (fresh load / direct link) both read ?email= and ?password= and pass
  them through. Login fresh-load path previously passed neither.
- RouteModal.vue: the login UAuthForm now has a `loginForm` template
  ref + watcher that sets state.email/state.password from the prefill
  (mirrors the existing register-form prefill). Fill only — no submit.