### PR TITLE
[SMOKE — do not merge] frontend-review gate fires on a v3 UDropdown

### DIFF
--- a/scratch-smoke/SmokeDropdown.vue
+++ b/scratch-smoke/SmokeDropdown.vue
@@ -1,0 +1,14 @@
+<!--
+  THROWAWAY smoke test for the frontend-review CI gate (epic #834).
+  Deliberately uses the v3 component name <UDropdown> (v4 is <UDropdownMenu>)
+  to confirm the gate fires 🔴 with a sticky comment. Delete after the smoke.
+-->
+<script setup lang="ts">
+const items = [[{ label: 'Profile' }, { label: 'Settings' }]]
+</script>
+
+<template>
+  <UDropdown :items="items">
+    <UButton label="Open" />
+  </UDropdown>
+</template>


### PR DESCRIPTION
**Throwaway smoke test — do not merge.** Verifies the `frontend-review` CI gate (epic #834, merged in #845) actually fires on a real diff.

This PR adds one `.vue` that deliberately uses the **v3** component name `<UDropdown>` (v4 is `<UDropdownMenu>`) — a 🔴 `v3-name` confirmed violation.

**Expected:** the **Frontend Review (PR)** check goes **red** with a sticky `<!-- frontend-review -->` comment naming `scratch-smoke/SmokeDropdown.vue:11`.

Once verified, this branch + PR will be torn down (not merged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2Si8ZS8gx5fmZnKEgH2FW)_