### PR TITLE
feat(crouton-devtools): folder-detect the dev-tools menu + unify the flag (#811)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -208,8 +208,12 @@ Both `scripts/*.mjs` are **app-name-agnostic** (they read the app's own
 `wrangler.jsonc`), shipped as raw templates in `lib/templates/wrangler/` and copied
 verbatim. The generated `package.json` chains them:
 `cf:deploy` = build → deploy (auto-provision) → `sync:ids` → migrate prod;
-`cf:staging` = `NUXT_PUBLIC_CROUTON_REVIEW=true` build → inject-env → deploy `--env staging` → `sync:ids` →
-re-inject-env → migrate staging. `nuxt.config` pins **no** nitro preset (supplied via
+`cf:staging` = build → inject-env → deploy `--env staging` → `sync:ids` →
+re-inject-env → migrate staging. The staging build no longer sets a dev-tools flag
+(#811) — the `@fyit/crouton-devtools` glasses menu auto-detects by folder (on under
+`pocs/` + `fixtures/`, off under `apps/`), so a launched app's staging build stays
+menu-off by default; opt one in with `NUXT_PUBLIC_CROUTON_DEVTOOLS=true`.
+`nuxt.config` pins **no** nitro preset (supplied via
 `NITRO_PRESET=cloudflare_module` in the scripts); `postinstall` is the guarded
 `nuxt prepare 2>/dev/null || true`. Reference app: `apps/three-demo`.
 

--- a/packages/crouton-cli/lib/scaffold-app.ts
+++ b/packages/crouton-cli/lib/scaffold-app.ts
@@ -152,7 +152,11 @@ function tmplPackageJson(vars: ScaffoldVars): string {
     // wrangler resolves migrations_dir relative to the config dir, doubling
     // `server/server/…` → "No migrations present" (#138). Drop --config so it
     // resolves from the app-root source config (where the synced ids live).
-    scripts['cf:staging'] = `NUXT_PUBLIC_CROUTON_REVIEW=true NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply ${vars.name}-staging-db --env staging --remote`
+    // No dev-tools flag here: the @fyit/crouton-devtools menu auto-detects by
+    // folder (on under pocs/ + fixtures/, off under apps/, #811), so a launched
+    // app's staging build stays menu-off by default. Opt an app in by setting
+    // NUXT_PUBLIC_CROUTON_DEVTOOLS=true on this build.
+    scripts['cf:staging'] = `NITRO_PRESET=cloudflare_module nuxt build && node scripts/inject-wrangler-env.mjs && npx wrangler deploy --config .output/server/wrangler.json --env staging && node scripts/sync-wrangler-ids.mjs && node scripts/inject-wrangler-env.mjs && npx wrangler d1 migrations apply ${vars.name}-staging-db --env staging --remote`
     scripts['sync:ids'] = 'node scripts/sync-wrangler-ids.mjs'
     scripts['db:generate'] = 'drizzle-kit generate'
     scripts['db:migrate'] = `npx wrangler d1 migrations apply ${vars.name}-db --local`

--- a/packages/crouton-devtools/CLAUDE.md
+++ b/packages/crouton-devtools/CLAUDE.md
@@ -9,6 +9,7 @@ DevTools integration for Nuxt Crouton. Provides visual inspection and management
 | File | Purpose |
 |------|---------|
 | `src/module.ts` | Nuxt module entry point |
+| `src/resolve-enabled.ts` | Pure, unit-tested resolver for the unified menu gate — folder default (pocs/fixtures on, apps off) + `NUXT_PUBLIC_CROUTON_DEVTOOLS` override + deprecated `_REVIEW`/`_ERUDA` aliases (#811) |
 | `src/runtime/composables/useCroutonDevTools.ts` | Dev-tools **tool registry** — `registerTool()` + reactive `tools`/`toggle` the launcher reads (#809) |
 | `src/runtime/components/CroutonDevTools.vue` | Unified **glasses launcher** → Nuxt UI dropdown of toggleable tools (#809) |
 | `src/runtime/plugins/crouton-devtools.client.ts` | Mounts the launcher into the host app's context (appContext) so global Nuxt UI components resolve (#809) |
@@ -56,9 +57,16 @@ export default defineNuxtConfig({
 })
 ```
 
-**Auto-included in `crouton init` scaffolds (#595):** `@fyit/crouton-devtools` is automatically added to the generated app's `devDependencies` and `modules` array. The generated `cf:staging` script prefixes `NUXT_PUBLIC_CROUTON_REVIEW=true` so staging builds activate the review overlay without any extra configuration. Production builds (`cf:deploy`) omit the flag, so there is zero production footprint.
+**Auto-included in `crouton init` scaffolds (#595):** `@fyit/crouton-devtools` is automatically added to the generated app's `devDependencies` and `modules` array. The generated `cf:staging` script no longer sets any dev-tools flag (#811) — the glasses menu **auto-detects by folder** (on under `pocs/` + `fixtures/`, off under `apps/`), so a launched app's staging build is menu-off by default while an incubating POC gets it for free. Opt a launched app's build in with `NUXT_PUBLIC_CROUTON_DEVTOOLS=true`; production builds (`cf:deploy`) carry nothing.
 
 ## Mobile DevTools (eruda) layer — `@fyit/crouton-devtools/eruda`
+
+> **Superseded by the Console tool (#810/#811).** eruda is now the **Console**
+> tool in the unified glasses menu, which auto-detects by folder — prefer it for
+> new apps. This standalone `extends` layer stays for backward compatibility, and
+> its env flag `NUXT_PUBLIC_CROUTON_ERUDA` now also doubles as a **deprecated
+> alias** that turns the whole menu on (with a deprecation warning). Use
+> `NUXT_PUBLIC_CROUTON_DEVTOOLS=true` going forward.
 
 A separate, **opt-in Nuxt layer** (not the DevTools module above) that adds
 [eruda](https://github.com/liriliri/eruda) — an **in-page** devtools panel for
@@ -163,13 +171,26 @@ registerTool({
     pure `overlay/capture.ts`) → POSTs to `/api/_review`. The launcher toggle drives
     select-mode; the **old standalone `review-overlay.client.ts` FAB is retired**
     (deleted). Comment panel rebuilt on Nuxt UI 4; the highlight is a styled div.
-- **Gating** — the module adds the plugins + auto-imports `useCroutonDevTools`
-  in local dev, when a build sets `NUXT_PUBLIC_CROUTON_DEVTOOLS=true`, or on a
-  staging review build (`NUXT_PUBLIC_CROUTON_REVIEW=true`, so Annotate replaces the
-  old overlay there) (→ `runtimeConfig.public.croutonDevtools`); the plugins
-  double-check at runtime, so production ships nothing. Registered **before** the
-  dev-only early return so a flagged staging build gets it. Folder-based auto-on for
-  pocs/fixtures + flag unification is #811.
+- **Gating (unified, #811)** — one decision (`src/resolve-enabled.ts`, pure +
+  unit-tested in `test/resolveEnabled.test.ts`) governs the whole menu:
+  - **Folder default** from `nuxt.options.rootDir` — **on** under `pocs/` +
+    `fixtures/`, **off** under `apps/` (and anything else). A launched app is
+    trusted to work, so it stays clean by default.
+  - **Always on in local dev** (`nuxt.options.dev`).
+  - **One override** — `NUXT_PUBLIC_CROUTON_DEVTOOLS=true|false` wins over the
+    folder default either way (`false` wins even in local dev).
+  - **Deprecated aliases** — `NUXT_PUBLIC_CROUTON_REVIEW` /
+    `NUXT_PUBLIC_CROUTON_ERUDA` are honoured as **on-only** aliases for one
+    transition (they log a deprecation warning); the override beats them. Remove
+    them once consumers migrate.
+  When enabled the module adds the launcher + tool plugins and auto-imports
+  `useCroutonDevTools` (→ `runtimeConfig.public.croutonDevtools = true`);
+  registered **before** the dev-only early return so a flagged/POC staging build
+  gets it, and the plugins double-check at runtime so production ships nothing.
+  **Annotate's build-time machinery** (the `data-crouton-src` transform + the
+  `/api/_review` bridge + `croutonReview` server config) installs whenever the
+  menu ships in a **non-dev** build (`annotateMachineryOn`), so a deployed
+  preview's Annotate tool can resolve files + post feedback — no separate flag.
 
 ## Preview-review source stamping — `data-crouton-src` (epic #488, #490)
 
@@ -184,15 +205,19 @@ is injected by a **dev-only** Vite middleware and is stripped from `nuxt build`,
 it can't help on a deployed Workers preview. A compiler `nodeTransform` runs during
 SFC compilation, so the attribute is present in the built SSR + client output.
 
-**Gating — staging only, NEVER production** (mirrors the eruda layer): the transform
-is installed only when `NUXT_PUBLIC_CROUTON_REVIEW=true` at build time (set it in an
-app's `cf:staging` script, never `cf:deploy`). Flag absent → transform not registered
-→ zero attributes in the build. It also skips third-party components under
-`node_modules`, so a click only ever resolves to a file in this repo.
+**Gating — staging only, NEVER production** (#811): the transform is part of
+Annotate's build-time machinery, so it installs whenever the **menu ships in a
+non-dev build** (`annotateMachineryOn` — a POC/`fixtures/` build, or an app build
+that opted in with `NUXT_PUBLIC_CROUTON_DEVTOOLS=true`; the deprecated
+`NUXT_PUBLIC_CROUTON_REVIEW` alias still works for a transition). Menu off →
+transform not registered → zero attributes in the build. It also skips
+third-party components under `node_modules`, so a click only ever resolves to a
+file in this repo.
 
 ```jsonc
-// app package.json
-"cf:staging": "NUXT_PUBLIC_CROUTON_REVIEW=true NITRO_PRESET=cloudflare_module nuxt build && …",
+// app package.json — no dev-tools flag needed; the menu auto-detects by folder.
+// A POC stamps automatically; opt a launched app in for a staging build with:
+"cf:staging": "NUXT_PUBLIC_CROUTON_DEVTOOLS=true NITRO_PRESET=cloudflare_module nuxt build && …",
 "cf:deploy":  "NITRO_PRESET=cloudflare_module nuxt build && …"   // no flag → never stamped
 ```
 

--- a/packages/crouton-devtools/src/module.ts
+++ b/packages/crouton-devtools/src/module.ts
@@ -1,6 +1,7 @@
-import { defineNuxtModule, createResolver, addServerHandler, addPlugin, addImports } from '@nuxt/kit'
+import { defineNuxtModule, createResolver, addServerHandler, addPlugin, addImports, useLogger } from '@nuxt/kit'
 import { addCustomTab } from '@nuxt/devtools-kit'
 import { createCroutonSrcTransform } from './runtime/transform/croutonSrc'
+import { resolveDevtools } from './resolve-enabled'
 
 export interface ModuleOptions {}
 
@@ -14,18 +15,38 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {},
   async setup(_options, nuxt) {
-    const reviewOn = process.env.NUXT_PUBLIC_CROUTON_REVIEW === 'true'
+    // --- Unified dev-tools gating (#811) ------------------------------------
+    // One flag drives the whole glasses menu. The default is folder-detected
+    // from rootDir (on under pocs/ + fixtures/, off under apps/), always on in
+    // local dev; NUXT_PUBLIC_CROUTON_DEVTOOLS=true|false overrides either way.
+    // The legacy NUXT_PUBLIC_CROUTON_REVIEW / _ERUDA flags live on as on-only
+    // deprecated aliases for one transition.
+    const { menuEnabled, annotateMachineryOn, deprecatedAliases } = resolveDevtools({
+      rootDir: nuxt.options.rootDir,
+      dev: nuxt.options.dev,
+      devtools: process.env.NUXT_PUBLIC_CROUTON_DEVTOOLS,
+      review: process.env.NUXT_PUBLIC_CROUTON_REVIEW,
+      eruda: process.env.NUXT_PUBLIC_CROUTON_ERUDA
+    })
+
+    if (deprecatedAliases.length) {
+      useLogger('@fyit/crouton-devtools').warn(
+        `Deprecated flag${deprecatedAliases.length > 1 ? 's' : ''} ${deprecatedAliases.join(' / ')} — `
+        + 'use NUXT_PUBLIC_CROUTON_DEVTOOLS=true instead (the old flags are honoured as aliases for one transition).'
+      )
+    }
 
     // --- Preview-review source stamping (epic #488, #490) -------------------
     // Inject `data-crouton-src="<relative .vue path>"` on each component's root
     // element at COMPILE time, so a click on a deployed staging preview resolves
     // to the owning source file (the capture half of the agent sign-off loop).
     //
-    // Gated like the eruda layer: opt-in via NUXT_PUBLIC_CROUTON_REVIEW (set by a
-    // `cf:staging` build), NEVER production. Flag absent → transform not installed
-    // → zero attributes in the build. Runs BEFORE the dev-only early return below
-    // because staging is a non-dev build.
-    if (reviewOn) {
+    // Tied to Annotate: installed whenever the menu ships in a real (non-dev)
+    // build — so the Annotate tool can resolve files + post feedback on a staging
+    // preview — NEVER production (apps are menu-off by default). Flag absent →
+    // transform not installed → zero attributes in the build. Runs BEFORE the
+    // dev-only early return below because staging is a non-dev build.
+    if (annotateMachineryOn) {
       const reviewResolver = createResolver(import.meta.url)
 
       // 1. Stamp components with their source path (#490).
@@ -40,14 +61,7 @@ export default defineNuxtModule<ModuleOptions>({
         createCroutonSrcTransform(nuxt.options.rootDir)
       ]
 
-      // 2. Expose the flag to the client. The in-page feedback UI is now the
-      // Annotate tool in the unified menu (#810) — the standalone overlay FAB
-      // (review-overlay.client) is retired; the launcher block below turns on
-      // under this flag too, so a staging review build gets the menu.
-      nuxt.options.runtimeConfig.public ||= {}
-      ;(nuxt.options.runtimeConfig.public as Record<string, any>).croutonReview = true
-
-      // 3. Server bridge: POST /api/_review → GitHub PR comment (#491).
+      // 2. Server bridge: POST /api/_review → GitHub PR comment (#491).
       // Credentials stay server-side; populated at runtime from Worker env so
       // nothing ships in the bundle. The bridge posts as the Crouton GitHub App
       // (#519) — it mints a short-lived installation token from these keys; the
@@ -70,21 +84,20 @@ export default defineNuxtModule<ModuleOptions>({
       })
     }
 
-    // --- Unified dev-tools launcher + tool registry (#809) ------------------
+    // --- Unified dev-tools launcher + tool registry (#809, #811) ------------
     // One neutral glasses launcher → a Nuxt UI dropdown of pluggable tools.
     // Tools register themselves via useCroutonDevTools().registerTool(); the
     // launcher only renders the registry, so adding the next tool is one call,
     // not another floating button. Console + Annotate fold in as the first two
     // tools (#810).
     //
-    // Enabled in local dev, when a build opts in via
-    // NUXT_PUBLIC_CROUTON_DEVTOOLS=true, or on a staging review build
-    // (NUXT_PUBLIC_CROUTON_REVIEW=true) so the Annotate tool replaces the old
-    // standalone overlay there. Folder-based auto-on for pocs/fixtures + flag
-    // unification is #811. Registered BEFORE the dev-only early return so a
-    // flagged staging build gets it too; runtime-gated as well, so production
-    // ships nothing.
-    if (nuxt.options.dev || process.env.NUXT_PUBLIC_CROUTON_DEVTOOLS === 'true' || reviewOn) {
+    // Gated by the unified `menuEnabled` decision (#811): local dev, the
+    // folder default (on under pocs/ + fixtures/), or the
+    // NUXT_PUBLIC_CROUTON_DEVTOOLS override (the legacy _REVIEW/_ERUDA flags map
+    // onto it as deprecated aliases). Registered BEFORE the dev-only early
+    // return so a flagged staging build gets it too; the plugins runtime-gate on
+    // `runtimeConfig.public.croutonDevtools` as well, so production ships nothing.
+    if (menuEnabled) {
       const devtoolsResolver = createResolver(import.meta.url)
       nuxt.options.runtimeConfig.public ||= {}
       ;(nuxt.options.runtimeConfig.public as Record<string, any>).croutonDevtools = true

--- a/packages/crouton-devtools/src/resolve-enabled.ts
+++ b/packages/crouton-devtools/src/resolve-enabled.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure resolution of the unified dev-tools decision (#811).
+ *
+ * One flag, `NUXT_PUBLIC_CROUTON_DEVTOOLS`, now governs the whole glasses menu
+ * (launcher + tools). The default is **folder-detected** from `rootDir`:
+ *   - on   under `pocs/` + `fixtures/` (the incubator)
+ *   - off  under `apps/` (and anything else) — a launched app is trusted to work
+ * Local dev is always on. An explicit override wins over the folder default
+ * either way. The old `NUXT_PUBLIC_CROUTON_REVIEW` / `NUXT_PUBLIC_CROUTON_ERUDA`
+ * flags are kept as **on-only deprecated aliases** for one transition (#808 #4).
+ *
+ * Kept pure (no Nuxt, no process) so it is unit-testable in isolation; the
+ * module wires `process.env` + `nuxt.options` into it.
+ */
+
+export interface DevtoolsEnvInput {
+  /** `nuxt.options.rootDir` — the consuming app's root */
+  rootDir: string
+  /** `nuxt.options.dev` */
+  dev: boolean
+  /** `NUXT_PUBLIC_CROUTON_DEVTOOLS` — the unified override, `'true'`/`'false'` */
+  devtools?: string | undefined
+  /** deprecated alias: `NUXT_PUBLIC_CROUTON_REVIEW` (on-only) */
+  review?: string | undefined
+  /** deprecated alias: `NUXT_PUBLIC_CROUTON_ERUDA` (on-only) */
+  eruda?: string | undefined
+}
+
+export interface DevtoolsResolution {
+  /** the menu (launcher + tool plugins) ships in this build */
+  menuEnabled: boolean
+  /**
+   * Annotate's build-time machinery — the `data-crouton-src` compiler transform
+   * + the `/api/_review` server bridge + the `croutonReview` server config —
+   * should be installed. Only meaningful on a real (non-dev) build that ships
+   * the menu, so a deployed staging preview's Annotate tool can resolve source
+   * files and post feedback.
+   */
+  annotateMachineryOn: boolean
+  /** which deprecated alias env vars were seen (for a one-time deprecation warning) */
+  deprecatedAliases: string[]
+}
+
+/** Folder-detected default: on under pocs/ + fixtures/, off everywhere else. */
+export function folderDefault(rootDir: string): boolean {
+  const norm = String(rootDir).replace(/\\/g, '/')
+  return /(^|\/)(pocs|fixtures)(\/|$)/.test(norm)
+}
+
+export function resolveDevtools(input: DevtoolsEnvInput): DevtoolsResolution {
+  const { rootDir, dev } = input
+  const reviewAlias = input.review === 'true'
+  const erudaAlias = input.eruda === 'true'
+
+  const deprecatedAliases: string[] = []
+  if (reviewAlias) deprecatedAliases.push('NUXT_PUBLIC_CROUTON_REVIEW')
+  if (erudaAlias) deprecatedAliases.push('NUXT_PUBLIC_CROUTON_ERUDA')
+
+  let menuEnabled: boolean
+  if (input.devtools === 'true') {
+    // Explicit opt-in — forces the menu on anywhere (incl. a launched app).
+    menuEnabled = true
+  } else if (input.devtools === 'false') {
+    // Explicit opt-out — wins everywhere, including local dev.
+    menuEnabled = false
+  } else if (dev) {
+    // No explicit flag → always on locally.
+    menuEnabled = true
+  } else {
+    // A build with no override → deprecated aliases (on-only) or the folder default.
+    menuEnabled = reviewAlias || erudaAlias || folderDefault(rootDir)
+  }
+
+  return {
+    menuEnabled,
+    annotateMachineryOn: menuEnabled && !dev,
+    deprecatedAliases
+  }
+}

--- a/packages/crouton-devtools/test/resolveEnabled.test.ts
+++ b/packages/crouton-devtools/test/resolveEnabled.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { folderDefault, resolveDevtools } from '../src/resolve-enabled'
+
+describe('folderDefault (#811)', () => {
+  it('is on under pocs/ and fixtures/', () => {
+    expect(folderDefault('/repo/pocs/blog')).toBe(true)
+    expect(folderDefault('/repo/fixtures/minimal')).toBe(true)
+  })
+
+  it('is off under apps/ and anything else', () => {
+    expect(folderDefault('/repo/apps/velo')).toBe(false)
+    expect(folderDefault('/repo/sandboxes/foo')).toBe(false)
+    expect(folderDefault('/somewhere/else')).toBe(false)
+  })
+
+  it('normalises windows separators', () => {
+    expect(folderDefault('C:\\repo\\pocs\\blog')).toBe(true)
+    expect(folderDefault('C:\\repo\\apps\\velo')).toBe(false)
+  })
+
+  it('matches the folder as a path segment, not a substring', () => {
+    // a folder literally named "apps-archive" must not read as apps/
+    expect(folderDefault('/repo/pocs-archive/x')).toBe(false)
+    expect(folderDefault('/repo/my-pocs')).toBe(false)
+  })
+})
+
+describe('resolveDevtools (#811)', () => {
+  const build = { dev: false }
+
+  it('POC build with no override → menu on + annotate machinery on', () => {
+    const r = resolveDevtools({ rootDir: '/repo/pocs/blog', ...build })
+    expect(r.menuEnabled).toBe(true)
+    expect(r.annotateMachineryOn).toBe(true)
+  })
+
+  it('app build with no override → menu off + annotate machinery off', () => {
+    const r = resolveDevtools({ rootDir: '/repo/apps/velo', ...build })
+    expect(r.menuEnabled).toBe(false)
+    expect(r.annotateMachineryOn).toBe(false)
+  })
+
+  it('explicit override forces on in an app', () => {
+    const r = resolveDevtools({ rootDir: '/repo/apps/velo', ...build, devtools: 'true' })
+    expect(r.menuEnabled).toBe(true)
+    expect(r.annotateMachineryOn).toBe(true)
+  })
+
+  it('explicit override forces off in a POC (wins over folder default)', () => {
+    const r = resolveDevtools({ rootDir: '/repo/pocs/blog', ...build, devtools: 'false' })
+    expect(r.menuEnabled).toBe(false)
+    expect(r.annotateMachineryOn).toBe(false)
+  })
+
+  it('local dev is always on, even in an app', () => {
+    const r = resolveDevtools({ rootDir: '/repo/apps/velo', dev: true })
+    expect(r.menuEnabled).toBe(true)
+    // …but annotate's build-time machinery never installs in dev
+    expect(r.annotateMachineryOn).toBe(false)
+  })
+
+  it('explicit off wins even in local dev', () => {
+    const r = resolveDevtools({ rootDir: '/repo/apps/velo', dev: true, devtools: 'false' })
+    expect(r.menuEnabled).toBe(false)
+  })
+
+  it('deprecated _REVIEW alias turns the menu on for a build (with a flagged warning)', () => {
+    const r = resolveDevtools({ rootDir: '/repo/apps/velo', ...build, review: 'true' })
+    expect(r.menuEnabled).toBe(true)
+    expect(r.annotateMachineryOn).toBe(true)
+    expect(r.deprecatedAliases).toEqual(['NUXT_PUBLIC_CROUTON_REVIEW'])
+  })
+
+  it('deprecated _ERUDA alias turns the menu on for a build', () => {
+    const r = resolveDevtools({ rootDir: '/repo/apps/velo', ...build, eruda: 'true' })
+    expect(r.menuEnabled).toBe(true)
+    expect(r.deprecatedAliases).toEqual(['NUXT_PUBLIC_CROUTON_ERUDA'])
+  })
+
+  it('aliases are on-only — review=false does not force off', () => {
+    const r = resolveDevtools({ rootDir: '/repo/pocs/blog', ...build, review: 'false' })
+    expect(r.menuEnabled).toBe(true) // folder default still wins
+    expect(r.deprecatedAliases).toEqual([])
+  })
+
+  it('explicit override wins over a deprecated alias', () => {
+    const r = resolveDevtools({ rootDir: '/repo/apps/velo', ...build, devtools: 'false', review: 'true' })
+    expect(r.menuEnabled).toBe(false)
+  })
+
+  it('reports no deprecated aliases when none are set', () => {
+    const r = resolveDevtools({ rootDir: '/repo/pocs/blog', ...build })
+    expect(r.deprecatedAliases).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #811. Part of epic #808.

## 👤 For humans

The glasses dev-tools menu now turns on **by itself** in `pocs/` + `fixtures/` (and always in local `pnpm dev`), and stays **off** in launched apps unless you opt in. The three old on-switches collapse into one env var — `NUXT_PUBLIC_CROUTON_DEVTOOLS` — with the old flags kept working for a transition.

- POC / fixture staging build → glasses button present, no config.
- Launched app staging build → no button (set `NUXT_PUBLIC_CROUTON_DEVTOOLS=true` to opt in).
- `NUXT_PUBLIC_CROUTON_REVIEW` / `NUXT_PUBLIC_CROUTON_ERUDA` still turn it on, with a deprecation warning.

## 🤖 For agents

**New `src/resolve-enabled.ts`** — a pure, unit-tested `resolveDevtools()` that is the single source of truth for the gate:
- **Folder default** from `nuxt.options.rootDir` via `folderDefault()` — on under `pocs/` + `fixtures/`, off under `apps/` and everything else (segment-matched, Windows-normalised).
- **Always on in local dev**; `NUXT_PUBLIC_CROUTON_DEVTOOLS=true|false` overrides either way (`false` wins even in dev).
- `_REVIEW` / `_ERUDA` honoured as **on-only deprecated aliases** (reported for a one-time warning); the override beats them.
- Returns `{ menuEnabled, annotateMachineryOn, deprecatedAliases }`.

**`module.ts`**
- Launcher + tool plugins gate on `menuEnabled`.
- Annotate's build-time machinery (the `data-crouton-src` transform + `/api/_review` bridge + `croutonReview` server config) gates on `annotateMachineryOn` (= menu-on **and** non-dev), so a POC / opted-in app staging build gets working Annotate with **no separate flag** — and production (apps menu-off) ships nothing.
- Drops the dead `runtimeConfig.public.croutonReview` write (no consumer remained after the standalone overlay was retired in #810).
- Logs a deprecation warning when an alias is used.

**`crouton-cli/lib/scaffold-app.ts`** — generated `cf:staging` no longer prefixes `NUXT_PUBLIC_CROUTON_REVIEW=true`; folder detection covers pocs, apps stay menu-off by default.

### Acceptance criteria
- [x] POC build (no override) → launcher on; app build (no override) → off; override flips either. *(covered by `test/resolveEnabled.test.ts`)*
- [x] Single `NUXT_PUBLIC_CROUTON_DEVTOOLS` flag; old flags work via alias with a deprecation note.
- [x] `pnpm -r --filter './apps/*' typecheck` clean.

### Verification
- `pnpm vitest run` in the package → **40 passed** (15 new in `resolveEnabled.test.ts`).
- `pnpm -r --filter './apps/*' typecheck` → clean (fanfare / triage / velo).
- `pnpm vitest run` in `crouton-cli` → 288 passed (scaffold script change, no assertion regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7AM81zP6j9tgs6skYYRaP)_