### PR TITLE
feat(velo): auto-seed bookings + pages demo on creation of a *-demo book

### DIFF
--- a/apps/velo/server/plugins/auto-seed-bookings.ts
+++ b/apps/velo/server/plugins/auto-seed-bookings.ts
@@ -1,11 +1,12 @@
 /**
- * Auto-seed the bookings demo when a *demo* book is created (#849).
+ * Auto-seed the demo content when a *demo* book is created (#849).
  *
  * Creating a book through the Velo UI emits the auth `crouton:operation` event
  * `auth:team:created` (fire-and-forget, from `afterCreateOrganization`). This
  * plugin listens for it and — ONLY for demo books — runs the shared
- * `@fyit/crouton-bookings` seed provider against the live D1, hung off the
- * real newly-created team, so the calendar/list open populated instead of empty.
+ * `@fyit/crouton-bookings` + `@fyit/crouton-pages` seed providers against the
+ * live D1, hung off the real newly-created team, so the calendar/list AND the
+ * public pages open populated instead of empty.
  *
  * Gating: the team slug must end with `-demo`. This is environment-independent
  * and explicit — a real customer book (e.g. `school-velotek`) is never touched,
@@ -27,6 +28,7 @@ import { defineNitroPlugin } from 'nitropack/runtime'
 import { sql, eq } from 'drizzle-orm'
 import { collectSeedSql } from '@fyit/crouton-core/shared/seed'
 import { provider as bookingsProvider } from '@fyit/crouton-bookings/seed'
+import { provider as pagesProvider, createPageWithBlocks } from '@fyit/crouton-pages/seed'
 import { organization } from '~~/server/db/schema'
 
 /** Demo books are explicitly named with a `-demo` slug suffix. */
@@ -51,13 +53,16 @@ export default defineNitroPlugin((nitroApp) => {
       const slug = org?.slug
       if (!slug || !isDemoSlug(slug)) return
 
-      // Build the bookings demo SQL bound to the REAL team (not a synthetic
-      // seed org) and execute it statement-by-statement against the live D1.
+      // Build the demo SQL bound to the REAL team (not a synthetic seed org)
+      // and execute it statement-by-statement against the live D1. Pages'
+      // `createPageWithBlocks` is injected so block-contributing providers can
+      // also seed a demo page (and the pages provider seeds its own demo page).
       const seedSql = await collectSeedSql({
-        providers: [bookingsProvider],
+        providers: [bookingsProvider, pagesProvider],
         teamId: payload.teamId,
         teamSlug: slug,
-        locale: 'nl'
+        locale: 'nl',
+        createPageWithBlocks
       })
 
       const statements = seedSql
@@ -69,11 +74,11 @@ export default defineNitroPlugin((nitroApp) => {
         await db.run(sql.raw(statement))
       }
 
-      console.log(`[velo/auto-seed] Seeded bookings demo for "${slug}" (${statements.length} statements)`)
+      console.log(`[velo/auto-seed] Seeded demo content for "${slug}" (${statements.length} statements)`)
     }
     catch (err) {
       // Non-blocking: a seed failure must never break team creation.
-      console.error('[velo/auto-seed] Failed to auto-seed bookings demo:', err)
+      console.error('[velo/auto-seed] Failed to auto-seed demo content:', err)
     }
   })
 })

--- a/apps/velo/server/plugins/auto-seed-bookings.ts
+++ b/apps/velo/server/plugins/auto-seed-bookings.ts
@@ -1,0 +1,79 @@
+/**
+ * Auto-seed the bookings demo when a *demo* book is created (#849).
+ *
+ * Creating a book through the Velo UI emits the auth `crouton:operation` event
+ * `auth:team:created` (fire-and-forget, from `afterCreateOrganization`). This
+ * plugin listens for it and — ONLY for demo books — runs the shared
+ * `@fyit/crouton-bookings` seed provider against the live D1, hung off the
+ * real newly-created team, so the calendar/list open populated instead of empty.
+ *
+ * Gating: the team slug must end with `-demo`. This is environment-independent
+ * and explicit — a real customer book (e.g. `school-velotek`) is never touched,
+ * even on production. The event payload carries no slug, so we look it up from
+ * the `organization` table by `teamId`.
+ *
+ * Transport: the CLI seeder (`crouton-seed`) shells out to `wrangler d1`, which
+ * isn't available at runtime in a Worker. Instead we reuse the public seed API
+ * (`collectSeedSql`) to build the idempotent SQL and execute each statement
+ * against the live drizzle D1 binding. `collectSeedSql` joins statements with
+ * newlines and every upsert is a single line (JSON values are escaped, never
+ * literal newlines), so splitting on `\n` yields one statement per line.
+ *
+ * Non-blocking: wrapped in try/catch and never throws — a seed failure must not
+ * surface into team creation. Idempotent — the provider's stable `seedId`s mean
+ * a re-fire upserts in place.
+ */
+import { defineNitroPlugin } from 'nitropack/runtime'
+import { sql, eq } from 'drizzle-orm'
+import { collectSeedSql } from '@fyit/crouton-core/shared/seed'
+import { provider as bookingsProvider } from '@fyit/crouton-bookings/seed'
+import { organization } from '~~/server/db/schema'
+
+/** Demo books are explicitly named with a `-demo` slug suffix. */
+function isDemoSlug(slug: string): boolean {
+  return slug.endsWith('-demo')
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('crouton:operation', async (payload: any) => {
+    if (payload?.type !== 'auth:team:created' || !payload.teamId) return
+
+    try {
+      const db = useDB()
+
+      // The event payload has no slug — resolve it from the org row.
+      const [org] = await db
+        .select({ slug: organization.slug })
+        .from(organization)
+        .where(eq(organization.id, payload.teamId))
+        .limit(1)
+
+      const slug = org?.slug
+      if (!slug || !isDemoSlug(slug)) return
+
+      // Build the bookings demo SQL bound to the REAL team (not a synthetic
+      // seed org) and execute it statement-by-statement against the live D1.
+      const seedSql = await collectSeedSql({
+        providers: [bookingsProvider],
+        teamId: payload.teamId,
+        teamSlug: slug,
+        locale: 'nl'
+      })
+
+      const statements = seedSql
+        .split('\n')
+        .map(s => s.trim())
+        .filter(Boolean)
+
+      for (const statement of statements) {
+        await db.run(sql.raw(statement))
+      }
+
+      console.log(`[velo/auto-seed] Seeded bookings demo for "${slug}" (${statements.length} statements)`)
+    }
+    catch (err) {
+      // Non-blocking: a seed failure must never break team creation.
+      console.error('[velo/auto-seed] Failed to auto-seed bookings demo:', err)
+    }
+  })
+})


### PR DESCRIPTION
## What & why

Creating a book through the Velo UI emits the auth `crouton:operation` event `auth:team:created` (fire-and-forget, from `afterCreateOrganization`) but **nothing fires the seed providers at runtime** — the `@fyit/crouton-bookings` / `@fyit/crouton-pages` providers are only run by the `crouton-seed` CLI / `db:seed` scripts. So a freshly created demo book booted empty (blank calendar, no pages).

This adds a Velo **server plugin** that listens for that event and — **only for demo books** — runs the shared bookings + pages seed providers against the live D1, hung off the real newly-created team.

## Approach

- New file: `apps/velo/server/plugins/auto-seed-bookings.ts` — uses only the existing **public** seed API (`collectSeedSql`), so **zero `packages/` edits** (the packages gate stays closed).
- **Gating (decided):** seed only when the org **slug ends with `-demo`**. Environment-independent and explicit — a real customer book (e.g. `school-velotek`) is never touched, even on prod. The event payload carries no slug, so it's looked up from the `organization` table by `teamId`.
- **Transport:** the CLI seeder shells out to `wrangler d1`, which isn't available in a Worker at runtime. Instead we reuse `collectSeedSql` to build the idempotent SQL and execute each statement against the live drizzle D1 binding (`db.run(sql.raw(stmt))`). Every upsert is a single line, so splitting on `\n` yields one statement each.
- **Non-blocking & idempotent:** wrapped in try/catch — a seed failure never surfaces into team creation; the provider's stable `seedId`s mean a re-fire upserts in place.

## Scope (per the issue's follow-up, pulled in)

Seeds **bookings + pages**. Pages' `createPageWithBlocks` helper is injected into `collectSeedSql`, so the pages provider seeds its demo "welcome" page (and any block-contributing provider could seed a page too).

## Verification

- Dry-run of `collectSeedSql([bookings, pages])` against a synthetic real-team id → **9 single-line statements** → `bookings_settings` + 3 `bookings_locations` + 4 `bookings_bookings` + 1 `pages_pages`, every statement bound to the real team id and targeting Velo's actual tables.
- Schema-compat: Velo's `bookings_*` and `pages_pages` set every NOT-NULL column the providers need; omitted columns are all nullable.
- `pnpm --filter velo typecheck` → green.
- Live UI verification: see PR thread.

## Note on layouts (raised in review)

Per-team `layout_configs` rows are **not** seeded here, by design — layout seeding is a generator/CLI step (`crouton-cli/lib/seed-app.ts` reads `crouton.layout.json` → upserts `layout_configs`), separate from the runtime providers. Velo has no `crouton.layout.json` and doesn't render via the layout engine, so there's nothing to seed there.

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANTtpiKMTGvromzHEoXcY)_