### PR TITLE
feat(crouton-sales): reproduce the Event Workspace via the layout engine (#711 test)

### DIFF
--- a/apps/fanfare/app/pages/admin/[team]/sales/events/[slug]/layout.vue
+++ b/apps/fanfare/app/pages/admin/[team]/sales/events/[slug]/layout.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+/**
+ * Event Workspace — driven by the LAYOUT ENGINE (#711 test).
+ *
+ * Same surface as the hand-coded workspace (EventWorkspace/Shell.vue: a
+ * horizontal splitter of POS / Orders / Clients), but expressed as a layout
+ * *data tree* and rendered by <CroutonLayoutRenderer>. Each leaf resolves to a
+ * sales layout block (`sales-pos` / `sales-orders` / `sales-clients`) via the
+ * allowlisted `croutonLayoutBlocks` registry; the event slug is passed as each
+ * block's config. The proportions (45 / 30 / 25) mirror Shell's SplitterPanel
+ * default-sizes, and the blocks' declared minWidths keep the panes viable.
+ *
+ * This is the proof that the layout engine can reproduce a real production
+ * surface from data — the evidence the #711 AI gate asks for.
+ *
+ * @route /admin/[team]/sales/events/[slug]/layout
+ */
+import type { LayoutTree } from '@fyit/crouton-core/app/types/layout'
+
+definePageMeta({ middleware: ['auth'] })
+
+const { t } = useT()
+const route = useRoute()
+
+const teamSlug = computed(() => String(route.params.team || ''))
+const eventSlug = computed(() => String(route.params.slug || ''))
+const workspacePath = computed(() => `/admin/${teamSlug.value}/sales/events/${eventSlug.value}`)
+
+// The layout tree — the same three panes as Shell.vue, but as data. The leaf
+// `defaultSize`s mirror Shell's SplitterPanel default-sizes (pos 45, orders 30,
+// clients 25); CroutonLayoutRenderer maps the split → reka-ui SplitterGroup and
+// enforces each block's declared minWidth.
+const tree = computed<LayoutTree>(() => ({
+  renderer: 'panes',
+  root: {
+    type: 'split',
+    direction: 'horizontal',
+    children: [
+      { type: 'leaf', blockId: 'sales-pos', defaultSize: 45, config: { eventSlug: eventSlug.value } },
+      { type: 'leaf', blockId: 'sales-orders', defaultSize: 30, config: { eventSlug: eventSlug.value } },
+      { type: 'leaf', blockId: 'sales-clients', defaultSize: 25, config: { eventSlug: eventSlug.value } },
+    ],
+  },
+}))
+</script>
+
+<template>
+  <div class="p-6 space-y-4">
+    <div class="flex items-center gap-2">
+      <UButton
+        icon="i-lucide-arrow-left"
+        color="neutral"
+        variant="ghost"
+        size="sm"
+        :label="t('sales.events.workspace')"
+        :to="workspacePath"
+      />
+      <UBadge color="neutral" variant="subtle" icon="i-lucide-layout-dashboard">
+        Layout engine
+      </UBadge>
+    </div>
+
+    <!-- Same frame + height as Shell's kassa container. -->
+    <div class="border border-default rounded-xl overflow-clip bg-default h-[calc(100dvh-12rem)] min-h-[28rem]">
+      <CroutonLayoutRenderer :node="tree.root" />
+    </div>
+  </div>
+</template>

--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -624,6 +624,27 @@ Components are auto-imported with `Sales` prefix (e.g., `SalesClientCart`, `Sale
 | `ReceiptSettingsModal.vue` | `SalesSettingsReceiptSettingsModal` | Receipt text customization |
 | `PrintPreviewModal.vue` | `SalesSettingsPrintPreviewModal` | Receipt preview with test print |
 
+### Layout Blocks (`Layout/`) — for the layout engine (`@fyit/crouton-layout`)
+
+Registered in `app/app.config.ts` under `croutonLayoutBlocks` (distinct from the
+TipTap `croutonBlocks` above) — placeable panes the deterministic layout engine
+(and `CroutonLayoutRenderer`) can arrange from a `LayoutTree`. They reproduce the
+Event Workspace (`EventWorkspace/Shell.vue`) as **data** instead of a hand-coded
+splitter (#711 test). Each takes the event by `eventSlug` (its only config field);
+`minWidth`/`defaultSize` mirror Shell's `SplitterPanel` `min-size`/`default-size`.
+
+| Block id | Component | Wraps | Sizing |
+|----------|-----------|-------|--------|
+| `sales-pos` | `SalesLayoutPos` | `SalesPosPanel` (kassa) | minWidth 480, default 45 |
+| `sales-orders` | `SalesLayoutOrders` | `SalesEventWorkspaceOrdersTab` (header + filters) | minWidth 280, default 30 |
+| `sales-clients` | `SalesLayoutClients` | `SalesEventWorkspaceClientsPanel` (recurring-client events) | minWidth 240, default 25 |
+
+The Orders/Clients blocks are team-members-only: they gate on `useAuth().loggedIn`
+and resolve the event member-side via `SalesBlocksEventResolver` inside `<Suspense>`
+(same pattern as the standalone CMS blocks). i18n keys live under
+`sales.blocks.layout.*`. Known gap vs Shell: the engine has no per-pane
+open/collapse state or gutter-tab affordance — that interactivity stays in Shell.
+
 ### CMS Page Blocks (`Blocks/`) — for `@fyit/crouton-pages`
 
 Registered in `app/app.config.ts` under `croutonBlocks`. Appear in the page

--- a/packages/crouton-sales/app/app.config.ts
+++ b/packages/crouton-sales/app/app.config.ts
@@ -1,5 +1,60 @@
 import type { CroutonBlockDefinition } from '@fyit/crouton-core/app/types/block-definition'
+import type { CroutonLayoutBlockRegistry } from '@fyit/crouton-core/app/types/layout-block'
 import { SALES_CHART_KIND_OPTIONS } from './utils/chart-blocks'
+
+// Placeable layout blocks (#711 test) — the Event Workspace surfaces exposed to
+// the deterministic layout engine, so the workspace can be reproduced from a
+// layout *data tree* (rendered by CroutonLayoutRenderer) instead of the
+// hand-coded splitter in EventWorkspace/Shell.vue. Each takes the event by slug
+// (its only config field). minWidth/defaultSize mirror Shell's SplitterPanel
+// min-size/default-size so the viability gate keeps the same proportions.
+const croutonLayoutBlocks: CroutonLayoutBlockRegistry = {
+  // The kassa — the workspace's primary surface (Shell `pos` panel, min-size 35).
+  'sales-pos': {
+    id: 'sales-pos',
+    name: 'sales.blocks.layout.pos.name',
+    description: 'sales.blocks.layout.pos.description',
+    icon: 'i-lucide-shopping-cart',
+    component: 'SalesLayoutPos',
+    kind: 'compound',
+    category: 'kassa',
+    minWidth: 480,
+    defaultSize: 45,
+    configSchema: [
+      { name: 'eventSlug', type: 'text', label: 'sales.blocks.layout.eventSlug', default: '' },
+    ],
+  },
+  // The live orders pane (Shell `orders` panel, default-size 30 / min-size 18).
+  'sales-orders': {
+    id: 'sales-orders',
+    name: 'sales.blocks.layout.orders.name',
+    description: 'sales.blocks.layout.orders.description',
+    icon: 'i-lucide-clipboard-list',
+    component: 'SalesLayoutOrders',
+    kind: 'compound',
+    category: 'kassa',
+    minWidth: 280,
+    defaultSize: 30,
+    configSchema: [
+      { name: 'eventSlug', type: 'text', label: 'sales.blocks.layout.eventSlug', default: '' },
+    ],
+  },
+  // The open-client-tabs pane (Shell `clients` panel, default-size 25 / min-size 15).
+  'sales-clients': {
+    id: 'sales-clients',
+    name: 'sales.blocks.layout.clients.name',
+    description: 'sales.blocks.layout.clients.description',
+    icon: 'i-lucide-users',
+    component: 'SalesLayoutClients',
+    kind: 'compound',
+    category: 'kassa',
+    minWidth: 240,
+    defaultSize: 25,
+    configSchema: [
+      { name: 'eventSlug', type: 'text', label: 'sales.blocks.layout.eventSlug', default: '' },
+    ],
+  },
+}
 
 // Sales analytics block for crouton-pages: editor picks a chart kind and an
 // event scope (one event or all). Renders via CroutonChartsWidget when
@@ -492,5 +547,7 @@ export default defineAppConfig({
     printBridgeBlock,
     salesChartBlock,
     salesProductMatrixBlock
-  }
+  },
+  // Placeable layout blocks (#711 test) — see the registry definition above.
+  croutonLayoutBlocks
 })

--- a/packages/crouton-sales/app/components/Layout/Clients.vue
+++ b/packages/crouton-sales/app/components/Layout/Clients.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+/**
+ * Layout-block wrapper: the Clients pane as a placeable pane.
+ *
+ * Reproduces the `clients` SplitterPanel of EventWorkspace/Shell.vue (the
+ * "Klanten" pane: h-14 header, then the open-client-tabs ClientsPanel), driven
+ * from a layout data tree (`croutonLayoutBlocks` id `sales-clients`) rendered
+ * by CroutonLayoutRenderer — the #711 test.
+ *
+ * Team-scoped and recurring-clients-only, exactly like the standalone clients
+ * block: gates on `loggedIn`, resolves the event by slug member-side via
+ * SalesBlocksEventResolver (<Suspense>), and shows an explanatory note for a
+ * non-`requiresClient` event. The renderer passes only the declared `eventSlug`
+ * config through.
+ */
+const props = defineProps<{ eventSlug?: string }>()
+
+const { t } = useT()
+const { loggedIn } = useAuth()
+
+const eventSlug = computed(() => props.eventSlug || '')
+</script>
+
+<template>
+  <div class="flex flex-col h-full min-h-0">
+    <div class="h-14 shrink-0 flex items-center justify-between gap-2 px-3 bg-elevated/60 border-b border-default">
+      <span class="flex items-center gap-1.5 text-sm font-medium">
+        <UIcon name="i-lucide-users" class="size-4 shrink-0 text-muted" />
+        {{ t('sales.workspace.clientsPanel.title') }}
+      </span>
+    </div>
+
+    <div class="flex-1 overflow-y-auto p-4 pt-2">
+      <!-- Team-members-only. -->
+      <div
+        v-if="!loggedIn"
+        class="p-6 text-center text-sm text-muted"
+      >
+        <UIcon name="i-lucide-lock" class="w-6 h-6 mx-auto mb-2 text-muted" />
+        {{ t('sales.blocks.salesClients.ui.teamOnly') }}
+      </div>
+
+      <Suspense v-else>
+        <SalesBlocksEventResolver
+          v-slot="{ event }"
+          :event-slug="eventSlug"
+          :not-found-label="t('sales.blocks.salesClients.ui.eventNotFound')"
+        >
+          <SalesEventWorkspaceClientsPanel v-if="event.requiresClient" :event="event" />
+          <div
+            v-else
+            class="p-6 text-center text-sm text-muted"
+          >
+            <UIcon name="i-lucide-user-x" class="w-6 h-6 mx-auto mb-2 text-muted" />
+            {{ t('sales.blocks.salesClients.ui.notRecurring') }}
+          </div>
+        </SalesBlocksEventResolver>
+        <template #fallback>
+          <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
+        </template>
+      </Suspense>
+    </div>
+  </div>
+</template>

--- a/packages/crouton-sales/app/components/Layout/Orders.vue
+++ b/packages/crouton-sales/app/components/Layout/Orders.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+/**
+ * Layout-block wrapper: the Orders pane as a placeable pane.
+ *
+ * Reproduces the `orders` SplitterPanel of EventWorkspace/Shell.vue (the
+ * "Bestellingen" pane: h-14 header with the filters toggle + chip, then the
+ * live OrdersTab), driven from a layout data tree (`croutonLayoutBlocks` id
+ * `sales-orders`) rendered by CroutonLayoutRenderer — the #711 test.
+ *
+ * Team-scoped: the orders come from team-scoped admin endpoints, so it gates on
+ * `loggedIn` and resolves the event by slug member-side via
+ * SalesBlocksEventResolver (top-level await ⇒ wrapped in <Suspense>, which also
+ * waits for the async-setup OrdersTab). The renderer passes only the declared
+ * `eventSlug` config through. Filters state is local to the pane.
+ */
+const props = defineProps<{ eventSlug?: string }>()
+
+const { t } = useT()
+const { loggedIn } = useAuth()
+
+const eventSlug = computed(() => props.eventSlug || '')
+
+// Lifted here so the header hosts the filters toggle (next to the chip) while
+// the selects live inside OrdersTab — same split as Shell's orders pane header.
+const filtersOpen = ref(false)
+const filterCount = ref(0)
+</script>
+
+<template>
+  <div class="flex flex-col h-full min-h-0">
+    <div class="h-14 shrink-0 flex items-center justify-between gap-2 px-3 bg-elevated/60 border-b border-default">
+      <span class="flex items-center gap-1.5 text-sm font-medium">
+        <UIcon name="i-lucide-clipboard-list" class="size-4 shrink-0 text-muted" />
+        {{ t('sales.orders.title') }}
+      </span>
+      <UChip v-if="loggedIn" :show="filterCount > 0" :text="filterCount" size="xl" inset>
+        <UButton
+          icon="i-lucide-filter"
+          size="xs"
+          color="neutral"
+          :variant="filtersOpen ? 'soft' : 'ghost'"
+          :aria-label="t('sales.workspace.filters')"
+          @click="filtersOpen = !filtersOpen"
+        />
+      </UChip>
+    </div>
+
+    <div class="flex-1 overflow-y-auto p-4 pt-2">
+      <!-- Team-members-only: anonymous visitors don't see orders. -->
+      <div
+        v-if="!loggedIn"
+        class="p-6 text-center text-sm text-muted"
+      >
+        <UIcon name="i-lucide-lock" class="w-6 h-6 mx-auto mb-2 text-muted" />
+        {{ t('sales.blocks.salesOrders.ui.teamOnly') }}
+      </div>
+
+      <Suspense v-else>
+        <SalesBlocksEventResolver
+          v-slot="{ event }"
+          :event-slug="eventSlug"
+          :not-found-label="t('sales.blocks.salesOrders.ui.eventNotFound')"
+        >
+          <SalesEventWorkspaceOrdersTab
+            v-model:filters-open="filtersOpen"
+            :event="event"
+            @update:active-filter-count="filterCount = $event"
+          />
+        </SalesBlocksEventResolver>
+        <template #fallback>
+          <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
+        </template>
+      </Suspense>
+    </div>
+  </div>
+</template>

--- a/packages/crouton-sales/app/components/Layout/Pos.vue
+++ b/packages/crouton-sales/app/components/Layout/Pos.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+/**
+ * Layout-block wrapper: the POS kassa as a placeable pane.
+ *
+ * Reproduces the `pos` SplitterPanel of EventWorkspace/Shell.vue, but driven
+ * from a layout *data tree* (`croutonLayoutBlocks` id `sales-pos`) rendered by
+ * CroutonLayoutRenderer instead of the hand-coded splitter — the #711 test
+ * ("can the layout engine reproduce a real production surface?").
+ *
+ * SalesPosPanel resolves the event by slug and loads its session client-side
+ * (admin token / helper PIN), so this needs no <Suspense> or loggedIn gate.
+ * The renderer passes only the block's declared config (`eventSlug`) through.
+ */
+const props = defineProps<{
+  /** Event slug — the block's only config field (see app.config croutonLayoutBlocks). */
+  eventSlug?: string
+  /** Team route param; defaults to route.params.team inside SalesPosPanel. */
+  teamParam?: string
+}>()
+</script>
+
+<template>
+  <SalesPosPanel
+    :event-slug="props.eventSlug || ''"
+    :team-param="props.teamParam"
+    :show-header="false"
+    class="h-full"
+  />
+</template>

--- a/packages/crouton-sales/i18n/locales/en.json
+++ b/packages/crouton-sales/i18n/locales/en.json
@@ -178,6 +178,21 @@
           "ticket": "Ticket",
           "receipt": "Receipt"
         }
+      },
+      "layout": {
+        "pos": {
+          "name": "Kassa",
+          "description": "Point of sale for the event"
+        },
+        "orders": {
+          "name": "Orders",
+          "description": "Live orders for the event"
+        },
+        "clients": {
+          "name": "Clients",
+          "description": "Open client tabs for the event"
+        },
+        "eventSlug": "Event"
       }
     },
     "admin": {

--- a/packages/crouton-sales/i18n/locales/fr.json
+++ b/packages/crouton-sales/i18n/locales/fr.json
@@ -177,6 +177,21 @@
           "ticket": "Ticket",
           "receipt": "Reçu"
         }
+      },
+      "layout": {
+        "pos": {
+          "name": "Caisse",
+          "description": "Point de vente pour l'événement"
+        },
+        "orders": {
+          "name": "Commandes",
+          "description": "Commandes en direct pour l'événement"
+        },
+        "clients": {
+          "name": "Clients",
+          "description": "Comptes clients ouverts pour l'événement"
+        },
+        "eventSlug": "Événement"
       }
     },
     "admin": {

--- a/packages/crouton-sales/i18n/locales/nl.json
+++ b/packages/crouton-sales/i18n/locales/nl.json
@@ -178,6 +178,21 @@
           "ticket": "Ticket",
           "receipt": "Bon"
         }
+      },
+      "layout": {
+        "pos": {
+          "name": "Kassa",
+          "description": "Kassa voor het evenement"
+        },
+        "orders": {
+          "name": "Bestellingen",
+          "description": "Live bestellingen voor het evenement"
+        },
+        "clients": {
+          "name": "Klanten",
+          "description": "Open klantrekeningen voor het evenement"
+        },
+        "eventSlug": "Evenement"
       }
     },
     "admin": {


### PR DESCRIPTION
## What & why

A **test toward #711** (the gated "Optional LLM /layout" sprint): can the deterministic layout engine reproduce a real production surface from data, rather than a hand-coded splitter? This expresses the sales **Event Workspace** (`EventWorkspace/Shell.vue` — a horizontal splitter of POS / Orders / Clients) as placeable **layout blocks** + a `LayoutTree`, rendered by `CroutonLayoutRenderer`.

## Changes

**`packages/crouton-sales`**
- New `app/components/Layout/{Pos,Orders,Clients}.vue` → `SalesLayout{Pos,Orders,Clients}` — thin wrappers around the existing surfaces (`SalesPosPanel`, `SalesEventWorkspaceOrdersTab`, `SalesEventWorkspaceClientsPanel`).
- Registered in `app.config.ts` under `croutonLayoutBlocks` as `sales-pos` / `sales-orders` / `sales-clients`. `minWidth`/`defaultSize` mirror Shell's `SplitterPanel` `min-size`/`default-size` (45 / 30 / 25).
- Orders/Clients gate on `useAuth().loggedIn` and resolve the event member-side via `SalesBlocksEventResolver` inside `<Suspense>` (same pattern as the standalone CMS blocks).
- i18n keys under `sales.blocks.layout.*` (en/nl/fr); `CLAUDE.md` documents the set.

**`apps/fanfare`**
- New `app/pages/admin/[team]/sales/events/[slug]/layout.vue` — builds the `LayoutTree` (one horizontal split, three leaves, each `config.eventSlug`) and renders `<CroutonLayoutRenderer>`. Same frame/height as Shell's kassa container.

## Verification

- `pnpm --filter fanfare typecheck` — clean.
- Booted fanfare, authenticated, and screenshotted the engine-driven page against the original hand-coded workspace: identical kassa + Bestellingen + Klanten panes, now data-driven.

## #711 takeaway

The engine reproduces the workspace's **structure and surfaces** faithfully. The one real gap: it has **no per-pane open/collapse state or gutter-tab affordance** — that interactivity lives only in `Shell.vue`. A concrete capability gap, not an "AI would lay it out better" gap — useful evidence for the gated AI-layout decision.

Refs #711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx7n22jywuXCBdJEaMyx1k)_