### PR TITLE
[spike] Add /ping health endpoint for pi.dev test

### DIFF
--- a/docs/server/api/ping.get.ts
+++ b/docs/server/api/ping.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ ok: true }))

--- a/docs/test/ping.test.ts
+++ b/docs/test/ping.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest'
+
+describe('/api/ping endpoint', () => {
+  it('should return { ok: true }', async () => {
+    // Mock defineEventHandler to just return the handler function it receives
+    vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+    
+    // Import the handler
+    const { default: pingHandler } = await import('../server/api/ping.get')
+    
+    // Call the handler with a mock event
+    const result = pingHandler({})
+    
+    // Assert the response
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node'
+  }
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     projects: [
-      'packages/*/vitest.config.ts'
+      'packages/*/vitest.config.ts',
+      'docs/vitest.config.ts'
     ],
     exclude: [
       '**/node_modules/**',


### PR DESCRIPTION
## Summary
Implements the pi.dev spike test (#859/#670) by adding a simple /ping health endpoint.

## Closes
- Closes #860 (Implement /ping health endpoint with test)
- Closes #859 (Spike throwaway issue)

## Changes
- Created GET /api/ping endpoint that returns { ok: true }
- Added Vitest test to verify endpoint functionality
- Added vitest.config.ts to docs app for test discovery
- Updated root vitest.config.ts to include docs tests

## Test Results
- All new tests pass ✓
- Endpoint returns { ok: true } as expected ✓
- No TypeScript errors in docs app ✓

## Notes
This is a throwaway spike issue for testing pi.dev as a GitHub Actions agent. Safe to close after.