### PR TITLE
docs(root): Mac mini self-hosted runner runbook + watchdog scripts (#653 #654 #657)

### DIFF
--- a/.github/workflows/mac-mini-smoke.yml
+++ b/.github/workflows/mac-mini-smoke.yml
@@ -1,0 +1,56 @@
+name: Mac mini runner smoke
+
+# Dispatch-only proof that the self-hosted `mac-mini` runner (epic #610 / #653) picks up a
+# job AND resolves the toolchain via its `.path` file (the launchd-PATH gotcha — runbook
+# §2a / writeups/setup/self-hosted-mac-mini-runner.md). This is the #654 acceptance check.
+#
+# SAFE on a public repo: `workflow_dispatch` only → it can be triggered ONLY by a human with
+# write access, manually. There is no `pull_request`/`push` trigger, so untrusted fork code
+# can never land on the self-hosted box through this workflow (epic #610 WS4).
+#
+# NB: `workflow_dispatch` only works once this file is on the DEFAULT branch (main). Until
+# #882 merges, the "Run workflow" button won't appear.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: mac-mini-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    # Hardcoded to the self-hosted box (not the AGENT_RUNNER toggle) — this job's whole point
+    # is to prove THIS runner works.
+    runs-on: [self-hosted, mac-mini]
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Identify the runner
+        run: |
+          echo "runner.name = ${{ runner.name }}"
+          echo "runner.os   = ${{ runner.os }}"
+          echo "runner.arch = ${{ runner.arch }}"
+          uname -a
+
+      # Proves git + a clean workspace checkout work on the box.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # The .path proof: these must resolve from the runner's launchd PATH. node/pnpm are
+      # also covered per-job by setup-node/pnpm-action-setup elsewhere, but gh + wrangler
+      # rely on `.path` carrying /opt/homebrew/bin. If any line errors "command not found",
+      # the `.path` file is missing/stale (re-run `echo "$PATH" > ~/actions-runner/.path`).
+      - name: Toolchain resolves (the .path proof)
+        run: |
+          echo "PATH=$PATH"
+          echo "--- versions ---"
+          node -v
+          pnpm -v
+          gh --version
+          wrangler --version
+
+      - name: Done
+        run: echo "✅ mac-mini runner executed this job and the toolchain resolved."

--- a/scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist
+++ b/scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  com.nuxtcrouton.runner-watchdog.plist — launchd agent that runs runner-healthcheck.sh
+  every 5 minutes to keep the Mac mini self-hosted GitHub Actions runner alive.
+
+  Epic #610 / issue #657 (WS5). This is the watchdog LAYER. It does NOT replace the
+  runner's own service (`./svc.sh install`, label `actions.runner.*`) nor its launchd
+  `KeepAlive` — it sits above them and catches the failures KeepAlive can't see (a
+  wedged-but-alive listener, a lost GitHub connection). See the runbook:
+  writeups/setup/self-hosted-mac-mini-runner.md
+
+  INSTALL (edit the two paths first — see <<EDIT>> markers):
+    cp scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist \
+       ~/Library/LaunchAgents/com.nuxtcrouton.runner-watchdog.plist
+    # then edit ProgramArguments path + WorkingDirectory to your absolute paths
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nuxtcrouton.runner-watchdog.plist
+    launchctl kickstart  gui/$(id -u)/com.nuxtcrouton.runner-watchdog   # run once now
+
+  UNINSTALL:
+    launchctl bootout gui/$(id -u)/com.nuxtcrouton.runner-watchdog
+
+  This is a LaunchAgent (per-user, GUI domain) on purpose: the runner itself installs as
+  a GUI-domain agent via svc.sh, so the watchdog must share that domain to `kickstart` it.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.nuxtcrouton.runner-watchdog</string>
+
+  <!-- <<EDIT>> Absolute path to bash + the checked-out script. Use the FULL path; launchd
+       has a minimal PATH. Replace YOURNAME with your macOS short username. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/YOURNAME/nuxt-crouton/scripts/mac-mini-runner/runner-healthcheck.sh</string>
+  </array>
+
+  <!-- Run every 300s (5 min). launchd fires it on load and then on the interval. -->
+  <key>StartInterval</key>
+  <integer>300</integer>
+
+  <!-- Don't keep it resident — it's a periodic one-shot, not a daemon. -->
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- <<EDIT>> Pass non-secret config here. SECRETS (GH_TOKEN, ALERT_WEBHOOK) should go in
+       a gitignored ~/.runner-watchdog.env that the script sources — NOT in this committed
+       plist. Keep only non-sensitive defaults here. -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>RUNNER_DIR</key>
+    <string>/Users/YOURNAME/actions-runner</string>
+    <key>RUNNER_LABEL</key>
+    <string>mac-mini</string>
+    <key>GH_REPO</key>
+    <string>FriendlyInternet/nuxt-crouton</string>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/YOURNAME/nuxt-crouton</string>
+
+  <!-- launchd captures the script's own stdout/stderr here; the script ALSO appends to
+       ~/Library/Logs/runner-watchdog.log via its log() helper. -->
+  <key>StandardOutPath</key>
+  <string>/Users/YOURNAME/Library/Logs/runner-watchdog.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/YOURNAME/Library/Logs/runner-watchdog.err.log</string>
+
+  <!-- Run with a normal nice value; the check is cheap. -->
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/scripts/mac-mini-runner/no-sleep.md
+++ b/scripts/mac-mini-runner/no-sleep.md
@@ -1,0 +1,76 @@
+# Keep the Mac mini awake (no-sleep) — `pmset` + `caffeinate`
+
+Epic #610 / issue #657 (WS5). A self-hosted runner that goes to sleep can't pick up a
+3am dispatched job. There are two complementary levers on macOS — set **both**.
+
+## 1. `pmset` — the persistent system policy (set once, survives reboot)
+
+`pmset` writes the power-management policy to NVRAM, so it sticks across reboots. Run on
+the mini (over SSH is fine). These need `sudo`.
+
+```bash
+# Never sleep the SYSTEM while on AC power (0 = never). The Mac mini is always on AC.
+sudo pmset -c sleep 0
+
+# Never sleep the DISK, and keep the system fully awake even with the display off.
+sudo pmset -c disksleep 0
+sudo pmset -c displaysleep 0     # optional; a headless mini has no display anyway
+
+# Belt-and-suspenders: disable "power nap" and auto-restart quirks, keep awake on AC.
+sudo pmset -c powernap 0
+sudo pmset -c womp 1             # wake-on-network (so a Wake-on-LAN can rouse it)
+
+# Auto-restart after a power failure — so a blackout doesn't leave the runner offline.
+sudo pmset -c autorestart 1
+
+# Verify the resulting policy:
+pmset -g custom
+```
+
+Key line to confirm in `pmset -g custom` output (the AC / `-c` block):
+`sleep 0`, `disksleep 0`, `powernap 0`, `autorestart 1`.
+
+> Why `-c` (AC power) and not `-b` (battery): a Mac mini has no battery, so the AC
+> profile is the only one that applies. If you ever run this on a laptop runner, decide
+> the battery policy separately.
+
+## 2. `caffeinate` — a belt over the policy (optional, runtime assertion)
+
+`pmset` is usually enough. If you want an explicit, observable "do not sleep" assertion
+tied to the runner's lifetime (useful if some other process keeps re-enabling sleep), run
+`caffeinate` under launchd so it's always asserting.
+
+- `caffeinate -s` asserts "system must not sleep" **only while on AC power**.
+- `caffeinate -i` prevents idle sleep.
+- `caffeinate -d` prevents display sleep.
+
+A always-on assertion as a launchd agent (`~/Library/LaunchAgents/com.nuxtcrouton.caffeinate.plist`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.nuxtcrouton.caffeinate</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/caffeinate</string>
+    <string>-s</string>   <!-- system sleep prevented while on AC -->
+    <string>-i</string>   <!-- idle sleep prevented -->
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>   <!-- if caffeinate ever exits, relaunch it -->
+</dict>
+</plist>
+```
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nuxtcrouton.caffeinate.plist
+# verify the assertion is active:
+pmset -g assertions | grep -i 'PreventUserIdleSystemSleep'
+```
+
+## Acceptance check (ties to #657 test 1)
+
+After setting both: `pmset -g assertions` shows a `PreventUserIdleSystemSleep` assertion,
+and `pmset -g custom` shows `sleep 0` on AC. Then force a reboot — the runner returns to
+**Idle** on its own (launchd) and the box does not drift back to sleep.

--- a/scripts/mac-mini-runner/runner-healthcheck.sh
+++ b/scripts/mac-mini-runner/runner-healthcheck.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# runner-healthcheck.sh — watchdog for the Mac mini self-hosted GitHub Actions runner.
+#
+# Epic #610 / issue #657 (WS5 — "keep the always-on agent loop reliable").
+#
+# What it checks, in order:
+#   1. The runner's own launchd service (`actions.runner.*`) is loaded and has a live PID.
+#   2. That PID is actually a `Runner.Listener` process (not a zombie / wrong PID).
+#   3. The box can reach GitHub (the runner is useless if it's online but isolated).
+#   4. (best-effort) The repo's GitHub API reports >=1 ONLINE self-hosted runner.
+#
+# On any failure it (a) tries to restart the runner via launchd, (b) alerts via the
+# optional ALERT_WEBHOOK (Slack/Discord-style JSON `{text}` POST), and (c) exits non-zero
+# so launchd/log readers can see the failure. A clean pass exits 0 quietly (one log line).
+#
+# This is the userspace twin of the pi runbook's "auth-retry-with-backoff" idea: the
+# launchd `KeepAlive` already restarts a crashed *process*; this watchdog catches the
+# cases KeepAlive can't see — a wedged-but-alive listener, or a lost GitHub connection.
+#
+# Designed to be driven by com.nuxtcrouton.runner-watchdog.plist (runs every 5 min), but
+# it's a plain script — run it by hand any time to get a status read.
+#
+# ── Configuration (all optional; sensible defaults) ──────────────────────────────────
+#   RUNNER_DIR        Path to the actions-runner install.  Default: ~/actions-runner
+#   RUNNER_LABEL      Custom label we expect (informational).  Default: mac-mini
+#   GH_REPO           owner/repo for the API liveness probe.   Default: FriendlyInternet/nuxt-crouton
+#   GH_TOKEN          PAT with `repo` (or admin:org) scope for the API probe. If unset,
+#                     step 4 is skipped (steps 1–3 still run — no token needed for those).
+#   ALERT_WEBHOOK     Slack/Discord-compatible incoming-webhook URL for failure alerts.
+#   LOG_FILE          Where to append logs.  Default: ~/Library/Logs/runner-watchdog.log
+#
+# NB: keep secrets OUT of this committed file — pass them via the launchd plist's
+# EnvironmentVariables or a sourced, gitignored ~/.runner-watchdog.env (see the runbook).
+
+set -uo pipefail
+
+RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner}"
+RUNNER_LABEL="${RUNNER_LABEL:-mac-mini}"
+GH_REPO="${GH_REPO:-FriendlyInternet/nuxt-crouton}"
+LOG_FILE="${LOG_FILE:-$HOME/Library/Logs/runner-watchdog.log}"
+
+# Optionally source a gitignored env file for GH_TOKEN / ALERT_WEBHOOK.
+[ -f "$HOME/.runner-watchdog.env" ] && . "$HOME/.runner-watchdog.env"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() { printf '%s %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG_FILE" >&2; }
+
+alert() {
+  local msg="$1"
+  log "ALERT: $msg"
+  if [ -n "${ALERT_WEBHOOK:-}" ]; then
+    curl -fsS -m 10 -X POST -H 'Content-Type: application/json' \
+      -d "{\"text\":\"🔴 mac-mini runner watchdog: ${msg}\"}" \
+      "$ALERT_WEBHOOK" >/dev/null 2>&1 \
+      || log "WARN: alert webhook POST failed"
+  fi
+}
+
+# The launchd label the runner's own `./svc.sh install` creates is of the form
+# `actions.runner.<owner>-<repo>.<runnerName>`. We don't know the suffix, so match the prefix.
+runner_launchd_label() {
+  launchctl list 2>/dev/null | awk '/actions\.runner\./ {print $3; exit}'
+}
+
+restart_runner() {
+  local label
+  label="$(runner_launchd_label)"
+  if [ -n "$label" ]; then
+    log "Restarting runner via launchctl kickstart (label=$label)…"
+    # `kickstart -k` kills then restarts the service in the GUI user's domain.
+    launchctl kickstart -k "gui/$(id -u)/$label" 2>>"$LOG_FILE" \
+      && return 0
+  fi
+  # Fallback: use the runner's own svc.sh if the label lookup failed.
+  if [ -x "$RUNNER_DIR/svc.sh" ]; then
+    log "Restarting runner via svc.sh (dir=$RUNNER_DIR)…"
+    ( cd "$RUNNER_DIR" && ./svc.sh stop; ./svc.sh start ) 2>>"$LOG_FILE" && return 0
+  fi
+  return 1
+}
+
+fail=0
+
+# ── 1+2. Is the runner service loaded and is its PID a live Runner.Listener? ──────────
+svc_label="$(runner_launchd_label)"
+if [ -z "$svc_label" ]; then
+  alert "no actions.runner.* launchd service is loaded"
+  fail=1
+else
+  # `launchctl list <label>` prints a plist; the PID line is `"PID" = N;` when running.
+  pid="$(launchctl list "$svc_label" 2>/dev/null | awk -F'= ' '/"PID"/ {gsub(/[ ;]/,"",$2); print $2}')"
+  if [ -z "$pid" ] || [ "$pid" = "-" ]; then
+    alert "runner service '$svc_label' is loaded but has no running PID"
+    fail=1
+  elif ! ps -p "$pid" -o command= 2>/dev/null | grep -q 'Runner.Listener'; then
+    alert "runner PID $pid is not a Runner.Listener (wedged/zombie)"
+    fail=1
+  else
+    log "OK: runner '$svc_label' alive (pid=$pid, label=$RUNNER_LABEL)"
+  fi
+fi
+
+# ── 3. Can the box reach GitHub at all? ───────────────────────────────────────────────
+if ! curl -fsS -m 10 -o /dev/null https://api.github.com; then
+  alert "cannot reach api.github.com (network down or GitHub unreachable)"
+  fail=1
+else
+  log "OK: api.github.com reachable"
+fi
+
+# ── 4. Does the repo report a live self-hosted runner? (needs GH_TOKEN) ───────────────
+if [ -n "${GH_TOKEN:-}" ]; then
+  online="$(curl -fsS -m 15 \
+    -H "Authorization: Bearer $GH_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/$GH_REPO/actions/runners" 2>/dev/null \
+    | grep -c '"status": *"online"')"
+  if [ "${online:-0}" -ge 1 ]; then
+    log "OK: GitHub reports $online online runner(s) for $GH_REPO"
+  else
+    alert "GitHub API reports 0 online runners for $GH_REPO"
+    fail=1
+  fi
+else
+  log "SKIP: GH_TOKEN unset — skipping GitHub API liveness probe (steps 1–3 still ran)"
+fi
+
+# ── Recover ───────────────────────────────────────────────────────────────────────────
+if [ "$fail" -ne 0 ]; then
+  if restart_runner; then
+    log "Recovery: restart issued. Re-verifying in 15s…"
+    sleep 15
+    new_pid="$(launchctl list "$(runner_launchd_label)" 2>/dev/null | awk -F'= ' '/"PID"/ {gsub(/[ ;]/,"",$2); print $2}')"
+    if [ -n "$new_pid" ] && [ "$new_pid" != "-" ]; then
+      log "Recovery: runner back up (pid=$new_pid)"
+      alert "runner was down and has been auto-restarted (pid=$new_pid)"
+    else
+      alert "runner restart attempted but it is STILL down — needs a human"
+    fi
+  else
+    alert "could not restart the runner (no launchd label and no svc.sh) — needs a human"
+  fi
+  exit 1
+fi
+
+log "PASS: all checks green"
+exit 0

--- a/scripts/mac-mini-runner/runner-healthcheck.sh
+++ b/scripts/mac-mini-runner/runner-healthcheck.sh
@@ -90,15 +90,21 @@ if [ -z "$svc_label" ]; then
   fail=1
 else
   # `launchctl list <label>` prints a plist; the PID line is `"PID" = N;` when running.
+  # NB: launchd tracks the PID of the runner's WRAPPER (`runsvc.sh`), NOT the listener —
+  # the real `Runner.Listener` runs as a child of that wrapper. So "healthy" = the service
+  # has a live wrapper PID AND a Runner.Listener process exists somewhere. (Checking that
+  # the wrapper PID itself is a Runner.Listener is wrong — it's bash — and would restart a
+  # perfectly healthy runner every cycle.)
   pid="$(launchctl list "$svc_label" 2>/dev/null | awk -F'= ' '/"PID"/ {gsub(/[ ;]/,"",$2); print $2}')"
   if [ -z "$pid" ] || [ "$pid" = "-" ]; then
     alert "runner service '$svc_label' is loaded but has no running PID"
     fail=1
-  elif ! ps -p "$pid" -o command= 2>/dev/null | grep -q 'Runner.Listener'; then
-    alert "runner PID $pid is not a Runner.Listener (wedged/zombie)"
+  elif ! pgrep -f 'Runner.Listener' >/dev/null 2>&1; then
+    alert "runner service '$svc_label' is up (wrapper pid=$pid) but no Runner.Listener process exists (wedged wrapper / dead listener)"
     fail=1
   else
-    log "OK: runner '$svc_label' alive (pid=$pid, label=$RUNNER_LABEL)"
+    listener_pid="$(pgrep -f 'Runner.Listener' | head -1)"
+    log "OK: runner '$svc_label' alive (wrapper pid=$pid, listener pid=$listener_pid, label=$RUNNER_LABEL)"
   fi
 fi
 
@@ -132,12 +138,12 @@ if [ "$fail" -ne 0 ]; then
   if restart_runner; then
     log "Recovery: restart issued. Re-verifying in 15s…"
     sleep 15
-    new_pid="$(launchctl list "$(runner_launchd_label)" 2>/dev/null | awk -F'= ' '/"PID"/ {gsub(/[ ;]/,"",$2); print $2}')"
-    if [ -n "$new_pid" ] && [ "$new_pid" != "-" ]; then
-      log "Recovery: runner back up (pid=$new_pid)"
-      alert "runner was down and has been auto-restarted (pid=$new_pid)"
+    if pgrep -f 'Runner.Listener' >/dev/null 2>&1; then
+      new_pid="$(pgrep -f 'Runner.Listener' | head -1)"
+      log "Recovery: runner back up (Runner.Listener pid=$new_pid)"
+      alert "runner was down and has been auto-restarted (listener pid=$new_pid)"
     else
-      alert "runner restart attempted but it is STILL down — needs a human"
+      alert "runner restart attempted but no Runner.Listener is up — needs a human"
     fi
   else
     alert "could not restart the runner (no launchd label and no svc.sh) — needs a human"

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -52,16 +52,46 @@ GitHub-hosted minutes, full control) and survive reboots, sleep, and network bli
 
 ---
 
-## 0. Prerequisites (on the Mac mini)
+## Conventions — WHERE each step runs (read this first)
 
-You're driving this from your own Mac over SSH into the mini — every step below is
-copy-pasteable into that SSH session (or run directly if you're sitting at the mini).
+This is where mistakes happen. Every step below is tagged with **where** it runs, and
+every terminal block starts by telling you the **folder** to be in. The tags:
+
+| Tag | Means | How you do it |
+|---|---|---|
+| 🖥️ **MINI (terminal)** | A shell **on the Mac mini** | You're SSH'd into the mini from your own Mac (`ssh you@mac-mini.local`). Run it there. |
+| 🌐 **GITHUB (browser)** | The **GitHub web UI** | In a browser on whatever machine — it's a website, not a terminal. |
+| ⚙️ **GITHUB (repo settings)** | **Repo** settings page, not org/account | `github.com/FriendlyInternet/nuxt-crouton/settings/...` — needs admin on the repo. |
+
+**Two separate folders on the mini — do not confuse them:**
+
+- **`~/actions-runner`** — the GitHub runner install (the tarball you unpack in §1). This
+  is NOT the repo. It has no app code; it's just the runner agent.
+- **`~/nuxt-crouton`** — a clone of this repo (only needed in §4 for the watchdog scripts).
+
+Each terminal block opens with a `cd` so you're never guessing the working directory. If a
+block has no `cd`, the folder doesn't matter for that command (e.g. `brew install`).
+
+---
+
+## 0. Prerequisites
+
+🖥️ **MINI (terminal)** — SSH in from your own Mac first, then run everything in this section
+there:
 
 ```bash
-# A working dir for the runner (NOT inside the repo — keep them separate).
+# From YOUR Mac, open a shell on the mini (adjust host/user to your box):
+ssh you@mac-mini.local
+```
+
+Then, on the mini:
+
+```bash
+# folder: anywhere (this just creates + enters the runner dir)
+# A working dir for the runner — NOT inside the repo, keep them separate:
 mkdir -p ~/actions-runner && cd ~/actions-runner
 
-# Confirm macOS arch (Apple Silicon = arm64; you'll pick the matching runner tarball).
+# Confirm macOS arch (Apple Silicon = arm64; you'll pick the matching runner tarball):
 uname -m            # arm64 (M-series) or x86_64 (Intel)
 ```
 
@@ -71,9 +101,15 @@ uname -m            # arm64 (M-series) or x86_64 (Intel)
 
 ### 1a. Get the registration token + download
 
-In the GitHub UI: **Settings → Actions → Runners → New self-hosted runner → macOS**.
-GitHub shows you the exact download URL + a **short-lived registration token**. Copy them
+⚙️ **GITHUB (repo settings)** — in a browser, go to the **repo** (not your account, not the
+org): `github.com/FriendlyInternet/nuxt-crouton` → **Settings** tab → left sidebar
+**Actions → Runners** → **New self-hosted runner** → **macOS**. Direct link:
+`https://github.com/FriendlyInternet/nuxt-crouton/settings/actions/runners`.
+
+That page shows the exact download URL + a **short-lived registration token** — copy both
 (the token expires in ~1h). The commands below mirror what that page generates.
+
+🖥️ **MINI (terminal):**
 
 ```bash
 cd ~/actions-runner
@@ -89,7 +125,10 @@ This is the load-bearing step: the routing toggle (#610 WS3, var `AGENT_RUNNER`)
 reports-only pi.dev workflow (`a11y-daily-pidev.yml`) both target the **single custom
 label `mac-mini`**. Label it exactly that.
 
+🖥️ **MINI (terminal)** — folder: `~/actions-runner` (where you just unpacked the tarball):
+
 ```bash
+cd ~/actions-runner
 ./config.sh \
   --url https://github.com/FriendlyInternet/nuxt-crouton \
   --token <REGISTRATION_TOKEN_FROM_THE_UI> \
@@ -117,7 +156,10 @@ Don't run `./run.sh` in a terminal — that dies on logout/reboot (explicitly th
 **considered-and-rejected** `tmux`/login-shell path in #653). Use the runner's own launchd
 installer:
 
+🖥️ **MINI (terminal)** — folder: `~/actions-runner`:
+
 ```bash
+cd ~/actions-runner
 ./svc.sh install      # registers a GUI-domain launchd agent: actions.runner.<owner>-<repo>.mac-mini
 ./svc.sh start
 ./svc.sh status       # → "started" with a live PID
@@ -136,7 +178,9 @@ installer:
 ### 2a. Toolchain on the box
 
 GitHub-hosted runners ship a toolchain; a self-hosted one starts bare. The Mac mini needs
-the full build toolchain (it *is* the build box now). Install once:
+the full build toolchain (it *is* the build box now). Install once.
+
+🖥️ **MINI (terminal)** — folder: anywhere (these are global installs; cwd doesn't matter):
 
 ```bash
 # Node 22 via nvm (matches the workflows' setup-node node-version: 22)
@@ -169,10 +213,11 @@ wrangler --version
 
 ### 2b. Secrets
 
-**GitHub repo secrets are delivered to self-hosted runners exactly like hosted ones** —
-they're injected into the job env at runtime; nothing is stored on the box. So the
-secrets the agent/deploy jobs need require **no on-box action** beyond confirming they
-resolve. The list (from #654):
+⚙️ **GITHUB (repo settings)** — nothing to run on the mini here. **GitHub repo secrets are
+delivered to self-hosted runners exactly like hosted ones** — injected into the job env at
+runtime; nothing is stored on the box. So the secrets the agent/deploy jobs need require
+**no on-box action** beyond confirming they exist at
+`github.com/FriendlyInternet/nuxt-crouton/settings/secrets/actions`. The list (from #654):
 
 | Secret | Used by |
 |---|---|
@@ -203,10 +248,12 @@ committed file.
 
 ## 3. Route jobs to the runner (#610 WS3 — context)
 
-The workflows that opt in already read a toggle: `runs-on: ${{ vars.AGENT_RUNNER ||
-'ubuntu-latest' }}`. Setting the **repo variable** `AGENT_RUNNER=mac-mini` (Settings →
-Secrets and variables → Actions → Variables) sends those jobs to the mini; unsetting it
-falls back to GitHub-hosted. One variable, reversible — no workflow edits needed.
+⚙️ **GITHUB (repo settings)** — nothing to run on the mini. The workflows that opt in
+already read a toggle: `runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}`. Add the
+**repo variable** `AGENT_RUNNER` = `mac-mini` at
+`github.com/FriendlyInternet/nuxt-crouton/settings/variables/actions` (**Variables** tab,
+*not* Secrets) to send those jobs to the mini; delete the variable to fall back to
+GitHub-hosted. One variable, reversible — no workflow edits needed.
 
 > This runbook covers WS1/WS2/WS5 (register + provision + keep-alive). Wiring *more*
 > workflows to the toggle, and the fork-PR security policy (WS4), are tracked separately
@@ -222,7 +269,9 @@ Three layers, set all three.
 
 Full detail + the optional `caffeinate` launchd agent are in
 [`scripts/mac-mini-runner/no-sleep.md`](../../scripts/mac-mini-runner/no-sleep.md). The
-essentials, run on the mini:
+essentials:
+
+🖥️ **MINI (terminal)** — folder: anywhere (needs `sudo`):
 
 ```bash
 sudo pmset -c sleep 0 disksleep 0 powernap 0 autorestart 1
@@ -232,7 +281,9 @@ pmset -g custom        # confirm: sleep 0 / disksleep 0 / autorestart 1 on AC
 ### 4b. launchd KeepAlive (process-level restart)
 
 `./svc.sh install` already installs a launchd agent that restarts the runner if its
-**process** dies. Confirm it's `KeepAlive`-d:
+**process** dies. Confirm it's `KeepAlive`-d.
+
+🖥️ **MINI (terminal)** — folder: anywhere:
 
 ```bash
 launchctl list | grep actions.runner          # shows the runner agent + its PID
@@ -259,19 +310,43 @@ Two committed files do this:
 - [`scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist`](../../scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist)
   — a launchd agent that runs the health-check every **5 minutes**.
 
-Install (edit the `<<EDIT>>` paths in the plist to your absolute home dir first):
+The watchdog files live in **this repo**, so the mini needs a clone of it (separate from
+`~/actions-runner`). 🖥️ **MINI (terminal)** — clone once, then `cd` into it:
 
 ```bash
+# folder: anywhere — clones the repo to ~/nuxt-crouton (skip if already cloned)
+git clone https://github.com/FriendlyInternet/nuxt-crouton.git ~/nuxt-crouton
+cd ~/nuxt-crouton
+git checkout chore/653-mac-mini-runner-runbook    # or `main` once PR #882 is merged
+```
+
+🖥️ **MINI (terminal)** — folder: `~/nuxt-crouton` (the repo clone — the `scripts/...` paths
+below are relative to it):
+
+```bash
+cd ~/nuxt-crouton
+
 # Optional: secrets for the API probe + alerts, in a gitignored env file the script sources.
+# (Lives in your HOME, ~/.runner-watchdog.env — NOT in the repo.)
 cat > ~/.runner-watchdog.env <<'EOF'
 GH_TOKEN=ghp_xxx          # a PAT with repo scope (only for the API liveness probe)
 ALERT_WEBHOOK=https://hooks.slack.com/services/...   # optional Slack/Discord webhook
 EOF
 chmod 600 ~/.runner-watchdog.env
 
+# Copy the launchd plist into your LaunchAgents folder:
 cp scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist \
    ~/Library/LaunchAgents/com.nuxtcrouton.runner-watchdog.plist
-# >>> edit the 4 YOURNAME paths in that copied plist <<<
+```
+
+🖥️ **MINI (editor)** — open `~/Library/LaunchAgents/com.nuxtcrouton.runner-watchdog.plist`
+and replace every `YOURNAME` with your macOS short username (run `whoami` to get it) so the
+paths are absolute and real. There are paths in `ProgramArguments`, `EnvironmentVariables`,
+`WorkingDirectory`, and the two `Standard*Path` entries.
+
+🖥️ **MINI (terminal)** — folder: anywhere — load + run it:
+
+```bash
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nuxtcrouton.runner-watchdog.plist
 launchctl kickstart  gui/$(id -u)/com.nuxtcrouton.runner-watchdog     # run it once now
 tail -f ~/Library/Logs/runner-watchdog.log                            # watch it work
@@ -289,7 +364,9 @@ tail -f ~/Library/Logs/runner-watchdog.log                            # watch it
 
 ## Three acceptance tests, in one place
 
-Pulled from #653 / #654 / #657 so you can run them top-to-bottom once the box is set up:
+Pulled from #653 / #654 / #657 so you can run them top-to-bottom once the box is set up.
+The reboot/kill steps are 🖥️ **MINI (terminal)**; "a job lands on it" / "routed workflow"
+are observed in 🌐 **GITHUB (browser)** on the Actions tab.
 
 1. **#653 — registered + always-on:** Runner shows **Idle** with label `mac-mini`; a
    trivial test job lands on it; after a **reboot** it returns to Idle automatically.

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -1,0 +1,310 @@
+# Self-Hosted Mac mini GitHub Actions Runner — Runbook
+
+**Date:** 2026-06-25
+**Status:** Active setup runbook (epic #610 / #669 — WS1/WS2/WS5)
+**Purpose:** Stand up the Mac mini at home as an **always-on GitHub Actions self-hosted
+runner**, so the agent + deploy workflows run on our own hardware (no metered
+GitHub-hosted minutes, full control) and survive reboots, sleep, and network blips.
+
+> This is a different pattern from the Pi runbook
+> (`writeups/setup/self-hosted-pi-agent-cloudflare-setup.md`). That one runs a **custom
+> pi.dev HTTP worker** behind a Cloudflare Tunnel and dispatches to it directly. This one
+> is a **stock GitHub Actions runner**: GitHub stays the orchestrator (issues = state,
+> Actions = the runner host), and our existing workflows just `runs-on:` the Mac mini.
+> No tunnel, no custom dispatcher, no open inbound ports — the runner makes an **outbound**
+> long-poll to GitHub and pulls jobs.
+
+## The shape of it
+
+```
+┌──────────────────┐   issue / comment / cron     ┌───────────────────────┐
+│  GitHub          │  fires a workflow            │  GitHub Actions queue │
+│  (issues =       │ ───────────────────────────▶ │  job tagged           │
+│   state,         │                              │  runs-on: mac-mini    │
+│   Actions =      │                              └──────────┬────────────┘
+│   orchestrator)  │                                         │ outbound long-poll
+└──────────────────┘                                         ▼  (no inbound ports)
+                                              ┌───────────────────────────────┐
+                                              │ Mac mini (at home)            │
+                                              │  actions-runner/  (launchd)   │
+                                              │   - label: mac-mini           │
+                                              │   - Node 22 / pnpm / gh /     │
+                                              │     wrangler toolchain        │
+                                              │   - pnpm typecheck + full     │
+                                              │     Nuxt builds  ✅           │
+                                              │   no-sleep (pmset) + watchdog │
+                                              └───────────────────────────────┘
+```
+
+## What the Mac mini can and cannot do (read first)
+
+- **Can:** everything a GitHub-hosted `macos-latest` runner can, on our own always-on box —
+  run agent jobs (`claude-code-action` / pi.dev), `gh` + `git`, `wrangler deploy`, **and
+  crucially `pnpm typecheck` and full Nuxt builds.** Unlike the **Pi** (which *cannot* build
+  — it's memory-constrained and offloads typecheck/build to CI; see the Pi runbook's "can/
+  cannot" box), the Mac mini has the RAM to be the build box itself. This is the key
+  difference: on the Pi you plan around no-builds; on the mini you don't.
+- **Cannot / shouldn't:** safely run **untrusted fork PR code**. A self-hosted runner on a
+  public repo executes whatever a `pull_request` from a fork contains, on *your* hardware,
+  with your local creds in reach. Keep fork CI on GitHub-hosted; route only trusted
+  (non-fork / known-actor) jobs to the mini. This is epic #610 WS4 — decide and document
+  the policy; the workflows that target `mac-mini` should guard on actor/fork.
+
+---
+
+## 0. Prerequisites (on the Mac mini)
+
+You're driving this from your own Mac over SSH into the mini — every step below is
+copy-pasteable into that SSH session (or run directly if you're sitting at the mini).
+
+```bash
+# A working dir for the runner (NOT inside the repo — keep them separate).
+mkdir -p ~/actions-runner && cd ~/actions-runner
+
+# Confirm macOS arch (Apple Silicon = arm64; you'll pick the matching runner tarball).
+uname -m            # arm64 (M-series) or x86_64 (Intel)
+```
+
+---
+
+## 1. Register the runner + launchd service (#653)
+
+### 1a. Get the registration token + download
+
+In the GitHub UI: **Settings → Actions → Runners → New self-hosted runner → macOS**.
+GitHub shows you the exact download URL + a **short-lived registration token**. Copy them
+(the token expires in ~1h). The commands below mirror what that page generates.
+
+```bash
+cd ~/actions-runner
+# Download the macOS arm64 runner (use the version/URL GitHub's page shows you):
+curl -o actions-runner-osx-arm64.tar.gz -L \
+  https://github.com/actions/runner/releases/download/v2.XXX.X/actions-runner-osx-arm64-2.XXX.X.tar.gz
+tar xzf actions-runner-osx-arm64.tar.gz
+```
+
+### 1b. Configure with the `mac-mini` label
+
+This is the load-bearing step: the routing toggle (#610 WS3, var `AGENT_RUNNER`) and the
+reports-only pi.dev workflow (`a11y-daily-pidev.yml`) both target the **single custom
+label `mac-mini`**. Label it exactly that.
+
+```bash
+./config.sh \
+  --url https://github.com/FriendlyInternet/nuxt-crouton \
+  --token <REGISTRATION_TOKEN_FROM_THE_UI> \
+  --name mac-mini \
+  --labels mac-mini \
+  --work _work \
+  --unattended \
+  --replace
+```
+
+- `--labels mac-mini` — adds our custom label (GitHub auto-adds `self-hosted`, `macOS`,
+  and the arch label `ARM64` on top; you don't list those).
+- `--name mac-mini` — the runner's display name in the Runners list.
+- `--replace` — if a stale `mac-mini` runner already exists, replace it cleanly.
+- **Repo-scoped** here (simplest). Org-scoped is an open question in #610 (org lets other
+  repos reuse the box later) — if you go org-scoped, register at the org's runner settings
+  instead; nothing else in this runbook changes.
+
+✅ **Checkpoint:** Settings → Actions → Runners shows a runner **`mac-mini`**, labels
+`self-hosted, macOS, ARM64, mac-mini`, status **Idle**. *(This is #653 acceptance test 1.)*
+
+### 1c. Install the launchd service (always-on across reboots)
+
+Don't run `./run.sh` in a terminal — that dies on logout/reboot (explicitly the
+**considered-and-rejected** `tmux`/login-shell path in #653). Use the runner's own launchd
+installer:
+
+```bash
+./svc.sh install      # registers a GUI-domain launchd agent: actions.runner.<owner>-<repo>.mac-mini
+./svc.sh start
+./svc.sh status       # → "started" with a live PID
+```
+
+✅ **Checkpoint:** `./svc.sh status` shows the service started; the UI runner is **Idle**.
+
+> The `./svc.sh install` agent already has launchd restart-on-crash behavior. The extra
+> **KeepAlive + watchdog** in §4 covers the failures launchd can't see (wedged listener,
+> lost GitHub connection).
+
+---
+
+## 2. Toolchain + secrets (#654)
+
+### 2a. Toolchain on the box
+
+GitHub-hosted runners ship a toolchain; a self-hosted one starts bare. The Mac mini needs
+the full build toolchain (it *is* the build box now). Install once:
+
+```bash
+# Node 22 via nvm (matches the workflows' setup-node node-version: 22)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+nvm install 22 && nvm alias default 22
+
+# pnpm via corepack (the repo's package manager)
+corepack enable && corepack prepare pnpm@latest --activate
+
+# GitHub CLI (agent jobs use `gh`)
+brew install gh
+
+# Wrangler (deploy jobs) — the repo pins it; a global is fine for ad-hoc use, but the
+# deploy jobs run it via `pnpm`/`npx` from the repo, so this is mostly for manual checks.
+brew install cloudflare-wrangler2 || npm i -g wrangler
+
+# Sanity:
+node -v   # v22.x
+pnpm -v
+gh --version
+wrangler --version
+```
+
+> **`actions/setup-node` on self-hosted macOS:** the workflows use
+> `actions/setup-node@v4` with `cache: pnpm`, which self-installs the requested Node
+> per-job and manages its own cache under `_work/`. That works on self-hosted macOS —
+> the nvm install above is for *interactive* shells and as a fallback; the per-job
+> `setup-node` is what the jobs actually rely on. (#654 asks to confirm the macOS cache
+> path works — it caches under the runner's `_work/_tool`, no extra config.)
+
+### 2b. Secrets
+
+**GitHub repo secrets are delivered to self-hosted runners exactly like hosted ones** —
+they're injected into the job env at runtime; nothing is stored on the box. So the
+secrets the agent/deploy jobs need require **no on-box action** beyond confirming they
+resolve. The list (from #654):
+
+| Secret | Used by |
+|---|---|
+| `ANTHROPIC_API_KEY` | the in-job agent (`claude-code-action`) |
+| `PI_PROVIDER_KEY` | the pi.dev variant (`a11y-daily-pidev.yml`) — model-provider key |
+| `CLOUDFLARE_ACCOUNT_ID` | `wrangler deploy` (Workers/D1/KV provisioning) |
+| `CLOUDFLARE_API_TOKEN` | `wrangler deploy` (account Workers/D1/KV/R2 + zone routes/DNS) |
+| `HARNESS_APP_ID` / `HARNESS_APP_PRIVATE_KEY` | `actions/create-github-app-token` — the App-token push path so pushes re-trigger CI |
+| `PROJECTS_TOKEN` | cross-repo / project-board automation in the agent flows |
+
+The **only** on-box secret in this whole runbook is the watchdog's optional `GH_TOKEN` /
+`ALERT_WEBHOOK` (§4) — and those live in a gitignored `~/.runner-watchdog.env`, never in a
+committed file.
+
+> **macOS portability (#654 / #610 WS4 audit):** `actions/create-github-app-token` and
+> `anthropics/claude-code-action@<pinned sha>` are Node actions → run fine on macOS
+> self-hosted. The deploy workflows currently `runs-on: ubuntu-latest`; `wrangler deploy`
+> itself is cross-platform Node, so it works from macOS — verify with the #654 test below
+> before flipping any deploy job's `runs-on`.
+
+✅ **Checkpoint (#654 acceptance):**
+1. Route a cheap agent workflow to the runner (set repo var `AGENT_RUNNER=mac-mini`, run
+   it) → it completes with **no missing-secret / missing-toolchain error**.
+2. A `cf:staging` deploy dispatched to the runner provisions/deploys and the **preview URL
+   responds**.
+
+---
+
+## 3. Route jobs to the runner (#610 WS3 — context)
+
+The workflows that opt in already read a toggle: `runs-on: ${{ vars.AGENT_RUNNER ||
+'ubuntu-latest' }}`. Setting the **repo variable** `AGENT_RUNNER=mac-mini` (Settings →
+Secrets and variables → Actions → Variables) sends those jobs to the mini; unsetting it
+falls back to GitHub-hosted. One variable, reversible — no workflow edits needed.
+
+> This runbook covers WS1/WS2/WS5 (register + provision + keep-alive). Wiring *more*
+> workflows to the toggle, and the fork-PR security policy (WS4), are tracked separately
+> in #610 — don't broaden `runs-on` to untrusted-triggered workflows without that policy.
+
+---
+
+## 4. Keep it always-on: no-sleep + KeepAlive + watchdog (#657)
+
+Three layers, set all three.
+
+### 4a. No-sleep (`pmset`)
+
+Full detail + the optional `caffeinate` launchd agent are in
+[`scripts/mac-mini-runner/no-sleep.md`](../../scripts/mac-mini-runner/no-sleep.md). The
+essentials, run on the mini:
+
+```bash
+sudo pmset -c sleep 0 disksleep 0 powernap 0 autorestart 1
+pmset -g custom        # confirm: sleep 0 / disksleep 0 / autorestart 1 on AC
+```
+
+### 4b. launchd KeepAlive (process-level restart)
+
+`./svc.sh install` already installs a launchd agent that restarts the runner if its
+**process** dies. Confirm it's `KeepAlive`-d:
+
+```bash
+launchctl list | grep actions.runner          # shows the runner agent + its PID
+```
+
+If you want belt-and-suspenders, the runner's generated plist lives at
+`~/Library/LaunchAgents/actions.runner.*.plist` — it ships with `KeepAlive` already; no
+edit needed in the normal case.
+
+### 4c. Watchdog (catches what KeepAlive can't)
+
+KeepAlive restarts a *crashed* process. It does **not** catch a **wedged-but-alive
+listener** or a **lost GitHub connection**. The watchdog does — it's the macOS twin of the
+Pi runbook's "auth-retry-with-backoff self-heal" idea.
+
+Two committed files do this:
+
+- [`scripts/mac-mini-runner/runner-healthcheck.sh`](../../scripts/mac-mini-runner/runner-healthcheck.sh)
+  — checks (1) the launchd service has a live PID, (2) that PID is a real
+  `Runner.Listener`, (3) the box can reach `api.github.com`, (4) — if a `GH_TOKEN` is
+  present — the repo's API reports ≥1 **online** runner. On any failure it restarts the
+  runner via `launchctl kickstart` (falling back to `svc.sh`), alerts via an optional
+  `ALERT_WEBHOOK`, and exits non-zero.
+- [`scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist`](../../scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist)
+  — a launchd agent that runs the health-check every **5 minutes**.
+
+Install (edit the `<<EDIT>>` paths in the plist to your absolute home dir first):
+
+```bash
+# Optional: secrets for the API probe + alerts, in a gitignored env file the script sources.
+cat > ~/.runner-watchdog.env <<'EOF'
+GH_TOKEN=ghp_xxx          # a PAT with repo scope (only for the API liveness probe)
+ALERT_WEBHOOK=https://hooks.slack.com/services/...   # optional Slack/Discord webhook
+EOF
+chmod 600 ~/.runner-watchdog.env
+
+cp scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist \
+   ~/Library/LaunchAgents/com.nuxtcrouton.runner-watchdog.plist
+# >>> edit the 4 YOURNAME paths in that copied plist <<<
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nuxtcrouton.runner-watchdog.plist
+launchctl kickstart  gui/$(id -u)/com.nuxtcrouton.runner-watchdog     # run it once now
+tail -f ~/Library/Logs/runner-watchdog.log                            # watch it work
+```
+
+✅ **Checkpoint (#657 acceptance):**
+1. **Force-reboot** the mini → runner returns to **Idle** within a couple minutes, no
+   manual step (launchd brings the service back; pmset kept it from sleeping).
+2. **Pull the network** briefly → the runner reconnects automatically when it's back
+   (GitHub's runner has built-in reconnect; the watchdog's step 3 also catches a wedge).
+3. **`kill` the runner process** → KeepAlive (or, within 5 min, the watchdog) restarts it.
+   `kill $(pgrep -f Runner.Listener)` then watch `./svc.sh status` / the watchdog log.
+
+---
+
+## Three acceptance tests, in one place
+
+Pulled from #653 / #654 / #657 so you can run them top-to-bottom once the box is set up:
+
+1. **#653 — registered + always-on:** Runner shows **Idle** with label `mac-mini`; a
+   trivial test job lands on it; after a **reboot** it returns to Idle automatically.
+2. **#654 — secrets + toolchain:** A routed agent workflow completes with no
+   missing-secret/toolchain error; a `cf:staging` deploy from the mini produces a
+   responding preview URL.
+3. **#657 — reliability:** Survives a force-reboot, a network drop, and a `kill` of the
+   runner process — each time the loop recovers with no human nudge.
+
+---
+
+## See also
+
+- The Pi pattern (custom worker + Cloudflare Tunnel, *cannot* build):
+  `writeups/setup/self-hosted-pi-agent-cloudflare-setup.md`
+- The reports-only pi.dev workflow that targets this runner: `.github/workflows/a11y-daily-pidev.yml`
+- No-sleep detail + caffeinate agent: `scripts/mac-mini-runner/no-sleep.md`
+- Epics: #610 (run the whole flow on the mini), #669 (pi.dev as the in-job agent)

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -109,14 +109,18 @@ org): `github.com/FriendlyInternet/nuxt-crouton` → **Settings** tab → left s
 That page shows the exact download URL + a **short-lived registration token** — copy both
 (the token expires in ~1h). The commands below mirror what that page generates.
 
-🖥️ **MINI (terminal):**
+🖥️ **MINI (terminal).** Paste these **without** the `# …` notes if your zsh has interactive
+comments off (you'll see `command not found: #` otherwise — or run `setopt
+interactive_comments` once). Note the `-o actions-runner.tar.gz` downloads to a **fixed
+local name** regardless of which version URL you paste, so the `tar` line always matches:
 
 ```bash
 cd ~/actions-runner
-# Download the macOS arm64 runner (use the version/URL GitHub's page shows you):
-curl -o actions-runner-osx-arm64.tar.gz -L \
+# Use the download URL GitHub's runners page shows you; the -o name stays fixed:
+curl -L -o actions-runner.tar.gz \
   https://github.com/actions/runner/releases/download/v2.XXX.X/actions-runner-osx-arm64-2.XXX.X.tar.gz
-tar xzf actions-runner-osx-arm64.tar.gz
+tar xzf actions-runner.tar.gz
+ls   # you should now see config.sh, svc.sh, run.sh
 ```
 
 ### 1b. Configure with the `mac-mini` label
@@ -225,8 +229,12 @@ runtime; nothing is stored on the box. So the secrets the agent/deploy jobs need
 | `PI_PROVIDER_KEY` | the pi.dev variant (`a11y-daily-pidev.yml`) — model-provider key |
 | `CLOUDFLARE_ACCOUNT_ID` | `wrangler deploy` (Workers/D1/KV provisioning) |
 | `CLOUDFLARE_API_TOKEN` | `wrangler deploy` (account Workers/D1/KV/R2 + zone routes/DNS) |
-| `HARNESS_APP_ID` / `HARNESS_APP_PRIVATE_KEY` | `actions/create-github-app-token` — the App-token push path so pushes re-trigger CI |
-| `PROJECTS_TOKEN` | cross-repo / project-board automation in the agent flows |
+| `HARNESS_APP_ID` / `HARNESS_APP_PRIVATE_KEY` | `actions/create-github-app-token` — the App-token push path so pushes re-trigger CI, **and** project-board / cross-repo automation (mints a short-lived installation token at runtime) |
+
+> **Not `PROJECTS_TOKEN`.** #654's body listed it, but it's **retired** — the HARNESS App
+> above replaced that human PAT (see the comments in `project-status.yml` /
+> `comment-dispatch.yml`). No workflow reads `secrets.PROJECTS_TOKEN` anymore; don't
+> re-add it.
 
 The **only** on-box secret in this whole runbook is the watchdog's optional `GH_TOKEN` /
 `ALERT_WEBHOOK` (§4) — and those live in a gitignored `~/.runner-watchdog.env`, never in a

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -215,6 +215,22 @@ wrangler --version
 > `setup-node` is what the jobs actually rely on. (#654 asks to confirm the macOS cache
 > path works — it caches under the runner's `_work/_tool`, no extra config.)
 
+> ⚠️ **GOTCHA — the runner's PATH is NOT your shell's PATH.** The runner runs under
+> **launchd**, which does **not** source `~/.zshrc` and starts with a minimal PATH
+> (`/usr/bin:/bin:/usr/sbin:/sbin`). So Homebrew (`/opt/homebrew/bin` → `gh`, `wrangler`)
+> and the nvm node dir are **invisible to jobs**, even though your interactive shell finds
+> them — any step that calls `gh`/`wrangler` directly fails with "command not found". Fix:
+> the runner reads a **`.path`** file in its own dir and uses it as the job PATH. Capture
+> your interactive PATH into it and restart the service:
+> ```bash
+> cd ~/actions-runner
+> echo "$PATH" > .path          # bakes /opt/homebrew/bin + nvm node into the runner PATH
+> ./svc.sh stop && ./svc.sh start && ./svc.sh status
+> ```
+> Node/pnpm are *also* covered per-job by `setup-node`/`pnpm/action-setup`; `.path` is what
+> rescues the direct `gh`/`wrangler` calls. (Re-run the `echo "$PATH" > .path` if you later
+> change the nvm default node version, since that dir is version-stamped.)
+
 ### 2b. Secrets
 
 ⚙️ **GITHUB (repo settings)** — nothing to run on the mini here. **GitHub repo secrets are


### PR DESCRIPTION
## Hypothesis

**We think that** providing the missing on-box runbook + copy-paste-deployable watchdog scripts will make standing up the Mac mini self-hosted runner turnkey — **so** the physical setup (which only the human can do) is a checkable step-by-step with no guesswork. **We'll know by** the human running the three acceptance tests (#653/#654/#657) top-to-bottom from the doc.

## 👤 For humans

This is the **repo-side** half of epic #610 / #669 WS1/WS2/WS5 — docs + scripts only, no app code. It writes the runbook that #653 referenced but didn't exist, plus the watchdog the #657 acceptance tests need. You do the on-box steps; this makes them turnkey.

The runbook's load-bearing difference from the Pi runbook: **the Mac mini CAN run `pnpm typecheck` and full Nuxt builds** (the Pi is memory-constrained and offloads those to CI).

## 🤖 For agents

New files:
- `writeups/setup/self-hosted-mac-mini-runner.md` — the runbook (modeled on `self-hosted-pi-agent-cloudflare-setup.md` but for a stock GitHub Actions runner, not the Pi dispatcher). Covers register + `./config.sh --labels mac-mini`, `./svc.sh` launchd install (#653); Node22/pnpm/gh/wrangler toolchain + the secrets list + macOS portability of the actions (#654); `pmset` no-sleep + launchd KeepAlive + watchdog (#657). Folds the three acceptance tests into one section.
- `scripts/mac-mini-runner/runner-healthcheck.sh` — watchdog: live-`Runner.Listener` PID check, GitHub reachability, optional API online-runner probe; auto-restart via `launchctl kickstart` → `svc.sh` + optional `ALERT_WEBHOOK`.
- `scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist` — launchd agent, 5-min interval (`<<EDIT>>` path markers).
- `scripts/mac-mini-runner/no-sleep.md` — `pmset` policy + optional `caffeinate` launchd agent.

Cross-linked into #653/#654/#657 (each points at its runbook section).

No Test/Schema/UI gate applies (docs/scripts only). The `.gitignore` dirty change in the tree was left out deliberately (unrelated).

Enables #653 · #654 · #657 (the on-box steps stay with the human; these issues close after the acceptance tests pass, not on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
