### PR TITLE
velo: /builder live preview of the Crouton Builder (#868)

### DIFF
--- a/apps/velo/app/app.config.ts
+++ b/apps/velo/app/app.config.ts
@@ -25,5 +25,13 @@ export default defineAppConfig({
     croutonAssets: croutonAssetsConfig,
     bookingsEmailtemplates: bookingsEmailtemplatesConfig,
     bookingsEmaillogs: bookingsEmaillogsConfig
+  },
+  // Backend-free demo blocks for the /builder preview (epic #868) — both reuse the
+  // generic KPI block under DISTINCT ids so the collapse demo can collapse one pane
+  // and reflow the other (collapse is keyed by blockId). defu-merged with the
+  // crouton-layout defaults; not used by velo's product.
+  croutonLayoutBlocks: {
+    'demo-a': { id: 'demo-a', name: 'Overview', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 40 },
+    'demo-b': { id: 'demo-b', name: 'Detail', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 60 },
   }
 })

--- a/apps/velo/app/pages/builder.vue
+++ b/apps/velo/app/pages/builder.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+/**
+ * Crouton Builder — live preview (epic #868). A public demo page that mounts the REAL
+ * builder surfaces with backend-free `stats` blocks, so the WS4 compose gestures, WS5
+ * responsiveness, and WS6 collapse motions can be driven by hand on a deployed URL.
+ * Throwaway review aid — not part of velo's product.
+ */
+import type { LayoutNode, LayoutTree, LayoutCollapseStyle } from '@fyit/crouton-core/app/types/layout'
+
+// Structural match for crouton-layout's ComposePiece (its composables subpath isn't
+// exposed for type imports; the canvas accepts any structurally-compatible piece).
+interface ComposePiece {
+  id: string
+  node: LayoutNode
+  x: number
+  y: number
+  width: number
+  height: number
+  label?: string
+}
+
+definePageMeta({ layout: false }) // standalone — no app chrome / no auth middleware
+
+const tab = ref<'compose' | 'responsive' | 'author'>('compose')
+
+// --- WS4: free pieces on the canvas (all `stats` — render with no backend) ---
+const pieces = ref<ComposePiece[]>([
+  { id: 'sales', node: { type: 'leaf', blockId: 'stats' }, x: 40, y: 40, width: 240, height: 150, label: 'Sales' },
+  { id: 'traffic', node: { type: 'leaf', blockId: 'stats' }, x: 360, y: 90, width: 240, height: 150, label: 'Traffic' },
+  { id: 'revenue', node: { type: 'leaf', blockId: 'stats' }, x: 200, y: 270, width: 240, height: 150, label: 'Revenue' },
+])
+
+// --- WS5/WS6: a tree with an authored breakpoint that collapses a pane below 640px ---
+const collapseStyle = ref<LayoutCollapseStyle>('iris-portal')
+const simWidth = ref(880)
+const respTree = computed<LayoutTree>(() => ({
+  renderer: 'panes',
+  root: {
+    type: 'split', direction: 'horizontal',
+    children: [
+      { type: 'leaf', blockId: 'demo-a', defaultSize: 38 },
+      { type: 'leaf', blockId: 'demo-b', defaultSize: 62 },
+    ],
+  },
+  breakpoints: [
+    // Below 640px the LEFT pane (demo-a) collapses with the chosen motion and demo-b
+    // reflows to fill; ≥640 both show.
+    { minWidth: 0, label: 'Phone', collapsed: ['demo-a'], collapseStyle: collapseStyle.value },
+    { minWidth: 640, label: 'Wide', collapsed: [] },
+  ],
+}))
+
+const authorTree = ref<LayoutTree>({
+  renderer: 'panes',
+  root: {
+    type: 'split', direction: 'horizontal',
+    children: [
+      { type: 'leaf', blockId: 'demo-a', defaultSize: 40 },
+      { type: 'leaf', blockId: 'demo-b', defaultSize: 60 },
+    ],
+  },
+})
+
+const styles: LayoutCollapseStyle[] = ['gutter-tabs', 'spring-drawer', 'crt-power-down', 'iris-portal']
+
+function resetPieces() {
+  pieces.value = [
+    { id: 'sales', node: { type: 'leaf', blockId: 'stats' }, x: 40, y: 40, width: 240, height: 150, label: 'Sales' },
+    { id: 'traffic', node: { type: 'leaf', blockId: 'stats' }, x: 360, y: 90, width: 240, height: 150, label: 'Traffic' },
+    { id: 'revenue', node: { type: 'leaf', blockId: 'stats' }, x: 200, y: 270, width: 240, height: 150, label: 'Revenue' },
+  ]
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-default p-6 text-default">
+    <header class="mb-5">
+      <h1 class="text-xl font-semibold">Crouton Builder — live preview</h1>
+      <p class="mt-1 text-sm text-muted">Drag the real components. Throwaway review page for epic #868 (WS4 compose · WS5 responsiveness · WS6 collapse).</p>
+    </header>
+
+    <div class="mb-5 flex gap-2">
+      <UButton
+        v-for="t in (['compose', 'responsive', 'author'] as const)"
+        :key="t"
+        :color="tab === t ? 'primary' : 'neutral'"
+        :variant="tab === t ? 'solid' : 'soft'"
+        size="sm"
+        @click="tab = t"
+      >
+        {{ t === 'compose' ? 'WS4 · Compose' : t === 'responsive' ? 'WS5/6 · Responsive + Collapse' : 'WS5 · Breakpoint author' }}
+      </UButton>
+    </div>
+
+    <!-- WS4 -->
+    <section v-if="tab === 'compose'">
+      <div class="mb-3 flex items-center gap-3 text-sm text-muted">
+        <span>Drag a card next to another → they snap into a bound layout. Hold one over another → it drops inside (nested).</span>
+        <UButton
+          size="xs"
+          variant="soft"
+          icon="i-lucide-rotate-ccw"
+          @click="resetPieces"
+        >Reset</UButton>
+      </div>
+      <ClientOnly>
+        <div class="h-[520px] w-full">
+          <CroutonLayoutComposeCanvas v-model="pieces" />
+        </div>
+      </ClientOnly>
+    </section>
+
+    <!-- WS5 + WS6 -->
+    <section v-else-if="tab === 'responsive'">
+      <div class="mb-3 flex flex-wrap items-center gap-4 text-sm">
+        <label class="flex items-center gap-2">
+          <span class="text-muted">Container width</span>
+          <input
+            v-model.number="simWidth"
+            type="range"
+            min="320"
+            max="1100"
+            class="w-56"
+          >
+          <span class="tabular-nums">{{ simWidth }}px</span>
+        </label>
+        <div class="flex items-center gap-2">
+          <span class="text-muted">Collapse style</span>
+          <UButton
+            v-for="s in styles"
+            :key="s"
+            size="xs"
+            :color="collapseStyle === s ? 'primary' : 'neutral'"
+            :variant="collapseStyle === s ? 'solid' : 'soft'"
+            @click="collapseStyle = s"
+          >{{ s }}</UButton>
+        </div>
+      </div>
+      <p class="mb-3 text-sm text-muted">Drag the width below 640px → the left pane collapses with the chosen motion and the other reflows in.</p>
+      <ClientOnly>
+        <div
+          class="mx-auto h-[460px] overflow-hidden rounded-lg border border-default transition-all"
+          :style="{ width: `${simWidth}px`, maxWidth: '100%' }"
+        >
+          <CroutonLayoutResponsiveRenderer
+            :tree="respTree"
+            :width="simWidth"
+          />
+        </div>
+      </ClientOnly>
+    </section>
+
+    <!-- WS5 L3 author -->
+    <section v-else>
+      <p class="mb-3 text-sm text-muted">The Breakpoints zoom level (L3): author responsiveness by demonstration — pick a device / drag the ruler, then collapse panes or switch widget variants at that width.</p>
+      <ClientOnly>
+        <div class="h-[560px] w-full overflow-hidden rounded-lg border border-default">
+          <CroutonLayoutBreakpointAuthor v-model="authorTree" />
+        </div>
+      </ClientOnly>
+    </section>
+  </div>
+</template>


### PR DESCRIPTION
Part of epic #868 (The Crouton Builder). A **public `/builder` preview page on velo** so the builder surfaces can be driven by hand on a deployed URL (`velo.pmcp.dev/builder`) — the live counterpart to the static mockups.

## What's on the page
- **WS4 · Compose** (#873) — free app cards; drag one near another → magnetic snap into a bound layout; hold one over another → dwell ring → drops inside (nested).
- **WS5/6 · Responsive + Collapse** (#874/#875) — a width slider + collapse-style picker; drag the width below 640px → the left pane collapses with the chosen motion (`gutter-tabs` / `spring-drawer` / `crt-power-down` / `iris-portal`) and the other reflows in.
- **WS5 · Breakpoint author** (#874) — the L3 authoring surface.

Backend-free: every pane is a generic `stats` block, so the page is public (no auth, `layout: false`) and needs no DB/team. Two demo blocks (`demo-a`/`demo-b`, both reusing `CroutonLayoutSpikeStats` under distinct ids) are registered in velo's `app.config` so the collapse demo collapses one pane and reflows the other (collapse is keyed by `blockId`).

## Verified live (locally)
Booted velo dev and drove a real pointer drag — snapping a card onto another's edge folded **3 free pieces → 2** (a bound split rendered through the normal renderer). Screenshots captured. Only console noise is blocked font-CDN 403s + a favicon 404 (both harmless).

## Notes
- Throwaway **review aid**, not velo product — a single self-contained page + two demo `app.config` blocks; nothing else in velo is touched.
- This page is intentionally **public** (velo's `auth` middleware is opt-in per-page, not global), so it's reachable on staging without login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqWt77JAP27Gh5HdpxQGS8)_