### PR TITLE
Spike · "Everything in Vue Flow" — drawer → drag onto a flow canvas → compile to a layout (#903)

### DIFF
--- a/pocs/crouton-builder-demo/app/app.config.ts
+++ b/pocs/crouton-builder-demo/app/app.config.ts
@@ -11,6 +11,12 @@ export default defineAppConfig({
   // other (collapse is keyed by blockId). defu-merged with the crouton-layout defaults.
   croutonLayoutBlocks: {
     'demo-a': { id: 'demo-a', name: 'Overview', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 40 },
-    'demo-b': { id: 'demo-b', name: 'Detail', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 60 }
+    'demo-b': { id: 'demo-b', name: 'Detail', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 60 },
+    // Spike (#903): the blocks a collection ("Artists") would offer — list / form / stats.
+    // All render the backend-free KPI block; the spike is about the drawer→drag→compile
+    // loop, not the block fidelity. Distinct names/icons so the drawer reads right.
+    'artists-list': { id: 'artists-list', name: 'Artists · List', description: 'All artists', icon: 'i-lucide-list', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 220, defaultSize: 50 },
+    'artists-form': { id: 'artists-form', name: 'Artists · New', description: 'Create an artist', icon: 'i-lucide-square-pen', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'form', minWidth: 220, defaultSize: 50 },
+    'artists-stats': { id: 'artists-stats', name: 'Artists · Stats', description: 'Artist KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50 }
   }
 })

--- a/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+/**
+ * SpikeBlockNode (spike #903) — a Vue Flow node that renders a layout BLOCK on the
+ * flow canvas. Dropped from the drawer, it shows the real block (via the normal
+ * read-only renderer as a single leaf) so "drag a collection's block onto the flow"
+ * looks like the actual thing, not a placeholder. Vue Flow forwards `data`.
+ *
+ * No `@vue-flow/core` import (connection handles aren't needed for fork A, and the
+ * package isn't a direct POC dep) — it's just a card Vue Flow positions.
+ */
+import type { LayoutNode } from '@fyit/crouton-core/app/types/layout'
+
+const props = defineProps<{
+  data: { blockId: string, label?: string }
+  selected?: boolean
+}>()
+
+const node = computed<LayoutNode>(() => ({ type: 'leaf', blockId: props.data.blockId }))
+</script>
+
+<template>
+  <div
+    class="spike-block-node w-64 overflow-hidden rounded-xl border bg-default shadow-sm transition-shadow"
+    :class="selected ? 'border-primary shadow-lg' : 'border-default'"
+  >
+    <div class="flex items-center gap-2 border-b border-default bg-elevated/60 px-3 py-1.5">
+      <UIcon name="i-lucide-box" class="size-3.5 text-primary" />
+      <span class="text-xs font-medium">{{ data.label || data.blockId }}</span>
+    </div>
+    <div class="h-36">
+      <CroutonLayoutRenderer :node="node" />
+    </div>
+  </div>
+</template>

--- a/pocs/crouton-builder-demo/app/pages/spike-app.vue
+++ b/pocs/crouton-builder-demo/app/pages/spike-app.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+/**
+ * Spike (#903) — "everything in Vue Flow": build an app by dragging a collection's
+ * blocks from a DRAWER onto a Vue Flow canvas, then COMPILE the placement into a real
+ * layout (fork A). Throwaway side-surface to feel whether the direction holds.
+ *
+ *   drawer (Artists' blocks) ──drag──▶ CroutonFlow (ephemeral) ──compile──▶ LayoutTree
+ *
+ * Reuses what already exists: CroutonFlow's drag-drop (`@node-drop`) and the WS8
+ * pieces↔tree bridge (`piecesToTree`). No backend — the Artists blocks are demo blocks.
+ */
+import { markRaw } from 'vue'
+import type { LayoutNode, LayoutTree } from '@fyit/crouton-core/app/types/layout'
+import SpikeBlockNode from '~/components/SpikeBlockNode.vue'
+
+useHead({ title: 'Spike · app on Vue Flow' })
+const BUILD = 'spike-a · #903 · drag blocks from the drawer → flow → Compile to a layout'
+
+const blockNode = markRaw(SpikeBlockNode)
+
+// The drawer = the blocks a collection ("Artists") offers. In the real thing this list
+// is derived from the collection; here it's the registered demo blocks.
+const drawer = [
+  { blockId: 'artists-list', label: 'Artists · List', icon: 'i-lucide-list' },
+  { blockId: 'artists-form', label: 'Artists · New', icon: 'i-lucide-square-pen' },
+  { blockId: 'artists-stats', label: 'Artists · Stats', icon: 'i-lucide-bar-chart-3' },
+]
+
+// Pre-built Vue Flow nodes (CroutonFlow ephemeral mode renders these directly).
+interface FlowNode { id: string, type: string, position: { x: number, y: number }, data: { blockId: string, label?: string } }
+const nodes = ref<FlowNode[]>([])
+let seq = 0
+
+/** HTML5 drag source: stamp the crouton-item payload CroutonFlow's drop handler reads. */
+function onDragStart(e: DragEvent, item: { blockId: string, label: string }) {
+  e.dataTransfer?.setData('application/json', JSON.stringify({
+    type: 'crouton-item',
+    collection: 'artists',
+    item: { id: `${item.blockId}-${++seq}`, ...item },
+  }))
+  if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move'
+}
+
+/** CroutonFlow emits this on drop with the flow-space position — add the node. */
+function onNodeDrop(item: Record<string, unknown>, position: { x: number, y: number }) {
+  nodes.value = [...nodes.value, {
+    id: String(item.id),
+    type: 'default',
+    position,
+    data: { blockId: String(item.blockId), label: String(item.label ?? item.blockId) },
+  }]
+}
+
+// Fork A — compile the placement into a layout. Same rule as the WS8 bridge's
+// piecesToTree, inlined (the package util isn't exposed as a POC import): 1 node → its
+// leaf is the root; many → a split whose axis is inferred from how they're laid out
+// (wider spread in x ⇒ horizontal), ordered along that axis. The productionised path
+// would call the real `piecesToTree`.
+const compiled = ref<LayoutTree | null>(null)
+function compile() {
+  const ns = nodes.value
+  if (!ns.length) { compiled.value = null; return }
+  const leaf = (n: FlowNode): LayoutNode => ({ type: 'leaf', blockId: n.data.blockId })
+  if (ns.length === 1) {
+    compiled.value = { renderer: 'panes', root: leaf(ns[0]!) }
+    return
+  }
+  const spread = (a: number[]) => Math.max(...a) - Math.min(...a)
+  const horizontal = spread(ns.map(n => n.position.x)) >= spread(ns.map(n => n.position.y))
+  const ordered = [...ns].sort((a, b) => (horizontal ? a.position.x - b.position.x : a.position.y - b.position.y))
+  compiled.value = {
+    renderer: 'panes',
+    root: {
+      type: 'split',
+      direction: horizontal ? 'horizontal' : 'vertical',
+      children: ordered.map(n => ({ ...leaf(n), defaultSize: Math.round((100 / ordered.length) * 10) / 10 })),
+    },
+  }
+}
+function reset() {
+  nodes.value = []
+  compiled.value = null
+}
+</script>
+
+<template>
+  <div class="flex h-screen flex-col bg-default text-default">
+    <header class="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-default px-5 py-3">
+      <h1 class="text-base font-semibold">Spike · build an app on Vue Flow</h1>
+      <p class="text-xs text-muted">Drag a block from the drawer onto the canvas → Compile. #903</p>
+      <span class="ml-auto rounded-full border border-default bg-elevated px-2 py-0.5 font-mono text-[10px] text-muted">{{ BUILD }}</span>
+    </header>
+
+    <div class="flex min-h-0 flex-1">
+      <!-- Drawer — the collection's blocks, draggable onto the canvas -->
+      <aside class="w-56 shrink-0 overflow-y-auto border-r border-default bg-elevated/40 p-3">
+        <p class="mb-2 text-xs uppercase tracking-widest text-muted">Artists · blocks</p>
+        <div class="flex flex-col gap-2">
+          <div
+            v-for="b in drawer"
+            :key="b.blockId"
+            draggable="true"
+            class="flex cursor-grab items-center gap-2 rounded-lg border border-default bg-default px-3 py-2 text-sm transition-colors hover:border-primary active:cursor-grabbing"
+            @dragstart="onDragStart($event, b)"
+          >
+            <UIcon :name="b.icon" class="size-4 text-primary" />
+            <span>{{ b.label }}</span>
+            <UIcon name="i-lucide-grip-vertical" class="ml-auto size-3.5 text-muted" />
+          </div>
+        </div>
+        <div class="mt-4 flex flex-col gap-2">
+          <UButton size="xs" icon="i-lucide-wand-2" :disabled="!nodes.length" block @click="compile">Compile to layout</UButton>
+          <UButton size="xs" color="neutral" variant="soft" icon="i-lucide-rotate-ccw" block @click="reset">Reset</UButton>
+        </div>
+      </aside>
+
+      <!-- The Vue Flow canvas -->
+      <div class="relative min-w-0 flex-1">
+        <ClientOnly>
+          <CroutonFlow
+            v-model:rows="nodes"
+            collection="artists"
+            data-mode="ephemeral"
+            :default-node-component="blockNode"
+            allow-drop
+            :minimap="false"
+            @node-drop="onNodeDrop"
+          />
+        </ClientOnly>
+        <p
+          v-if="!nodes.length"
+          class="pointer-events-none absolute inset-0 grid place-items-center text-sm text-muted"
+        >
+          Drag a block from the drawer onto the canvas →
+        </p>
+      </div>
+
+      <!-- Compiled layout — the result of fork A -->
+      <aside
+        v-if="compiled"
+        class="w-96 shrink-0 overflow-hidden border-l border-default p-3"
+      >
+        <p class="mb-2 text-xs uppercase tracking-widest text-muted">Compiled layout</p>
+        <div class="h-[calc(100%-2rem)] overflow-hidden rounded-xl border border-default">
+          <CroutonLayoutRenderer :node="compiled.root" />
+        </div>
+      </aside>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Part of epic #868. **Exploratory spike** — testing the owner's "everything in Vue Flow" direction, not a committed build. Closes #903.

> **Stacked on #894** (the POC stack) — base is `claude/poc-crouton-builder-demo`, not `main`. A self-contained new page (`/spike-app`); it does **not** touch the working zoom shell.

## What it proves

The owner's loop — *a collection offers blocks (list / form / stats) → drag them from a **drawer** onto a **Vue Flow** canvas → arrange → **compile** into a real app-layout* — runs end-to-end, **reusing what already exists**:

- **The drawer-drag is already ours.** `CroutonFlow` (ephemeral mode) emits `@node-drop` on an HTML5 drop — the drawer just stamps the `crouton-item` payload its drop handler reads. No new flow plumbing.
- **Compile = the WS8 bridge.** Placed nodes → a `LayoutTree` (1 → leaf root; many → a split, axis inferred from on-canvas spread) — the same rule as `piecesToTree`, inlined here (the package util isn't exposed as a POC import). Rendered through the normal `CroutonLayoutRenderer`.

So *graph (free nodes) → layout (tiled panes)* is bridgeable, which was the open architectural question.

## How to try it

`/spike-app` on the POC (live once CI deploys this PR): drag **Artists · List / New / Stats** from the left drawer onto the canvas, then **Compile to layout** → the right panel renders the arrangement as a real tiled layout.

## Verified

- `pnpm --filter crouton-builder-demo typecheck` clean.
- Headless chromium: 2 drops → 2 block nodes on the Vue Flow canvas → Compile → layout renders, no page errors. (screenshot in `screenshots/spike-03-compiled.png`)

## Deliberately out of scope (it's a spike)

- Real "Artists" collection backend — the blocks are demo KPIs.
- **Fork B** (snap-to-tile on drop, the WS4 magnetic feel on the flow surface) — the follow-up if fork A's "compile" feels too loose.
- Named/reusable apps, placing apps into pages, the full Vue-Flow drill-down zoom across levels.

## What we learned (for the epic)

Feasible and cheap to reach, because the two hard pieces already exist (CroutonFlow drop + the pieces↔tree bridge). The real product questions are now UX, not plumbing: *when* does a placement become a layout (explicit "compile" vs live snap), and how apps get named + reused into pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ag3ovfJN4ypP4ZzqNZ6sDH)_