### PR TITLE
A · Component cleanup + mobile drawer (UDrawer / USlider / UCard) (#906)

### DIFF
--- a/packages/crouton-layout/app/components/LayoutBreakpointAuthor.vue
+++ b/packages/crouton-layout/app/components/LayoutBreakpointAuthor.vue
@@ -185,15 +185,14 @@ const frameScale = computed(() => {
 
     <!-- The ruler: a min-width track with authored checkpoints (each locks upward) -->
     <div class="relative h-9 select-none">
-      <input
-        v-model.number="simWidth"
-        type="range"
+      <USlider
+        v-model="simWidth"
         :min="MIN"
         :max="MAX"
-        step="1"
+        :step="1"
         aria-label="Container width"
-        class="absolute inset-x-0 top-1/2 z-10 w-full -translate-y-1/2 accent-primary"
-      >
+        class="absolute inset-x-0 top-1/2 z-10 w-full -translate-y-1/2"
+      />
       <!-- "locks upward" fill from the active checkpoint to the handle -->
       <div
         v-if="activeMin !== null"

--- a/packages/crouton-layout/app/components/LayoutZoomShell.vue
+++ b/packages/crouton-layout/app/components/LayoutZoomShell.vue
@@ -134,10 +134,11 @@ function onComposeZoom(piece: ComposePiece): void {
   if (path) zoom.zoomIntoNested(path)
 }
 
+// Theme tokens (semantic), not raw palette steps, so the dots track the active theme.
 const levelDot: Record<string, string> = {
-  site: 'bg-violet-400',
+  site: 'bg-secondary',
   layout: 'bg-primary',
-  breakpoints: 'bg-blue-400',
+  breakpoints: 'bg-info',
 }
 
 /**

--- a/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
@@ -19,16 +19,15 @@ const node = computed<LayoutNode>(() => ({ type: 'leaf', blockId: props.data.blo
 </script>
 
 <template>
-  <div
-    class="spike-block-node w-64 overflow-hidden rounded-xl border bg-default shadow-sm transition-shadow"
-    :class="selected ? 'border-primary shadow-lg' : 'border-default'"
+  <UCard
+    class="spike-block-node w-64 transition-shadow"
+    :class="selected ? 'ring-primary shadow-lg' : ''"
+    :ui="{ root: 'overflow-hidden', header: 'flex items-center gap-2 bg-elevated/60 px-3 py-1.5 sm:px-3', body: 'h-36 p-0 sm:p-0' }"
   >
-    <div class="flex items-center gap-2 border-b border-default bg-elevated/60 px-3 py-1.5">
+    <template #header>
       <UIcon name="i-lucide-box" class="size-3.5 text-primary" />
       <span class="text-xs font-medium">{{ data.label || data.blockId }}</span>
-    </div>
-    <div class="h-36">
-      <CroutonLayoutRenderer :node="node" />
-    </div>
-  </div>
+    </template>
+    <CroutonLayoutRenderer :node="node" />
+  </UCard>
 </template>

--- a/pocs/crouton-builder-demo/app/pages/index.vue
+++ b/pocs/crouton-builder-demo/app/pages/index.vue
@@ -15,7 +15,7 @@ useHead({ title: 'Crouton Builder — live POC' })
 
 // Bump on every deploy so you can confirm (esp. on mobile, where the browser caches
 // hard) that you're looking at the latest build, not a stale one.
-const BUILD = 'b19 · 26 Jun · collapse-motion picker in Breakpoints + spring-drawer demo (drag the ruler past 640)'
+const BUILD = 'b20 · 26 Jun · Nuxt UI 4 cleanup — USlider ruler + theme-token zoom dots (#906)'
 
 // Backend-free demo blocks (registered in app.config) so the canvas/author can be
 // driven without auth. A `nested` app on the Reports page demonstrates

--- a/pocs/crouton-builder-demo/app/pages/spike-app.vue
+++ b/pocs/crouton-builder-demo/app/pages/spike-app.vue
@@ -1,22 +1,33 @@
 <script setup lang="ts">
 /**
- * Spike (#903) — "everything in Vue Flow": build an app by dragging a collection's
- * blocks from a DRAWER onto a Vue Flow canvas, then COMPILE the placement into a real
- * layout (fork A). Throwaway side-surface to feel whether the direction holds.
+ * Spike (#903 → #906) — "everything in Vue Flow": build an app by dragging a
+ * collection's blocks from a DRAWER onto a Vue Flow canvas, then COMPILE the placement
+ * into a real layout (fork A). Sub-issue A (#906) re-skins the hand-rolled spike onto
+ * proper Nuxt UI 4 components and makes the drawer out-of-the-way on a phone.
  *
  *   drawer (Artists' blocks) ──drag──▶ CroutonFlow (ephemeral) ──compile──▶ LayoutTree
  *
  * Reuses what already exists: CroutonFlow's drag-drop (`@node-drop`) and the WS8
  * pieces↔tree bridge (`piecesToTree`). No backend — the Artists blocks are demo blocks.
+ *
+ * Responsive shell: the palette is a persistent slim sidebar on desktop (so HTML5
+ * drag-drop onto the canvas stays usable) and a toggled `UDrawer` bottom sheet on a
+ * phone (out of the way — fork A; touch drag / snapping is epic #905 sub-issue B). The
+ * compiled result rides in a `USlideover`. The palette markup is defined once with
+ * VueUse's `createReusableTemplate` and reused in both places.
  */
 import { markRaw } from 'vue'
+import { createReusableTemplate } from '@vueuse/core'
 import type { LayoutNode, LayoutTree } from '@fyit/crouton-core/app/types/layout'
 import SpikeBlockNode from '~/components/SpikeBlockNode.vue'
 
 useHead({ title: 'Spike · app on Vue Flow' })
-const BUILD = 'spike-a · #903 · drag blocks from the drawer → flow → Compile to a layout'
+const BUILD = 'spike-a · #906 · Nuxt UI 4 drawer + slideover + slider'
 
 const blockNode = markRaw(SpikeBlockNode)
+
+// Define the palette markup once; render it in the desktop sidebar AND the mobile drawer.
+const [DefinePalette, ReusePalette] = createReusableTemplate()
 
 // The drawer = the blocks a collection ("Artists") offers. In the real thing this list
 // is derived from the collection; here it's the registered demo blocks.
@@ -30,6 +41,10 @@ const drawer = [
 interface FlowNode { id: string, type: string, position: { x: number, y: number }, data: { blockId: string, label?: string } }
 const nodes = ref<FlowNode[]>([])
 let seq = 0
+
+// Mobile palette (bottom sheet) + the compiled-layout slideover open state.
+const paletteOpen = ref(false)
+const resultOpen = ref(false)
 
 /** HTML5 drag source: stamp the crouton-item payload CroutonFlow's drop handler reads. */
 function onDragStart(e: DragEvent, item: { blockId: string, label: string }) {
@@ -63,55 +78,85 @@ function compile() {
   const leaf = (n: FlowNode): LayoutNode => ({ type: 'leaf', blockId: n.data.blockId })
   if (ns.length === 1) {
     compiled.value = { renderer: 'panes', root: leaf(ns[0]!) }
-    return
   }
-  const spread = (a: number[]) => Math.max(...a) - Math.min(...a)
-  const horizontal = spread(ns.map(n => n.position.x)) >= spread(ns.map(n => n.position.y))
-  const ordered = [...ns].sort((a, b) => (horizontal ? a.position.x - b.position.x : a.position.y - b.position.y))
-  compiled.value = {
-    renderer: 'panes',
-    root: {
-      type: 'split',
-      direction: horizontal ? 'horizontal' : 'vertical',
-      children: ordered.map(n => ({ ...leaf(n), defaultSize: Math.round((100 / ordered.length) * 10) / 10 })),
-    },
+  else {
+    const spread = (a: number[]) => Math.max(...a) - Math.min(...a)
+    const horizontal = spread(ns.map(n => n.position.x)) >= spread(ns.map(n => n.position.y))
+    const ordered = [...ns].sort((a, b) => (horizontal ? a.position.x - b.position.x : a.position.y - b.position.y))
+    compiled.value = {
+      renderer: 'panes',
+      root: {
+        type: 'split',
+        direction: horizontal ? 'horizontal' : 'vertical',
+        children: ordered.map(n => ({ ...leaf(n), defaultSize: Math.round((100 / ordered.length) * 10) / 10 })),
+      },
+    }
   }
+  paletteOpen.value = false
+  resultOpen.value = true
 }
 function reset() {
   nodes.value = []
   compiled.value = null
+  resultOpen.value = false
 }
 </script>
 
 <template>
   <div class="flex h-screen flex-col bg-default text-default">
+    <!-- Palette markup, defined once and reused in the desktop sidebar + mobile drawer -->
+    <DefinePalette>
+      <div class="flex flex-col gap-2">
+        <UCard
+          v-for="b in drawer"
+          :key="b.blockId"
+          draggable="true"
+          :ui="{ root: 'cursor-grab transition-colors hover:ring-primary active:cursor-grabbing', body: 'flex items-center gap-2 p-3 sm:p-3' }"
+          @dragstart="onDragStart($event, b)"
+        >
+          <UIcon :name="b.icon" class="size-4 text-primary" />
+          <span class="text-sm">{{ b.label }}</span>
+          <UIcon name="i-lucide-grip-vertical" class="ml-auto size-3.5 text-muted" />
+        </UCard>
+      </div>
+      <div class="mt-4 flex flex-col gap-2">
+        <UButton size="sm" icon="i-lucide-wand-2" :disabled="!nodes.length" block @click="compile">Compile to layout</UButton>
+        <UButton size="sm" color="neutral" variant="soft" icon="i-lucide-rotate-ccw" block @click="reset">Reset</UButton>
+      </div>
+    </DefinePalette>
+
     <header class="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-default px-5 py-3">
       <h1 class="text-base font-semibold">Spike · build an app on Vue Flow</h1>
-      <p class="text-xs text-muted">Drag a block from the drawer onto the canvas → Compile. #903</p>
-      <span class="ml-auto rounded-full border border-default bg-elevated px-2 py-0.5 font-mono text-[10px] text-muted">{{ BUILD }}</span>
+      <p class="hidden text-xs text-muted sm:block">Drag a block from the drawer onto the canvas → Compile. #903</p>
+      <div class="ml-auto flex items-center gap-2">
+        <!-- Mobile: open the palette as a bottom sheet (desktop has the persistent sidebar) -->
+        <UButton
+          class="md:hidden"
+          size="xs"
+          icon="i-lucide-layout-grid"
+          label="Blocks"
+          color="neutral"
+          variant="soft"
+          @click="paletteOpen = true"
+        />
+        <UButton
+          v-if="compiled"
+          size="xs"
+          icon="i-lucide-panel-right-open"
+          label="Layout"
+          color="neutral"
+          variant="soft"
+          @click="resultOpen = true"
+        />
+        <span class="hidden rounded-full border border-default bg-elevated px-2 py-0.5 font-mono text-[10px] text-muted sm:inline">{{ BUILD }}</span>
+      </div>
     </header>
 
     <div class="flex min-h-0 flex-1">
-      <!-- Drawer — the collection's blocks, draggable onto the canvas -->
-      <aside class="w-56 shrink-0 overflow-y-auto border-r border-default bg-elevated/40 p-3">
+      <!-- Desktop drawer — the collection's blocks, draggable onto the canvas -->
+      <aside class="hidden w-56 shrink-0 overflow-y-auto border-r border-default bg-elevated/40 p-3 md:block">
         <p class="mb-2 text-xs uppercase tracking-widest text-muted">Artists · blocks</p>
-        <div class="flex flex-col gap-2">
-          <div
-            v-for="b in drawer"
-            :key="b.blockId"
-            draggable="true"
-            class="flex cursor-grab items-center gap-2 rounded-lg border border-default bg-default px-3 py-2 text-sm transition-colors hover:border-primary active:cursor-grabbing"
-            @dragstart="onDragStart($event, b)"
-          >
-            <UIcon :name="b.icon" class="size-4 text-primary" />
-            <span>{{ b.label }}</span>
-            <UIcon name="i-lucide-grip-vertical" class="ml-auto size-3.5 text-muted" />
-          </div>
-        </div>
-        <div class="mt-4 flex flex-col gap-2">
-          <UButton size="xs" icon="i-lucide-wand-2" :disabled="!nodes.length" block @click="compile">Compile to layout</UButton>
-          <UButton size="xs" color="neutral" variant="soft" icon="i-lucide-rotate-ccw" block @click="reset">Reset</UButton>
-        </div>
+        <ReusePalette />
       </aside>
 
       <!-- The Vue Flow canvas -->
@@ -129,22 +174,30 @@ function reset() {
         </ClientOnly>
         <p
           v-if="!nodes.length"
-          class="pointer-events-none absolute inset-0 grid place-items-center text-sm text-muted"
+          class="pointer-events-none absolute inset-0 grid place-items-center px-6 text-center text-sm text-muted"
         >
-          Drag a block from the drawer onto the canvas →
+          <span class="hidden md:inline">Drag a block from the drawer onto the canvas →</span>
+          <span class="md:hidden">Tap <strong>Blocks</strong> to open the palette.</span>
         </p>
       </div>
-
-      <!-- Compiled layout — the result of fork A -->
-      <aside
-        v-if="compiled"
-        class="w-96 shrink-0 overflow-hidden border-l border-default p-3"
-      >
-        <p class="mb-2 text-xs uppercase tracking-widest text-muted">Compiled layout</p>
-        <div class="h-[calc(100%-2rem)] overflow-hidden rounded-xl border border-default">
-          <CroutonLayoutRenderer :node="compiled.root" />
-        </div>
-      </aside>
     </div>
+
+    <!-- Mobile palette — a bottom sheet, out of the way until summoned (#906) -->
+    <UDrawer v-model:open="paletteOpen" :handle="true" title="Artists · blocks">
+      <template #body>
+        <div class="p-1 pb-4">
+          <ReusePalette />
+        </div>
+      </template>
+    </UDrawer>
+
+    <!-- Compiled layout — the result of fork A, in a contextual slideover (#906) -->
+    <USlideover v-model:open="resultOpen" title="Compiled layout" :ui="{ content: 'sm:max-w-md' }">
+      <template #body>
+        <div class="h-full overflow-hidden rounded-xl border border-default">
+          <CroutonLayoutRenderer v-if="compiled" :node="compiled.root" />
+        </div>
+      </template>
+    </USlideover>
   </div>
 </template>


### PR DESCRIPTION
Sub-issue **A** of epic #905 — graduate the hand-rolled `/spike-app` onto proper Nuxt UI 4 components and make the block drawer usable on a phone *now*.

Closes #906

## What changed

**`packages/crouton-layout`** (gated edit, approved)
- `LayoutBreakpointAuthor.vue` — the Breakpoints ruler: raw `<input type="range">` + `accent-primary` hack → **`USlider`** (`v-model` number, `:min`/`:max`/`:step`, `aria-label="Container width"` preserved). This is the one *confirmed* `/frontend-review` finding. The min-width checkpoint markers still overlay the slider.
- `LayoutZoomShell.vue` — zoom-level breadcrumb dots `bg-violet-400`/`bg-blue-400` → **theme tokens** `bg-secondary`/`bg-info` (`bg-primary` unchanged), so they track the active theme.

**`pocs/crouton-builder-demo`** (`/spike-app`)
- Block palette → **`UDrawer`** bottom sheet on a phone (toggled by a header **Blocks** button, out of the way), persistent slim sidebar on desktop (HTML5 drag-drop onto the canvas stays usable). Defined once with VueUse `createReusableTemplate`, reused in both.
- Compiled-layout result panel → **`USlideover`** (opens on Compile).
- Drag chips + `SpikeBlockNode` → **`UCard`** surfaces (the `draggable` div / Vue Flow node wrapper kept for the drop protocol).
- `index.vue` BUILD stamp → `b20`.

> Touch drag / manual snapping on a phone stays out of scope — that's epic #905 sub-issue B (#907).

## Acceptance criteria (#906)

- [x] Spike drawer → Nuxt UI 4 `UDrawer` out of the way on mobile (bottom sheet), not a fixed `aside` eating ~57% of the screen
- [x] Compiled-layout result panel → `USlideover`
- [x] `USlider` replaces the raw range + `accent-primary` in `LayoutBreakpointAuthor` (v-model number, MIN/MAX/step, aria-label preserved)
- [x] Drag chips & the Vue Flow block-node use a `UCard` surface (draggable div kept)
- [x] Zoom-level dots → theme tokens
- [x] `pnpm --filter crouton-builder-demo typecheck` clean · `crouton-layout` unit tests green (196) · verified on a phone viewport with chromium

## Verification

Driven on the running dev server (`localhost:3010`) with the pre-installed chromium:
- **Desktop** — slim UCard sidebar; drop 3 Artists blocks → **Compile** → `USlideover` renders the 3-pane horizontal split.
- **Phone (390×780)** — palette gone (full canvas + slim **Blocks** toggle); tap → `UDrawer` bottom sheet with the chips + Compile/Reset.
- **Breakpoints level** — ruler is the themed `USlider`; markers still align; breadcrumb dot uses the `bg-secondary`/`bg-info` token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RP9jLEU3rNxhJfMNUeDGPt)_