### PR TITLE
C · ✨ Magic v1 — deterministic auto-arrange + archetype proposals (#908)

### DIFF
--- a/pocs/crouton-builder-demo/app/composables/useSpikeMagic.ts
+++ b/pocs/crouton-builder-demo/app/composables/useSpikeMagic.ts
@@ -1,0 +1,203 @@
+/**
+ * Spike Magic v1 (#908, epic #905) — the ✨ "arrange it for me" tier, the cheap,
+ * instant, no-API one. Given the blocks dropped on the app-canvas, it produces a
+ * handful of **archetype proposals** (master-detail / form-centric / calendar-primary
+ * / dashboard / stacked) you can flip between — every one **viability-guaranteed**.
+ *
+ * Reuses the deterministic engine we already have (`@fyit/crouton-layout`):
+ *   - `composeDefault` (#709) is run over the dropped blocks to pick the *strong*
+ *     default pattern (and to prove the engine drives the choice);
+ *   - `checkViability` (#710) gates every archetype — a horizontal split that would
+ *     squish a block below its `minWidth` falls back to a vertical stack (which keeps
+ *     each child's full width, so it's always viable).
+ *
+ * POC-local glue (pocs are test-exempt): the archetype expansion lives here while the
+ * shape settles; the genuine logic graduates into `packages/*` test-first later (#774).
+ */
+import type { LayoutLeaf, LayoutNode, LayoutTree } from '@fyit/crouton-core/app/types/layout'
+
+/** A block the user dropped on the canvas (collection-derived: artists-list/form/stats). */
+export interface MagicBlockInput {
+  blockId: string
+  label?: string
+}
+
+export type MagicPattern = 'master-detail' | 'form-centric' | 'calendar-primary' | 'dashboard' | 'stacked'
+
+export interface MagicProposal {
+  id: MagicPattern
+  label: string
+  icon: string
+  note: string
+  tree: LayoutTree
+  /** Passes the #710 viability gate at every target width (always true — the builders fall back to a stack). */
+  viable: boolean
+}
+
+/** The role a dropped block plays in an arrangement, inferred from its registry def. */
+type BlockRole = 'list' | 'form' | 'calendar' | 'stats'
+
+// Desktop + tablet, same gate the deterministic composer uses.
+const TARGET_WIDTHS = [1280, 768]
+
+const PATTERN_META: Record<MagicPattern, { label: string, icon: string, note: string }> = {
+  'calendar-primary': { label: 'Calendar', icon: 'i-lucide-calendar', note: 'Calendar dominant, list as a side rail' },
+  'master-detail': { label: 'Master–detail', icon: 'i-lucide-columns-2', note: 'List beside the form, stats below' },
+  'form-centric': { label: 'Form-first', icon: 'i-lucide-square-pen', note: 'Form dominant, the rest as a rail' },
+  'dashboard': { label: 'Dashboard', icon: 'i-lucide-layout-dashboard', note: 'Stats across the top, list + form below' },
+  'stacked': { label: 'Stacked', icon: 'i-lucide-rows-3', note: 'Everything in one column — always fits' },
+}
+
+export function useSpikeMagic() {
+  const { getBlock, composeDefault, checkViability } = useCroutonLayoutBlocks()
+
+  /** Infer a block's arrangement role from its registry category / id. */
+  function roleOf(blockId: string): BlockRole {
+    const def = getBlock(blockId)
+    const id = blockId.toLowerCase()
+    const comp = (def?.component ?? '').toLowerCase()
+    if (id.includes('calendar') || comp.includes('calendar')) return 'calendar'
+    if (def?.category === 'form' || id.includes('form') || id.includes('new') || id.includes('create')) return 'form'
+    if (id.includes('stats') || id.includes('kpi') || id.includes('chart')) return 'stats'
+    return 'list'
+  }
+
+  function leaf(b: MagicBlockInput, size?: number): LayoutLeaf {
+    return {
+      type: 'leaf',
+      blockId: b.blockId,
+      config: { collection: 'artists', ...(b.label ? { heading: b.label } : {}) },
+      ...(size != null ? { defaultSize: size } : {}),
+    }
+  }
+
+  const withSize = (node: LayoutNode, size: number): LayoutNode => ({ ...node, defaultSize: size })
+
+  /** A vertical stack (one child collapses to itself). Width isn't divided → stays viable. */
+  function col(children: LayoutNode[]): LayoutNode {
+    return children.length === 1 ? children[0]! : { type: 'split', direction: 'vertical', children }
+  }
+
+  /** Side by side when that's viable at every target width; otherwise stacked. */
+  function rowOrStack(children: LayoutNode[]): LayoutNode {
+    if (children.length === 1) return children[0]!
+    const horizontal: LayoutNode = { type: 'split', direction: 'horizontal', children }
+    if (checkViability({ renderer: 'panes', root: horizontal }, TARGET_WIDTHS).viable) return horizontal
+    return { type: 'split', direction: 'vertical', children }
+  }
+
+  /** Group dropped blocks by inferred role, preserving drop order within a role. */
+  function group(blocks: MagicBlockInput[]): Record<BlockRole, MagicBlockInput[]> {
+    const g: Record<BlockRole, MagicBlockInput[]> = { list: [], form: [], calendar: [], stats: [] }
+    for (const b of blocks) g[roleOf(b.blockId)].push(b)
+    return g
+  }
+
+  // --- archetype builders: each returns a root node, or null when not applicable ---
+
+  function buildMasterDetail(g: Record<BlockRole, MagicBlockInput[]>): LayoutNode | null {
+    if (!g.list.length || !g.form.length) return null
+    const core = rowOrStack([
+      withSize(col(g.list.map(b => leaf(b))), 40),
+      withSize(col(g.form.map(b => leaf(b))), 60),
+    ])
+    if (!g.stats.length) return core
+    return col([withSize(core, 70), withSize(rowOrStack(g.stats.map(b => leaf(b))), 30)])
+  }
+
+  function buildFormCentric(g: Record<BlockRole, MagicBlockInput[]>): LayoutNode | null {
+    if (!g.form.length) return null
+    const form = withSize(col(g.form.map(b => leaf(b))), 65)
+    const rail = [...g.list, ...g.stats]
+    if (!rail.length) return col(g.form.map(b => leaf(b)))
+    return rowOrStack([form, withSize(col(rail.map(b => leaf(b))), 35)])
+  }
+
+  function buildCalendarPrimary(g: Record<BlockRole, MagicBlockInput[]>): LayoutNode | null {
+    if (!g.calendar.length) return null
+    const cal = withSize(col(g.calendar.map(b => leaf(b))), 70)
+    const rail = [...g.list, ...g.stats]
+    if (!rail.length) return cal
+    // List rail left, calendar right — mirrors the composer's buildCalendarPrimary.
+    return rowOrStack([withSize(col(rail.map(b => leaf(b))), 30), cal])
+  }
+
+  function buildDashboard(g: Record<BlockRole, MagicBlockInput[]>): LayoutNode | null {
+    if (!g.stats.length || (!g.list.length && !g.form.length)) return null
+    const top = withSize(rowOrStack(g.stats.map(b => leaf(b))), 30)
+    const below = withSize(rowOrStack([...g.list.map(b => leaf(b)), ...g.form.map(b => leaf(b))]), 70)
+    return col([top, below])
+  }
+
+  function buildStacked(blocks: MagicBlockInput[]): LayoutNode {
+    return col(blocks.map(b => leaf(b)))
+  }
+
+  /**
+   * Arrange the dropped blocks into 1–3 viability-guaranteed archetype proposals.
+   * The pattern `composeDefault` (#709) selects is surfaced first (the *strong* default);
+   * the others are the "propose another layout" alternatives the owner asked for.
+   */
+  function magicArrange(blocks: MagicBlockInput[]): { proposals: MagicProposal[], defaultId: MagicPattern | null } {
+    if (!blocks.length) return { proposals: [], defaultId: null }
+
+    const g = group(blocks)
+
+    // Run the deterministic composer to learn the strong default pattern (and to gate
+    // it). composeDefault is collection-oriented, so feed the dropped blocks as one
+    // "artists" collection, remapping its block ids to the ones actually dropped.
+    const base = composeDefault(
+      [{ key: 'artists', label: 'Artists', calendar: g.calendar.length > 0 }],
+      {
+        targetWidths: TARGET_WIDTHS,
+        blockIds: {
+          list: g.list[0]?.blockId,
+          form: g.form[0]?.blockId,
+          calendar: g.calendar[0]?.blockId,
+        },
+      },
+    )
+    // base.pattern is the engine's pick; 'empty' shouldn't happen with ≥1 block, but guard.
+    const KNOWN: readonly string[] = ['calendar-primary', 'master-detail', 'form-centric', 'stacked']
+    const defaultPattern: MagicPattern = KNOWN.includes(base.pattern)
+      ? base.pattern as MagicPattern
+      : 'stacked'
+
+    // Candidate archetypes in a stable priority; null ones (not applicable) drop out.
+    const candidates: Array<{ id: MagicPattern, root: LayoutNode | null }> = [
+      { id: 'calendar-primary', root: buildCalendarPrimary(g) },
+      { id: 'master-detail', root: buildMasterDetail(g) },
+      { id: 'form-centric', root: buildFormCentric(g) },
+      { id: 'dashboard', root: buildDashboard(g) },
+      { id: 'stacked', root: buildStacked(blocks) },
+    ]
+
+    const seen = new Set<string>()
+    const built = candidates
+      .filter((c): c is { id: MagicPattern, root: LayoutNode } => c.root !== null)
+      .map((c) => {
+        const tree: LayoutTree = { renderer: 'panes', root: c.root }
+        return { id: c.id, tree, viable: checkViability(tree, TARGET_WIDTHS).viable }
+      })
+      // Drop structurally-identical archetypes (e.g. one block → every builder yields the same).
+      .filter((p) => {
+        const sig = JSON.stringify(p.tree.root)
+        if (seen.has(sig)) return false
+        seen.add(sig)
+        return true
+      })
+
+    // Default pattern first, then the rest; cap at 3 (one strong + up to two alternatives).
+    built.sort((a, b) => Number(b.id === defaultPattern) - Number(a.id === defaultPattern))
+    const proposals: MagicProposal[] = built.slice(0, 3).map(p => ({
+      id: p.id,
+      ...PATTERN_META[p.id],
+      tree: p.tree,
+      viable: p.viable,
+    }))
+
+    return { proposals, defaultId: proposals[0]?.id ?? null }
+  }
+
+  return { magicArrange }
+}

--- a/pocs/crouton-builder-demo/app/pages/spike-app.vue
+++ b/pocs/crouton-builder-demo/app/pages/spike-app.vue
@@ -1,20 +1,23 @@
 <script setup lang="ts">
 /**
- * Spike (#903 → #906) — "everything in Vue Flow": build an app by dragging a
- * collection's blocks from a DRAWER onto a Vue Flow canvas, then COMPILE the placement
- * into a real layout (fork A). Sub-issue A (#906) re-skins the hand-rolled spike onto
- * proper Nuxt UI 4 components and makes the drawer out-of-the-way on a phone.
+ * Spike (#903 → #906 → #908) — "everything in Vue Flow": build an app by dragging a
+ * collection's blocks from a DRAWER onto a Vue Flow canvas, then turn the placement
+ * into a real layout. Two paths:
+ *   - ✨ **Magic arrange** (#908) — the deterministic composer + viability gate pick a
+ *     strong layout and offer 2–3 archetype proposals to flip between (no API cost).
+ *   - **As placed** — the dumb positional infer (the original spike's "Compile").
  *
- *   drawer (Artists' blocks) ──drag──▶ CroutonFlow (ephemeral) ──compile──▶ LayoutTree
+ *   drawer (Artists' blocks) ──drag──▶ CroutonFlow (ephemeral) ──✨/compile──▶ LayoutTree
  *
- * Reuses what already exists: CroutonFlow's drag-drop (`@node-drop`) and the WS8
- * pieces↔tree bridge (`piecesToTree`). No backend — the Artists blocks are demo blocks.
+ * Reuses what already exists: CroutonFlow's drag-drop (`@node-drop`); the layout engine's
+ * `composeDefault` (#709) + `checkViability` (#710) via `useSpikeMagic`. No backend — the
+ * Artists blocks are demo blocks.
  *
  * Responsive shell: the palette is a persistent slim sidebar on desktop (so HTML5
  * drag-drop onto the canvas stays usable) and a toggled `UDrawer` bottom sheet on a
  * phone (out of the way — fork A; touch drag / snapping is epic #905 sub-issue B). The
- * compiled result rides in a `USlideover`. The palette markup is defined once with
- * VueUse's `createReusableTemplate` and reused in both places.
+ * result rides in a `USlideover`. The palette markup is defined once with VueUse's
+ * `createReusableTemplate` and reused in both places.
  */
 import { markRaw } from 'vue'
 import { createReusableTemplate } from '@vueuse/core'
@@ -22,9 +25,15 @@ import type { LayoutNode, LayoutTree } from '@fyit/crouton-core/app/types/layout
 import SpikeBlockNode from '~/components/SpikeBlockNode.vue'
 
 useHead({ title: 'Spike · app on Vue Flow' })
-const BUILD = 'spike-a · #906 · Nuxt UI 4 drawer + slideover + slider'
+const BUILD = 'spike-c · #908 · ✨ Magic arrange (deterministic) + archetype proposals'
 
 const blockNode = markRaw(SpikeBlockNode)
+
+const { magicArrange } = useSpikeMagic()
+const { checkViability } = useCroutonLayoutBlocks()
+
+/** A layout the result slideover can render + let you flip between (magic or positional). */
+interface CanvasProposal { id: string, label: string, icon: string, note: string, tree: LayoutTree, viable: boolean }
 
 // Define the palette markup once; render it in the desktop sidebar AND the mobile drawer.
 const [DefinePalette, ReusePalette] = createReusableTemplate()
@@ -66,38 +75,64 @@ function onNodeDrop(item: Record<string, unknown>, position: { x: number, y: num
   }]
 }
 
-// Fork A — compile the placement into a layout. Same rule as the WS8 bridge's
-// piecesToTree, inlined (the package util isn't exposed as a POC import): 1 node → its
-// leaf is the root; many → a split whose axis is inferred from how they're laid out
-// (wider spread in x ⇒ horizontal), ordered along that axis. The productionised path
-// would call the real `piecesToTree`.
-const compiled = ref<LayoutTree | null>(null)
-function compile() {
-  const ns = nodes.value
-  if (!ns.length) { compiled.value = null; return }
+// The proposals the result slideover shows; you flip between them by id.
+const proposals = ref<CanvasProposal[]>([])
+const selectedId = ref<string>('')
+const resultTitle = ref('Layout')
+const selected = computed<CanvasProposal | null>(
+  () => proposals.value.find(p => p.id === selectedId.value) ?? proposals.value[0] ?? null,
+)
+
+/** ✨ Magic v1 (#908) — deterministic arrange + viability-gated archetype proposals. */
+function magic() {
+  const blocks = nodes.value.map(n => ({ blockId: n.data.blockId, label: n.data.label }))
+  const { proposals: ps, defaultId } = magicArrange(blocks)
+  proposals.value = ps
+  selectedId.value = defaultId ?? ps[0]?.id ?? ''
+  resultTitle.value = '✨ Magic layout'
+  paletteOpen.value = false
+  resultOpen.value = ps.length > 0
+}
+
+// "As placed" — the original spike's dumb positional infer: 1 node → its leaf is the
+// root; many → a split whose axis is inferred from how they're laid out (wider spread in
+// x ⇒ horizontal), ordered along that axis. Kept beside ✨ Magic as the literal placement.
+function inferPositional(ns: FlowNode[]): LayoutTree | null {
+  if (!ns.length) return null
   const leaf = (n: FlowNode): LayoutNode => ({ type: 'leaf', blockId: n.data.blockId })
-  if (ns.length === 1) {
-    compiled.value = { renderer: 'panes', root: leaf(ns[0]!) }
+  if (ns.length === 1) return { renderer: 'panes', root: leaf(ns[0]!) }
+  const spread = (a: number[]) => Math.max(...a) - Math.min(...a)
+  const horizontal = spread(ns.map(n => n.position.x)) >= spread(ns.map(n => n.position.y))
+  const ordered = [...ns].sort((a, b) => (horizontal ? a.position.x - b.position.x : a.position.y - b.position.y))
+  return {
+    renderer: 'panes',
+    root: {
+      type: 'split',
+      direction: horizontal ? 'horizontal' : 'vertical',
+      children: ordered.map(n => ({ ...leaf(n), defaultSize: Math.round((100 / ordered.length) * 10) / 10 })),
+    },
   }
-  else {
-    const spread = (a: number[]) => Math.max(...a) - Math.min(...a)
-    const horizontal = spread(ns.map(n => n.position.x)) >= spread(ns.map(n => n.position.y))
-    const ordered = [...ns].sort((a, b) => (horizontal ? a.position.x - b.position.x : a.position.y - b.position.y))
-    compiled.value = {
-      renderer: 'panes',
-      root: {
-        type: 'split',
-        direction: horizontal ? 'horizontal' : 'vertical',
-        children: ordered.map(n => ({ ...leaf(n), defaultSize: Math.round((100 / ordered.length) * 10) / 10 })),
-      },
-    }
-  }
+}
+function compile() {
+  const tree = inferPositional(nodes.value)
+  if (!tree) { proposals.value = []; return }
+  proposals.value = [{
+    id: 'positional',
+    label: 'As placed',
+    icon: 'i-lucide-move',
+    note: 'Exactly where you dropped them',
+    tree,
+    viable: checkViability(tree, [1280, 768]).viable,
+  }]
+  selectedId.value = 'positional'
+  resultTitle.value = 'Compiled layout'
   paletteOpen.value = false
   resultOpen.value = true
 }
 function reset() {
   nodes.value = []
-  compiled.value = null
+  proposals.value = []
+  selectedId.value = ''
   resultOpen.value = false
 }
 </script>
@@ -120,8 +155,9 @@ function reset() {
         </UCard>
       </div>
       <div class="mt-4 flex flex-col gap-2">
-        <UButton size="sm" icon="i-lucide-wand-2" :disabled="!nodes.length" block @click="compile">Compile to layout</UButton>
-        <UButton size="sm" color="neutral" variant="soft" icon="i-lucide-rotate-ccw" block @click="reset">Reset</UButton>
+        <UButton size="sm" color="primary" icon="i-lucide-wand-2" :disabled="!nodes.length" block @click="magic">✨ Magic arrange</UButton>
+        <UButton size="sm" color="neutral" variant="soft" icon="i-lucide-move" :disabled="!nodes.length" block @click="compile">As placed</UButton>
+        <UButton size="sm" color="neutral" variant="ghost" icon="i-lucide-rotate-ccw" block @click="reset">Reset</UButton>
       </div>
     </DefinePalette>
 
@@ -140,7 +176,7 @@ function reset() {
           @click="paletteOpen = true"
         />
         <UButton
-          v-if="compiled"
+          v-if="proposals.length"
           size="xs"
           icon="i-lucide-panel-right-open"
           label="Layout"
@@ -191,11 +227,47 @@ function reset() {
       </template>
     </UDrawer>
 
-    <!-- Compiled layout — the result of fork A, in a contextual slideover (#906) -->
-    <USlideover v-model:open="resultOpen" title="Compiled layout" :ui="{ content: 'sm:max-w-md' }">
+    <!-- Result — magic proposals (or the positional compile), in a contextual slideover -->
+    <USlideover v-model:open="resultOpen" :title="resultTitle" :ui="{ content: 'sm:max-w-lg' }">
       <template #body>
-        <div class="h-full overflow-hidden rounded-xl border border-default">
-          <CroutonLayoutRenderer v-if="compiled" :node="compiled.root" />
+        <div class="flex h-full flex-col gap-3">
+          <!-- Flip between archetype proposals (#908) -->
+          <div v-if="proposals.length > 1" class="flex flex-wrap gap-1.5">
+            <UButton
+              v-for="p in proposals"
+              :key="p.id"
+              :icon="p.icon"
+              :label="p.label"
+              size="xs"
+              :color="p.id === selectedId ? 'primary' : 'neutral'"
+              :variant="p.id === selectedId ? 'soft' : 'ghost'"
+              @click="selectedId = p.id"
+            />
+          </div>
+          <div v-if="selected" class="flex items-center gap-2 text-xs text-muted">
+            <span>{{ selected.note }}</span>
+            <UBadge
+              v-if="selected.viable"
+              color="success"
+              variant="subtle"
+              size="sm"
+              icon="i-lucide-check"
+            >viable</UBadge>
+            <UBadge
+              v-else
+              color="warning"
+              variant="subtle"
+              size="sm"
+              icon="i-lucide-alert-triangle"
+            >tight fit</UBadge>
+          </div>
+          <div class="min-h-0 flex-1 overflow-hidden rounded-xl border border-default">
+            <CroutonLayoutRenderer
+              v-if="selected"
+              :key="selected.id"
+              :node="selected.tree.root"
+            />
+          </div>
         </div>
       </template>
     </USlideover>


### PR DESCRIPTION
Sub-issue **C** of epic #905 — the ✨ "arrange it for me" button, the cheap, instant, no-API tier, reusing the deterministic layout engine we already have.

Closes #908

> **Stacked on #910 (sub-issue A).** C extends the same `spike-app.vue` that A re-skinned onto Nuxt UI 4, so this PR is based on the A branch — its diff is just the Magic work. GitHub auto-retargets the base to `main` when #910 merges. Review/merge #910 first.

## What changed

**New `useSpikeMagic` composable** (POC-local glue; pocs are test-exempt — graduates to `packages/*` test-first later, #774)
- `magicArrange(blocks)` → 1–3 **viability-guaranteed** archetype proposals.
- Reuses the engine: **`composeDefault`** (#709) is run over the dropped blocks to pick the *strong* default pattern; **`checkViability`** (#710) gates every archetype — a horizontal split that would breach a block's `minWidth` falls back to a vertical stack (keeps each child's full width → always viable).
- Roles (list / form / calendar / stats) inferred from each block's registry def; builders for **master-detail / form-centric / calendar-primary / dashboard / stacked**; deduped by structural signature, default-pattern-first, capped at 3.

**`spike-app.vue`**
- **✨ Magic arrange** button → a `USlideover` listing the proposals as **flip chips** with a `viable`/`tight fit` badge, rendering the selected tree through the normal `CroutonLayoutRenderer`.
- The old positional **Compile** → **As placed** (same dumb infer, unchanged) feeding the same slideover, so both paths sit side by side.

## Acceptance criteria (#908)

- [x] ✨ button runs `composeDefaultLayout` (#709) + viability (#710) over the dropped blocks → one strong arranged `LayoutTree`, rendered through the normal renderer
- [x] Offers 2–3 archetype proposals you can flip between and pick
- [x] Viability-guaranteed — every block gets ≥ its `minWidth`; no squished panes (the gate, with a vertical fallback)
- [x] Sits beside the spike's positional Compile (now "As placed")
- [x] `pnpm --filter crouton-builder-demo typecheck` clean · `crouton-layout` 196 tests green · verified with chromium

## Verification

Drove it on `localhost:3000`: drop Artists list + form + stats → **✨ Magic arrange** → slideover offers **Master-detail** (default), **Form-first**, **Dashboard**; each renders viable and flips instantly. Master-detail = list ↔ form with stats stacked below; Form-first = form dominant + list/stats rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RP9jLEU3rNxhJfMNUeDGPt)_