### PR TITLE
chore(root): add poc:skillissue label for the skill/issue marketing site

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -138,6 +138,9 @@
 - name: "poc:crouton-builder"
   color: "fef2c0"
   description: "POC: pocs/crouton-builder"
+- name: "poc:skillissue"
+  color: "fef2c0"
+  description: "POC: pocs/skillissue (skill/issue marketing site)"
 
 # ── Sandboxes (sandboxes/*) — throwaway, human-eyeball test apps (delete-after) ──
 - name: "sandbox:minimal-theme-demo"


### PR DESCRIPTION
## 👤 For humans
Registers the `poc:skillissue` component label so the new **skill/issue marketing site** POC can be labeled by app — matching the `pocs/skillissue` directory that the epic [#917](https://github.com/FriendlyInternet/nuxt-crouton/issues/917) will create. Tiny, fast-merge infra PR; the actual site work lands on its own branch.

Once this merges, the labels workflow syncs `poc:skillissue` live, and it should be applied to epic #917 and its sub-issues #918–#922.

## 🤖 For agents
- `.github/labels.yml`: adds `poc:skillissue` (color `fef2c0`, "POC: pocs/skillissue (skill/issue marketing site)") in the POCs block.
- Labels sync non-destructively via `.github/workflows/labels.yml` on merge to `main`.
- Follow-up (post-merge): apply `poc:skillissue` to #917, #918, #919, #920, #921, #922.

Relates to #917 (does not close it).

---
_Generated by [Claude Code](https://claude.ai/code/session_013moghmZEZBJUUtChAi9sjx)_