### PR TITLE
feat(root): Loop Station WS2 — invocation trace capture

### DIFF
--- a/.claude/skills/loop-station/SKILL.md
+++ b/.claude/skills/loop-station/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: loop-station
-description: Measure the harness's own context budget — tokens per CLAUDE.md / skill / agent, lexical redundancy, per-CI cold-write totals — as a deterministic, trendable inventory (no LLM). Appends one point to a committed history.jsonl per relevant merge. Use when asked for "context budget", "how big is CLAUDE.md / our skills", "is the harness bloating", "loop station inventory", or to run the inventory by hand.
+description: Observe the harness itself — (WS1) measure context budget as a deterministic, trendable inventory (tokens per CLAUDE.md / skill / agent, lexical redundancy, per-CI cold-write totals; committed history.jsonl), and (WS2) reconstruct the real invocation trace (which skills/agents/tools fired and how they nested) from session transcripts. Use for "context budget", "how big is CLAUDE.md / our skills", "is the harness bloating", "how do our agent loops actually run", "trace this session", "loop station".
 ---
 
-# Loop Station — context-budget inventory (WS1)
+# Loop Station — harness observatory (WS1 inventory + WS2 trace)
+
+> WS1 (context-budget inventory) is below; the WS2 invocation trace is the second
+> section. Both are producers — WS3 (`pocs/loop-station`) renders them.
+
+# WS1 — context-budget inventory
 
 The first, cheapest layer of the **Loop Station observatory** (epic #926): a
 **deterministic** snapshot of how big our always-on harness context is and how
@@ -61,3 +66,54 @@ path-filtered to `CLAUDE.md` / `.claude/skills/**` / `.claude/agents/**`. It
 gathers (with `ANTHROPIC_API_KEY` → `count_tokens`), appends, and commits the new
 `history.jsonl` line back with `[skip ci]` and the causing PR recorded — one data
 point per relevant merge, with the cause attached, no filler.
+
+---
+
+# WS2 — invocation trace
+
+Reconstructs the **real call tree** of a session — which skills/agents/tools
+fired, how they nested, how long sub-agents ran — from Claude Code transcripts.
+
+> **Hard privacy rule:** the trace carries **names + correlation ids + durations
+> only**, never a tool's `input` or a `tool_result`'s content. It is runtime
+> exhaust → **gitignored**, shipped from CI as an artifact, never committed
+> (unlike WS1's `history.jsonl`).
+
+## What it reads
+
+`~/.claude/projects/<slug>/<session>.jsonl` (+ its `subagents/agent-*.jsonl`).
+Two transcript layouts are auto-detected — the parser handles both because
+Claude Code has shipped both:
+
+- **inline** (current local schema) — sub-agents are `isSidechain` records in the
+  main transcript; skills tag their calls with `attributionSkill`. Nesting comes
+  from the `parentUuid` tree + those markers.
+- **files** (the proven prototype layout) — each sub-agent is its own
+  `subagents/agent-*.jsonl`, linked to its spawning Agent call by global
+  start-time order (robust for sync *and* async agents), carrying durations.
+
+Both reconstruct **2+-level recursion** (agent→agent→…) to the correct depth.
+
+## Files
+
+| file | role |
+|------|------|
+| `parse-transcripts.mjs` | parse one session → `trace.jsonl` of `{ts,kind,name,parent,depth,agentId?,durMs?}` (also importable: `parseSession()`) |
+| `collect-traces.mjs` | CI collector — discover the run's session across all project dirs, tag events with the run id, write one NDJSON file (meta header + tagged events) for artifact upload |
+| `lib/parse-transcripts.test.mjs` | fixtures for both layouts, 2-level recursion, payload-freeness, defensiveness |
+
+## Run by hand
+
+```bash
+node .claude/skills/loop-station/parse-transcripts.mjs --out trace.jsonl   # latest session
+node .claude/skills/loop-station/parse-transcripts.mjs <session> --json     # inspect
+node .claude/skills/loop-station/collect-traces.mjs --out loop-station-trace.jsonl
+```
+
+## In CI
+
+`claude.yml` carries the reusable two-step snippet (collect → upload artifact),
+`if: always()` and tolerant so it never fails the agent job. Copy those two steps
+into any LLM workflow to capture its trace. Each ephemeral runner ships its
+trace tagged by `run_id`; aggregating the artifacts gives the all-runs topology
+WS3 renders.

--- a/.claude/skills/loop-station/collect-traces.mjs
+++ b/.claude/skills/loop-station/collect-traces.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Cross-CI-run trace collector (Loop Station WS2, #929).
+ *
+ *   node .claude/skills/loop-station/collect-traces.mjs [--out <file>] [--all]
+ *
+ * Each CI runner is ephemeral: the agent runs, writes its session transcript
+ * under ~/.claude/projects/<slug>/, and the runner is then discarded. This script
+ * runs at job end, reconstructs the trace (via parse-transcripts.mjs), tags it
+ * with the run identity, and writes ONE file the CI step uploads as an artifact —
+ * so every run's topology lands in one place for the all-runs view (WS3).
+ *
+ * Output is NDJSON: a `meta` header line then one tagged event per line, so the
+ * all-runs dataset is just `cat` of every run's file. Each event gains a `run`
+ * field; nothing else changes (still names + ids + durations, NEVER payloads).
+ *
+ * The runner doesn't know the project slug, so we discover the most-recently
+ * active session across every project dir under ~/.claude/projects.
+ *
+ * Defensive: if no transcript is found (e.g. the action wrote elsewhere) it emits
+ * a meta-only file and exits 0 — never fails the agent job it rides along with.
+ *
+ * No deps. Pure ESM.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { parseSession } from './parse-transcripts.mjs'
+
+function flag(name, fallback = null) {
+  const i = process.argv.indexOf(name)
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const PROJECTS = process.env.CLAUDE_PROJECTS_DIR || path.join(process.env.HOME || '/root', '.claude/projects')
+const OUT = flag('--out', process.env.LOOP_STATION_TRACE_OUT || 'loop-station-trace.jsonl')
+const ALL = process.argv.includes('--all')
+
+/** Every project dir under ~/.claude/projects (each holds <session>.jsonl files). */
+function projectDirs() {
+  try {
+    return fs
+      .readdirSync(PROJECTS, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(PROJECTS, d.name))
+  } catch {
+    return []
+  }
+}
+
+/** All sessions across all projects, each tagged with its transcript mtime. */
+function allSessions() {
+  const out = []
+  for (const dir of projectDirs()) {
+    let files = []
+    try {
+      files = fs.readdirSync(dir)
+    } catch {
+      continue
+    }
+    for (const f of files) {
+      if (!f.endsWith('.jsonl')) continue
+      let mtime = 0
+      try {
+        mtime = fs.statSync(path.join(dir, f)).mtimeMs
+      } catch {}
+      out.push({ projDir: dir, session: f.replace(/\.jsonl$/, ''), mtime })
+    }
+  }
+  return out.sort((a, b) => b.mtime - a.mtime)
+}
+
+const run = {
+  run: process.env.GITHUB_RUN_ID || null,
+  attempt: process.env.GITHUB_RUN_ATTEMPT || null,
+  workflow: process.env.GITHUB_WORKFLOW || null,
+  job: process.env.GITHUB_JOB || null,
+  repo: process.env.GITHUB_REPOSITORY || null,
+  sha: process.env.GITHUB_SHA || null
+}
+
+const sessions = allSessions()
+const picked = ALL ? sessions : sessions.slice(0, 1)
+
+const lines = []
+let totalEvents = 0
+const parsed = []
+for (const { projDir, session } of picked) {
+  const result = parseSession({ projDir, session })
+  if (result.events.length === 0) continue
+  parsed.push({ session: result.session, layout: result.layout, events: result.events.length })
+  for (const e of result.events) {
+    lines.push(JSON.stringify({ ...e, run: run.run, session: result.session }))
+    totalEvents++
+  }
+}
+
+const meta = {
+  kind: 'meta',
+  generatedAt: process.env.LOOP_STATION_NOW || new Date().toISOString(),
+  ...run,
+  sessions: parsed,
+  eventCount: totalEvents
+}
+
+fs.writeFileSync(OUT, [JSON.stringify(meta), ...lines].join('\n') + '\n')
+process.stderr.write(
+  `collect-traces: ${totalEvents} events from ${parsed.length} session(s) → ${OUT}` +
+    (run.run ? ` (run ${run.run}, ${run.workflow})` : ' (no CI run id — local)') +
+    '\n'
+)

--- a/.claude/skills/loop-station/lib/parse-transcripts.test.mjs
+++ b/.claude/skills/loop-station/lib/parse-transcripts.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Tests for the WS2 transcript parser (#929). Run:
+ *   node --test .claude/skills/loop-station/lib/parse-transcripts.test.mjs
+ *
+ * Synthetic transcripts are written to a temp project dir so the linkage logic is
+ * covered deterministically — no dependency on a live ~/.claude session. Covers
+ * both layouts, 2-level recursion, payload-freeness, and defensiveness.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { parseSession, readJsonl } from '../parse-transcripts.mjs'
+
+const ALLOWED_KEYS = new Set(['ts', 'kind', 'name', 'parent', 'depth', 'agentId', 'durMs'])
+
+function tmpProj() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'loopstation-'))
+}
+const writeJsonl = (file, recs) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, recs.map((r) => JSON.stringify(r)).join('\n') + '\n')
+}
+const asst = (uuid, parentUuid, tu, extra = {}) => ({
+  type: 'assistant',
+  uuid,
+  parentUuid,
+  timestamp: extra.ts || '2026-01-01T00:00:00.000Z',
+  message: { content: [{ type: 'tool_use', id: `tu-${uuid}`, name: tu.name, input: tu.input || {} }] },
+  ...extra
+})
+
+test('inline layout: a skill nests its attributed tool calls one level down', () => {
+  const proj = tmpProj()
+  const s = 'sess-skill'
+  writeJsonl(path.join(proj, `${s}.jsonl`), [
+    asst('u1', null, { name: 'Bash', input: { command: 'ls' } }), // depth 0, main line
+    asst('u2', 'u1', { name: 'Skill', input: { skill: 'commit' } }), // skill invocation
+    asst('u3', 'u2', { name: 'Bash', input: { command: 'git add' } }, { attributionSkill: 'commit' }),
+    asst('u4', 'u3', { name: 'Bash', input: { command: 'git commit' } }, { attributionSkill: 'commit' })
+  ])
+  const { layout, events } = parseSession({ projDir: proj, session: s })
+  assert.equal(layout, 'inline')
+  const skillCalls = events.filter((e) => e.kind === 'tool' && e.parent === 'commit')
+  assert.equal(skillCalls.length, 2, 'both git calls attributed under the skill')
+  assert.ok(skillCalls.every((e) => e.depth === 1))
+  assert.equal(events.find((e) => e.kind === 'skill').name, 'commit')
+})
+
+test('inline layout: 2-level sub-agent recursion links to the correct depth', () => {
+  const proj = tmpProj()
+  const s = 'sess-recurse'
+  writeJsonl(path.join(proj, `${s}.jsonl`), [
+    // main line spawns Explore
+    asst('m1', null, { name: 'Task', input: { subagent_type: 'Explore' } }),
+    { type: 'user', uuid: 'm2', parentUuid: 'm1', message: { content: [{ type: 'tool_result', tool_use_id: 'tu-m1', content: 'ok' }] } },
+    // Explore's sidechain: a Bash, then it spawns a deeper agent
+    asst('a1', 'm1', { name: 'Bash', input: { command: 'grep' } }, { isSidechain: true }),
+    asst('a2', 'a1', { name: 'Agent', input: { subagent_type: 'deep' } }, { isSidechain: true }),
+    // the deep agent's sidechain: a Read
+    asst('a3', 'a2', { name: 'Read', input: { file_path: '/x' } }, { isSidechain: true })
+  ])
+  const { events } = parseSession({ projDir: proj, session: s })
+  const explore = events.find((e) => e.name === 'Explore')
+  const bash = events.find((e) => e.name === 'Bash')
+  const deep = events.find((e) => e.name === 'deep')
+  const read = events.find((e) => e.name === 'Read')
+  assert.equal(explore.depth, 0)
+  assert.equal(bash.depth, 1)
+  assert.equal(deep.depth, 1)
+  assert.equal(read.depth, 2, 'a sub-agent spawned by a sub-agent nests to depth 2')
+  assert.equal(read.parent, 'deep')
+})
+
+test('files layout: subagents/agent-*.jsonl recurse to depth 2 with durations', () => {
+  const proj = tmpProj()
+  const s = 'sess-files'
+  writeJsonl(path.join(proj, `${s}.jsonl`), [
+    asst('m1', null, { name: 'Agent', input: { subagent_type: 'Explore' } }, { ts: '2026-01-01T00:00:00.000Z' })
+  ])
+  // earlier-starting file = the Explore agent (linked first by start-time order)
+  writeJsonl(path.join(proj, s, 'subagents', 'agent-aaaaaa.jsonl'), [
+    asst('e1', null, { name: 'Bash', input: {} }, { ts: '2026-01-01T00:00:01.000Z' }),
+    asst('e2', 'e1', { name: 'Agent', input: { subagent_type: 'deep' } }, { ts: '2026-01-01T00:00:02.000Z' })
+  ])
+  // later-starting file = the deep agent
+  writeJsonl(path.join(proj, s, 'subagents', 'agent-bbbbbb.jsonl'), [
+    asst('d1', null, { name: 'Read', input: {} }, { ts: '2026-01-01T00:00:05.000Z' })
+  ])
+  const { layout, events } = parseSession({ projDir: proj, session: s })
+  assert.equal(layout, 'files')
+  const read = events.find((e) => e.name === 'Read')
+  assert.equal(read.depth, 2, 'deep agent under Explore under root → depth 2')
+  const explore = events.find((e) => e.name === 'Explore')
+  assert.equal(explore.agentId, 'aaaaaa')
+  assert.equal(explore.durMs, 1000, 'duration = last - first timestamp of the sub-file')
+})
+
+test('trace carries names + ids + durations ONLY — never tool payloads', () => {
+  const proj = tmpProj()
+  const s = 'sess-priv'
+  writeJsonl(path.join(proj, `${s}.jsonl`), [
+    asst('u1', null, { name: 'Bash', input: { command: 'cat /etc/passwd', secret: 'shh' } })
+  ])
+  const { events } = parseSession({ projDir: proj, session: s })
+  const serialized = JSON.stringify(events)
+  assert.ok(!serialized.includes('passwd'), 'no command input in the trace')
+  assert.ok(!serialized.includes('shh'), 'no input fields leak')
+  for (const e of events) {
+    for (const k of Object.keys(e)) assert.ok(ALLOWED_KEYS.has(k), `unexpected key "${k}" in event`)
+  }
+})
+
+test('defensive: malformed lines, missing fields, and no subagents dir do not crash', () => {
+  const proj = tmpProj()
+  const s = 'sess-bad'
+  const file = path.join(proj, `${s}.jsonl`)
+  fs.mkdirSync(proj, { recursive: true })
+  fs.writeFileSync(
+    file,
+    [
+      '{ this is not json',
+      '',
+      JSON.stringify({ type: 'assistant' }), // no message
+      JSON.stringify({ type: 'assistant', message: { content: 'plain string' } }), // wrong content shape
+      JSON.stringify(asst('u1', null, { name: 'Bash', input: {} })), // one good event
+      '{"truncated":'
+    ].join('\n')
+  )
+  const { events } = parseSession({ projDir: proj, session: s })
+  assert.equal(events.length, 1)
+  assert.equal(events[0].name, 'Bash')
+  // readJsonl on a missing file returns [] rather than throwing
+  assert.deepEqual(readJsonl(path.join(proj, 'nope.jsonl')), [])
+})
+
+test('empty/absent session → empty trace, no throw', () => {
+  const proj = tmpProj()
+  const r = parseSession({ projDir: proj, session: 'does-not-exist' })
+  assert.equal(r.events.length, 0)
+})

--- a/.claude/skills/loop-station/parse-transcripts.mjs
+++ b/.claude/skills/loop-station/parse-transcripts.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * Reconstruct an invocation trace from Claude Code session transcripts
+ * (Loop Station WS2, #929). Promotes + hardens the proven prototype.
+ *
+ *   node .claude/skills/loop-station/parse-transcripts.mjs [session] [--out trace.jsonl]
+ *   node .claude/skills/loop-station/parse-transcripts.mjs --proj <dir> --json
+ *
+ * Emits trace.jsonl of events { ts, kind, name, parent, depth, agentId?, durMs? }
+ * — the real call tree: which skills/agents/tools fired, how they nested, how
+ * long sub-agents ran.
+ *
+ * HARD PRIVACY RULE: names + correlation ids + durations ONLY. Never a tool's
+ * `input` or a `tool_result`'s content. The trace is runtime exhaust → gitignored,
+ * not committed (unlike WS1's history.jsonl).
+ *
+ * Two transcript layouts are supported (auto-detected), because Claude Code has
+ * shipped both and CI may differ from local:
+ *
+ *   A. INLINE (current local schema) — sub-agents live in the main transcript as
+ *      `isSidechain` records; skills attribute their tool calls with
+ *      `attributionSkill`. Nesting comes from the parentUuid tree + those markers.
+ *   B. FILES (the prototype's proven layout) — each sub-agent is its own
+ *      `<session>/subagents/agent-*.jsonl`, linked to its spawning Agent call by
+ *      global start-time order (robust for sync AND async agents). Recurses.
+ *
+ * Defensive throughout: tolerates malformed JSON lines, missing
+ * type/message/content/timestamp, an absent subagents/ dir, and empty files.
+ *
+ * No deps. Pure ESM. Also importable: `import { parseSession } from './parse-transcripts.mjs'`.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+// ── defensive readers ─────────────────────────────────────────────────────────
+
+/** Read a .jsonl file into records, skipping unparseable/empty lines. Never throws. */
+export function readJsonl(file) {
+  let text
+  try {
+    text = fs.readFileSync(file, 'utf8')
+  } catch {
+    return []
+  }
+  const out = []
+  for (const line of text.split('\n')) {
+    const t = line.trim()
+    if (!t) continue
+    try {
+      const rec = JSON.parse(t)
+      if (rec && typeof rec === 'object') out.push(rec)
+    } catch {
+      /* tolerate a truncated/garbled line (partial flush, schema drift) */
+    }
+  }
+  return out
+}
+
+/** tool_use blocks out of one record's message content (defensive on shape). */
+function toolUsesOf(rec) {
+  const content = rec?.message?.content
+  if (!Array.isArray(content)) return []
+  const out = []
+  for (const b of content) {
+    if (b && b.type === 'tool_use' && typeof b.name === 'string') {
+      out.push({ id: b.id, name: b.name, input: b.input || {} })
+    }
+  }
+  return out
+}
+
+// Classify a tool_use into the trace's three kinds, and derive its display name.
+// NB: `input` is read ONLY to pick the human name (skill / subagent_type); it is
+// never emitted into the trace.
+const SKILL_TOOLS = new Set(['Skill'])
+const AGENT_TOOLS = new Set(['Agent', 'Task'])
+function kindOf(name) {
+  if (SKILL_TOOLS.has(name)) return 'skill'
+  if (AGENT_TOOLS.has(name)) return 'agent'
+  return 'tool'
+}
+function nameOf(tu) {
+  if (SKILL_TOOLS.has(tu.name)) return String(tu.input.skill || tu.input.command || 'skill')
+  if (AGENT_TOOLS.has(tu.name)) {
+    return String(tu.input.subagent_type || tu.input.description || 'agent')
+  }
+  return tu.name
+}
+
+// ── layout A: inline (isSidechain + attributionSkill on the parentUuid tree) ──
+
+/**
+ * Build events from a single records array where sub-agents are inline
+ * `isSidechain` records and skills tag their calls with `attributionSkill`.
+ *
+ * Depth model (data-grounded):
+ *   - agent depth = number of spawning Agent/Task tool_use records on the
+ *     parentUuid path while still inside the sidechain subtree. Sidechain records
+ *     form a real subtree (they descend from their spawning Task), so counting up
+ *     the tree is correct and supports recursion (agent→agent→…).
+ *   - +1 if the record carries `attributionSkill` (it ran inside that skill).
+ *   parent = innermost open frame: the attributed skill if set, else the nearest
+ *   Agent/Task ancestor, else 'root'.
+ */
+function eventsInline(records) {
+  const byUuid = new Map()
+  for (const r of records) if (r.uuid) byUuid.set(r.uuid, r)
+
+  // Map uuid → its agent-kind tool_use name (so an ancestor record that issued an
+  // Agent/Task call can be identified while walking the tree).
+  const agentCallName = new Map()
+  for (const r of records) {
+    for (const tu of toolUsesOf(r)) {
+      if (kindOf(tu.name) === 'agent') agentCallName.set(r.uuid, nameOf(tu))
+    }
+  }
+
+  const parentOf = (r) => (r?.parentUuid ? byUuid.get(r.parentUuid) : null)
+
+  function frames(r) {
+    // Walk up the parentUuid chain, counting Agent/Task ancestors until we leave
+    // the sidechain subtree. Returns { agentDepth, nearestAgent }.
+    let agentDepth = 0
+    let nearestAgent = null
+    let cur = r
+    let guard = 0
+    while (cur && guard++ < 10000) {
+      const p = parentOf(cur)
+      if (!p) break
+      if (agentCallName.has(p.uuid)) {
+        agentDepth++
+        if (!nearestAgent) nearestAgent = agentCallName.get(p.uuid)
+      }
+      if (!cur.isSidechain) break // left the sidechain region — stop counting
+      cur = p
+    }
+    return { agentDepth, nearestAgent }
+  }
+
+  const events = []
+  for (const r of records) {
+    const tus = toolUsesOf(r)
+    if (tus.length === 0) continue
+    const { agentDepth, nearestAgent } = frames(r)
+    const skill = typeof r.attributionSkill === 'string' ? r.attributionSkill : null
+    const depth = agentDepth + (skill ? 1 : 0)
+    const parent = skill || nearestAgent || 'root'
+    for (const tu of tus) {
+      events.push({
+        ts: r.timestamp || null,
+        kind: kindOf(tu.name),
+        name: nameOf(tu),
+        parent,
+        depth
+      })
+    }
+  }
+  return events
+}
+
+// ── layout B: files (subagents/agent-*.jsonl, start-time-order linkage) ────────
+
+/**
+ * The prototype's proven approach, hardened. Sub-agent transcripts are linked to
+ * Agent/Task calls by global start-time order (works for sync AND async agents).
+ * Recurses into each sub-agent file, so agent→agent→… nests to real depth.
+ */
+function eventsFiles(mainFile, subDir) {
+  const subFiles = (() => {
+    let names = []
+    try {
+      names = fs.readdirSync(subDir)
+    } catch {
+      return []
+    }
+    return names
+      .filter((f) => /^agent-.*\.jsonl$/.test(f))
+      .map((f) => {
+        const recs = readJsonl(path.join(subDir, f))
+        const ts = recs.map((r) => r.timestamp).filter(Boolean).sort()
+        return {
+          aid: f.replace(/^agent-|\.jsonl$/g, ''),
+          file: path.join(subDir, f),
+          first: ts[0] || null,
+          last: ts[ts.length - 1] || null
+        }
+      })
+      .sort((a, b) => String(a.first || '').localeCompare(String(b.first || '')))
+  })()
+
+  let subPtr = 0
+  const events = []
+  function walk(file, parent, depth, guard) {
+    if (guard > 64) return // runaway-recursion backstop
+    for (const r of readJsonl(file)) {
+      for (const tu of toolUsesOf(r)) {
+        const ev = { ts: r.timestamp || null, kind: kindOf(tu.name), name: nameOf(tu), parent, depth }
+        events.push(ev)
+        if (kindOf(tu.name) === 'agent' && subPtr < subFiles.length) {
+          const s = subFiles[subPtr++]
+          ev.agentId = s.aid
+          if (s.first && s.last) {
+            const d = new Date(s.last) - new Date(s.first)
+            if (Number.isFinite(d) && d >= 0) ev.durMs = d
+          }
+          walk(s.file, `${ev.name}:${s.aid.slice(0, 6)}`, depth + 1, guard + 1)
+        }
+      }
+    }
+  }
+  walk(mainFile, 'root', 0, 0)
+  return { events, hadSubFiles: subFiles.length > 0 }
+}
+
+// ── graph derivation (nodes ∝ invocations, edges = parent → child) ────────────
+
+export function deriveGraph(events) {
+  const nodes = {}
+  const edges = {}
+  for (const e of events) {
+    nodes[e.name] = (nodes[e.name] || 0) + 1
+    const from = e.parent ? String(e.parent).split(':')[0] : 'root'
+    const key = `${from} → ${e.name}`
+    edges[key] = (edges[key] || 0) + 1
+  }
+  return { nodes, edges }
+}
+
+// ── top-level: parse one session (auto-detect layout) ─────────────────────────
+
+export function defaultProj() {
+  return (
+    process.env.CLAUDE_PROJ ||
+    path.join(
+      process.env.HOME || '/root',
+      '.claude/projects',
+      (process.env.CLAUDE_PROJECT_SLUG || '-home-user-nuxt-crouton')
+    )
+  )
+}
+
+export function latestSession(projDir) {
+  let files = []
+  try {
+    files = fs.readdirSync(projDir)
+  } catch {
+    return null
+  }
+  const sessions = files
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => {
+      let t = 0
+      try {
+        t = fs.statSync(path.join(projDir, f)).mtimeMs
+      } catch {}
+      return { f, t }
+    })
+    .sort((a, b) => b.t - a.t)
+  return sessions[0]?.f.replace(/\.jsonl$/, '') || null
+}
+
+/**
+ * @param {{projDir?:string, session?:string}} opts
+ * @returns {{session:string, layout:'inline'|'files'|'empty', events:Array, nodes:object, edges:object}}
+ */
+export function parseSession(opts = {}) {
+  const projDir = opts.projDir || defaultProj()
+  const session = opts.session || latestSession(projDir)
+  if (!session) return { session: null, layout: 'empty', events: [], nodes: {}, edges: {} }
+
+  const mainFile = path.join(projDir, `${session}.jsonl`)
+  const subDir = path.join(projDir, session, 'subagents')
+
+  // Prefer the files layout when sub-agent files actually exist (the richer,
+  // duration-carrying signal); otherwise reconstruct from the inline records.
+  const filesResult = eventsFiles(mainFile, subDir)
+  if (filesResult.hadSubFiles) {
+    return { session, layout: 'files', events: filesResult.events, ...deriveGraph(filesResult.events) }
+  }
+  const records = readJsonl(mainFile)
+  const events = eventsInline(records)
+  return { session, layout: 'inline', events, ...deriveGraph(events) }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function main(argv) {
+  const args = argv.slice(2)
+  const flag = (name) => {
+    const i = args.indexOf(name)
+    return i !== -1 ? args[i + 1] : null
+  }
+  const out = flag('--out')
+  const projDir = flag('--proj') || defaultProj()
+  const asJson = args.includes('--json')
+  const positional = args.filter((a, i) => !a.startsWith('--') && args[i - 1]?.startsWith('--') !== true)
+  // first positional that isn't a flag value = session id
+  const session = positional.find((a) => !a.startsWith('--')) || null
+
+  const result = parseSession({ projDir, session: session || undefined })
+
+  if (out) {
+    fs.writeFileSync(out, result.events.map((e) => JSON.stringify(e)).join('\n') + (result.events.length ? '\n' : ''))
+  }
+  if (asJson) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+    return
+  }
+
+  const byKind = result.events.reduce((a, e) => ((a[e.kind] = (a[e.kind] || 0) + 1), a), {})
+  process.stderr.write(`session ${result.session} · layout ${result.layout}\n`)
+  process.stderr.write(`events: ${result.events.length}  ${JSON.stringify(byKind)}\n`)
+  const nested = result.events.filter((e) => e.depth > 0)
+  if (nested.length) {
+    process.stderr.write(`\nnested (depth > 0):\n`)
+    for (const e of nested.slice(0, 40)) {
+      process.stderr.write(`  ${'  '.repeat(e.depth)}↳ [${e.kind}] ${e.name}  (under ${e.parent})\n`)
+    }
+  }
+  process.stderr.write(`\ngraph nodes (∝ invocations):\n`)
+  for (const [n, c] of Object.entries(result.nodes).sort((a, b) => b[1] - a[1]).slice(0, 20)) {
+    process.stderr.write(`  ${String(c).padStart(3)} ${n}\n`)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main(process.argv)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,3 +37,19 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 25"
           show_full_output: true
+
+      # Loop Station WS2 (#929): reconstruct this ephemeral runner's invocation
+      # trace and ship it as an artifact for the all-runs topology. Read-only,
+      # payload-free (names + ids + durations only), tolerant — never fails the
+      # agent job. Reusable snippet: copy these two steps into any LLM workflow.
+      - name: Collect invocation trace
+        if: always()
+        run: node .claude/skills/loop-station/collect-traces.mjs --out loop-station-trace.jsonl || true
+
+      - name: Upload invocation trace
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: loop-station-trace-${{ github.run_id }}-${{ github.run_attempt }}
+          path: loop-station-trace.jsonl
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,10 @@ writeups/reports/red-team-*.md
 !writeups/reports/red-team-TEMPLATE.md
 
 pocs/crouton-builder-demo/.data
+# Loop Station invocation traces (WS2, #929) — runtime exhaust, NOT committed.
+# Reconstructed from session transcripts (names + ids + durations only, no tool
+# payloads); shipped from CI as artifacts and aggregated for the WS3 view. The
+# committed Loop Station dataset is only writeups/loop-station/history.jsonl (WS1).
+trace.jsonl
+loop-station-trace*.jsonl
+writeups/loop-station/traces/

--- a/writeups/architecture/skills-and-triggers.html
+++ b/writeups/architecture/skills-and-triggers.html
@@ -255,7 +255,7 @@
     <div class="grid">
       <div class="skill">
         <div class="skill-head"><span class="name">/loop-station</span><span class="badges"><span class="b ask">on ask</span><span class="b auto">auto</span></span></div>
-        <p class="what">Measure the harness's own context budget — tokens per CLAUDE.md / skill / agent, lexical redundancy, per-CI cold-write totals — as a deterministic, trendable inventory (no LLM). Appends one point to a committed history.jsonl per relevant merge. Use when asked for "context budget", "how big is CLAUDE.md / our skills", "is the harness bloating", "loop station inventory", or to run the inventory by hand.</p>
+        <p class="what">Observe the harness itself — (WS1) measure context budget as a deterministic, trendable inventory (tokens per CLAUDE.md / skill / agent, lexical redundancy, per-CI cold-write totals; committed history.jsonl), and (WS2) reconstruct the real invocation trace (which skills/agents/tools fired and how they nested) from session transcripts. Use for "context budget", "how big is CLAUDE.md / our skills", "is the harness bloating", "how do our agent loops actually run", "trace this session", "loop station".</p>
       </div>
       <div class="skill">
         <div class="skill-head"><span class="name">/think-aloud</span><span class="badges"><span class="b ask">on ask</span></span></div>


### PR DESCRIPTION
Closes #929. Second layer of the Loop Station observatory (epic #926).

> **Stacked on WS1 (#927, PR #928).** Base is the WS1 branch so this diff shows **only WS2**. Retarget to `main` once #928 merges.

## What this is

Reconstructs the **real call tree** of a session — which skills/agents/tools fired, how they nested, how long sub-agents ran — from Claude Code's own transcripts. Promotes + hardens the proven prototype into the loop-station skill.

> **Hard privacy rule:** names + correlation ids + durations **only** — never a tool's `input` or a `tool_result`'s content. The trace is runtime exhaust → **gitignored**, shipped from CI as an artifact, never committed (unlike WS1's `history.jsonl`).

```mermaid
flowchart LR
  T["session transcripts<br/>(main + isSidechain / subagents/*.jsonl)"] -->|parse-transcripts.mjs| TR[trace.jsonl]
  TR -->|collect-traces.mjs + run id| A[artifact per CI run]
  A --> V["WS3 all-runs topology"]
```

## 👤 For humans

Nothing showed how our agent loops *actually* run — which skills fire, what calls what, where recursion happens, which big skills never get used. This reads it straight from the session transcripts and records only the shape (names + timings), never the contents. Verified on this very session: the `/commit` skill's 8 sub-calls correctly nest one level under it.

## 🤖 For agents

| file | role |
|------|------|
| `parse-transcripts.mjs` | parse one session → `trace.jsonl` of `{ts,kind,name,parent,depth,agentId?,durMs?}`; importable `parseSession()` |
| `collect-traces.mjs` | CI collector — discover the run's session across all project dirs, tag events with `run_id`, write one NDJSON file (meta header + tagged events) |
| `lib/parse-transcripts.test.mjs` | both layouts, 2-level recursion, payload-freeness, defensiveness |
| `.github/workflows/claude.yml` | reusable 2-step snippet (collect → upload artifact), `if: always()`, tolerant |
| `.gitignore` | trace outputs ignored; `history.jsonl` stays tracked |

**Schema hardening:** the prototype assumed the separate-file layout (`subagents/agent-*.jsonl`). The current local Claude Code stores sub-agents **inline** as `isSidechain` records and tags skill calls with `attributionSkill`, linked on the `parentUuid` tree. The parser **auto-detects and supports both** — files layout (start-time-order linkage, carries durations) and inline layout (parentUuid tree + markers) — and reconstructs 2+-level recursion in each.

## 🧪 Verify

- `node .claude/skills/loop-station/parse-transcripts.mjs` → reconstructs the latest session (inline layout); `/commit`'s sub-calls nest at depth 1.
- `node --test .claude/skills/loop-station/lib/parse-transcripts.test.mjs` → 6 pass.
- `node .claude/skills/loop-station/collect-traces.mjs --out loop-station-trace.jsonl` → meta header + run-tagged events.
- `git check-ignore trace.jsonl` → ignored; `git check-ignore writeups/loop-station/history.jsonl` → not ignored.

### Acceptance criteria (#929)

- [x] Reconstructs a real session into a trace matching the conversation (tree + nesting + durations)
- [x] Defensive: malformed lines / missing fields / no `subagents/` dir → no crash
- [x] 2+-level sub-agent recursion links to the correct depth (fixture tests, both layouts)
- [x] Trace contains names + ids + durations only, never tool/skill payloads (asserted in a test)
- [x] Cross-CI-run collector ships each ephemeral runner's trace to one place, tagged by run id
- [x] Traces gitignored; no TS surface (pure `.mjs`/`.md`/`.yml`) — validated with `node --check`, `node --test`, and YAML parse

## Notes
- Wired the collector into `claude.yml` as the representative LLM workflow; the same two steps drop into the other 10 LLM workflows when we want their traces too.
- `parseSession()` is exported so WS3 can import it directly rather than shelling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTQtCbsZHtdAHhFJ1SxwuC)_