### PR TITLE
feat(root): Loop Station WS4 — budget readout in the housekeeping digest

### DIFF
--- a/.claude/skills/housekeeping/gather.mjs
+++ b/.claude/skills/housekeeping/gather.mjs
@@ -137,6 +137,39 @@ function labelCoverage() {
   return missing.sort((a, b) => a.expected.localeCompare(b.expected))
 }
 
+// ── Loop Station budget readout (#934, WS4) ───────────────────────────────────
+// Read-only: the producer (WS1) writes writeups/loop-station/history.jsonl; this
+// reporter just surfaces the latest point + delta as one digest line. No LLM, no
+// recompute. Null (line omitted) when the inventory hasn't run yet.
+function loopStationBudget() {
+  const file = 'writeups/loop-station/history.jsonl'
+  if (!existsSync(file)) return null
+  const lines = readFileSync(file, 'utf8').trim().split('\n').filter(Boolean)
+  if (lines.length === 0) return null
+  const recs = lines
+    .slice(-2)
+    .map((l) => {
+      try {
+        return JSON.parse(l)
+      } catch {
+        return null
+      }
+    })
+    .filter(Boolean)
+  const latest = recs[recs.length - 1]
+  const prev = recs.length > 1 ? recs[recs.length - 2] : null
+  if (!latest) return null
+  const tok = (r) => r?.totals?.alwaysOnTokens ?? null
+  return {
+    alwaysOnTokens: tok(latest),
+    redundancyPct: latest.redundancy?.pct ?? null,
+    scorecard: latest.scorecard?.overall ?? null,
+    tokenizer: latest.tokenizer ?? null,
+    commit: latest.commit ?? null,
+    deltaTokens: prev && tok(latest) != null && tok(prev) != null ? tok(latest) - tok(prev) : null
+  }
+}
+
 // ── Issue / PR drift (API) ───────────────────────────────────────────────────
 const COMPONENT_RE = /^(pkg|app|worker|poc):/
 
@@ -203,6 +236,7 @@ const data = {
   staleDays,
   staleBranches: staleBranches(),
   labelCoverage: labelCoverage(),
+  loopStation: loopStationBudget(),
   ...drift
 }
 

--- a/.claude/skills/housekeeping/render.mjs
+++ b/.claude/skills/housekeeping/render.mjs
@@ -104,8 +104,27 @@ if (data.idlePRs?.length) {
   ])
 }
 
+// Loop Station budget readout (#934, WS4) — one read-only line, always shown when
+// the inventory has produced data. Sourced from the latest committed history.jsonl
+// record (gathered, not recomputed). Omitted when WS1 hasn't run yet.
+function loopStationLine(ls) {
+  if (!ls || ls.alwaysOnTokens == null) return null
+  const k = (n) => (n / 1000).toFixed(1) + 'k'
+  const dot = ls.scorecard === 'green' ? '🟢' : ls.scorecard === 'amber' ? '🟡' : ls.scorecard === 'red' ? '🔴' : '⚪'
+  const delta =
+    ls.deltaTokens == null
+      ? 'baseline'
+      : ls.deltaTokens === 0
+        ? 'Δ +0'
+        : `Δ ${ls.deltaTokens > 0 ? '+' : '−'}${k(Math.abs(ls.deltaTokens))}`
+  const red = ls.redundancyPct == null ? '' : ` · redundancy ${ls.redundancyPct}%`
+  const tk = ls.tokenizer ? ` _(${ls.tokenizer})_` : ''
+  return `📟 **Context budget:** ${k(ls.alwaysOnTokens)} always-on tok${red} · scorecard ${dot} · ${delta}${tk}`
+}
+
 const when = new Date(data.generatedAt).toISOString().slice(0, 10)
-const head = [`## 🧹 Housekeeping — ${when}`, '']
+const lsLine = loopStationLine(data.loopStation)
+const head = [`## 🧹 Housekeeping — ${when}`, '', ...(lsLine ? [lsLine, ''] : [])]
 const body = sections.length
   ? sections.flatMap(([h, lines]) => [`### ${h}`, ...lines, ''])
   : ['✨ Nothing needs your eyes — branches, labels, and issue state look clean.', '']


### PR DESCRIPTION
Closes #934. The small reporter layer of the Loop Station observatory (epic #926).

> Stacked on WS3 (#932) → WS2 (#930) → WS1 (#928). Base is WS3 so the diff is just WS4; retarget down the stack as they merge.

## What

The daily housekeeping digest opens with one **read-only** context-budget line:

```
📟 Context budget: 18.2k always-on tok · redundancy 2.9% · scorecard 🔴 · baseline (heuristic)
```

(With ≥2 data points the `baseline` becomes `Δ +1.2k` / `Δ −0.4k` / `Δ +0`.)

## 🤖 For agents

- `housekeeping/gather.mjs` — `loopStationBudget()` reads the latest (+prev) record from the committed `writeups/loop-station/history.jsonl` (WS1's output) → `data.loopStation`. cwd-relative read, mirroring `labelCoverage`. Null when the inventory hasn't run.
- `housekeeping/render.mjs` — `loopStationLine()` prints the head line; `baseline` for a single point; omitted entirely when absent.
- **Producer writes, reporter reads** — no LLM, no recompute. Reuses the existing daily housekeeping run (`.github/digests.yml`); no new workflow.

## 🧪 Verify
Fed `render.mjs` a digest data file with the real `loopStation` block → head line renders as above; with `loopStation: null` the line is omitted and the digest is unchanged.

### Acceptance criteria (#934)
- [x] One-line budget readout from the latest `history.jsonl` record
- [x] Δ vs previous record (or `baseline` with one point)
- [x] Degrades cleanly (line omitted) when `history.jsonl` is absent/empty
- [x] No LLM, no recompute — reporter only reads WS1 output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTQtCbsZHtdAHhFJ1SxwuC)_