### PR TITLE
feat(root): Loop Station WS5 — advisor (state → actionable ticket)

### DIFF
--- a/.claude/skills/loop-station/SKILL.md
+++ b/.claude/skills/loop-station/SKILL.md
@@ -117,3 +117,36 @@ node .claude/skills/loop-station/collect-traces.mjs --out loop-station-trace.jso
 into any LLM workflow to capture its trace. Each ephemeral runner ships its
 trace tagged by `run_id`; aggregating the artifacts gives the all-runs topology
 WS3 renders.
+
+---
+
+# WS5 — advisor (state → actionable ticket)
+
+Turns the observatory from numbers-to-look-at into decisions. An agent reviews the
+inventory state and, **only when something's actionable**, files a single GitHub
+issue assigned to the maintainer with concrete recommendations.
+
+> Two layers, kept separate: deterministic **numbers → the WS4 digest** (no LLM);
+> qualitative **remarks → a ticket** (this). The LLM never touches the trend and
+> only *recommends* — epic #926's observatory-not-builder boundary holds.
+
+## Files
+
+| file | role |
+|------|------|
+| `advisor.mjs` | **deterministic gate** — reads `history.jsonl`, surfaces candidate findings (scorecard reds, sharp always-on growth, redundancy jumps), decides `actionable`. No LLM, no issue. Importable `analyze()`. |
+| `lib/advisor.test.mjs` | findings logic (reds flag, growth flags, cross-tokenizer deltas are NOT compared, deterministic) |
+| `.github/workflows/loop-station-advisor.yml` | weekly: run the gate → **only if actionable** invoke `claude-code-action` to open/update ONE `loop-station-advisor` issue assigned to `pmcp` |
+
+## Why the gate is deterministic
+
+The cheap deterministic pass decides *whether to bother the human* (and whether to
+spend an LLM call) — so the model runs only on a real signal, never on a quiet
+week, and the trend numbers stay LLM-free. Deltas are compared **only within the
+same tokenizer** (a heuristic→anthropic switch isn't real growth).
+
+## Run by hand
+
+```bash
+node .claude/skills/loop-station/advisor.mjs --pretty   # see findings + actionable verdict
+```

--- a/.claude/skills/loop-station/advisor.mjs
+++ b/.claude/skills/loop-station/advisor.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Loop Station advisor — the "should we bother the human?" gate (WS5, #933).
+ *
+ *   node .claude/skills/loop-station/advisor.mjs            # → findings JSON on stdout
+ *   node .claude/skills/loop-station/advisor.mjs --pretty   # + human summary on stderr
+ *
+ * DETERMINISTIC by design. It reads the committed inventory history (WS1) and
+ * surfaces *candidate* findings — scorecard reds, threshold crossings, sudden
+ * growth — and decides whether anything is worth a human's attention. It writes
+ * NO issue and runs NO LLM: it's the cheap gate in front of the (separate) LLM
+ * advisor step, so the model only ever runs when there's genuinely something to
+ * say (and never touches the deterministic trend — epic #926's boundary).
+ *
+ * Output: { actionable, generatedAt, tokenizer, latest, findings[] }. The CI
+ * workflow sets `actionable` as a step output; only then does it invoke the LLM
+ * to open/update ONE issue assigned to the maintainer with recommendations.
+ *
+ * Findings are based on the INVENTORY only (no trace) — dead-weight-by-usage
+ * (size × invocations) joins later once collected traces are aggregated (WS2).
+ *
+ * No deps. Pure ESM. Also importable: `import { analyze } from './advisor.mjs'`.
+ */
+
+import { readFileSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const HISTORY = join(ROOT, 'writeups/loop-station/history.jsonl')
+
+// Tunable thresholds for what's worth flagging. Absolute reds reuse the scorecard;
+// growth/redundancy-jump are advisor-specific deltas between consecutive points.
+export const ADVISOR = {
+  growthTokens: 2000, // always-on jumped this many tokens since last point
+  growthPct: 12, // …or this %
+  redundancyJumpPct: 5 // corpus redundancy rose this many points
+}
+
+function tok(r) {
+  return r?.totals?.alwaysOnTokens ?? null
+}
+
+/**
+ * @param {object[]} records  parsed history.jsonl records, oldest→newest
+ * @returns {{actionable:boolean, tokenizer:string|null, latest:object|null, findings:object[]}}
+ */
+export function analyze(records) {
+  const recs = (records || []).filter(Boolean)
+  const latest = recs[recs.length - 1] || null
+  const prev = recs.length > 1 ? recs[recs.length - 2] : null
+  const findings = []
+  if (!latest) return { actionable: false, tokenizer: null, latest: null, findings }
+
+  const card = latest.scorecard || {}
+  const push = (dim, severity, message, evidence) => findings.push({ dim, severity, message, evidence })
+
+  // Absolute scorecard reds (the deterministic bands from WS1).
+  if (card.length?.score === 'red') {
+    push('length', 'high', 'Always-on context (CLAUDE.md) is in the red band.', {
+      alwaysOnTokens: card.length.alwaysOnTokens ?? tok(latest),
+      oversized: (card.length.oversized || []).slice(0, 5)
+    })
+  }
+  if (card.redundancy?.score === 'red') {
+    push('redundancy', 'medium', 'Corpus redundancy is in the red band.', {
+      pct: card.redundancy.pct,
+      topPairs: (latest.redundancy?.topPairs || []).slice(0, 3)
+    })
+  }
+  if (card.driftRisk?.score === 'red') {
+    push('drift-risk', 'medium', 'Several artifact pairs must be kept in sync (drift risk).', {
+      pairs: card.driftRisk.pairs,
+      examples: (card.driftRisk.examples || []).slice(0, 3)
+    })
+  }
+
+  // Deltas vs the previous point (only meaningful with ≥2 points AND the same
+  // tokenizer — comparing a heuristic point to an API point is apples/oranges).
+  if (prev && prev.tokenizer === latest.tokenizer) {
+    const dTok = (tok(latest) ?? 0) - (tok(prev) ?? 0)
+    const pct = tok(prev) ? (dTok / tok(prev)) * 100 : 0
+    if (dTok >= ADVISOR.growthTokens || pct >= ADVISOR.growthPct) {
+      push('growth', 'high', 'Always-on context grew sharply since the last merge.', {
+        from: tok(prev),
+        to: tok(latest),
+        deltaTokens: dTok,
+        deltaPct: Math.round(pct * 10) / 10,
+        causedBy: latest.pr ? `#${latest.pr}` : latest.commit?.slice(0, 8)
+      })
+    }
+    const dRed = (latest.redundancy?.pct ?? 0) - (prev.redundancy?.pct ?? 0)
+    if (dRed >= ADVISOR.redundancyJumpPct) {
+      push('redundancy-growth', 'medium', 'Redundancy rose noticeably since the last merge.', {
+        from: prev.redundancy?.pct,
+        to: latest.redundancy?.pct,
+        delta: Math.round(dRed * 10) / 10
+      })
+    }
+  }
+
+  return { actionable: findings.length > 0, tokenizer: latest.tokenizer ?? null, latest, findings }
+}
+
+export function readHistory(file = HISTORY) {
+  if (!existsSync(file)) return []
+  return readFileSync(file, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => {
+      try {
+        return JSON.parse(l)
+      } catch {
+        return null
+      }
+    })
+    .filter(Boolean)
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const records = readHistory()
+  const result = analyze(records)
+  const out = {
+    actionable: result.actionable,
+    generatedAt: process.env.LOOP_STATION_NOW || new Date().toISOString(),
+    tokenizer: result.tokenizer,
+    latest: result.latest
+      ? { commit: result.latest.commit, pr: result.latest.pr, alwaysOnTokens: tok(result.latest), scorecard: result.latest.scorecard?.overall }
+      : null,
+    findings: result.findings
+  }
+  process.stdout.write(JSON.stringify(out, null, 2) + '\n')
+
+  // Step output for the workflow gate (only invoke the LLM when actionable).
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFileSync } = await import('node:fs')
+    appendFileSync(process.env.GITHUB_OUTPUT, `actionable=${result.actionable}\n`)
+  }
+
+  if (process.argv.includes('--pretty')) {
+    process.stderr.write(
+      `\n── Loop Station advisor ────────────────────────────────\n` +
+        `points        ${records.length}\n` +
+        `tokenizer     ${result.tokenizer}\n` +
+        `actionable    ${result.actionable ? 'YES' : 'no — nothing to report'}\n` +
+        result.findings.map((f) => `  • [${f.severity}] ${f.dim}: ${f.message}`).join('\n') +
+        (result.findings.length ? '\n' : '') +
+        `────────────────────────────────────────────────────────\n`
+    )
+  }
+}

--- a/.claude/skills/loop-station/lib/advisor.test.mjs
+++ b/.claude/skills/loop-station/lib/advisor.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * Tests for the WS5 advisor gate (#933).
+ *   node --test .claude/skills/loop-station/lib/advisor.test.mjs
+ *
+ * The advisor is the deterministic "should we bother the human?" gate, so its
+ * decisions must be predictable: reds + sharp growth flag; a quiet/baseline state
+ * stays silent; deltas across different tokenizers are NOT compared.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { analyze, ADVISOR } from '../advisor.mjs'
+
+const rec = (over = {}) => ({
+  commit: over.commit || 'abc1234',
+  pr: over.pr ?? null,
+  tokenizer: over.tokenizer || 'anthropic',
+  totals: { alwaysOnTokens: over.tokens ?? 10000 },
+  redundancy: { pct: over.red ?? 5, topPairs: [] },
+  scorecard: {
+    overall: over.overall || 'green',
+    length: { score: over.lengthBand || 'green', alwaysOnTokens: over.tokens ?? 10000, oversized: [] },
+    redundancy: { score: over.redBand || 'green', pct: over.red ?? 5 },
+    driftRisk: { score: over.driftBand || 'green', pairs: over.drift ?? 0, examples: [] }
+  }
+})
+
+test('no records → not actionable', () => {
+  const r = analyze([])
+  assert.equal(r.actionable, false)
+  assert.equal(r.findings.length, 0)
+})
+
+test('all-green single point → silent (nothing to report)', () => {
+  const r = analyze([rec()])
+  assert.equal(r.actionable, false)
+})
+
+test('scorecard red bands surface as findings', () => {
+  const r = analyze([rec({ lengthBand: 'red', redBand: 'red', driftBand: 'red', overall: 'red' })])
+  assert.equal(r.actionable, true)
+  const dims = r.findings.map((f) => f.dim).sort()
+  assert.deepEqual(dims, ['drift-risk', 'length', 'redundancy'])
+})
+
+test('sharp always-on growth (same tokenizer) flags a growth finding', () => {
+  const prev = rec({ tokens: 10000 })
+  const next = rec({ tokens: 10000 + ADVISOR.growthTokens + 1 })
+  const r = analyze([prev, next])
+  const growth = r.findings.find((f) => f.dim === 'growth')
+  assert.ok(growth, 'growth finding present')
+  assert.equal(growth.evidence.to, 10000 + ADVISOR.growthTokens + 1)
+})
+
+test('growth across DIFFERENT tokenizers is NOT compared (no false alarm)', () => {
+  const prev = rec({ tokens: 10000, tokenizer: 'heuristic' })
+  const next = rec({ tokens: 18000, tokenizer: 'anthropic' }) // big jump but ruler changed
+  const r = analyze([prev, next])
+  assert.ok(!r.findings.some((f) => f.dim === 'growth'), 'no growth finding across tokenizers')
+})
+
+test('redundancy jump (same tokenizer) flags', () => {
+  const prev = rec({ red: 5 })
+  const next = rec({ red: 5 + ADVISOR.redundancyJumpPct + 1 })
+  const r = analyze([prev, next])
+  assert.ok(r.findings.some((f) => f.dim === 'redundancy-growth'))
+})
+
+test('analyze is deterministic', () => {
+  const input = [rec({ tokens: 10000 }), rec({ lengthBand: 'red', tokens: 20000 })]
+  assert.deepEqual(analyze(input), analyze(input))
+})

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -195,6 +195,9 @@
 - name: "workflow"
   color: "006b75"
   description: "Loop/skill/flow improvement (often minted by a postmortem)"
+- name: "loop-station-advisor"
+  color: "1d76db"
+  description: "Loop Station advisor recommendation (agent-filed, assigned to maintainer) — #933"
 
 # ── Security (red-team agent findings — epic #540) ──
 - name: "security"

--- a/.github/workflows/loop-station-advisor.yml
+++ b/.github/workflows/loop-station-advisor.yml
@@ -1,0 +1,80 @@
+name: loop-station-advisor
+
+# Loop Station advisor (WS5, #933). Weekly: a DETERMINISTIC gate (advisor.mjs)
+# reads the committed inventory history (WS1) and decides whether anything is worth
+# a human's attention — scorecard reds, sharp always-on growth, redundancy jumps.
+# ONLY when it's actionable do we invoke the LLM to open/update ONE issue assigned
+# to the maintainer with recommendations. So the model never runs on a quiet week,
+# never touches the deterministic trend, and only ever *recommends* (epic #926's
+# observatory-not-builder boundary). The deterministic numbers stay in the WS4
+# housekeeping digest; this is the separate, opt-in, actionable layer.
+
+on:
+  schedule:
+    - cron: '23 7 * * 1'   # Mondays 07:23 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: loop-station-advisor
+  cancel-in-progress: false
+
+jobs:
+  advisor:
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    # id-token MUST be at the job level for claude-code-action's OIDC (see claude.yml).
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Deterministic gate — no LLM. Writes findings + sets `actionable`.
+      - name: Analyze inventory (deterministic gate)
+        id: advisor
+        run: node .claude/skills/loop-station/advisor.mjs --pretty > advisor-findings.json
+
+      - name: No action needed
+        if: steps.advisor.outputs.actionable != 'true'
+        run: echo "Loop Station advisor — nothing actionable this week; no issue filed."
+
+      # Only here does the LLM run — to turn deterministic findings into a human-readable
+      # recommendation issue. Pinned to the same SHA as the repo's other claude-code-action
+      # workflows — bump together.
+      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        if: steps.advisor.outputs.actionable == 'true'
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
+          claude_args: "--max-turns 12"
+          prompt: |
+            You are the **Loop Station advisor** (#933). Read `advisor-findings.json` in
+            the repo root — it lists DETERMINISTIC findings about the harness's own
+            context budget (always-on tokens, redundancy, scorecard bands, growth since
+            the last merge). For deeper context you may also read
+            `writeups/loop-station/history.jsonl`.
+
+            Your job: turn these findings into ONE concise, actionable GitHub issue for
+            the maintainer — "an appointment". Steps:
+            1. Search open issues labeled `loop-station-advisor`. If one exists, UPDATE it
+               (edit the body and/or add a comment) — do NOT open a duplicate. Otherwise
+               create a new issue: label `loop-station-advisor`, assignee `pmcp`,
+               title like "🔭 Loop Station advisor — <one-line headline>".
+            2. Body: for each finding, write *what changed*, *why it matters*, and **1–3
+               concrete recommended actions** (e.g. "retire skill X (4.5k tok, restates
+               root)", "split the deploy section out of CLAUDE.md"). Cite the evidence
+               numbers you keyed off. Note the `tokenizer` — if it's `heuristic`, say the
+               numbers are an offline estimate (the API baseline lands on the next merge).
+            3. Keep it terse and skimmable. RECOMMEND only — do NOT edit `CLAUDE.md`,
+               skills, agents, or any product code, and do NOT open a PR.
+
+            If you POST A COMMENT (when updating), lead it with the CI provenance header:
+            `> 🤖 **Claude Code** · agent pipeline (CI) · _Loop Station advisor_`
+            (Issue bodies are already clearly agent-authored — no header needed there.)


### PR DESCRIPTION
Closes #933. The advisor layer of the Loop Station observatory (epic #926).

> Stacked on WS4 (#935) → WS3 (#932) → WS2 (#930) → WS1 (#928). Base is WS4; retarget down the stack as they merge.

## What

Weekly, a **deterministic gate** reviews the inventory state and — *only when something's actionable* — invokes an LLM to file **one** issue assigned to the maintainer with concrete recommendations. Two layers, kept separate (as discussed):

- **Numbers → the WS4 digest** (deterministic, no LLM) — always there.
- **Remarks → a ticket "appointment"** (this) — silent on a quiet week; an issue with recommended *actions* when not.

This honors epic #926's "no LLM in the deterministic cron path": the cheap gate decides *whether to bother the human* (and whether to spend an LLM call); the model only ever writes recommendations and **never touches the trend numbers**.

```mermaid
flowchart LR
  H[history.jsonl] --> G[advisor.mjs · deterministic gate]
  G -->|actionable=false| Q[no issue — quiet week]
  G -->|actionable=true| L[claude-code-action] --> I["one loop-station-advisor issue<br/>assigned to maintainer · recommends, doesn't edit"]
```

## 🤖 For agents

- `advisor.mjs` — deterministic: surfaces findings (scorecard reds, sharp always-on growth, redundancy jumps), decides `actionable`. **Deltas compared only within the same tokenizer** (a heuristic→anthropic switch isn't real growth). Importable `analyze()`; files nothing itself.
- `lib/advisor.test.mjs` — 7 tests (reds flag, growth flags, cross-tokenizer NOT compared, deterministic).
- `.github/workflows/loop-station-advisor.yml` — weekly gate → only-if-actionable `claude-code-action` opens/updates one `loop-station-advisor` issue assigned to `pmcp` (dedup, recommend-don't-edit, CI provenance header on comments).
- `loop-station-advisor` label added; SKILL.md WS5 section.

## 🧪 Verify
`node --test .claude/skills/loop-station/lib/advisor.test.mjs` → 7 pass. `node advisor.mjs --pretty` on the real seed → `actionable YES` (flags the red `length` band). Workflow YAML validated.

### Acceptance criteria (#933)
- [x] Agent reviews state; files an issue assigned to the maintainer only when actionable
- [x] Quiet state → no issue (deterministic gate)
- [x] Deterministic numbers (WS4 digest) unaffected and LLM-free
- [x] Recommends — does not auto-edit CLAUDE.md/skills; dedups against an open advisor issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTQtCbsZHtdAHhFJ1SxwuC)_