### PR TITLE
feat(root): derive epic status:in-progress from children (#980)

### DIFF
--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -28,6 +28,12 @@ the only thing it writes.
   action each needs (read from the `status:ready-to-close` / `status:needs-postmortem` label
   the labeller stamps — see below): *run the postmortem then close* vs *postmortem done, just
   close*.
+- **🚧 Epics with active work but not marked in-progress** — a sub-issue is
+  `status:in-progress` but the epic isn't, so it reads as "open, not started" (#980). The
+  labeller reconciles this (see below); the digest just surfaces it.
+- **🧭 In-progress under a non-open-epic parent** — `status:in-progress` issues whose parent
+  isn't a currently-open epic: a closed epic left with unfinished work, or a parent missing
+  the `epic` label (#980).
 - **🔀 Idle PRs** — open PRs with no activity in >N days.
 
 ## Pipeline (deterministic — no LLM, no secrets)
@@ -89,17 +95,21 @@ GITHUB_TOKEN=$(gh auth token) node .claude/skills/housekeeping/prune-merged-bran
 GITHUB_TOKEN=$(gh auth token) APPLY=true node .claude/skills/housekeeping/prune-merged-branches.mjs  # delete
 ```
 
-## Epic close-state labels (separate workflow — the only auto-label) (#763)
+## Epic status labels (separate workflow — the only auto-label) (#763 / #980)
 
-The "✅ Epics ready to close" section reads two labels it does **not** set:
-`status:ready-to-close` and `status:needs-postmortem`. They're stamped by a separate daily
+The epic sections above read labels the digest does **not** set: `status:ready-to-close`,
+`status:needs-postmortem`, and `status:in-progress`. They're reconciled by a separate daily
 workflow (`.github/workflows/label-ready-epics.yml` → `scripts/label-ready-epics.mjs`), split
 off by blast radius exactly like the branch janitor — it's the **only** auto-*label* mutation,
-and the digest stays report-only. For each open epic whose sub-issues are all closed it applies
-`status:ready-to-close` if a `<!-- postmortem:done -->` marker exists on a comment (left by the
-`postmortem` skill), else `status:needs-postmortem`; it removes both when the epic no longer
-qualifies. The same labels drive the daily epic-digest email's "Ready to close" band, so both
-digests agree. Dry-run by default; set repo var `LABEL_READY_EPICS_APPLY=true` to write.
+and the digest stays report-only. The labeller **derives** each open epic's status from its
+children (mutually-exclusive, at most one):
+- all sub-issues closed → `status:ready-to-close` if a `<!-- postmortem:done -->` marker exists
+  on a comment (left by the `postmortem` skill), else `status:needs-postmortem`;
+- ≥1 sub-issue `status:in-progress` → `status:in-progress` (the opening side, #980);
+- otherwise (open-but-idle or no children) → none.
+It removes any managed label the epic no longer qualifies for. The same labels drive the daily
+epic-digest email's bands, so both digests agree. Dry-run by default; set repo var
+`LABEL_READY_EPICS_APPLY=true` to write.
 
 ## Tuning
 

--- a/.claude/skills/housekeeping/gather.mjs
+++ b/.claude/skills/housekeeping/gather.mjs
@@ -199,20 +199,55 @@ async function gather() {
     .map((i) => ({ number: i.number, title: i.title, url: i.html_url, ageDays: ageDays(i.updated_at) }))
     .sort((a, b) => b.ageDays - a.ageDays)
 
-  // Epics whose sub-issues are ALL closed but the epic is still open (stale tracking).
-  // Tag each with the action it needs, read from the label the labeller stamps (#763):
-  // needs-postmortem (run the retro first) vs ready-to-close (postmortem done, just close).
+  // One pass over open epics (sub-issues fetched once each) computes two facts about
+  // the parent↔child status relationship (#763 / #980):
+  //   • staleEpics — ALL children closed but the epic is still open (closing side).
+  //     Tagged with the action it needs from the label the labeller stamps:
+  //     needs-postmortem (run the retro first) vs ready-to-close (postmortem done).
+  //   • epicsMissingInProgress — ≥1 child is `status:in-progress` but the epic itself
+  //     isn't labelled in-progress, so it reads as "open, not started" (the opening
+  //     side, #980).
+  // Both are REPORT-ONLY; scripts/label-ready-epics.mjs is what reconciles the labels.
   const staleEpics = []
+  const epicsMissingInProgress = []
   for (const e of openEpics) {
     const kids = await subIssues(e.number)
+    const names = labelNames(e)
     if (kids.length > 0 && kids.every((k) => k.state === 'closed')) {
-      const names = labelNames(e)
       const state = names.includes('status:ready-to-close')
         ? 'ready-to-close'
         : 'needs-postmortem' // default until/unless a postmortem marker flips the label
       staleEpics.push({ number: e.number, title: e.title, url: e.html_url, children: kids.length, state })
+    } else if (!names.includes('status:in-progress')) {
+      const active = kids.filter(
+        (k) => k.state === 'open' && labelNames(k).includes('status:in-progress')
+      )
+      if (active.length) {
+        epicsMissingInProgress.push({
+          number: e.number,
+          title: e.title,
+          url: e.html_url,
+          activeChildren: active.map((k) => k.number).sort((a, b) => a - b)
+        })
+      }
     }
   }
+
+  // In-progress issues whose parent isn't a currently-open epic — a closed epic left
+  // with an unfinished child, or a parent that should carry the `epic` label but
+  // doesn't (#980). Uses parent_issue_url already on the search payload (zero extra
+  // API calls). Standalone in-progress tasks (no parent) are allowed → skipped.
+  const openEpicNums = new Set(openEpics.map((e) => e.number))
+  const orphanedInProgress = openIssues
+    .filter((i) => labelNames(i).includes('status:in-progress') && i.parent_issue_url)
+    .map((i) => {
+      const parent = Number(i.parent_issue_url.split('/').pop())
+      return Number.isNaN(parent) || openEpicNums.has(parent)
+        ? null
+        : { number: i.number, title: i.title, url: i.html_url, parent }
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.parent - b.parent)
 
   // Idle open PRs — draft or not, nothing has moved in N days.
   const idlePRs = openPRs
@@ -226,7 +261,7 @@ async function gather() {
     }))
     .sort((a, b) => b.ageDays - a.ageDays)
 
-  return { unlabeled, stuck, staleEpics, idlePRs }
+  return { unlabeled, stuck, staleEpics, epicsMissingInProgress, orphanedInProgress, idlePRs }
 }
 
 const drift = await gather()

--- a/.claude/skills/housekeeping/render.mjs
+++ b/.claude/skills/housekeeping/render.mjs
@@ -94,6 +94,28 @@ if (data.staleEpics?.length) {
   sections.push(['✅ Epics ready to close', lines])
 }
 
+if (data.epicsMissingInProgress?.length) {
+  sections.push([
+    '🚧 Epics with active work but not marked in-progress',
+    [
+      'A child is `status:in-progress` but the epic isn\'t — so it reads as "open, not started". `label-ready-epics.mjs --apply` reconciles this:',
+      ...data.epicsMissingInProgress.map(
+        (e) => `- ${link(e.number, e.title, e.url)} — active: ${e.activeChildren.map((n) => `#${n}`).join(', ')}`
+      )
+    ]
+  ])
+}
+
+if (data.orphanedInProgress?.length) {
+  sections.push([
+    '🧭 In-progress under a non-open-epic parent',
+    [
+      '`status:in-progress` issues whose parent isn\'t a currently-open epic — a closed epic left with unfinished work, or a parent missing the `epic` label:',
+      ...data.orphanedInProgress.map((i) => `- ${link(i.number, i.title, i.url)} — parent #${i.parent}`)
+    ]
+  ])
+}
+
 if (data.idlePRs?.length) {
   sections.push([
     '🔀 Idle PRs',

--- a/scripts/label-ready-epics.mjs
+++ b/scripts/label-ready-epics.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Stamp open epics with their "finished but still open" state — the single source
- * of truth both digests (epic-digest, housekeeping) read. Deterministic, no LLM.
+ * Reconcile each open epic's `status:*` label FROM its children — derive, don't
+ * hand-apply — the single source of truth both digests (epic-digest, housekeeping)
+ * read. Deterministic, no LLM.
  *
  *   GITHUB_TOKEN=... node scripts/label-ready-epics.mjs            # dry-run (default)
  *   GITHUB_TOKEN=... APPLY=true node scripts/label-ready-epics.mjs # actually mutate labels
@@ -11,9 +12,10 @@
  *     comment  → `status:ready-to-close`
  *   - all sub-issues closed (total > 0) AND no postmortem marker
  *                                            → `status:needs-postmortem`
- *   - otherwise (open children, or no children)
- *                                            → neither (remove both if present)
- * An epic carries AT MOST ONE of the two labels at any time.
+ *   - ≥1 sub-issue is `status:in-progress`   → `status:in-progress`  (opening side, #980)
+ *   - otherwise (open-but-idle children, or no children)
+ *                                            → none (remove any managed label present)
+ * The three managed labels are mutually exclusive — an epic carries AT MOST ONE.
  *
  * This is the ONLY piece of the #763 system that MUTATES GitHub — the digests stay
  * report-only. It's split into its own script + workflow by blast radius, exactly like
@@ -36,7 +38,8 @@ if (!token) {
 
 const READY = 'status:ready-to-close'
 const NEEDS = 'status:needs-postmortem'
-const MANAGED = [READY, NEEDS]
+const INPROGRESS = 'status:in-progress'
+const MANAGED = [READY, NEEDS, INPROGRESS]
 const MARKER = 'postmortem:done'
 
 async function gh(path, init) {
@@ -76,13 +79,18 @@ async function hasPostmortem(number) {
   }
 }
 
-// Decide the target label for an epic from its children + postmortem state.
-// null ⇒ epic doesn't qualify (carry neither managed label).
+// Decide the target managed label for an epic from its children + postmortem state.
+//   • all children closed → ready-to-close (postmortem done) | needs-postmortem (not)
+//   • ≥1 child in-progress → in-progress   (the opening side, #980)
+//   • otherwise            → null (carry none of the managed labels)
+// The closing side wins by construction: an all-closed epic has no in-progress child.
 async function targetLabel(epic) {
   const kids = await subIssues(epic.number)
-  const allClosed = kids.length > 0 && kids.every((k) => k.state === 'closed')
-  if (!allClosed) return null
-  return (await hasPostmortem(epic.number)) ? READY : NEEDS
+  if (kids.length > 0 && kids.every((k) => k.state === 'closed')) {
+    return (await hasPostmortem(epic.number)) ? READY : NEEDS
+  }
+  const active = kids.some((k) => k.state === 'open' && labelNames(k).includes(INPROGRESS))
+  return active ? INPROGRESS : null
 }
 
 async function setLabels(number, current, target) {


### PR DESCRIPTION
Closes #980

## 👤 For humans

Epics now reflect that they're being worked on **automatically**. Today an epic only shows `status:in-progress` if someone hand-applied the label — so most actively-worked epics read as "open, not started" (a snapshot found 9 of 10 active issues sitting under an epic that wasn't marked in-progress). This derives an epic's status from its children, and the housekeeping digest flags the gap until it's reconciled.

This is the **opening half** of the `#763` epic-status machinery — the closing half (all-children-closed → ready-to-close / needs-postmortem) already existed. No new skill, no LLM; it extends the existing cron scripts.

## 🤖 For agents

**Mutate side — `scripts/label-ready-epics.mjs`**
- `status:in-progress` added to the managed set; `targetLabel()` returns it when ≥1 child is `status:in-progress`.
- The three managed labels stay **mutually exclusive** (all-closed → ready/needs wins by construction, since an all-closed epic has no in-progress child).
- Removes a stale `status:in-progress` when no child qualifies (derive, don't declare).

**Report side — `.claude/skills/housekeeping/`**
- `gather.mjs`: `epicsMissingInProgress` folded into the existing per-epic loop (no extra API calls); `orphanedInProgress` — in-progress issues whose parent isn't a currently-open epic (catches the closed-epic-with-unfinished-child / missing-`epic`-label smell, e.g. #865/#325) via the `parent_issue_url` already on the search payload.
- `render.mjs`: two new digest sections.
- `SKILL.md`: kept in sync (check list + labeller behaviour).

**⚠️ Blast radius:** `label-ready-epics.mjs` now adds *and removes* `status:in-progress` on epics, where before it only touched the two closing-side labels. Still dry-run by default (`APPLY`-gated via `LABEL_READY_EPICS_APPLY`), so worth a human eye on the first `APPLY` run.

**Considered & rejected:** a new *skill* (skills cost context budget every session — this is deterministic label reconciliation, belongs in the scripts); auto-deriving in the `task-worker` flow (keeps all epic-label mutation in one auditable place instead).

## 🧪 How to test

Env had no live GitHub REST token, so logic was verified by stubbing `fetch` against the real modules:
- **Labeller decisions:** active-unlabelled → `+in-progress`; all-closed-but-mislabelled → `+needs-postmortem -in-progress`; idle children → no change; stale in-progress → `-in-progress`. ✅
- **Gather:** flags the active-but-unlabelled epic, the orphaned in-progress child, keeps the all-closed epic in `staleEpics`. ✅
- **Render:** both sections format cleanly. ✅

To run against the live repo:
1. `GITHUB_TOKEN=… node scripts/label-ready-epics.mjs` (dry-run) lists actively-worked epics (#952, #917, #669, #838, #801…) as `+status:in-progress`.
2. Housekeeping `gather.mjs` → same epics under **🚧 Epics with active work but not marked in-progress**; parents like #865/#325 under **🧭 In-progress under a non-open-epic parent**.
3. `APPLY=true …` stamps them; re-querying `is:issue is:open label:epic label:status:in-progress` returns the active set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SisCeogphLYwuveG2qVHj6)_