### PR TITLE
feat(playground): Crouton Builder spike — variants, sizing-descriptor, drop-beside-pane, composite sizing (v45→v52)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1633,6 +1633,9 @@ importers:
       '@fyit/crouton-devtools':
         specifier: workspace:*
         version: link:../../packages/crouton-devtools
+      '@fyit/crouton-feedback':
+        specifier: workspace:*
+        version: link:../../packages/crouton-feedback
       '@fyit/crouton-flow':
         specifier: workspace:*
         version: link:../../packages/crouton-flow

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -187,6 +187,12 @@ Two decisions that resolve "how do blocks size / how do I preview responsiveness
   `minWidth`/`fill`-`hug`; a composite *derives* them, recursively. Prototyped POC-side: the per-element
   **resize can't drag a card below its hard floor** (so a layout literally can't violate its
   components' rules), and a selected card shows a **floor readout** (`stacks <Npx · floor Mpx`).
+  - **Considered & deferred — a MANUAL min/max override on a composite.** Sometimes you may want to
+    pin a specific row/layout to its own min or max (not just the derived floor). Deliberately **not
+    built**: composite rules are *derived* for now, and a per-instance min/max settings panel risks
+    reintroducing the per-instance flex control we avoid. **Revisit after graduation** — build it test-
+    first in the real setting only if the derived floors prove insufficient there. (Leaf intrinsic
+    rules stay component-level/declared; per-breakpoint behaviour stays in the responsive editor.)
 - **Graduation note:** the descriptor currently rides the **inferred** app.config type (the POC adds
   `sizing` to entries without touching the package type). Two pieces remain package work in
   `crouton-layout`: (1) move `sizing` onto the typed `CroutonLayoutBlockDefinition` so it's a first-class

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -277,7 +277,10 @@ expressiveness boundary: a variant is an **enum an agent could equally pick**, n
   the card box (re-measured on resize/arm/re-render), with the `defaultSize` math kept only as a
   pre-measurement fallback. Same lesson as the edit-view selection — hit-test the real DOM, never the
   abstract tree. (NB: the watch that re-measures eagerly reads `renderNode`, which references the pull
-  state, so it must be declared *after* `activeIndex` et al. or it throws a TDZ error.)
+  state, so it must be declared *after* `activeIndex` et al. or it throws a TDZ error.) **Each measured
+  pane is CLAMPED to the card box on all four edges (#972 follow-up, IMG_1071):** when the content is
+  taller than the card it overflows, so a lower pane's raw rect extends below — clamp keeps a face on
+  the pane's *visible* portion, and a pane scrolled fully out collapses to zero size (hidden by `paneRect`).
 - **Hit-test the RENDERED panes, never the abstract tree.** Anything that maps a screen point to a pane
   (the edit view's block selection + dim overlay) must measure the real DOM (`.croutonpane` leaf
   elements), because the renderer reflows panes via CSS `@container` (a horizontal split STACKS

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -202,17 +202,21 @@ expressiveness boundary: a variant is an **enum an agent could equally pick**, n
   Hold ~0.6 s → **armed** (green, release-to-snap). The arm timer is keyed on the **target only**
   (not the exact seam), so finger jitter that flips the nearest seam doesn't reset it; the seam keeps
   tracking your finger. (No "release to snap" text — the green ring + guide bar say it.)
-- **Insert *between* panes (Phase A).** Over a combined (split) layout, a card inserts between panes,
-  not just onto an outer edge. Triggers on **≥35 % overlap** with the split (not centre-strictly-inside
-  — a big card overlapping heavily used to match neither insert nor edge); seam picked from the centre
-  **clamped** into the target.
-- **Single items are snap targets too.** Hovering a dragged card **over** a single block (a leaf, or a
-  nested app — anything with no inner seams) snaps it **beside** that block into a new split; the edge is
-  picked from which half of the target's centre you're over (right half → merge right, top half → top…).
-  Before, only multi-pane splits armed on hover-over, so a lone block couldn't be built onto by dragging
-  onto it (only by edge-snapping beside it). The drop reuses the existing `combineNodes` edge-merge.
-- **Ghost mirrors the dragged item; panes ease apart to make room (#946/#947).** On an armed insert the
-  target splices a **ghost skeleton with the dragged node's footprint** (every leaf → a dashed
+- **Pane-drop: drop OVER a layout → add beside the targeted pane (#972).** Dragging a card over a
+  composed layout (≥35 % overlap) targets the **rendered pane under the cursor** and adds the dragged
+  node as a **sibling on the side you're nearest** (L/R/T/B by quadrant of that pane). It **flattens
+  into the parent row/column** when the side runs *along* it (drop right of a block in a row → it joins
+  the row), and **wraps the pane in a new perpendicular split** otherwise — so you can add to the
+  **right of a pane that lives in a vertical stack** ("right of the chart"), which the old seam-only
+  insert couldn't reach (a vertical stack has no right-seam). A lone block is one pane (path `[]`).
+  Targeting = `collectLeaves` (tree sub-rects) → leaf under cursor + edge; apply = `applyPaneDrop`
+  (`app/utils/spike-layout.ts`) → `insertAtPath` (flatten) or the package's `dropNode` (wrap). The
+  armed ghost reuses the #946 ease-apart (applies the same edit with a `__dropghost__` skeleton).
+  **The drop commits by tracking the dragged node's id** (`draggedId`) — position-delta detection
+  misses it because Vue Flow mutates node positions in place, so the re-emitted rows show no delta;
+  the target pane node is likewise re-found by **stable id** (`paneDrop`/`targetId`), not by reference.
+- **Ghost mirrors the dragged item; panes ease apart to make room (#946/#947).** On an armed pane-drop the
+  target applies the drop with a **ghost skeleton matching the dragged node's footprint** (every leaf → a dashed
   `__dropghost__` placeholder, splits/nested preserved) and renders that — a 2-row stack opens a *2-row*
   slot, growing the row to fit (not a flat 1×1 sliver). Real panes slide via the FLIP reflow; the card
   grows with a transition. Reverts on un-arm.

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -283,7 +283,16 @@ expressiveness boundary: a variant is an **enum an agent could equally pick**, n
   panes are keyed by index so a count change rebuilds them — a CSS `flex-grow` transition can't fire.
   `useLayoutFlip` measures-before / tweens-from-old-box, purely additive (no key/size/reka change),
   survivors matched by a structure-derived `contentKey`.
-- **`fitOverview` is dead code** — superseded by center-on-add; remove on next cleanup.
+- **Deploy needs `@fyit/crouton-feedback` declared as a direct dep (#976 fallout).** `crouton-devtools`
+  calls `installModule('@fyit/crouton-feedback')` at build time, resolving it from the *consuming app's*
+  context. Under pnpm's strict `node_modules` a transitive dep isn't reachable from the POC, so
+  `nuxt build` (= the staging deploy) fails with *"Could not load `@fyit/crouton-feedback`"* even though
+  `pnpm dev` is fine. **Two POC-side fixes are needed:** (1) declare `@fyit/crouton-feedback:
+  workspace:*` in the POC's `package.json` so it resolves; AND (2) add `@fyit/crouton-feedback` to
+  `deploy.config.json` `layerPackages` so CI builds its (gitignored) `dist` — the deploy only builds
+  `layerPackages + crouton-devtools`, so without this the module file never exists on the runner.
+  (Systemic — every `crouton-devtools` consumer hits this; the clean fix is in the package: have
+  `crouton-devtools` resolve/build feedback via its OWN resolver, or guard the `installModule`.)
 - **POC block components must be registered GLOBALLY.** `CroutonLayoutRenderer` resolves a leaf's block
   via `<component :is="block.component">` (a runtime string), which only resolves globally-registered
   components. Nuxt's per-file auto-import (`<SpikeSpacer/>`) does NOT make the name resolvable that way,

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -176,6 +176,26 @@ Two decisions that resolve "how do blocks size / how do I preview responsiveness
   field; (2) have the package **renderer honour it INSIDE a split** — make a *pane* hug its content
   between siblings (the Preview only hugs at the region level today).
 
+### Per-block display variants (#970 — bounded "collection viewer options")
+
+A block can expose **display variants** — bounded, enumerated layouts of the *same* data (e.g. the
+Artists list: **rows · cards · table**). It's the "collection viewer options" ask, kept inside the
+expressiveness boundary: a variant is an **enum an agent could equally pick**, not free config.
+
+- **Declared on the registry** as a `variant` **select** field in the block's `configSchema`
+  (`artists-list` in `app/app.config.ts`) — the bounded option list lives in one place the renderer's
+  `sanitizeConfig` enforces (an unknown value is dropped) and an agent reads.
+- **Serialised on the leaf** (`leaf.config.variant`), so the choice persists with the layout and
+  round-trips. Set via `setLeafConfigValue()` (`app/utils/spike-layout.ts`) onto the base root **and**
+  every breakpoint-root override (mirrors `setCollapseRecipe`), so whichever root resolves carries it.
+- **Picked in the edit view**: select a pane → the options panel shows a **Display** chip row
+  (`SpikeFocusShell`); a tap re-renders the block in that variant. The package renderer already merges
+  `config.variant` into the block's props, so the block (`SpikeListBlock`) just reads a `variant` prop.
+- **Graduation note:** this reuses the package's existing per-breakpoint variant channel
+  (`LAYOUT_VARIANTS_KEY`) only at render-merge time; the *leaf-serialised* variant + the in-view picker
+  are POC-side. On graduation, fold the picker into the package author and keep variant declaration on
+  the typed block definition.
+
 ### Board gestures (direct manipulation)
 
 - **Snap = two-stage dwell-to-arm (#941, #948).** Near a snap point → **soft** (blue, wide, pulsing).

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -262,12 +262,18 @@ expressiveness boundary: a variant is an **enum an agent could equally pick**, n
     union of each node's `position + sizeOf` — Vue Flow's own `fitView` (and its controls' ⛶) measure
     the small wrapper and zoom INTO the oversized card. (The Site flow's normal-sized cards are fine, so
     the VF ⛶ is left enabled there.)
-- **Overlays must match the RENDERER's sizing (`defaultSize`), not footprint.** The wiggle/pull faces +
-  reorder slot bounds (`panes` in SpikeBlockNode) are positioned along the split axis by each child's
-  `defaultSize` % — the same value the renderer feeds reka's splitter panels. Footprint (cols/rows) was
-  wrong: a spacer beside a dense grid renders 50/50 but footprint said ~1:4, so the faces drifted off
-  the panes (#953, IMG_1061/1062). Any overlay drawn over the rendered layout has to use the renderer's
-  own sizing source.
+- **Overlays must MEASURE the rendered panes, not compute them.** The wiggle/pull faces + reorder slot
+  bounds (`panes` in SpikeBlockNode) sit over the layout's top-level panes. Footprint (cols/rows) was
+  wrong first (#953); `defaultSize` % was the next attempt but *also* drifts, because the renderer's
+  real geometry diverges from the tree whenever it reflows — reka enforces per-pane min-widths, a
+  horizontal split **stacks vertically** when narrow (`@container`), nested splits carry their own
+  proportions, and **a resized card renders through the responsive renderer** (so the panes reflow to
+  the resized width while `defaultSize` is unchanged) (#954, IMG_1069). The fix: `panes` MEASURES the
+  shallowest rendered panes (`[data-panel]` / stacked `[data-crouton-pane]`) inside the card as % of
+  the card box (re-measured on resize/arm/re-render), with the `defaultSize` math kept only as a
+  pre-measurement fallback. Same lesson as the edit-view selection — hit-test the real DOM, never the
+  abstract tree. (NB: the watch that re-measures eagerly reads `renderNode`, which references the pull
+  state, so it must be declared *after* `activeIndex` et al. or it throws a TDZ error.)
 - **Hit-test the RENDERED panes, never the abstract tree.** Anything that maps a screen point to a pane
   (the edit view's block selection + dim overlay) must measure the real DOM (`.croutonpane` leaf
   elements), because the renderer reflows panes via CSS `@container` (a horizontal split STACKS

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -161,15 +161,20 @@ Two decisions that resolve "how do blocks size / how do I preview responsiveness
   card has a **corner resize handle** (shown when selected) — drag it to set the node's width/height,
   and the card renders **responsively at that width** (its own preview). Opening edit lands at the
   node's resized width. (`data.width/height` on the FlowNode; `SPIKE_SET_SIZE_KEY`.)
-- **The component decides its own size ("intrinsic sizing").** A block declares how it lays out *once*,
-  in the component — so it behaves the same everywhere it's dropped, and there's **no per-instance
-  align/size UI to build**. A **Top bar / Bottom nav are fixed-height bars**; List/Form/Chart fill. So a
-  pinned Top bar comes out as a **short pill** automatically (the Preview's pinned regions hug the
-  block's intrinsic height via `height:auto` on the pane). The agent picks *blocks*, not flex values.
-- **Graduation note:** truly making a *pane hug its content inside a split* (vs in the Preview regions)
-  is layout-engine work in the `crouton-layout` package renderer; here it's prototyped POC-side. A
-  block-type **sizing descriptor** in the registry (`{ width:'fill'|'hug', height:… }`) is the clean
-  formalisation so the renderer (and an agent) read one declared source.
+- **The component decides its own size ("intrinsic sizing"), as DECLARED DATA (#971).** Each block
+  carries a **sizing descriptor** on the `croutonLayoutBlocks` registry entry —
+  `sizing: { width: 'fill' | 'hug', height: 'fill' | 'hug' }` (defaults to fully `fill`). `hug` = size
+  to content, `fill` = stretch. A **Top bar / Bottom nav declare `height: 'hug'`**; List/Form/Chart/
+  Stats `fill`. So a pinned Top bar comes out as a **short pill** *because the block declares `hug`* —
+  not because of where it's pinned, and with **no per-instance align/size UI**. One source the renderer,
+  the viability metric, and an agent all read; the agent picks *blocks*, not flex values. Read POC-side
+  via `blockSizing()` / `nodeHeightSizing()` (`app/utils/spike-layout.ts`); honoured in the Preview
+  (`SpikePagePreview` maps a `hug`-height node → an `height:auto` pane → short bar, per region).
+- **Graduation note:** the descriptor currently rides the **inferred** app.config type (the POC adds
+  `sizing` to entries without touching the package type). Two pieces remain package work in
+  `crouton-layout`: (1) move `sizing` onto the typed `CroutonLayoutBlockDefinition` so it's a first-class
+  field; (2) have the package **renderer honour it INSIDE a split** — make a *pane* hug its content
+  between siblings (the Preview only hugs at the region level today).
 
 ### Board gestures (direct manipulation)
 

--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -20,6 +20,14 @@ the house style — heavily **Nuxt UI 4 / crouton-opinionated**, not freeform ge
 a random UI, you get *your* system's UI, consistently. That consistency is exactly what makes the blocks
 composable and the round-trip (below) safe to automate.
 
+**It's COMPONENT-DRIVEN: the layout obeys what each component declares about itself** — not arbitrary
+styling imposed on top. A component publishes its rules as data (min-width, `fill`/`hug`, display
+variants), and the builder's job is *arranging components within the bounds each one publishes*. Those
+declared rules ARE the bounded vocabulary a human and an agent both edit against. And it's recursive —
+a composed layout is itself a component that **derives** its own rules from its children (see "Composites
+derive their rules" below), so the contract holds all the way up a layout-of-layouts. (Today only some
+rules are declared; completing the component contract + making it round-trippable is the durable work.)
+
 **The full lifecycle — close to end-to-end automation, with a human checkpoint:**
 
 ```
@@ -170,11 +178,23 @@ Two decisions that resolve "how do blocks size / how do I preview responsiveness
   the viability metric, and an agent all read; the agent picks *blocks*, not flex values. Read POC-side
   via `blockSizing()` / `nodeHeightSizing()` (`app/utils/spike-layout.ts`); honoured in the Preview
   (`SpikePagePreview` maps a `hug`-height node → an `height:auto` pane → short bar, per region).
+- **Composites DERIVE their rules — component-driven, all the way up (#972 follow-up).** A composed
+  layout (a split, or a `nested` layout-of-layouts) is itself a component and **publishes the same
+  contract its children do**, folded bottom-up by `deriveSizing()` (`app/utils/spike-layout.ts`):
+  a **hard floor** = the widest single leaf (a row can always reflow to a column, so this is the
+  absolute min it survives down to) and a **soft floor** = `sum` of children along a horizontal axis /
+  `max` across a vertical one (the comfortable width before it stacks). A leaf *declares* its
+  `minWidth`/`fill`-`hug`; a composite *derives* them, recursively. Prototyped POC-side: the per-element
+  **resize can't drag a card below its hard floor** (so a layout literally can't violate its
+  components' rules), and a selected card shows a **floor readout** (`stacks <Npx · floor Mpx`).
 - **Graduation note:** the descriptor currently rides the **inferred** app.config type (the POC adds
   `sizing` to entries without touching the package type). Two pieces remain package work in
   `crouton-layout`: (1) move `sizing` onto the typed `CroutonLayoutBlockDefinition` so it's a first-class
   field; (2) have the package **renderer honour it INSIDE a split** — make a *pane* hug its content
-  between siblings (the Preview only hugs at the region level today).
+  between siblings (the Preview only hugs at the region level today). (3) **Composite derivation**
+  (`deriveSizing`) belongs in the `crouton-layout` viability engine (it already folds leaf min-widths
+  for stacking) with the derived contract carried **on the `nested` node**, so a parent reads a
+  sub-layout's floor without re-deriving — the formalisation of "a leaf declares, a composite derives".
 
 ### Per-block display variants (#970 — bounded "collection viewer options")
 

--- a/pocs/crouton-builder-demo/app/app.config.ts
+++ b/pocs/crouton-builder-demo/app/app.config.ts
@@ -20,7 +20,20 @@ export default defineAppConfig({
     // loop, not the block fidelity. Distinct names/icons so the drawer reads right.
     // Distinct demo blocks (#956) — each renders a DIFFERENT, recognizable UI so you can see which
     // block landed where (list vs form vs chart vs toolbar vs nav), instead of every card looking alike.
-    'artists-list': { id: 'artists-list', name: 'Artists · List', description: 'All artists', icon: 'i-lucide-list', component: 'SpikeListBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },
+    // Display variants (#970) — `variant` is a BOUNDED ENUM (select) declared on the registry, so the
+    // renderer's `sanitizeConfig` keeps only a known value and the edit-view picker (and an agent) read
+    // one source. Serialised on the leaf's `config.variant`; the block renders rows / cards / table.
+    'artists-list': {
+      id: 'artists-list', name: 'Artists · List', description: 'All artists', icon: 'i-lucide-list', component: 'SpikeListBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50, sizing: { width: 'fill', height: 'fill' },
+      configSchema: [{
+        name: 'variant', type: 'select', label: 'Display', default: 'rows',
+        options: [
+          { label: 'Rows', value: 'rows' },
+          { label: 'Cards', value: 'cards' },
+          { label: 'Table', value: 'table' },
+        ],
+      }],
+    },
     'artists-form': { id: 'artists-form', name: 'Artists · New', description: 'Create an artist', icon: 'i-lucide-square-pen', component: 'SpikeFormBlock', kind: 'atomic', category: 'form', minWidth: 200, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },
     'artists-stats': { id: 'artists-stats', name: 'Artists · Stats', description: 'Artist KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 180, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },
     'artists-chart': { id: 'artists-chart', name: 'Bookings · Chart', description: 'Bookings per week', icon: 'i-lucide-bar-chart-3', component: 'SpikeChartBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },

--- a/pocs/crouton-builder-demo/app/app.config.ts
+++ b/pocs/crouton-builder-demo/app/app.config.ts
@@ -9,24 +9,28 @@ export default defineAppConfig({
   // Backend-free demo blocks for the builder preview — both reuse the generic KPI
   // block under DISTINCT ids so the collapse demo collapses one pane and reflows the
   // other (collapse is keyed by blockId). defu-merged with the crouton-layout defaults.
+  // `sizing` (#971): the intrinsic sizing descriptor — `{ width, height: 'fill' | 'hug' }` — declared
+  // as DATA so the renderer / viability metric / an agent read one source ("the component decides").
+  // A bar HUGS its height (→ short pill wherever pinned); list/form/stats/chart FILL. Defaults to fill.
   croutonLayoutBlocks: {
-    'demo-a': { id: 'demo-a', name: 'Overview', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 40 },
-    'demo-b': { id: 'demo-b', name: 'Detail', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 60 },
+    'demo-a': { id: 'demo-a', name: 'Overview', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 40, sizing: { width: 'fill', height: 'fill' } },
+    'demo-b': { id: 'demo-b', name: 'Detail', description: 'Demo KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 60, sizing: { width: 'fill', height: 'fill' } },
     // Spike (#903): the blocks a collection ("Artists") would offer — list / form / stats.
     // All render the backend-free KPI block; the spike is about the drawer→drag→compile
     // loop, not the block fidelity. Distinct names/icons so the drawer reads right.
     // Distinct demo blocks (#956) — each renders a DIFFERENT, recognizable UI so you can see which
     // block landed where (list vs form vs chart vs toolbar vs nav), instead of every card looking alike.
-    'artists-list': { id: 'artists-list', name: 'Artists · List', description: 'All artists', icon: 'i-lucide-list', component: 'SpikeListBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50 },
-    'artists-form': { id: 'artists-form', name: 'Artists · New', description: 'Create an artist', icon: 'i-lucide-square-pen', component: 'SpikeFormBlock', kind: 'atomic', category: 'form', minWidth: 200, defaultSize: 50 },
-    'artists-stats': { id: 'artists-stats', name: 'Artists · Stats', description: 'Artist KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 180, defaultSize: 50 },
-    'artists-chart': { id: 'artists-chart', name: 'Bookings · Chart', description: 'Bookings per week', icon: 'i-lucide-bar-chart-3', component: 'SpikeChartBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50 },
-    'app-toolbar': { id: 'app-toolbar', name: 'Top bar', description: 'Title + search + actions (pin to top)', icon: 'i-lucide-panel-top', component: 'SpikeToolbarBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 100 },
-    'app-nav': { id: 'app-nav', name: 'Bottom nav', description: 'Tab bar (pin to bottom)', icon: 'i-lucide-panel-bottom', component: 'SpikeNavBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 100 },
+    'artists-list': { id: 'artists-list', name: 'Artists · List', description: 'All artists', icon: 'i-lucide-list', component: 'SpikeListBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },
+    'artists-form': { id: 'artists-form', name: 'Artists · New', description: 'Create an artist', icon: 'i-lucide-square-pen', component: 'SpikeFormBlock', kind: 'atomic', category: 'form', minWidth: 200, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },
+    'artists-stats': { id: 'artists-stats', name: 'Artists · Stats', description: 'Artist KPIs', icon: 'i-lucide-bar-chart-3', component: 'CroutonLayoutSpikeStats', kind: 'atomic', category: 'data', minWidth: 180, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },
+    'artists-chart': { id: 'artists-chart', name: 'Bookings · Chart', description: 'Bookings per week', icon: 'i-lucide-bar-chart-3', component: 'SpikeChartBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 50, sizing: { width: 'fill', height: 'fill' } },
+    // Bars HUG their height → a pinned Top bar / Bottom nav comes out SHORT automatically (#971).
+    'app-toolbar': { id: 'app-toolbar', name: 'Top bar', description: 'Title + search + actions (pin to top)', icon: 'i-lucide-panel-top', component: 'SpikeToolbarBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 100, sizing: { width: 'fill', height: 'hug' } },
+    'app-nav': { id: 'app-nav', name: 'Bottom nav', description: 'Tab bar (pin to bottom)', icon: 'i-lucide-panel-bottom', component: 'SpikeNavBlock', kind: 'atomic', category: 'data', minWidth: 200, defaultSize: 100, sizing: { width: 'fill', height: 'hug' } },
     // Spacer (#952): a layout primitive that renders empty space — add it to push blocks around or
     // hold a gap. A real block, so it snaps/reorders/resizes like any other; small minWidth so it can
     // be a thin gutter. Renders SpikeSpacer (a faint dashed hint in the builder, blank in a real app).
-    'spacer': { id: 'spacer', name: 'Spacer', description: 'Empty space (push blocks around / hold a gap)', icon: 'i-lucide-square-dashed', component: 'SpikeSpacer', kind: 'atomic', category: 'data', minWidth: 40, defaultSize: 20 },
+    'spacer': { id: 'spacer', name: 'Spacer', description: 'Empty space (push blocks around / hold a gap)', icon: 'i-lucide-square-dashed', component: 'SpikeSpacer', kind: 'atomic', category: 'data', minWidth: 40, defaultSize: 20, sizing: { width: 'fill', height: 'fill' } },
     // Drop-ghost (#946): the placeholder pane spliced in while an internal insert is armed, so the
     // real panes ease apart to open its slot. NOT shown in the drawer (that list is hardcoded). A
     // small minWidth so opening the slot never forces the split to stack.

--- a/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
@@ -146,8 +146,14 @@ function toggleRegion(region: SpikeRegion) {
 // Per-node resize (#954): the corner handle sets this node's display width/height. When a width is set,
 // the card renders RESPONSIVELY at that width (its own width preview) — the per-element "slider".
 const setSize = inject(SPIKE_SET_SIZE_KEY, null)
-const RESIZE_MIN_W = 240
 const RESIZE_MIN_H = 140
+// Composite sizing (#972 follow-up): the layout's DERIVED floor — folded from its components' declared
+// minWidths. The resize handle can't drag the card below its HARD floor (the widest single block; below
+// that a block would break even after stacking), so a layout literally "follows the rules of its
+// components". `softMinWidth` is where it stops being a row and stacks — shown in the readout.
+const blockRegistry = computed(() => (useAppConfig().croutonLayoutBlocks ?? {}) as Record<string, { sizing?: { width?: string, height?: string }, minWidth?: number }>)
+const derived = computed(() => deriveSizing(props.data.node, blockRegistry.value))
+const resizeFloorW = computed(() => Math.max(80, derived.value.hardMinWidth))
 const resizing = ref(false)
 function onResizeDown(e: PointerEvent) {
   if (e.button !== 0 || !setSize) return
@@ -159,7 +165,7 @@ function onResizeDown(e: PointerEvent) {
   const startH = props.data.height ?? (r ? r.height / zoom : SPIKE_BASE_H)
   const ox = e.clientX, oy = e.clientY
   const move = (ev: PointerEvent) => {
-    const w = Math.max(RESIZE_MIN_W, Math.round(startW + (ev.clientX - ox) / zoom))
+    const w = Math.max(resizeFloorW.value, Math.round(startW + (ev.clientX - ox) / zoom))
     const h = Math.max(RESIZE_MIN_H, Math.round(startH + (ev.clientY - oy) / zoom))
     setSize!(props.data.node, { width: w, height: h })
   }
@@ -632,6 +638,20 @@ watch(() => props.data.node, () => {
       <CroutonLayoutResponsiveRenderer :tree="tree" :width="data.width!" :interactive="false" />
     </div>
     <CroutonLayoutRenderer v-else :node="renderNode" />
+
+    <!-- Derived sizing readout (#972 follow-up) — the layout's floor, FOLDED from its components'
+         declared min-widths. `floor` = the hard min the resize can't go below; when the layout would
+         stack before then, we also show the soft "stacks <Npx" threshold. Shows it follows its
+         components' rules, all the way up a layout-of-layouts. -->
+    <div
+      v-if="selected && !jiggling"
+      class="nodrag pointer-events-none absolute -bottom-3 left-2 z-40 flex items-center gap-1 rounded-full border border-default bg-elevated/95 px-2 py-0.5 font-mono text-[10px] text-muted shadow-sm backdrop-blur"
+      title="Floor derived from the components' min-widths"
+    >
+      <UIcon name="i-lucide-ruler" class="size-3" />
+      <span v-if="derived.softMinWidth > derived.hardMinWidth">stacks &lt;{{ derived.softMinWidth }} · floor {{ derived.hardMinWidth }}px</span>
+      <span v-else>floor {{ derived.hardMinWidth }}px</span>
+    </div>
 
     <!-- Resize handle (#954) — drag the corner to set this node's width (drives responsive reflow) +
          height. The per-element "slider". `.nodrag`/`.stop` keep it off Vue Flow's node drag. Shown when

--- a/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
@@ -266,11 +266,21 @@ function syncPanes() {
   if (els.length !== n.children.length) { measuredPanes.value = []; return }
   measuredPanes.value = els.map((el) => {
     const r = el.getBoundingClientRect()
+    // CLAMP each pane to the card box (ALL four edges). When the content is taller than the card it
+    // overflows (the body is `overflow-hidden`/`-visible`) and a lower pane's measured rect extends
+    // below — or entirely past — the card, which drew the face sprawling outside it (#972 follow-up,
+    // IMG_1071). Clamping every edge into [0, card] means a face only ever covers the pane's VISIBLE
+    // portion; a pane scrolled fully out collapses to zero size (hidden by `paneRect`).
+    const cw = cr.width, ch = cr.height
+    const left = Math.min(Math.max(0, r.left - cr.left), cw)
+    const top = Math.min(Math.max(0, r.top - cr.top), ch)
+    const right = Math.min(Math.max(0, r.right - cr.left), cw)
+    const bottom = Math.min(Math.max(0, r.bottom - cr.top), ch)
     return {
-      left: ((r.left - cr.left) / cr.width) * 100,
-      top: ((r.top - cr.top) / cr.height) * 100,
-      width: (r.width / cr.width) * 100,
-      height: (r.height / cr.height) * 100,
+      left: (left / cw) * 100,
+      top: (top / ch) * 100,
+      width: ((right - left) / cw) * 100,
+      height: ((bottom - top) / ch) * 100,
     }
   })
 }
@@ -328,6 +338,8 @@ onMounted(scheduleSyncPanes)
 const gap = computed(() => (pulling.value ? 18 : jiggling.value ? 16 : 6))
 
 function paneRect(p: { left: number, top: number, width: number, height: number }) {
+  // A pane clamped to ~nothing (scrolled out of an overflowing card) has no grabbable face (#972).
+  if (p.width < 0.5 || p.height < 0.5) return { display: 'none' }
   return { left: `${p.left}%`, top: `${p.top}%`, width: `${p.width}%`, height: `${p.height}%` }
 }
 function faceStyle(i: number) {

--- a/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
@@ -20,8 +20,8 @@
  *
  * Editing moved OFF the canvas (#907 focus-view redesign): double-clicking a node opens a dedicated
  * full-screen edit view (no Vue Flow camera, so framing is deterministic) — so this node carries NO
- * in-flow editable surface. It stays a read-only card: footprint render, survey render, the snap
- * guide, and the board-level pull-pane detach gesture.
+ * in-flow editable surface. It stays a read-only card: footprint render, per-node width preview, the
+ * snap guide, and the board-level pull-pane detach gesture.
  *
  * No `@vue-flow/core` import (connection handles aren't needed here). `footprint` / `SPIKE_*`
  * / `SPIKE_SNAP_KEY` / `SPIKE_DETACH_KEY` are auto-imported from app/utils/spike-layout.
@@ -39,13 +39,7 @@ const props = defineProps<{
   dragging?: boolean
 }>()
 
-// Global viewport survey (#907 layer 3): when a device is active, size the card to that device
-// and render the layout AT that width (so the board becomes a wall of phones/tablets/desktops).
-const viewport = inject(SPIKE_VIEWPORT_KEY, null)
-const surveying = computed(() => !!viewport?.value)
-
 const size = computed(() => {
-  if (viewport?.value) return { width: `${viewport.value.width}px`, height: `${viewport.value.height}px` }
   // Per-node resize (#954): once you've dragged the corner, the card is sized to its own width/height
   // and previews responsively at that width. Height falls back to the footprint height.
   if (typeof props.data.width === 'number') {
@@ -59,13 +53,13 @@ const size = computed(() => {
 })
 
 // A LayoutTree wrapper for the responsive renderer — carries any breakpoints authored in the
-// edit view, so the survey resolves the SAME authored responsiveness at the device width.
+// edit view, so the per-node width preview resolves the SAME authored responsiveness.
 const tree = computed(() => ({ renderer: 'panes' as const, root: props.data.node, breakpoints: props.data.bp }))
 
 // --- live snap guide (target edge lights up while a peer is dragged) ------------------
 const snapPreview = inject(SPIKE_SNAP_KEY, null)
 // This node is the snap target when the injected preview names its layout node.
-const guideMatch = computed(() => !surveying.value && !!snapPreview?.value && snapPreview.value.node === props.data.node)
+const guideMatch = computed(() => !!snapPreview?.value && snapPreview.value.node === props.data.node)
 // A preview is EITHER an internal insert seam (Phase A) OR an outer edge.
 const guideInsert = computed(() => (guideMatch.value ? snapPreview!.value!.insert ?? null : null))
 const guideEdge = computed<SnapEdge | null>(() => (guideMatch.value && !guideInsert.value ? snapPreview!.value!.edge ?? null : null))
@@ -184,8 +178,8 @@ function onResizeDown(e: PointerEvent) {
 function resetSize() { setSize?.(props.data.node, { width: null }) }
 // Delete this node (block or whole layout) from the canvas (#955).
 const deleteNode = inject(SPIKE_DELETE_KEY, null)
-// Render responsively at the node's own width when one is set (and not in the global survey).
-const previewing = computed(() => !surveying.value && typeof props.data.width === 'number')
+// Render responsively at the node's own width when one is set.
+const previewing = computed(() => typeof props.data.width === 'number')
 const isGroup = computed(() => props.data.node.type === 'split')
 
 // Long-press → jiggle (#941): detach is gated behind a deliberate HOLD, so a merged group's panes
@@ -199,7 +193,7 @@ let pressTimer: number | null = null
 let pressOrigin = { x: 0, y: 0 }
 function clearPress() { if (pressTimer != null) { window.clearTimeout(pressTimer); pressTimer = null } }
 function onCardDown(e: PointerEvent) {
-  if (surveying.value || !isGroup.value) return
+  if (!isGroup.value) return
   if (jiggling.value) { jiggling.value = false; return } // already wiggling → a tap/drag off a face exits
   pressOrigin = { x: e.clientX, y: e.clientY }
   clearPress()
@@ -249,7 +243,7 @@ onClickOutside(cardRef, () => { if (jiggling.value) jiggling.value = false })
 // Show the detach faces only while WIGGLING (or while a pull is mid-flight, so the grabbed pane
 // isn't orphaned if the finger leaves the card). Tapping/selecting no longer auto-arms detach —
 // that surface is the #942 promote/duplicate toolbar now; pulling apart is the deliberate hold.
-const armed = computed(() => !surveying.value && isGroup.value && (jiggling.value || activeIndex.value !== null))
+const armed = computed(() => isGroup.value && (jiggling.value || activeIndex.value !== null))
 
 // Top-level pane faces (as % of the card), laid out along the split's axis — the regions you grab to
 // pull a pane out, the seams on ease-apart, AND the slot bounds the reorder hit-test reads. They must
@@ -465,7 +459,7 @@ watch(() => props.data.node, () => {
   >
     <!-- "Page" badge — this node is the live layout a user sees (#942). -->
     <UBadge
-      v-if="data.isPage && !surveying"
+      v-if="data.isPage"
       color="primary"
       variant="solid"
       size="sm"
@@ -475,7 +469,7 @@ watch(() => props.data.node, () => {
 
     <!-- Region badge (#953) — this node is pinned to the page's top/bottom edge (a sticky pill). -->
     <UBadge
-      v-if="data.region && !surveying"
+      v-if="data.region"
       color="primary"
       variant="subtle"
       size="sm"
@@ -488,7 +482,7 @@ watch(() => props.data.node, () => {
          `.stop` so tapping a button neither drags the node nor bubbles to the card. -->
     <!-- Done — exit wiggle mode (#941). Shown while wiggling; tapping outside the layout also exits. -->
     <div
-      v-if="jiggling && !surveying"
+      v-if="jiggling"
       class="nodrag pointer-events-auto absolute -top-10 left-1/2 z-40 flex -translate-x-1/2 items-center gap-1 rounded-full border border-primary/40 bg-elevated/95 p-1 shadow-xl backdrop-blur"
     >
       <UButton
@@ -503,7 +497,7 @@ watch(() => props.data.node, () => {
     </div>
 
     <div
-      v-if="selected && !jiggling && !surveying"
+      v-if="selected && !jiggling"
       class="nodrag pointer-events-auto absolute -top-10 left-1/2 z-40 flex -translate-x-1/2 items-center gap-1 rounded-full border border-default bg-elevated/95 p-1 shadow-xl backdrop-blur"
     >
       <UButton
@@ -572,24 +566,13 @@ watch(() => props.data.node, () => {
       />
     </div>
 
-    <!-- Survey mode renders the layout AT the device width (authored breakpoints + intrinsic reflow); -->
-    <!-- topology mode renders it plain at its footprint size. -->
-    <!-- Survey: scroll the PREVIEW, don't pan the canvas (#940). `nopan`/`nodrag` keep Vue Flow's
-         hands off the gesture, `overflow-auto` + `touch-action` let an overflowing layout scroll. -->
+    <!-- Per-node width preview (#954): render responsively at the node's own width so it reflows
+         per-element. Scroll the PREVIEW, don't pan the canvas — `nopan`/`nodrag` keep Vue Flow's
+         hands off the gesture, `overflow-auto` + `touch-action` let an overflowing layout scroll.
+         Read-only splitters (`interactive: false`) resize the CARD, not internal panes — editing
+         sizes is the edit view's job (double-click). Plain footprint render otherwise. -->
     <div
-      v-if="surveying"
-      class="nopan nodrag h-full w-full overflow-auto"
-      style="touch-action: pan-x pan-y; -webkit-overflow-scrolling: touch;"
-    >
-      <!-- Survey is READ-ONLY (#953): `interactive: false` drops the splitter resize handles, so you
-           can't accidentally resize panes while previewing a device width. Editing sizes is the edit
-           view's job (double-click), not the survey. -->
-      <CroutonLayoutResponsiveRenderer :tree="tree" :width="viewport!.width" :interactive="false" />
-    </div>
-    <!-- Per-node width preview (#954): render responsively at the node's own width so it reflows like
-         the survey did, but per-element. Read-only splitters (resize the CARD, not internal panes). -->
-    <div
-      v-else-if="previewing"
+      v-if="previewing"
       class="nopan nodrag h-full w-full overflow-auto"
       style="touch-action: pan-x pan-y; -webkit-overflow-scrolling: touch;"
     >
@@ -599,9 +582,9 @@ watch(() => props.data.node, () => {
 
     <!-- Resize handle (#954) — drag the corner to set this node's width (drives responsive reflow) +
          height. The per-element "slider". `.nodrag`/`.stop` keep it off Vue Flow's node drag. Shown when
-         selected (not wiggling/surveying). Double-click clears back to the intrinsic footprint size. -->
+         selected (not wiggling). Double-click clears back to the intrinsic footprint size. -->
     <div
-      v-if="selected && !jiggling && !surveying"
+      v-if="selected && !jiggling"
       class="nodrag absolute -bottom-3 -right-3 z-40 flex size-12 cursor-nwse-resize items-center justify-center touch-none"
       title="Drag to resize · double-click to reset"
       @pointerdown.stop="onResizeDown"

--- a/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
@@ -60,9 +60,10 @@ const tree = computed(() => ({ renderer: 'panes' as const, root: props.data.node
 const snapPreview = inject(SPIKE_SNAP_KEY, null)
 // This node is the snap target when the injected preview names its layout node.
 const guideMatch = computed(() => !!snapPreview?.value && snapPreview.value.node === props.data.node)
-// A preview is EITHER an internal insert seam (Phase A) OR an outer edge.
-const guideInsert = computed(() => (guideMatch.value ? snapPreview!.value!.insert ?? null : null))
-const guideEdge = computed<SnapEdge | null>(() => (guideMatch.value && !guideInsert.value ? snapPreview!.value!.edge ?? null : null))
+// A preview is EITHER a pane-drop (drop OVER this layout — add beside a pane, #972) OR an outer edge
+// (proximity merge from a nearby loose card).
+const guidePaneDrop = computed(() => (guideMatch.value ? snapPreview!.value!.paneDrop ?? null : null))
+const guideEdge = computed<SnapEdge | null>(() => (guideMatch.value && !guidePaneDrop.value ? snapPreview!.value!.edge ?? null : null))
 // Dwell stages (#941): SOFT = just approached (blue, wide — "snap point here"); ARMED = held long
 // enough that releasing now snaps (green, tighter solid line).
 const guideArmed = computed(() => guideMatch.value && snapPreview!.value!.armed === true)
@@ -79,39 +80,35 @@ const guideStyle = computed(() => {
     default: return {}
   }
 })
-// Internal insert seam (#950): a line at the seam, positioned by card-fractions and spanning only
-// the TARGET split's sub-region — so a seam inside a NESTED split draws in the right place, not
-// across the whole card. `pos` is the main-axis position; `cross0..cross1` the cross-axis span.
-const guideInsertStyle = computed(() => {
-  const ins = guideInsert.value
-  if (!ins) return {}
+// Pane-drop guide (#972): a band on the chosen EDGE of the targeted pane — drawn from the pane's rect
+// (% of the card) so it lands on the right pane at any depth, on the side you're nearest.
+const guidePaneDropStyle = computed(() => {
+  const pd = guidePaneDrop.value
+  if (!pd) return {}
   const t = guideArmed.value ? '5px' : '8px'
-  const pos = `${ins.pos * 100}%`
-  const c0 = `${ins.cross0 * 100}%`
-  const c1 = `${(1 - ins.cross1) * 100}%`
-  return ins.axis === 'horizontal'
-    ? { left: pos, top: c0, bottom: c1, width: t, transform: 'translateX(-50%)' }
-    : { top: pos, left: c0, right: c1, height: t, transform: 'translateY(-50%)' }
+  const r = pd.rect
+  switch (pd.edge) {
+    case 'left': return { left: `${r.left}%`, top: `${r.top}%`, height: `${r.height}%`, width: t, transform: 'translateX(-50%)' }
+    case 'right': return { left: `${r.left + r.width}%`, top: `${r.top}%`, height: `${r.height}%`, width: t, transform: 'translateX(-50%)' }
+    case 'top': return { top: `${r.top}%`, left: `${r.left}%`, width: `${r.width}%`, height: t, transform: 'translateY(-50%)' }
+    case 'bottom': return { top: `${r.top + r.height}%`, left: `${r.left}%`, width: `${r.width}%`, height: t, transform: 'translateY(-50%)' }
+    default: return {}
+  }
 })
-// Ease-apart preview (#946): once an internal insert ARMS (green), splice a ghost pane into the
-// layout at the target index and render THAT — the renderer lays out the extra pane and the #943
-// FLIP eases the real panes apart to physically open its slot, the ghost landing in the gap. The
-// ghost block (`__dropghost__` → SpikeGhostPane) shows the incoming item's label, which we provide
-// (the renderer doesn't thread arbitrary config to a block). Reverts on un-arm → panes close back.
-const guideArmedInsert = computed(() => guideArmed.value && !!guideInsert.value)
+// Ease-apart preview (#946): once a pane-drop ARMS (green), apply the SAME edit with a ghost in place
+// of the real node and render THAT — the renderer lays out the extra pane and the #943 FLIP eases the
+// real panes apart to physically open its slot, the ghost landing in the gap. Reverts on un-arm.
+const guideArmedPaneDrop = computed(() => guideArmed.value && !!guidePaneDrop.value)
 const ghostLabel = computed(() => snapPreview?.value?.dragLabel ?? 'Drops here')
 provide(SPIKE_GHOST_LABEL_KEY, ghostLabel)
 // Build a ghost SKELETON with the same shape as the dragged node — every leaf becomes a
 // `__dropghost__` placeholder, splits/nested preserved — so its FOOTPRINT matches the dragged item.
-// Inserted into a horizontal split, a 2-row stack stays 2 rows, growing the row to fit (so the
-// opened slot matches the item's size, not a flat 1×1 sliver). Sizes preserved for inner proportions.
 function ghostify(node: LayoutNode): LayoutNode {
   if (node.type === 'leaf') return { type: 'leaf', blockId: '__dropghost__', ...(node.defaultSize !== undefined ? { defaultSize: node.defaultSize } : {}) }
   if (node.type === 'nested') return { type: 'nested', layout: { ...node.layout, root: ghostify(node.layout.root) } }
   return { ...node, children: node.children.map(ghostify) }
 }
 const renderNode = computed<LayoutNode>(() => {
-  const ins = guideInsert.value
   const n = props.data.node
   // Live reorder preview (#952): while pulling a pane toward a different slot (and not detaching), show
   // the panes ALREADY in their reordered order, so you SEE where the block lands as you move — the FLIP
@@ -123,15 +120,13 @@ const renderNode = computed<LayoutNode>(() => {
     if (m) arr.splice(reorderTo.value, 0, m)
     return { ...n, children: arr }
   }
-  if (!guideArmedInsert.value || !ins || n.type !== 'split') return n
-  // The seam may be in a NESTED split — resolve it by path so the ghost opens the slot at the right
-  // depth (#950). Size the ghost to that split's child count, then splice it in via insertAtPath.
-  const targetSplit = splitAtPath(n, ins.path)
-  if (!targetSplit || targetSplit.type !== 'split') return n
+  const pd = guidePaneDrop.value
+  if (!guideArmedPaneDrop.value || !pd) return n
+  // Apply the pane-drop with a ghost skeleton (same shape as the dragged item) so the opened slot
+  // matches its footprint; `applyPaneDrop` flattens-or-wraps exactly like the real drop will.
   const dn = snapPreview?.value?.dragNode
-  const skeleton = dn ? ghostify(dn) : { type: 'leaf' as const, blockId: '__dropghost__' }
-  const ghost: LayoutNode = { ...skeleton, defaultSize: Math.round(100 / (targetSplit.children.length + 1)) }
-  return insertAtPath(n, ins.path, ins.index, ghost)
+  const ghost: LayoutNode = dn ? ghostify(dn) : { type: 'leaf', blockId: '__dropghost__' }
+  return applyPaneDrop(n, pd, ghost)
 })
 
 // --- pull-the-pane-to-detach ----------------------------------------------------------
@@ -491,7 +486,7 @@ watch(() => props.data.node, () => {
   <UCard
     ref="cardRef"
     class="spike-block-node transition-[width,height,box-shadow] duration-300 ease-out"
-    :class="[guideArmed ? 'ring-2 ring-emerald-500 shadow-lg' : (guideEdge || guideInsert) ? 'ring-2 ring-sky-400/70 shadow-lg' : (dragging || data.justAdded) ? 'spike-drag-glow' : selected ? 'ring-primary shadow-lg' : '', { 'spike-reflowing': reflowing }]"
+    :class="[guideArmed ? 'ring-2 ring-emerald-500 shadow-lg' : (guideEdge || guidePaneDrop) ? 'ring-2 ring-sky-400/70 shadow-lg' : (dragging || data.justAdded) ? 'spike-drag-glow' : selected ? 'ring-primary shadow-lg' : '', { 'spike-reflowing': reflowing }]"
     :style="size"
     :ui="{ root: 'relative overflow-visible', body: `h-full ${pulling ? 'overflow-visible' : 'overflow-hidden'} rounded-[inherit] p-0 sm:p-0` }"
     @pointerdown="onCardDown"
@@ -644,8 +639,8 @@ watch(() => props.data.node, () => {
       </div>
     </div>
 
-    <!-- Live snap guide (#941): an outer EDGE (merge onto a side) or an internal INSERT seam (drop
-         between panes). SOFT = blue, wide, pulsing ("snap point here"); ARMED = green, crisp, steady. -->
+    <!-- Live snap guide (#941): an outer EDGE (merge a nearby card onto a side) or a PANE-DROP band on
+         the targeted pane's edge (#972). SOFT = blue, wide, pulsing; ARMED = green, crisp, steady. -->
     <div
       v-if="guideEdge"
       class="pointer-events-none absolute z-10 rounded-full"
@@ -653,10 +648,10 @@ watch(() => props.data.node, () => {
       :style="guideStyle"
     />
     <div
-      v-if="guideInsert && !guideArmedInsert"
+      v-if="guidePaneDrop && !guideArmedPaneDrop"
       class="pointer-events-none absolute z-10 rounded-full"
       :class="guideBarClass"
-      :style="guideInsertStyle"
+      :style="guidePaneDropStyle"
     />
     <!-- Detach overlay: armed merged node → grab a pane face and pull it out past the threshold.
          The container is `.nodrag` so Vue Flow pulls the pane, not the node; the seams/frame

--- a/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue
@@ -26,8 +26,8 @@
  * No `@vue-flow/core` import (connection handles aren't needed here). `footprint` / `SPIKE_*`
  * / `SPIKE_SNAP_KEY` / `SPIKE_DETACH_KEY` are auto-imported from app/utils/spike-layout.
  */
-import { ref, inject, computed, watch } from 'vue'
-import { onKeyStroke, onClickOutside } from '@vueuse/core'
+import { ref, inject, computed, watch, nextTick, onMounted } from 'vue'
+import { onKeyStroke, onClickOutside, useElementSize } from '@vueuse/core'
 import type { LayoutNode, LayoutBreakpoint } from '@fyit/crouton-core/app/types/layout'
 import type { SpikeRegion } from '~/utils/spike-layout'
 
@@ -245,13 +245,45 @@ onClickOutside(cardRef, () => { if (jiggling.value) jiggling.value = false })
 // that surface is the #942 promote/duplicate toolbar now; pulling apart is the deliberate hold.
 const armed = computed(() => isGroup.value && (jiggling.value || activeIndex.value !== null))
 
-// Top-level pane faces (as % of the card), laid out along the split's axis — the regions you grab to
-// pull a pane out, the seams on ease-apart, AND the slot bounds the reorder hit-test reads. They must
-// match what the renderer actually DRAWS: it sizes each splitter panel by `defaultSize` (% along the
-// axis), NOT footprint — so a spacer beside a dense grid renders 50/50, while footprint would've said
-// e.g. 1:4. Using footprint here made the faces drift off the panes (#953, IMG_1061/1062). Mirror the
-// renderer's `child.defaultSize ?? (100 / n)` exactly so faces/seams/reorder-slots line up.
-const panes = computed(() => {
+// Top-level pane faces (as % of the card) — the regions you grab to pull a pane out, the seams on
+// ease-apart, AND the slot bounds the reorder hit-test reads. They MUST sit exactly over the panes the
+// renderer actually draws. Computing them from `defaultSize` drifts whenever the rendered geometry
+// differs — reka enforces each pane's min-width, a horizontal split STACKS vertically when it's too
+// narrow (`@container`), and nested splits carry their own proportions — none of which `defaultSize`
+// reflects (#953/#954, IMG_1069). So we MEASURE the real panes (same lesson as the edit-view
+// selection): the shallowest reka panels (`[data-panel]`) / stacked panes (`[data-crouton-pane]`)
+// inside the card, as % of the card box. Fall back to the `defaultSize` math only until a measurement
+// lands (or if the counts ever disagree — e.g. a pane collapsed into the gutter).
+const measuredPanes = ref<{ left: number, top: number, width: number, height: number }[]>([])
+function cardEl(): HTMLElement | null {
+  return (cardRef.value as { $el?: HTMLElement } | null)?.$el ?? null
+}
+function syncPanes() {
+  const card = cardEl()
+  const n = props.data.node
+  if (!card || n.type !== 'split') { measuredPanes.value = []; return }
+  const cr = card.getBoundingClientRect()
+  if (!cr.width || !cr.height) { measuredPanes.value = []; return }
+  // Shallowest panes only (a pane's own ancestor chain has no other pane) → the TOP-LEVEL row/column,
+  // in document order = the split's child order.
+  const els = Array.from(card.querySelectorAll<HTMLElement>('[data-panel],[data-crouton-pane]'))
+    .filter(el => !el.parentElement?.closest('[data-panel],[data-crouton-pane]'))
+  if (els.length !== n.children.length) { measuredPanes.value = []; return }
+  measuredPanes.value = els.map((el) => {
+    const r = el.getBoundingClientRect()
+    return {
+      left: ((r.left - cr.left) / cr.width) * 100,
+      top: ((r.top - cr.top) / cr.height) * 100,
+      width: (r.width / cr.width) * 100,
+      height: (r.height / cr.height) * 100,
+    }
+  })
+}
+// nextTick (DOM settled) + a short follow-up (reka's flex sizing + the @container reflow settle async).
+function scheduleSyncPanes() { nextTick(syncPanes); window.setTimeout(syncPanes, 60) }
+
+// Tree-derived fallback: mirror the renderer's `child.defaultSize ?? (100 / n)` along the split axis.
+const treePanes = computed(() => {
   const n = props.data.node
   if (n.type !== 'split') return []
   const horizontal = n.direction === 'horizontal'
@@ -267,6 +299,12 @@ const panes = computed(() => {
       : { left: 0, top: start, width: 100, height: sizePct }
   })
 })
+const childCount = computed(() => (props.data.node.type === 'split' ? props.data.node.children.length : 0))
+const panes = computed(() => (
+  measuredPanes.value.length === childCount.value && childCount.value > 0
+    ? measuredPanes.value
+    : treePanes.value
+))
 
 // Active pull state.
 const activeIndex = ref<number | null>(null) // the pane being pulled
@@ -279,6 +317,14 @@ let origin = { x: 0, y: 0 }
 let faceEl: HTMLElement | null = null // the grabbed pane face — its rect at release = the drop spot
 let moveHandler: ((e: PointerEvent) => void) | null = null
 let upHandler: ((e: PointerEvent) => void) | null = null
+
+// Re-measure the rendered panes when the card resizes (per-node resize / canvas zoom), when it arms
+// (faces appear), and after the layout re-renders (reorder preview, detach/insert, merge). Declared
+// here — below `activeIndex` etc. — because the watch eagerly reads `renderNode`, which references the
+// pull state; reading it before these are initialized throws a TDZ error. Cheap; only the overlay reads it.
+const { width: cardW, height: cardH } = useElementSize(cardEl)
+watch([cardW, cardH, jiggling, renderNode, () => props.data.width], scheduleSyncPanes)
+onMounted(scheduleSyncPanes)
 
 // Gap each pane insets by: a resting seam (so the seams/frame stay node-draggable) that widens
 // when a pull starts, so the group visibly eases apart the moment you grab a pane.

--- a/pocs/crouton-builder-demo/app/components/SpikeChartBlock.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeChartBlock.vue
@@ -9,9 +9,14 @@ const days = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
     <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted">
       <UIcon name="i-lucide-bar-chart-3" class="size-3.5" /> Bookings / week
     </div>
-    <div class="flex min-h-0 flex-1 items-end gap-1.5">
+    <!-- Each column is FULL height (default items-stretch); the bar lives in a flex-1 track with a
+         definite height, so the bar's `height: X%` resolves reliably. Anchoring the column to
+         `items-end` collapsed the track to content height → % heights rounded to nothing (#975). -->
+    <div class="flex min-h-0 flex-1 gap-1.5">
       <div v-for="(b, i) in bars" :key="i" class="flex min-w-0 flex-1 flex-col items-center gap-1">
-        <div class="w-full rounded-t bg-primary/70" :style="{ height: `${b}%` }" />
+        <div class="flex min-h-0 w-full flex-1 items-end">
+          <div class="w-full rounded-t bg-primary/70" :style="{ height: `${b}%` }" />
+        </div>
         <span class="text-[10px] text-dimmed">{{ days[i] }}</span>
       </div>
     </div>

--- a/pocs/crouton-builder-demo/app/components/SpikeFocusShell.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeFocusShell.vue
@@ -24,6 +24,13 @@ import type { LayoutTree, LayoutNode, LayoutCollapseEdge, LayoutCollapseAffordan
 import { applySizes, setCollapseRecipe, type NodePath } from '@fyit/crouton-layout/app/utils/layout-edit'
 // resolveLayoutAtWidth / listBlocks / patchBreakpoint / removeBreakpoint are auto-imported from the
 // crouton-layout layer (its `app/utils/layout-responsive` isn't in the package `exports` map).
+// leafConfigValue / setLeafConfigValue are auto-imported from app/utils/spike-layout.
+
+// Display variants (#970) — a block can expose bounded DISPLAY variants (e.g. List: rows/cards/table)
+// as a `variant` select field on its registry `configSchema`. The picker below sets the chosen value on
+// the leaf's `config.variant` (serialised on the leaf, agent-pickable); the renderer merges it into the
+// block's props. One source: the SAME registry an agent reads.
+const { getBlock } = useCroutonLayoutBlocks()
 
 const props = defineProps<{
   modelValue: LayoutTree
@@ -84,6 +91,36 @@ function setRecipe(blockId: string, p: RecipePreset) {
     ...tree.value,
     root: setCollapseRecipe(tree.value.root, blockId, recipe),
     ...(bps ? { breakpoints: bps.map(bp => (bp.root ? { ...bp, root: setCollapseRecipe(bp.root, blockId, recipe) } : bp)) } : {}),
+  })
+}
+
+// --- display variants (#970) — the selected block's bounded `variant` enum (rows/cards/table) -------
+interface VariantOption { label: string, value: string }
+/** The selected block's display-variant options, or null if it declares none. */
+const variantOptions = computed<VariantOption[]>(() => {
+  const id = selectedBlockId.value
+  if (!id) return []
+  const field = getBlock(id)?.configSchema?.find(f => f.name === 'variant' && f.type === 'select')
+  return (field?.options ?? []) as VariantOption[]
+})
+const hasVariants = computed(() => variantOptions.value.length > 1)
+/** The active variant — the leaf's serialised `config.variant`, else the field's declared default. */
+const activeVariant = computed<string>(() => {
+  const id = selectedBlockId.value
+  if (!id) return ''
+  const onLeaf = leafConfigValue(tree.value.root, id, 'variant')
+  if (typeof onLeaf === 'string') return onLeaf
+  const field = getBlock(id)?.configSchema?.find(f => f.name === 'variant')
+  return typeof field?.default === 'string' ? field.default : (variantOptions.value[0]?.value ?? '')
+})
+/** Set the variant on the leaf's config — on the base root AND every breakpoint root override (like
+ *  setRecipe), so whichever root resolves at the current width carries it. Serialised on the leaf. */
+function setVariant(blockId: string, value: string) {
+  const bps = tree.value.breakpoints
+  update({
+    ...tree.value,
+    root: setLeafConfigValue(tree.value.root, blockId, 'variant', value),
+    ...(bps ? { breakpoints: bps.map(bp => (bp.root ? { ...bp, root: setLeafConfigValue(bp.root, blockId, 'variant', value) } : bp)) } : {}),
   })
 }
 
@@ -436,6 +473,22 @@ watch([() => regions.value.length, () => regions.value.map(r => r.blockId).join(
                     >
                       <UIcon :name="r.icon" class="size-3.5 shrink-0" />
                       {{ r.label }}
+                    </button>
+                  </div>
+                  <!-- Display variants (#970) — a bounded enum the block declares; a tap re-renders it in
+                       that variant and serialises the choice on the leaf. Shown only when it has ≥2. -->
+                  <div v-if="hasVariants" class="flex items-center gap-1 overflow-x-auto pb-0.5">
+                    <span class="shrink-0 pr-0.5 text-[10px] uppercase tracking-widest text-muted">Display</span>
+                    <button
+                      v-for="opt in variantOptions"
+                      :key="opt.value"
+                      type="button"
+                      class="flex shrink-0 items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium transition-colors active:scale-95"
+                      :class="activeVariant === opt.value ? 'border-primary bg-primary/10 text-primary' : 'border-default text-muted hover:text-default'"
+                      :title="opt.label"
+                      @click="setVariant(selectedBlock!.blockId, opt.value)"
+                    >
+                      {{ opt.label }}
                     </button>
                   </div>
                 </div>

--- a/pocs/crouton-builder-demo/app/components/SpikeListBlock.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikeListBlock.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
-/** SpikeListBlock (#956) — a recognizable LIST block for the demo palette (rows of artists). Distinct
- *  from the other demo blocks so you can SEE which block landed where in a composition/preview. */
+/** SpikeListBlock (#956) — a recognizable LIST block for the demo palette. Distinct from the other
+ *  demo blocks so you can SEE which block landed where in a composition/preview.
+ *
+ *  Display variants (#970) — the same data, three bounded layouts: `rows` (list), `cards` (grid),
+ *  `table`. The variant is a BOUNDED ENUM declared on the block registry (`artists-list` configSchema)
+ *  and serialised on the leaf's `config.variant`, so an agent could pick it just as a human does in the
+ *  edit view. The renderer merges `config.variant` into props; we read it here. Unknown → `rows`. */
+const props = defineProps<{ variant?: string }>()
+const variant = computed<'rows' | 'cards' | 'table'>(() =>
+  props.variant === 'cards' || props.variant === 'table' ? props.variant : 'rows')
+
 const items = [
   { initials: 'AD', name: 'Aria Delgado', role: 'Vocalist' },
   { initials: 'MK', name: 'Milo Kane', role: 'Producer' },
@@ -14,13 +23,47 @@ const items = [
     <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted">
       <UIcon name="i-lucide-list" class="size-3.5" /> Artists
     </div>
-    <div v-for="a in items" :key="a.initials" class="flex items-center gap-2.5 rounded-lg border border-default bg-elevated/40 px-2.5 py-2">
-      <div class="grid size-7 shrink-0 place-items-center rounded-full bg-primary/15 text-[11px] font-semibold text-primary">{{ a.initials }}</div>
-      <div class="min-w-0">
+
+    <!-- ROWS — a stacked list (the default). -->
+    <template v-if="variant === 'rows'">
+      <div v-for="a in items" :key="a.initials" class="flex items-center gap-2.5 rounded-lg border border-default bg-elevated/40 px-2.5 py-2">
+        <div class="grid size-7 shrink-0 place-items-center rounded-full bg-primary/15 text-[11px] font-semibold text-primary">{{ a.initials }}</div>
+        <div class="min-w-0">
+          <div class="truncate text-sm font-medium text-highlighted">{{ a.name }}</div>
+          <div class="truncate text-xs text-muted">{{ a.role }}</div>
+        </div>
+        <UIcon name="i-lucide-chevron-right" class="ml-auto size-4 text-dimmed" />
+      </div>
+    </template>
+
+    <!-- CARDS — a responsive grid of avatar cards. -->
+    <div v-else-if="variant === 'cards'" class="grid grid-cols-2 gap-2 @sm:grid-cols-3">
+      <div v-for="a in items" :key="a.initials" class="flex flex-col items-center gap-1.5 rounded-xl border border-default bg-elevated/40 p-3 text-center">
+        <div class="grid size-10 place-items-center rounded-full bg-primary/15 text-sm font-semibold text-primary">{{ a.initials }}</div>
         <div class="truncate text-sm font-medium text-highlighted">{{ a.name }}</div>
         <div class="truncate text-xs text-muted">{{ a.role }}</div>
       </div>
-      <UIcon name="i-lucide-chevron-right" class="ml-auto size-4 text-dimmed" />
     </div>
+
+    <!-- TABLE — a compact rows/columns grid. -->
+    <table v-else class="w-full border-separate border-spacing-0 text-left text-sm">
+      <thead>
+        <tr class="text-[11px] uppercase tracking-wide text-muted">
+          <th class="border-b border-default px-2 py-1.5 font-medium">Artist</th>
+          <th class="border-b border-default px-2 py-1.5 font-medium">Role</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="a in items" :key="a.initials" class="hover:bg-elevated/40">
+          <td class="border-b border-default/60 px-2 py-1.5">
+            <div class="flex items-center gap-2">
+              <div class="grid size-6 shrink-0 place-items-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary">{{ a.initials }}</div>
+              <span class="truncate text-highlighted">{{ a.name }}</span>
+            </div>
+          </td>
+          <td class="border-b border-default/60 px-2 py-1.5 text-muted">{{ a.role }}</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </template>

--- a/pocs/crouton-builder-demo/app/components/SpikePagePreview.vue
+++ b/pocs/crouton-builder-demo/app/components/SpikePagePreview.vue
@@ -23,6 +23,15 @@ const props = defineProps<{
 const emit = defineEmits<{ close: [] }>()
 
 const hasContent = computed(() => props.top.length || props.main.length || props.bottom.length)
+
+// Intrinsic block sizing as DECLARED DATA (#971): a node renders `hug` (height:auto → short bar) or
+// `fill` (stretch) per the BLOCK's `sizing.height` descriptor on the registry — so a pinned Top bar is
+// short because the component says `hug`, not because of where it's pinned, and with no per-instance
+// control. `nodeHeightSizing` reads the same one source an agent would.
+const registry = computed(() => (useAppConfig().croutonLayoutBlocks ?? {}) as Record<string, { sizing?: { width?: string, height?: string } }>)
+function hugs(node: LayoutNode): boolean {
+  return nodeHeightSizing(node, registry.value) === 'hug'
+}
 </script>
 
 <template>
@@ -37,18 +46,23 @@ const hasContent = computed(() => props.top.length || props.main.length || props
 
       <!-- Phone frame: pinned top region · scrolling main · pinned bottom region -->
       <div class="relative flex h-[78vh] w-full max-w-sm flex-col overflow-hidden rounded-[2rem] border-4 border-default bg-default shadow-2xl">
-        <!-- Pinned TOP region (sticky pill/bar) — hugs the block's intrinsic height (#954): a Top bar
-             block is ~56px, so the bar is short, not a tall panel. -->
+        <!-- Pinned TOP region (sticky pill/bar). Each node hugs/fills per its block's sizing descriptor
+             (#971): a Top bar declares `height:'hug'` → ~56px short pill (not because it's pinned). -->
         <div v-if="top.length" class="z-10 shrink-0 border-b border-default bg-default/95 backdrop-blur">
-          <div v-for="n in top" :key="n.id" class="spike-preview-region spike-region-pinned">
+          <div v-for="n in top" :key="n.id" class="spike-preview-region" :class="hugs(n.data.node) ? 'spike-hug' : 'spike-fill'">
             <CroutonLayoutRenderer :node="n.data.node" />
           </div>
         </div>
 
-        <!-- MAIN (scrolls) -->
+        <!-- MAIN (scrolls). A `hug` block stays content-height; a `fill` block grows (#971). -->
         <div class="min-h-0 flex-1 overflow-auto">
           <div v-if="main.length" class="flex min-h-full flex-col">
-            <div v-for="n in main" :key="n.id" class="spike-preview-region min-h-0 flex-1">
+            <div
+              v-for="n in main"
+              :key="n.id"
+              class="spike-preview-region"
+              :class="hugs(n.data.node) ? 'spike-hug shrink-0' : 'spike-fill min-h-0 flex-1'"
+            >
               <CroutonLayoutRenderer :node="n.data.node" />
             </div>
           </div>
@@ -57,9 +71,9 @@ const hasContent = computed(() => props.top.length || props.main.length || props
           </div>
         </div>
 
-        <!-- Pinned BOTTOM region — hugs the block's intrinsic height (#954). -->
+        <!-- Pinned BOTTOM region — hug/fill per the block's descriptor (#971). -->
         <div v-if="bottom.length" class="z-10 shrink-0 border-t border-default bg-default/95 backdrop-blur">
-          <div v-for="n in bottom" :key="n.id" class="spike-preview-region spike-region-pinned">
+          <div v-for="n in bottom" :key="n.id" class="spike-preview-region" :class="hugs(n.data.node) ? 'spike-hug' : 'spike-fill'">
             <CroutonLayoutRenderer :node="n.data.node" />
           </div>
         </div>
@@ -73,17 +87,18 @@ const hasContent = computed(() => props.top.length || props.main.length || props
 </template>
 
 <style scoped>
-/* Give each region's rendered layout a sensible intrinsic height so pinned bars hug their content
-   while the main area fills. The renderer's panes are h-full; the region wrapper bounds that. */
+/* Give each region's rendered layout a sensible intrinsic height. The renderer's panes are h-full;
+   the region wrapper bounds that. */
 .spike-preview-region {
   container-type: inline-size;
 }
 .spike-preview-region :deep(.croutonpane) {
   min-height: 0;
 }
-/* Pinned bars HUG their block's intrinsic height (#954) — the renderer's panes are `h-full`, which
-   would otherwise stretch the bar to fill; auto lets a ~56px Top bar / 64px Nav stay short. */
-.spike-region-pinned :deep(.croutonpane) {
+/* A `hug`-height block (#971): the renderer's panes are `h-full`, which would stretch it to fill;
+   `auto` lets the block's own content height stand — a ~56px Top bar / 64px Nav stays short, driven
+   by the block's declared `sizing.height: 'hug'`, not by which region it sits in. */
+.spike-hug :deep(.croutonpane) {
   height: auto;
 }
 </style>

--- a/pocs/crouton-builder-demo/app/pages/spike-app.vue
+++ b/pocs/crouton-builder-demo/app/pages/spike-app.vue
@@ -114,18 +114,16 @@ function undo() {
 // ⌘/Ctrl-Z undoes, on the board only (let inputs/textareas keep their native undo).
 onKeyStroke('z', (e) => {
   if (!(e.metaKey || e.ctrlKey) || e.shiftKey) return
-  if (!selectedPageId.value || viewport.value) return
+  if (!selectedPageId.value) return
   const t = e.target as HTMLElement | null
   if (t && /^(INPUT|TEXTAREA)$/.test(t.tagName)) return
   e.preventDefault()
   undo()
 })
 
-// Camera: re-frame the whole board to an overview after adding a block. CroutonFlow only
-// fits-to-view on mount (when the board is empty), so without this a freshly-added block sits at
-// the default zoom — which on a narrow phone fills the screen. fitView with maxZoom:1 keeps a
-// single block at a comfortable size and shows everything you've added. Survey/focus own the
-// camera, so skip then.
+// Camera: re-frame the whole board after adding a block. CroutonFlow only fits-to-view on mount
+// (when the board is empty), so without this a freshly-added block sits at the default zoom —
+// which on a narrow phone fills the screen. The edit view owns the camera, so skip then.
 const flowRef = ref<{
   fitView?: (o?: Record<string, unknown>) => void
   fitBounds?: (b: { x: number, y: number, width: number, height: number }, o?: Record<string, unknown>) => void
@@ -137,9 +135,8 @@ const flowRef = ref<{
 // node's drag eats it). We read the live viewport transform and re-`setCenter` with the math that
 // keeps the pinched point fixed under the fingers (Vue Flow exposes setCenter but not setViewport).
 function pinchZoom(ratio: number, midX: number, midY: number) {
-  // Pinch zooms the CANVAS — fine during a survey (the slider previewing a device width); only the
-  // full-screen edit view (zoomNodeId) owns the screen and must not be pinched. (Was also bailing on
-  // `viewport`, which killed pinch whenever the slider wasn't at max → "pinch broken in other views".)
+  // Pinch zooms the CANVAS — only the full-screen edit view (zoomNodeId) owns the screen and must
+  // not be pinched.
   if (zoomNodeId.value) return
   const container = document.querySelector('.crouton-vue-flow') as HTMLElement | null
   // The zoom transform lives on `.vue-flow__transformationpane` — `.vue-flow__viewport` has NO
@@ -160,14 +157,6 @@ function pinchZoom(ratio: number, midX: number, midY: number) {
   flowRef.value.setCenter(cx, cy, { zoom: nz, duration: 0 })
 }
 provide(SPIKE_PINCH_KEY, pinchZoom)
-function fitOverview() {
-  if (viewport.value || zoomNodeId.value) return // survey / edit-view own the screen
-  const fit = () => flowRef.value?.fitView?.({ duration: 350, padding: 0.3, maxZoom: 1 })
-  // Fit on nextTick, then once more after the new node's dimensions settle (Vue Flow measures
-  // node size async, so a single immediate fit can frame a stale/zero-width box and miscenter).
-  nextTick(fit)
-  window.setTimeout(fit, 180)
-}
 
 // Live snap preview (#907): while a block is dragged, the target node it will snap to lights
 // up the joining edge. Provided here; SpikeBlockNode injects it and matches by object identity.
@@ -223,20 +212,6 @@ function onReorder(group: LayoutNode, payload: SpikeReorderPayload) {
   nodes.value = nodes.value.map((n, i) => i === idx ? { ...n, data: { ...n.data, node: next } } : n)
 }
 provide(SPIKE_REORDER_KEY, onReorder)
-
-// Global viewport survey (#907 layer 3) — flip the whole board to a device width to see what every
-// page looks like at that viewport. Read-only: snapping/detach off, nodes tiled & non-draggable.
-const viewport = ref<SpikeViewport | null>(null)
-provide(SPIKE_VIEWPORT_KEY, viewport)
-
-// While surveying, tile the nodes in a row at device size — non-destructive (the real topology
-// positions in `nodes` are untouched, so flipping back to Fit restores your arrangement).
-const flowRows = computed<FlowNode[]>(() => {
-  if (!viewport.value) return nodes.value
-  const vw = viewport.value
-  const GAP = 80
-  return nodes.value.map((n, i) => ({ ...n, position: { x: i * (vw.width + GAP), y: 0 } }))
-})
 
 // Focus EDIT (#907 v2) — double-click a node and its layout ZOOMS UP in place: SpikeFocusShell
 // animates the card from the node's real on-screen rect to centre (a shared-element transition, NOT
@@ -298,10 +273,8 @@ const paletteOpen = ref(false)
 const resultOpen = ref(false)
 
 // The global responsive slider was removed (#954): responsiveness is now PER-ELEMENT — drag a card's
-// resize handle to preview its layout at that width. `viewport` (the old board-wide survey state) is
-// kept only as a dormant null so the SpikeBlockNode survey branch still compiles; nothing sets it.
-// Top-level Fit = zoom the camera to show every node. Doesn't touch the survey width (the slider owns
-// that now) — just frames the board. We frame by the nodes' KNOWN geometry (position + sizeOf), NOT Vue
+// resize handle to preview its layout at that width. Top-level Fit = zoom the camera to show every
+// node — just frames the board. We frame by the nodes' KNOWN geometry (position + sizeOf), NOT Vue
 // Flow's `fitView` — VF measures the `.vue-flow__node` wrapper, which is smaller than our overflowing
 // card, so its fit zooms into a corner of the oversized content. fitBounds on the real union box (like
 // fitPage does for one node) frames correctly. (#952 follow-up — same wrapper-vs-card mismatch.)
@@ -310,9 +283,7 @@ function boardBounds(): { x: number, y: number, width: number, height: number } 
   if (!ns.length) return null
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
   for (const n of ns) {
-    const s = viewport.value
-      ? { width: viewport.value.width, height: viewport.value.height }
-      : sizeOf(n.data.node)
+    const s = sizeOf(n.data.node)
     minX = Math.min(minX, n.position.x); minY = Math.min(minY, n.position.y)
     maxX = Math.max(maxX, n.position.x + s.width); maxY = Math.max(maxY, n.position.y + s.height)
   }
@@ -496,7 +467,6 @@ function clearSnapTimer() { if (snapTimer != null) { window.clearTimeout(snapTim
 function resetSnap() { snapPreview.value = null; snapKey = null; clearSnapTimer() }
 
 function onNodeDragLive(id: string, pos: { x: number, y: number }) {
-  if (viewport.value) { resetSnap(); return } // survey mode is read-only
   const moved = nodes.value.find(n => n.id === id)
   if (!moved) { resetSnap(); return }
   const intent = snapIntent(moved.data.node, pos, nodes.value.filter(n => n.id !== id))
@@ -532,7 +502,6 @@ function onNodeDragLive(id: string, pos: { x: number, y: number }) {
 function onRowsUpdate(rowsRaw: Record<string, unknown>[]) {
   const armed = snapPreview.value?.armed === true ? snapPreview.value : null // the green candidate at release
   resetSnap() // drag has ended — clear the live guide + dwell timer
-  if (viewport.value) return // survey mode is read-only — don't merge or persist tiled positions
   const rows = rowsRaw as unknown as FlowNode[]
   const prev = new Map(nodes.value.map(n => [n.id, n.position]))
   const moved = rows.find((r) => {
@@ -612,7 +581,6 @@ const blockCount = computed(() => currentBlocks().length)
 /** Enter Snap mode — seed the compose canvas from the free nodes (each node's layout + size). */
 function enterSnap() {
   if (mode.value === 'snap') return
-  viewport.value = null // survey is a Free-mode overlay; leave it when switching to Snap
   const ns = nodes.value
   if (ns.length) {
     const minX = Math.min(...ns.map(n => n.position.x))
@@ -870,7 +838,7 @@ function stashCurrentBoard() {
  *  measures node size async, so a single early fit frames a stale (zero/partial) box and the
  *  layout falls off-screen — retry across a few frames until the node is measured. */
 function fitPage() {
-  if (viewport.value || zoomNodeId.value) return
+  if (zoomNodeId.value) return
   const fit = () => {
     const page = nodes.value.find(n => n.data.isPage)
     if (page) {
@@ -894,7 +862,7 @@ function enterPage(id: string) {
   if (!page) return
   stashCurrentBoard()
   // clean transient board state for a fresh entry
-  mode.value = 'free'; viewport.value = null; zoomNodeId.value = null; originRect.value = null
+  mode.value = 'free'; zoomNodeId.value = null; originRect.value = null
   proposals.value = []; resultOpen.value = false; paletteOpen.value = false
   undoStack.value = [] // fresh board context — don't undo across page boundaries
   zoomDir.value = 'in'
@@ -905,7 +873,7 @@ function enterPage(id: string) {
 /** Page → Site: persist the board and go back to the page flow. */
 function exitToPages() {
   stashCurrentBoard()
-  zoomNodeId.value = null; originRect.value = null; viewport.value = null
+  zoomNodeId.value = null; originRect.value = null
   zoomDir.value = 'out'
   selectedPageId.value = null
 }
@@ -1035,19 +1003,22 @@ function exitToPages() {
             </div>
           </div>
         </header>
-        <!-- The flow itself lives inside the container -->
-        <div class="relative min-h-0 flex-1">
+        <!-- The flow itself lives inside the container. `spike-board-canvas` scopes the CSS that hides
+             Vue Flow's own ⛶ fitView button HERE — it measures the small `.vue-flow__node` wrapper and
+             zooms INTO our oversized cards; our pill Fit (fitBounds) is the correct one. The Site
+             flow's normal-sized cards are fine, so its ⛶ stays. (#975) -->
+        <div class="spike-board-canvas relative min-h-0 flex-1">
         <ClientOnly>
           <!-- Free placement: drag blocks from the drawer, position freely -->
           <CroutonFlow
             v-if="mode === 'free'"
             ref="flowRef"
-            :rows="flowRows"
+            :rows="nodes"
             collection="artists"
             :fit-view-on-mount="false"
             data-mode="ephemeral"
             :default-node-component="blockNode"
-            :draggable="viewport === null && !editing"
+            :draggable="!editing"
             allow-drop
             :minimap="false"
             @node-drop="onNodeDrop"
@@ -1294,6 +1265,13 @@ function exitToPages() {
   right: 0.5rem;
   bottom: auto;
   left: auto;
+}
+
+/* Hide Vue Flow's ⛶ fitView button on the BOARD only (#975) — VF's fitView measures the small
+   `.vue-flow__node` wrapper and zooms into our oversized cards; the pill Fit (fitBounds) is correct.
+   The Site flow keeps its ⛶ (normal-sized cards frame fine). Keeps the +/− zoom buttons. */
+.spike-board-canvas :deep(.vue-flow__controls-fitview) {
+  display: none;
 }
 
 /* Page ⇄ Site cross-fade (#940): both views absolute + overlapping, so enter and leave run at the

--- a/pocs/crouton-builder-demo/app/pages/spike-app.vue
+++ b/pocs/crouton-builder-demo/app/pages/spike-app.vue
@@ -369,50 +369,41 @@ function snapAt(movedNode: LayoutNode, pos: { x: number, y: number }, others: Fl
   return { target: others[snap.path[0]!]!, edge: snap.edge, tRect: targets[snap.path[0]!]!.rect, md }
 }
 
-// Where a dragged node wants to land (#941 Phase A): INSERT between the panes of a combined (split)
-// target it's dragged OVER, or EDGE-merge onto a side of a target it's near (the original snap).
+// Where a dragged node wants to land (#972): PANEDROP — dropped OVER a layout, add it beside the pane
+// under the cursor on the side you're nearest; or EDGE-merge onto a side of a NEARBY card (the original
+// proximity snap, for building from loose cards).
 type SnapIntent =
-  | { kind: 'insert', target: FlowNode, insert: SpikeSnapInsert }
+  | { kind: 'panedrop', target: FlowNode, paneDrop: SpikePaneDrop }
   | { kind: 'edge', target: FlowNode, edge: SnapEdge }
 type FlowRect = { x: number, y: number, w: number, h: number }
 const clamp = (v: number, lo: number, hi: number) => Math.min(Math.max(v, lo), hi)
-// Recurse to the DEEPEST split under (cx,cy): walk each split's child sub-rects so a drop can land
-// inside a NESTED layout (a split within a pane), not just the top-level split. Returns that split,
-// its flow-space sub-rect, and the child-index path to it.
-// A candidate insert seam, in flow-space: `main` = the seam line's position on its split's MAIN axis;
-// [c0,c1] = its CROSS-axis span. Carries the split's `path` + the seam `index` within it.
-interface SeamCand { path: number[], index: number, axis: 'horizontal' | 'vertical', main: number, c0: number, c1: number }
-// Collect EVERY insertable seam across ALL splits in the tree (parent AND nested), so the nearest one
-// to the cursor wins — near a top-level gap → the parent; deep inside a child near its seam → the
-// child. (Deepest-split-always-wins made the parent unreachable; #950 follow-up.)
-function collectSeams(node: LayoutNode, rect: FlowRect, path: number[], out: SeamCand[]) {
-  if (node.type !== 'split') return
+// Collect every LEAF pane (and nested app — a single drop target) with its flow-space sub-rect, walking
+// each split's children by their `defaultSize` proportions. The pane under the cursor is the drop
+// target; `[]` means the whole node is one pane (a lone block). Mirrors the renderer's child sizing.
+function collectLeaves(node: LayoutNode, rect: FlowRect, path: number[], out: { path: number[], rect: FlowRect }[]) {
+  if (node.type !== 'split') { out.push({ path, rect }); return } // leaf OR nested app = a drop target
   const horizontal = node.direction === 'horizontal'
   const sizes = node.children.map(c => c.defaultSize ?? (100 / node.children.length))
   const total = sizes.reduce((a, b) => a + b, 0) || node.children.length
-  const bounds = [0]
   let acc = 0
-  for (const s of sizes) { acc += s / total; bounds.push(acc) } // [0, f1, …, 1] — children+1 seams
-  bounds.forEach((b, index) => out.push(horizontal
-    ? { path, index, axis: 'horizontal', main: rect.x + b * rect.w, c0: rect.y, c1: rect.y + rect.h }
-    : { path, index, axis: 'vertical', main: rect.y + b * rect.h, c0: rect.x, c1: rect.x + rect.w }))
-  acc = 0
   for (let i = 0; i < node.children.length; i++) {
     const frac0 = acc / total, len = sizes[i]! / total
     acc += sizes[i]!
     const cr: FlowRect = horizontal
       ? { x: rect.x + frac0 * rect.w, y: rect.y, w: len * rect.w, h: rect.h }
       : { x: rect.x, y: rect.y + frac0 * rect.h, w: rect.w, h: len * rect.h }
-    collectSeams(node.children[i]!, cr, [...path, i], out)
+    collectLeaves(node.children[i]!, cr, [...path, i], out)
   }
 }
 function snapIntent(movedNode: LayoutNode, pos: { x: number, y: number }, others: FlowNode[]): SnapIntent | null {
   const md = sizeOf(movedNode)
   const cx = pos.x + md.width / 2
   const cy = pos.y + md.height / 2
-  // 1) INSERT: the drag OVERLAPS a split target → drop between its panes. Overlap (≥35% of the dragged
-  // area), not strict centre-inside. Then pick the NEAREST seam across every split (parent + nested):
-  // near a top-level gap targets the parent, near a child's seam targets the child — so both are reachable.
+  // 1) PANEDROP: the drag OVERLAPS a target (≥35% of the dragged area) → drop beside the PANE under the
+  // cursor. Find the leaf pane the cursor (clamped into the target) sits in, then the side from which
+  // quadrant of that pane the cursor is over — so you can add to ANY edge of ANY pane, incl. the right
+  // of a pane that lives in a vertical stack (no pre-existing seam needed). A lone block is one pane
+  // (path []). (#972 — replaces the seam-only insert.)
   const dl = pos.x, dr = pos.x + md.width, dt = pos.y, db = pos.y + md.height
   for (const o of others) {
     const node = o.data.node
@@ -421,33 +412,27 @@ function snapIntent(movedNode: LayoutNode, pos: { x: number, y: number }, others
     const ox = Math.max(0, Math.min(dr, tx + ts.width) - Math.max(dl, tx))
     const oy = Math.max(0, Math.min(db, ty + ts.height) - Math.max(dt, ty))
     if ((ox * oy) / (md.width * md.height) < 0.35) continue // not enough over this node → try edge-snap
-    // A single block (leaf) or a nested app has no inner seams to insert between — but hovering OVER it
-    // should still be snappable: merge BESIDE it into a new split. Pick the edge from which side of the
-    // target's CENTRE the cursor is on (over its right half → merge right, top half → merge top, etc.),
-    // so a single item becomes a drop target just like a combined layout. (#952 follow-up)
-    if (node.type !== 'split') {
-      const relx = (cx - (tx + ts.width / 2)) / ts.width
-      const rely = (cy - (ty + ts.height / 2)) / ts.height
-      const edge: SnapEdge = Math.abs(relx) >= Math.abs(rely) ? (relx >= 0 ? 'right' : 'left') : (rely >= 0 ? 'bottom' : 'top')
-      return { kind: 'edge', target: o, edge }
-    }
     const ccx = clamp(cx, tx, tx + ts.width), ccy = clamp(cy, ty, ty + ts.height)
-    const seams: SeamCand[] = []
-    collectSeams(node, { x: tx, y: ty, w: ts.width, h: ts.height }, [], seams)
-    let best: SeamCand | null = null, bestD = Infinity
-    for (const s of seams) {
-      const inCross = s.axis === 'horizontal' ? (ccy >= s.c0 && ccy <= s.c1) : (ccx >= s.c0 && ccx <= s.c1)
-      if (!inCross) continue
-      const d = s.axis === 'horizontal' ? Math.abs(ccx - s.main) : Math.abs(ccy - s.main)
-      if (d < bestD) { bestD = d; best = s }
+    const leaves: { path: number[], rect: FlowRect }[] = []
+    collectLeaves(node, { x: tx, y: ty, w: ts.width, h: ts.height }, [], leaves)
+    // The pane containing the (clamped) cursor; else the nearest by centre.
+    let hit = leaves.find(l => ccx >= l.rect.x && ccx <= l.rect.x + l.rect.w && ccy >= l.rect.y && ccy <= l.rect.y + l.rect.h)
+    if (!hit) {
+      let bestD = Infinity
+      for (const l of leaves) {
+        const d = Math.hypot(ccx - (l.rect.x + l.rect.w / 2), ccy - (l.rect.y + l.rect.h / 2))
+        if (d < bestD) { bestD = d; hit = l }
+      }
     }
-    if (!best) continue
-    const insert: SpikeSnapInsert = best.axis === 'horizontal'
-      ? { axis: 'horizontal', path: best.path, index: best.index, pos: (best.main - tx) / ts.width, cross0: (best.c0 - ty) / ts.height, cross1: (best.c1 - ty) / ts.height }
-      : { axis: 'vertical', path: best.path, index: best.index, pos: (best.main - ty) / ts.height, cross0: (best.c0 - tx) / ts.width, cross1: (best.c1 - tx) / ts.width }
-    return { kind: 'insert', target: o, insert }
+    if (!hit) continue
+    const lr = hit.rect
+    const relx = (ccx - (lr.x + lr.w / 2)) / lr.w
+    const rely = (ccy - (lr.y + lr.h / 2)) / lr.h
+    const edge: SnapEdge = Math.abs(relx) >= Math.abs(rely) ? (relx >= 0 ? 'right' : 'left') : (rely >= 0 ? 'bottom' : 'top')
+    const rect = { left: ((lr.x - tx) / ts.width) * 100, top: ((lr.y - ty) / ts.height) * 100, width: (lr.w / ts.width) * 100, height: (lr.h / ts.height) * 100 }
+    return { kind: 'panedrop', target: o, paneDrop: { path: hit.path, edge, rect } }
   }
-  // 2) EDGE: original side-snap (merge onto a target's outer edge).
+  // 2) EDGE: proximity side-snap — merge onto the outer edge of a NEARBY (non-overlapping) card.
   const s = snapAt(movedNode, pos, others)
   return s ? { kind: 'edge', target: s.target, edge: s.edge } : null
 }
@@ -463,22 +448,27 @@ function snapIntent(movedNode: LayoutNode, pos: { x: number, y: number }, others
 const SNAP_DWELL_MS = 600
 let snapKey: string | null = null
 let snapTimer: number | null = null
+// The id of the node currently being dragged — the reliable way for onRowsUpdate to know WHICH node
+// moved. (Position-delta detection misses it: Vue Flow mutates node positions in place, so the rows
+// it re-emits on drag-end already equal our stored positions → no delta.) Set live, consumed on release.
+let draggedId: string | null = null
 function clearSnapTimer() { if (snapTimer != null) { window.clearTimeout(snapTimer); snapTimer = null } }
 function resetSnap() { snapPreview.value = null; snapKey = null; clearSnapTimer() }
 
 function onNodeDragLive(id: string, pos: { x: number, y: number }) {
+  draggedId = id
   const moved = nodes.value.find(n => n.id === id)
   if (!moved) { resetSnap(); return }
   const intent = snapIntent(moved.data.node, pos, nodes.value.filter(n => n.id !== id))
   if (!intent) { resetSnap(); return } // out of range → no candidate, dwell resets
-  // Dwell key is COARSE for inserts — keyed on the target only, NOT the seam index — so small
-  // movements that flip the nearest seam don't reset the arm timer; the seam keeps following the
-  // finger live (base carries the current index/frac) and the green arms reliably after the hold.
-  const key = intent.kind === 'insert' ? `ins-${intent.target.id}` : `edge-${intent.target.id}-${intent.edge}`
+  // Dwell key is COARSE for pane-drops — keyed on the target + the PANE (path), NOT the side — so small
+  // movements that flip the nearest edge don't reset the arm timer; the side keeps tracking the finger
+  // live (base carries the current edge) and the green arms reliably after the hold.
+  const key = intent.kind === 'panedrop' ? `pane-${intent.target.id}-${intent.paneDrop.path.join('.')}` : `edge-${intent.target.id}-${intent.edge}`
   const dragLabel = moved.data.label ?? labelFor(moved.data.node)
-  const base: SpikeSnapPreview = intent.kind === 'insert'
-    ? { node: intent.target.data.node, insert: intent.insert, dragLabel, dragNode: moved.data.node }
-    : { node: intent.target.data.node, edge: intent.edge, dragLabel }
+  const base: SpikeSnapPreview = intent.kind === 'panedrop'
+    ? { node: intent.target.data.node, targetId: intent.target.id, paneDrop: intent.paneDrop, dragLabel, dragNode: moved.data.node }
+    : { node: intent.target.data.node, targetId: intent.target.id, edge: intent.edge, dragLabel }
   if (key === snapKey) {
     // Same candidate as last frame — keep the (possibly already-armed) state; don't restart dwell.
     snapPreview.value = { ...base, armed: snapPreview.value?.armed === true }
@@ -503,27 +493,31 @@ function onRowsUpdate(rowsRaw: Record<string, unknown>[]) {
   const armed = snapPreview.value?.armed === true ? snapPreview.value : null // the green candidate at release
   resetSnap() // drag has ended — clear the live guide + dwell timer
   const rows = rowsRaw as unknown as FlowNode[]
+  const dragId = draggedId
+  draggedId = null
+  // Which node moved: prefer the live-tracked drag id (robust); fall back to a position delta.
   const prev = new Map(nodes.value.map(n => [n.id, n.position]))
-  const moved = rows.find((r) => {
-    const p = prev.get(r.id)
-    return p && (p.x !== r.position.x || p.y !== r.position.y)
-  })
+  const moved = (dragId ? rows.find(r => r.id === dragId) : undefined)
+    ?? rows.find((r) => { const p = prev.get(r.id); return p && (p.x !== r.position.x || p.y !== r.position.y) })
   if (!moved) { nodes.value = rows; return }
   pushUndo() // a real move (reposition / merge / insert) is about to apply — snapshot first
   // Released while only SOFT (not held long enough) → just place it; snapping requires the dwell.
   if (!armed) { nodes.value = rows; return }
 
-  // The target FlowNode is the one whose layout node is the armed candidate (node identity is stable
-  // across a drag — only positions change — so this matches what the green guide pointed at).
-  const target = rows.find(r => r.id !== moved.id && r.data.node === armed.node)
+  // The target FlowNode — matched by STABLE id (CroutonFlow re-emits rows on drag-end that don't keep
+  // `data.node` by reference, so the old identity match missed and the drop silently no-op'd). Fall back
+  // to node identity for safety.
+  const target = rows.find(r => r.id !== moved.id && (r.id === armed.targetId || r.data.node === armed.node))
   if (!target) { nodes.value = rows; return }
   const md = sizeOf(moved.data.node)
   // Page (favorited) ALWAYS consumes (#942): if either side is the page, the result stays the page.
   const keepPage = (target.data.isPage || moved.data.isPage) ? { isPage: true } : {}
 
-  // INSERT between the panes — at the targeted split, which may be NESTED (armed.insert.path). (#950)
-  if (armed.insert && target.data.node.type === 'split') {
-    const newNode = insertAtPath(target.data.node, armed.insert.path, armed.insert.index, moved.data.node)
+  // PANEDROP — add the dragged node beside the targeted pane (flatten into the row if the side runs
+  // along it, else wrap the pane perpendicular). Works on any pane edge, incl. the right of a pane in
+  // a vertical stack. The targeted pane may be a lone block (path []). (#972)
+  if (armed.paneDrop) {
+    const newNode = applyPaneDrop(target.data.node, armed.paneDrop, moved.data.node)
     const groupNode: FlowNode = { ...target, data: { node: newNode, ...keepPage } }
     nodes.value = rows.filter(r => r.id !== moved.id && r.id !== target.id).concat(groupNode)
     return

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 47,
+    "note": "Per-block DISPLAY VARIANTS — a block can now offer bounded layouts of the same data (the Artists list: Rows · Cards · Table). Select a pane in the edit view → a Display chip row lets you (or an agent) flip the variant; the choice is a bounded enum declared on the registry and serialised on the leaf, so it persists and round-trips. This is the 'collection viewer options' ask, kept inside the expressiveness boundary (an enum, not free config).",
+    "commit": ""
+  },
+  {
     "v": 46,
     "note": "Block sizing as DECLARED DATA — each block in the registry now carries a sizing descriptor ({ width, height: 'fill' | 'hug' }), so 'the component decides its own size' is one source the renderer and an agent both read, not per-component CSS. A Top bar / Bottom nav declare height:'hug', so a pinned bar comes out SHORT because the BLOCK says so (not because of where it's pinned) — no per-instance size control. Honoured in the page Preview (a hug block → a short bar, a fill block grows).",
-    "commit": ""
+    "commit": "8936b5d"
   },
   {
     "v": 45,

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 45,
+    "note": "Cleanup pass — ripped out the dormant survey/viewport code left over after the slider→per-element-resize pivot (and the dead fitOverview), so the board path is one clear model. Chart block bars now render reliably (each bar sits in a definite-height track, so its % height resolves). And the board hides Vue Flow's own ⛶ fit button — it zooms into our oversized cards; the pill Fit is the right one (the Site flow keeps its ⛶).",
+    "commit": ""
+  },
+  {
     "v": 44,
     "note": "Fixed the selection highlight not scrolling with the content in the edit view — a tall layout scrolls inside the frame, so the dim/focus overlay now re-measures on scroll and stays locked to the selected pane.",
-    "commit": ""
+    "commit": "0566812"
   },
   {
     "v": 43,

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 49,
+    "note": "Fixed the wiggle/detach drag-border SIZING — the green pane faces were computed from the tree's defaultSize, so once you RESIZED a card (which renders it through the responsive renderer, reflowing/stacking the panes) the borders drifted off the real panes. They now MEASURE the actual rendered panes, so the faces sit exactly on them whether or not the card is resized / stacked / nested. (Verified headless: resized narrow → panes stacked → faces aligned with 0px offset.)",
+    "commit": ""
+  },
+  {
     "v": 48,
     "note": "Deploy fix — the staging build broke because crouton-devtools loads @fyit/crouton-feedback at build time (from #976). Two parts: (1) declare the dep on the POC so pnpm's strict node_modules can resolve it, and (2) add it to the deploy's layerPackages so CI builds its dist (it wasn't in the build set, so the module file never existed). User-invisible; unblocks the preview deploy.",
-    "commit": ""
+    "commit": "91c4326"
   },
   {
     "v": 47,

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 48,
+    "note": "Deploy fix — the staging build broke because crouton-devtools loads @fyit/crouton-feedback at build time (from #976). Two parts: (1) declare the dep on the POC so pnpm's strict node_modules can resolve it, and (2) add it to the deploy's layerPackages so CI builds its dist (it wasn't in the build set, so the module file never existed). User-invisible; unblocks the preview deploy.",
+    "commit": ""
+  },
+  {
     "v": 47,
     "note": "Per-block DISPLAY VARIANTS — a block can now offer bounded layouts of the same data (the Artists list: Rows · Cards · Table). Select a pane in the edit view → a Display chip row lets you (or an agent) flip the variant; the choice is a bounded enum declared on the registry and serialised on the leaf, so it persists and round-trips. This is the 'collection viewer options' ask, kept inside the expressiveness boundary (an enum, not free config).",
-    "commit": ""
+    "commit": "418bfd1"
   },
   {
     "v": 46,

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 51,
+    "note": "Fixed the wiggle drag-borders spilling OUTSIDE the card when the layout is taller than the card (scrolls/overflows) — the green faces are measured from the rendered panes, and a pane below the fold reported a rect extending past the card, so its border sprawled down the canvas. Faces are now clamped to the card box (a pane scrolled out of view just has no face). Caught from your IMG_1071.",
+    "commit": ""
+  },
+  {
     "v": 50,
     "note": "Drop a block BESIDE a pane inside a layout — drag a block over a composed layout and it now targets the pane under your finger and adds the new block on the side you're nearest (left/right/top/bottom). It flattens into the row when the side runs along it, and wraps the pane perpendicular otherwise — so you can finally add to the RIGHT of a pane that sits in a vertical stack (e.g. right of the chart), which wasn't possible before (no pre-existing seam there). Replaces the old between-seams-only insert with one unified 'add beside the pane you point at' rule.",
-    "commit": ""
+    "commit": "3af5039"
   },
   {
     "v": 49,

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 52,
+    "note": "Composite layout sizing — a layout now DERIVES its own size rules from its components (folded bottom-up): a 'hard floor' = the widest single block (it can always reflow to a column), and a 'soft floor' = the sum across a row (where it starts to stack). The per-element resize can't shrink a card below its hard floor — so a layout literally can't break its components' rules — and a selected card shows the derived floor ('stacks <Npx · floor Mpx'). Component-driven, all the way up a layout-of-layouts.",
+    "commit": ""
+  },
+  {
     "v": 51,
     "note": "Fixed the wiggle drag-borders spilling OUTSIDE the card when the layout is taller than the card (scrolls/overflows) — the green faces are measured from the rendered panes, and a pane below the fold reported a rect extending past the card, so its border sprawled down the canvas. Faces are now clamped to the card box (a pane scrolled out of view just has no face). Caught from your IMG_1071.",
-    "commit": ""
+    "commit": "0613db0"
   },
   {
     "v": 50,

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 46,
+    "note": "Block sizing as DECLARED DATA — each block in the registry now carries a sizing descriptor ({ width, height: 'fill' | 'hug' }), so 'the component decides its own size' is one source the renderer and an agent both read, not per-component CSS. A Top bar / Bottom nav declare height:'hug', so a pinned bar comes out SHORT because the BLOCK says so (not because of where it's pinned) — no per-instance size control. Honoured in the page Preview (a hug block → a short bar, a fill block grows).",
+    "commit": ""
+  },
+  {
     "v": 45,
     "note": "Cleanup pass — ripped out the dormant survey/viewport code left over after the slider→per-element-resize pivot (and the dead fitOverview), so the board path is one clear model. Chart block bars now render reliably (each bar sits in a definite-height track, so its % height resolves). And the board hides Vue Flow's own ⛶ fit button — it zooms into our oversized cards; the pill Fit is the right one (the Site flow keeps its ⛶).",
-    "commit": ""
+    "commit": "fd0c1d5"
   },
   {
     "v": 44,

--- a/pocs/crouton-builder-demo/app/spike-changelog.json
+++ b/pocs/crouton-builder-demo/app/spike-changelog.json
@@ -1,8 +1,13 @@
 [
   {
+    "v": 50,
+    "note": "Drop a block BESIDE a pane inside a layout — drag a block over a composed layout and it now targets the pane under your finger and adds the new block on the side you're nearest (left/right/top/bottom). It flattens into the row when the side runs along it, and wraps the pane perpendicular otherwise — so you can finally add to the RIGHT of a pane that sits in a vertical stack (e.g. right of the chart), which wasn't possible before (no pre-existing seam there). Replaces the old between-seams-only insert with one unified 'add beside the pane you point at' rule.",
+    "commit": ""
+  },
+  {
     "v": 49,
     "note": "Fixed the wiggle/detach drag-border SIZING — the green pane faces were computed from the tree's defaultSize, so once you RESIZED a card (which renders it through the responsive renderer, reflowing/stacking the panes) the borders drifted off the real panes. They now MEASURE the actual rendered panes, so the faces sit exactly on them whether or not the card is resized / stacked / nested. (Verified headless: resized narrow → panes stacked → faces aligned with 0px offset.)",
-    "commit": ""
+    "commit": "a542c5f"
   },
   {
     "v": 48,

--- a/pocs/crouton-builder-demo/app/utils/spike-layout.ts
+++ b/pocs/crouton-builder-demo/app/utils/spike-layout.ts
@@ -6,6 +6,7 @@
  */
 import type { InjectionKey, Ref, ShallowRef } from 'vue'
 import type { LayoutNode } from '@fyit/crouton-core/app/types/layout'
+import { dropNode } from '@fyit/crouton-layout/app/utils/layout-edit'
 
 export const SPIKE_BASE_W = 256
 export const SPIKE_BASE_H = 184
@@ -23,21 +24,8 @@ export type SnapEdge = 'left' | 'right' | 'top' | 'bottom'
 // `armed` (#941 dwell): false = "snap point here" (soft/blue, just approached); true = held long
 // enough that releasing now WILL snap (green). Two-stage so a snap takes intent, not a brush-past.
 //
-// A preview is EITHER an `edge` snap (merge the dragged node onto a side of the target) OR an
-// `insert` (drop the dragged node BETWEEN the panes of a combined target, Phase A). `insert.frac`
-// is the seam position as a 0..1 fraction along the split axis; the target draws a guide line there.
-// An insert targets a split addressed by `path` (the child-index route from the target node's root —
-// `[]` is the root split, `[1,0]` a split nested two levels deep), at seam `index` within it. The
-// `pos`/`cross0`/`cross1` are the seam's geometry as fractions of the WHOLE target card, so the soft
-// guide bar can draw at the right place AND only across the nested split's sub-region. (#950)
-export interface SpikeSnapInsert {
-  axis: 'horizontal' | 'vertical'
-  path: number[]
-  index: number
-  pos: number
-  cross0: number
-  cross1: number
-}
+// A preview is EITHER an `edge` snap (merge the dragged node onto a side of a NEARBY card) OR a
+// `paneDrop` (drop OVER a layout → add beside the targeted pane, #972 — see SpikePaneDrop below).
 
 /** Resolve the split at `path` within `root` (or null). Walks split children by index. */
 export function splitAtPath(root: LayoutNode, path: number[]): LayoutNode | null {
@@ -67,11 +55,47 @@ export function insertAtPath(root: LayoutNode, path: number[], index: number, ch
   children[head!] = insertAtPath(target, rest, index, child)
   return { ...root, children }
 }
-// `dragLabel` (#946 ghost) — a human label for the node being dragged, so the armed insert target
-// can render a "this is where it lands" ghost slab at the seam carrying the incoming item's name.
+/**
+ * Pane-drop (#972) — dropping a block OVER a layout targets the rendered PANE under the cursor and
+ * adds the dragged node as a sibling on the side you're nearest. Unlike `insert` (which only used
+ * seams that already existed), this works on ANY pane edge — so you can add a block to the RIGHT of a
+ * pane that sits in a vertical stack (no pre-existing right-seam), e.g. "right of the chart". It's a
+ * bounded, agent-pickable edit: "insert node X beside pane at `path` on side `edge`". `path` is the
+ * child-index route to the leaf within the target node's root (`[]` = the whole node is one pane);
+ * `rect` is that pane's box as % of the target card, so the guide band draws on the right edge.
+ */
+export interface SpikePaneDrop { path: number[], edge: SnapEdge, rect: { left: number, top: number, width: number, height: number } }
+
+/**
+ * Apply a pane-drop to `root`: add `child` beside the pane at `paneDrop.path` on `paneDrop.edge`.
+ * FLATTENS into the parent row when the side is ALONG the parent split's axis (drop right of a block
+ * in a row → it joins the row), and WRAPS the pane in a new perpendicular split otherwise (drop right
+ * of a pane in a vertical stack → `[pane | child]`). Used for BOTH the ghost preview and the real drop.
+ */
+export function applyPaneDrop(root: LayoutNode, paneDrop: { path: number[], edge: SnapEdge }, child: LayoutNode): LayoutNode {
+  const { path, edge } = paneDrop
+  const direction = edge === 'left' || edge === 'right' ? 'horizontal' : 'vertical'
+  const before = edge === 'left' || edge === 'top'
+  if (path.length > 0) {
+    const parentPath = path.slice(0, -1)
+    const leafIndex = path[path.length - 1]!
+    const parent = splitAtPath(root, parentPath)
+    if (parent && parent.type === 'split' && parent.direction === direction) {
+      // Side runs ALONG the parent → flatten into the existing row/column.
+      return insertAtPath(root, parentPath, leafIndex + (before ? 0 : 1), child)
+    }
+  }
+  // Perpendicular (or a lone pane) → wrap the pane in a new split. `dropNode` handles a leaf root too.
+  return dropNode(root, path, child, edge)
+}
+
+// `dragLabel` (#946 ghost) — a human label for the node being dragged, so the armed pane-drop target
+// can render a "this is where it lands" ghost slab carrying the incoming item's name.
 // `dragNode` (#947) — the dragged node's actual subtree, so the target can build a ghost skeleton
 // with the SAME footprint (a 2-row stack → a 2-row ghost), making the opened slot match its size.
-export interface SpikeSnapPreview { node: LayoutNode, armed?: boolean, edge?: SnapEdge, insert?: SpikeSnapInsert, dragLabel?: string, dragNode?: LayoutNode }
+// `targetId` — the target FlowNode's id, so the on-release apply can re-find it by STABLE id (CroutonFlow
+// re-emits rows on drag-end that don't preserve `data.node` by reference, so identity matching missed).
+export interface SpikeSnapPreview { node: LayoutNode, targetId?: string, armed?: boolean, edge?: SnapEdge, paneDrop?: SpikePaneDrop, dragLabel?: string, dragNode?: LayoutNode }
 export const SPIKE_SNAP_KEY = Symbol('spike-snap') as InjectionKey<ShallowRef<SpikeSnapPreview | null>>
 
 /**

--- a/pocs/crouton-builder-demo/app/utils/spike-layout.ts
+++ b/pocs/crouton-builder-demo/app/utils/spike-layout.ts
@@ -174,3 +174,41 @@ export function sizeOf(node: LayoutNode): { width: number, height: number } {
   const f = footprint(node)
   return { width: f.cols * SPIKE_BASE_W, height: f.rows * SPIKE_BASE_H }
 }
+
+/**
+ * Block sizing descriptor (#971) — "the component decides its own size" as DECLARED DATA, not
+ * per-instance CSS. Each block declares how it fills a pane per axis: `fill` stretches to the pane,
+ * `hug` sizes to its own content. A Top bar / Bottom nav declare `height: 'hug'`, so they come out as
+ * SHORT bars wherever they land (incl. pinned regions) with NO per-instance size control — the agent
+ * picks the BLOCK, the block's descriptor does the rest. It lives on the `croutonLayoutBlocks` registry
+ * entries (app.config), so one source feeds the renderer, the viability metric, and an agent alike.
+ *
+ * Honoured POC-side in the Preview (a `hug`-height block → an `height:auto` pane → short bar). Making a
+ * pane hug its content INSIDE a split is the `crouton-layout` package renderer's job — graduation work;
+ * the clean formalisation is exactly this descriptor moving onto the typed `CroutonLayoutBlockDefinition`.
+ */
+export type SpikeSizing = 'fill' | 'hug'
+export interface SpikeBlockSizing { width: SpikeSizing, height: SpikeSizing }
+export const SPIKE_DEFAULT_SIZING: SpikeBlockSizing = { width: 'fill', height: 'fill' }
+
+/** A registry shape carrying the optional POC sizing descriptor (the app.config entries). The fields
+ *  are read loosely (app.config literals widen to `string`) and validated to the enum here. */
+type SizedRegistry = Record<string, { sizing?: { width?: string, height?: string } } | undefined>
+
+/** Narrow an arbitrary value to a `SpikeSizing` (default `fill`) — robust to widened/tampered data. */
+const asSizing = (v: unknown): SpikeSizing => (v === 'hug' ? 'hug' : 'fill')
+
+/** The sizing a block declares (defaults to fully `fill`). Reads the descriptor off the registry. */
+export function blockSizing(blockId: string, registry: SizedRegistry): SpikeBlockSizing {
+  const s = registry[blockId]?.sizing
+  return { width: asSizing(s?.width), height: asSizing(s?.height) }
+}
+
+/**
+ * How a NODE wants to size on the page's vertical axis. Only a single leaf hugs by its block's
+ * descriptor; a composed split/nested fills (a real layout claims its space). Drives the Preview's
+ * per-region hug/fill so a pinned Top bar is short because the BLOCK says `hug`, not because it's pinned.
+ */
+export function nodeHeightSizing(node: LayoutNode, registry: SizedRegistry): SpikeSizing {
+  return node.type === 'leaf' ? blockSizing(node.blockId, registry).height : 'fill'
+}

--- a/pocs/crouton-builder-demo/app/utils/spike-layout.ts
+++ b/pocs/crouton-builder-demo/app/utils/spike-layout.ts
@@ -212,3 +212,27 @@ export function blockSizing(blockId: string, registry: SizedRegistry): SpikeBloc
 export function nodeHeightSizing(node: LayoutNode, registry: SizedRegistry): SpikeSizing {
   return node.type === 'leaf' ? blockSizing(node.blockId, registry).height : 'fill'
 }
+
+/**
+ * Per-leaf config field read/write (#970 display variants) — a block's `variant` (rows/cards/table) is
+ * a bounded enum SERIALISED on the leaf's `config`, so it persists with the layout and an agent can
+ * read/set it. Read the first matching leaf's value; set it immutably on EVERY matching leaf (mirrors
+ * how `setCollapseRecipe` addresses a block by id across the tree, vs by NodePath).
+ */
+export function leafConfigValue(node: LayoutNode, blockId: string, key: string): unknown {
+  if (node.type === 'leaf') return node.blockId === blockId ? node.config?.[key] : undefined
+  if (node.type === 'nested') return leafConfigValue(node.layout.root, blockId, key)
+  for (const c of node.children) {
+    const v = leafConfigValue(c, blockId, key)
+    if (v !== undefined) return v
+  }
+  return undefined
+}
+
+export function setLeafConfigValue(node: LayoutNode, blockId: string, key: string, value: unknown): LayoutNode {
+  if (node.type === 'leaf') {
+    return node.blockId === blockId ? { ...node, config: { ...(node.config ?? {}), [key]: value } } : node
+  }
+  if (node.type === 'nested') return { ...node, layout: { ...node.layout, root: setLeafConfigValue(node.layout.root, blockId, key, value) } }
+  return { ...node, children: node.children.map(c => setLeafConfigValue(c, blockId, key, value)) }
+}

--- a/pocs/crouton-builder-demo/app/utils/spike-layout.ts
+++ b/pocs/crouton-builder-demo/app/utils/spike-layout.ts
@@ -152,24 +152,6 @@ export const SPIKE_GHOST_LABEL_KEY = Symbol('spike-ghost-label') as InjectionKey
  */
 export const SPIKE_PINCH_KEY = Symbol('spike-pinch') as InjectionKey<(ratio: number, midX: number, midY: number) => void>
 
-/**
- * Global viewport survey (#907, "layer 3") — the flow has no real concept of screen size;
- * size there is just topology. Flipping a viewport makes the WHOLE board render every layout
- * AT that width, so you can scan all your pages as phone/tablet/desktop at a glance. It's a
- * read-only survey: while a viewport is active, snapping/detach are off and nodes tile rather
- * than drag. `null` = back to the topology (footprint) view. Provided by the page; SpikeBlockNode
- * injects it to size its card to the device + render via CroutonLayoutResponsiveRenderer at `width`.
- */
-export interface SpikeViewport { label: string, icon: string, width: number, height: number }
-export const SPIKE_VIEWPORT_KEY = Symbol('spike-viewport') as InjectionKey<Ref<SpikeViewport | null>>
-
-/** The device presets the viewport chips offer (width/height in px). */
-export const SPIKE_VIEWPORTS: SpikeViewport[] = [
-  { label: 'Phone', icon: 'i-lucide-smartphone', width: 375, height: 720 },
-  { label: 'Tablet', icon: 'i-lucide-tablet', width: 768, height: 1024 },
-  { label: 'Desktop', icon: 'i-lucide-monitor', width: 1280, height: 800 },
-]
-
 // Focus editing (#907 redesign) lives in a DEDICATED full-screen edit VIEW, not an in-flow
 // camera zoom — so there's no SPIKE_FOCUS/RESIZE injection here anymore. The overlay renders the
 // node's layout through CroutonLayoutBreakpointAuthor (ruler + devices + width slider + collapse

--- a/pocs/crouton-builder-demo/app/utils/spike-layout.ts
+++ b/pocs/crouton-builder-demo/app/utils/spike-layout.ts
@@ -217,7 +217,7 @@ export const SPIKE_DEFAULT_SIZING: SpikeBlockSizing = { width: 'fill', height: '
 
 /** A registry shape carrying the optional POC sizing descriptor (the app.config entries). The fields
  *  are read loosely (app.config literals widen to `string`) and validated to the enum here. */
-type SizedRegistry = Record<string, { sizing?: { width?: string, height?: string } } | undefined>
+type SizedRegistry = Record<string, { sizing?: { width?: string, height?: string }, minWidth?: number } | undefined>
 
 /** Narrow an arbitrary value to a `SpikeSizing` (default `fill`) — robust to widened/tampered data. */
 const asSizing = (v: unknown): SpikeSizing => (v === 'hug' ? 'hug' : 'fill')
@@ -235,6 +235,44 @@ export function blockSizing(blockId: string, registry: SizedRegistry): SpikeBloc
  */
 export function nodeHeightSizing(node: LayoutNode, registry: SizedRegistry): SpikeSizing {
   return node.type === 'leaf' ? blockSizing(node.blockId, registry).height : 'fill'
+}
+
+/**
+ * Composite sizing derivation (#972 follow-up) — "component-driven, all the way up". A LEAF declares
+ * its rules (minWidth + fill/hug on the registry); a COMPOSITE (split / nested layout) DERIVES its own,
+ * bottom-up, so a layout-of-layouts publishes the same contract its children do and a parent (or an
+ * agent) can reason about it as one unit. The fold is direction-aware, with TWO width floors:
+ *   • softMinWidth — the comfortable width that keeps a horizontal split a ROW: `sum` of children
+ *     along a horizontal axis, `max` across a vertical one. Below it, the renderer stacks the row.
+ *   • hardMinWidth — the absolute floor it can reflow DOWN to: a horizontal split can always stack to
+ *     a column whose width floor is the widest child, so hard = `max` of children's hard floors
+ *     (recursively, the widest single leaf in the subtree).
+ * Height mirrors width with the axes swapped (`sum` vertical, `max` horizontal). `width`/`height`
+ * fill/hug: a composite always `fill`s (a real layout claims its space); a leaf uses its descriptor.
+ *
+ * Prototyped POC-side; the clean home is the `crouton-layout` viability engine (it already folds leaf
+ * min-widths for stacking) + the `nested` node carrying this as its declared contract (graduation).
+ */
+export interface SpikeDerivedSizing { hardMinWidth: number, softMinWidth: number, minHeight: number, width: SpikeSizing, height: SpikeSizing }
+export function deriveSizing(node: LayoutNode, registry: SizedRegistry): SpikeDerivedSizing {
+  if (node.type === 'leaf') {
+    const mw = registry[node.blockId]?.minWidth ?? 0
+    const s = blockSizing(node.blockId, registry)
+    return { hardMinWidth: mw, softMinWidth: mw, minHeight: 0, width: s.width, height: s.height }
+  }
+  if (node.type === 'nested') return deriveSizing(node.layout.root, registry)
+  const kids = node.children.map(c => deriveSizing(c, registry))
+  const horizontal = node.direction === 'horizontal'
+  // Hard floor: the subtree can always reflow to a single column → the widest single leaf.
+  const hardMinWidth = Math.max(0, ...kids.map(k => k.hardMinWidth))
+  // Soft floor: keep the arrangement as-is — sum along the axis, max across it.
+  const softMinWidth = horizontal
+    ? kids.reduce((sum, k) => sum + k.softMinWidth, 0)
+    : Math.max(0, ...kids.map(k => k.softMinWidth))
+  const minHeight = horizontal
+    ? Math.max(0, ...kids.map(k => k.minHeight))
+    : kids.reduce((sum, k) => sum + k.minHeight, 0)
+  return { hardMinWidth, softMinWidth, minHeight, width: 'fill', height: 'fill' }
 }
 
 /**

--- a/pocs/crouton-builder-demo/deploy.config.json
+++ b/pocs/crouton-builder-demo/deploy.config.json
@@ -1,4 +1,4 @@
 {
   "stagingUrl": "https://crouton-builder-demo.pmcp.dev",
-  "layerPackages": "@fyit/crouton-core @fyit/crouton-auth @fyit/crouton-i18n @fyit/crouton"
+  "layerPackages": "@fyit/crouton-core @fyit/crouton-auth @fyit/crouton-i18n @fyit/crouton @fyit/crouton-feedback"
 }

--- a/pocs/crouton-builder-demo/package.json
+++ b/pocs/crouton-builder-demo/package.json
@@ -24,6 +24,7 @@
     "@fyit/crouton-ai": "workspace:*",
     "@fyit/crouton-core": "workspace:*",
     "@fyit/crouton-devtools": "workspace:*",
+    "@fyit/crouton-feedback": "workspace:*",
     "@fyit/crouton-flow": "workspace:*",
     "@fyit/crouton-i18n": "workspace:*",
     "@fyit/crouton-layout": "workspace:*",

--- a/writeups/briefings/crouton-builder-graduation-brief.md
+++ b/writeups/briefings/crouton-builder-graduation-brief.md
@@ -1,0 +1,95 @@
+# Crouton Builder — graduation brief
+
+> The cold-readable spec for graduating `pocs/crouton-builder-demo` → a test-first `@fyit/crouton-layout`
+> package contribution + a consuming builder app. Epic **#983** (sub-issues #984–#988 + #974). Backbone
+> is `pocs/crouton-builder-demo/HANDOFF.md` (kept to current truth all through the spike, v11→v52);
+> this brief adds the per-unit **shape call** + the **test checklist**. Single source of truth for the
+> rebuild — don't re-read the `spike-*` history.
+
+## What it does
+
+A visual builder for composing **collection-driven apps**: you arrange a collection's blocks into a
+`LayoutTree` on a Vue Flow canvas (Site flow of pages → per-page board of blocks), tune how they
+behave across sizes, and get a working, opinionated (Nuxt UI 4 / crouton) app. It is **the human seat
+in an AI app-generation loop** ("Lovable, but opinionated") — a human and an agent meet on **one
+shared artifact, the `LayoutTree`**. It is **component-driven**: the layout obeys what each component
+*declares about itself* (min-width, `fill`/`hug`, display variants); composites *derive* their rules
+from their children. Every expressive control is a **bounded, enumerated, agent-pickable** choice —
+never a freeform canvas.
+
+## Features (proven in the POC → each becomes ≥1 test)
+
+**Composition model**
+- [ ] `LayoutTree` of `split` (h/v) · `leaf` (block) · `nested` (a layout that is itself a block).
+- [ ] Block registry (`croutonLayoutBlocks`) is the allowlisted source of truth; unknown id → safe fallback.
+
+**Component contract (the durable value)**
+- [ ] **Sizing descriptor** per block: `sizing: { width, height: 'fill' | 'hug' }` (default fill). `hug` sizes to content (a Top bar is a short bar wherever it lands); `fill` stretches.
+- [ ] **Display variants**: a block declares a bounded `variant` enum (List: rows/cards/table); chosen per-pane, **serialised on the leaf** (`config.variant`), agent-pickable.
+- [ ] **Composite derivation** (`deriveSizing`): a split/nested derives its own floor bottom-up — **hard** = widest leaf (can always reflow to a column), **soft** = sum-along-axis / max-across (where a row stacks). Height mirrors with axes swapped.
+- [ ] **min-width / viability**: a block declares `minWidth`; the renderer stacks a row → column when the children can't fit at their floors.
+
+**Board gestures (direct manipulation)**
+- [ ] Snap: two-stage dwell-to-arm (soft blue → held ~0.6 s → armed green).
+- [ ] **Drop-beside-pane**: drag a block over a layout → it targets the **pane under the cursor** and adds beside it on the nearest side; **flattens into the row** when aligned, **wraps perpendicular** otherwise (so "right of a pane in a vertical stack" works). Ghost/ease-apart preview.
+- [ ] Detach / reorder: long-press → panes wiggle; pull a pane across to reorder or out (past a margin) to detach. FLIP reflow.
+- [ ] Per-element resize: a corner handle sets a node's width (responsive preview); **clamped to the composite hard floor**, with a floor readout.
+- [ ] Pinch-to-zoom over a node; add-block lands clear/centred/green; fit by known geometry.
+
+**Page model & assembly**
+- [ ] One node is "the page" (★); set-as-page / duplicate.
+- [ ] **Regions**: pin a node top/bottom (sticky pill); ▶ Preview assembles pinned bars + scrolling main.
+- [ ] Edit view (focus): per-breakpoint authoring (device/width slider, breakpoints, collapse "tuck-as" recipe, display variant) over the package `CroutonLayoutBreakpointAuthor`.
+- [ ] Site ⇄ Page flow (currently one route + cross-fade — graduates to real routing).
+
+## Watch out for (gotchas — the "looks done but isn't" traps)
+
+- **Overlays drift; measure the real DOM.** Pane faces / hit-tests must measure the rendered
+  `.croutonpane` / `[data-panel]` elements, **not** the abstract tree or `defaultSize` — the renderer
+  reflows (`@container` stacking), enforces min-widths, and a resized card renders responsively. Clamp
+  measured rects to the card box (overflowing/scrolling layouts spill otherwise). *In the rebuild this
+  whole class disappears — the renderer should **own its pane handles** (WS2 #985) instead of an overlay.*
+- **Vue Flow geometry:** the `.vue-flow__node` wrapper is smaller than our card (`.spike-block-node`);
+  the zoom transform is on `.vue-flow__transformationpane`, not `.vue-flow__viewport`; fit by known
+  geometry (`fitBounds`), not `fitView` (it measures the small wrapper).
+- **Drag commit:** Vue Flow mutates node positions in place and re-emits rows by value — track the
+  **dragged node id** (not a position delta) and re-find the target by **stable id** (not object ref).
+- **Renderer resolves blocks by global component name** (`<component :is>`); POC block components must
+  be registered globally — in the package they're real components.
+- **Deploy:** `crouton-devtools` installs `@fyit/crouton-feedback` at build time → a consumer must
+  declare it AND add it to the deploy build set (pre-existing #976; systemic — fix at the package level).
+- **Cross-fade page⇄site is a stopgap** — graduates to real routing + View Transitions.
+
+## The shape call (reusable → package vs app-specific)
+
+| Unit | Home | Opinionated / ecosystem-grade | Sub-issue |
+|---|---|---|---|
+| Editable renderer that **owns its pane handles** (wiggle/reorder/detach on the real panes; proxy only for detach) | `@fyit/crouton-layout` | ecosystem-grade (any layout-engine consumer) | #985 |
+| **Typed component contract** — sizing descriptor + variants + composite derivation onto `CroutonLayoutBlockDefinition` / viability engine; renderer hugs a pane *inside* a split | `@fyit/crouton-layout` | ecosystem-grade | #986 |
+| **`LayoutTree` serialisation** — stable, diffable interchange format | `@fyit/crouton-layout` | ecosystem-grade | #987 |
+| Drop-beside-pane gesture (`applyPaneDrop` flatten/wrap) | `@fyit/crouton-layout` (compose utils) | ecosystem-grade | folds into #985/#986 |
+| **Builder app** — Site/Page real routing, the demo blocks, AI hooks | new app (`apps/` on launch) | app-specific | #988 |
+| **Round-trip a version onto the GitHub ticket** (agent⇄human seat) | app + a thin serialise/poster (pairs with #987) | opinionated (crouton/GitHub) | #974 |
+
+## Test-first plan (feature checklist → signed-off tests, #774 gate on `packages/`)
+
+Each `packages/*` unit: write the failing test(s) first → `/test-review` to sign off the behaviour →
+build to green, **re-derived** from this brief (not ported from `spike-*`). Priority order:
+1. **#987 serialisation** — round-trip stability tests (the contract everything else rides). Nail the shape first.
+2. **#986 typed contract** — `deriveSizing` fold (hard/soft, nested), sizing-honoured-in-split, variant resolution. (POC already has 8/8 derive + 9/9 pane-drop logic tests to seed these.)
+3. **#985 editable renderer** — pane-handle hit-tests, detach/reorder/drop-beside transforms, no overlay-drift.
+4. **#988 app** + **#974 round-trip** on top.
+
+## Reconcile gate (step 1.5 — do before freezing the brief)
+
+Drive the running **v52** POC (`crouton-builder-demo.pmcp.dev` / `pnpm dev`) against this brief +
+`HANDOFF.md`, sort behaviour into **confirmed / contradicted / undocumented**, and add stable
+`data-testid` / `data-handoff` hooks wherever a state is hard to locate (armed snap, ghost slot, active
+page badge, floor readout, region pills). Those hook names become the shared vocabulary the rebuild
+(WS) reproduces, so the same agent runs identically against the POC and the graduated app.
+
+## Promotion path
+
+`pocs/crouton-builder-demo` → package contributions land in `@fyit/crouton-layout` (test-first, gated)
+→ a fresh **builder app** consumes them (real routing) → `/deploy` → retire the POC (`/remove-app`)
+once the app supersedes it. Does not auto-merge/deploy; each step under the existing gates.


### PR DESCRIPTION
Continues the Crouton Builder spike (`pocs/crouton-builder-demo`, epic #905) after PR #969 (v11→v44). Iterations **v45→v52** — see `app/spike-changelog.json`. POC-only (no `packages/` edits); all deployed to `crouton-builder-demo.pmcp.dev` and verified headless.

## 👤 For humans
Clears the filed polish backlog, fixes everything surfaced from the live preview, and prototypes the "component-driven layout" model:

- **Cleanup (#975)** — removed dead survey/slider code + `fitOverview`; chart bars render reliably; the board hides Vue Flow's own ⛶ (it mis-frames our oversized cards).
- **Block sizing-descriptor (#971)** — "the component decides its own size" as declared data (`fill`/`hug`); a pinned Top bar is short because the *block* says so.
- **Display variants (#970)** — a block offers bounded layouts of the same data (Artists list: rows · cards · table), picked per-pane in the edit view, serialised on the leaf.
- **Drop-beside-pane (#972)** — drag a block over a layout and drop it on any side of the pane you point at (flatten into the row, or wrap perpendicular) — so you can finally add to the right of a pane in a vertical stack.
- **Composite layout sizing** — a layout *derives* its own floor from its components (hard = widest block; soft = summed row), enforced on resize + shown as a readout. Component-driven, all the way up a layout-of-layouts.
- **Bug fixes** — wiggle drag-border sizing (measure real panes, not `defaultSize`), the same borders clamped on scrolling layouts, and the drop actually committing (Vue Flow mutates positions in place / re-emits rows by value).

## 🤖 For agents
- Pure logic is unit-tested (pane-drop fold 9/9, composite `deriveSizing` 8/8) and gestures reproduced in headless chromium.
- Key files: `app/pages/spike-app.vue` (snapIntent → pane-drop, drag tracking), `app/components/SpikeBlockNode.vue` (measured pane faces + clamp, resize floor, variant/region toolbars), `app/utils/spike-layout.ts` (`blockSizing`/`nodeHeightSizing`/`deriveSizing`/`applyPaneDrop`), `app/components/SpikePagePreview.vue`, `app/app.config.ts` (sizing + variant registry data).
- `HANDOFF.md` is current truth (North Star sharpened: component-driven; composites derive their rules) and is the brief the upcoming **graduation** consumes.
- Deploy fix included: declare `@fyit/crouton-feedback` + add it to `deploy.config.json` layerPackages (pre-existing #976 fallout — flagged in HANDOFF gotchas; systemic across crouton-devtools consumers).

Part of epic #905 (does not close it — graduation into `packages/` + the agent⇄human round-trip remain).

Closes #970
Closes #971
Closes #972
Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119yThmqQJJKo6WUK23MaY2)_