### PR TITLE
fix(root): pi.dev a11y flow — load skills via --skill, pin anthropic provider (#888)

### DIFF
--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -80,10 +80,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # ── The agent: pi.dev, REPORTS-ONLY, scoped to the model key only ──────────────
-      # env carries ONLY the provider key — no GH_TOKEN/GITHUB_TOKEN. «VERIFY» pi's CLI
-      # surface on the runner (print flag / model flag) via `pi --help`; the working
-      # invocation from the spike is `pi --print --model <m> "<prompt>"`. Skills: bridge
-      # .claude/skills → .pi/skills so pi loads them (Agent Skills standard).
+      # env carries ONLY the provider key — no GH_TOKEN/GITHUB_TOKEN. CI pins
+      # `--provider anthropic` with a FUNDED API key (PI_PROVIDER_KEY) — NOT a Claude
+      # subscription (subscription OAuth must never back unattended CI — Anthropic terms;
+      # the box's interactive `pi-claude-cli`/subscription path stays interactive-only).
+      # Invocation + skills confirmed on the mac-mini (#888): the `.pi/skills` symlink
+      # bridge does NOT load — pi's discovery ignores it — so skills are passed via the
+      # explicit `--skill .claude/skills` flag (our SKILL.md format is drop-in portable).
       - id: pi
         env:
           ANTHROPIC_API_KEY: ${{ secrets.PI_PROVIDER_KEY }}
@@ -91,7 +94,6 @@ jobs:
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent
-          mkdir -p .pi && [ -e .pi/skills ] || ln -s ../.claude/skills .pi/skills
           DATE=$(date -u +%Y%m%d)
           LOG="a11y-pidev-exec-${{ github.run_id }}.log"
           PROMPT=$(cat <<EOF
@@ -113,8 +115,8 @@ jobs:
           echo "report=writeups/reports/a11y-repo-pidev-${DATE}.md" >> "$GITHUB_OUTPUT"
           echo "exec=$LOG" >> "$GITHUB_OUTPUT"
           START=$(date +%s)
-          # «VERIFY» flags — single source of truth for the invocation:
-          pi --print --model "$PI_MODEL" "$PROMPT" 2>&1 | tee "$LOG"
+          # Confirmed on the mac-mini (#888): pin provider + load skills via --skill.
+          pi --print --provider anthropic --model "$PI_MODEL" --skill .claude/skills "$PROMPT" 2>&1 | tee "$LOG"
           RC=${PIPESTATUS[0]}
           END=$(date +%s)
           echo "wall=$((END-START))" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Fixes the reports-only pi.dev a11y workflow (`a11y-daily-pidev.yml`, merged via #869) so it actually loads our skills and uses a CI-safe auth path. Both changes are **verified on the mac-mini runner** during #888 on-box verification.

## Why

Two latent bugs the on-box session surfaced:

1. **Skills ran blind.** The step bridged `.claude/skills → .pi/skills` via a symlink, but pi's skill discovery **ignores `.pi/skills`** — confirmed on the box: bare `pi -p "name the /commit skill"` couldn't see it, while `pi --skill .claude/skills …` answered correctly. So the flow would have swept a11y *without our `/a11y` skill loaded*. Now passes `--skill .claude/skills` (our `SKILL.md` format is drop-in portable to pi).
2. **Auth path was ambiguous.** `claude-haiku-4-5` resolves across both the native `anthropic` provider (API key) and the `pi-claude-cli` extension (which on the box auths via the **Claude subscription** — fine interactively, but **must not back unattended CI** per Anthropic's terms). Pinned `--provider anthropic` so CI deterministically uses the funded `PI_PROVIDER_KEY` API key.

Clears both `«VERIFY»` flags that were hardcoded in the workflow.

## Note

Still requires the `PI_PROVIDER_KEY` secret to be a **funded** Anthropic API key for the flow to actually run (the dispatch-only + default-OFF `AGENT_HARNESS` gate is unchanged).

Refs #888. Part of #669.