### PR TITLE
chore(root): drop the daily a11y + red-team whole-repo sweeps (#823)

### DIFF
--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -12,8 +12,8 @@ name: A11y (daily sweep)
 # Required repo config: secrets.ANTHROPIC_API_KEY (shared with the other claude workflows).
 
 on:
-  schedule:
-    - cron: '42 6 * * *'   # 06:42 UTC daily (offset from red-team's 06:17 to avoid pile-up)
+  # Daily schedule dropped to cut cost (#823) — rely on the per-PR a11y.yml gate (diff-scoped).
+  # Kept dispatchable for an occasional manual whole-repo sweep.
   workflow_dispatch:        # manual run
 
 concurrency:

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -17,8 +17,8 @@ name: Red-Team (daily deep sweep)
 # If RESEND_API_KEY / the vars are unset the email step warns and skips (the job stays green).
 
 on:
-  schedule:
-    - cron: '17 6 * * *'   # 06:17 UTC daily, before the working day
+  # Daily schedule dropped to cut cost (#823) — rely on the per-PR red-team.yml gate
+  # (scope:diff, depth:quick). Kept dispatchable for an occasional manual whole-repo sweep.
   workflow_dispatch:        # manual run
 
 concurrency:


### PR DESCRIPTION
Per the cost discussion: the daily deep sweeps are a fixed expensive AI run every day; the **per-PR gates already hone in on the diff** (red-team.yml = `scope:diff, depth:quick`; a11y.yml likewise) and catch issues at introduction. So the dailies were mostly re-scanning unchanged code. Drops both `schedule:` blocks (keeps `workflow_dispatch` for manual full sweeps). Reversible; a weekly cron is a one-line alternative. Part of #823.