### PR TITLE
chore(root): tier orchestrator to haiku (#824)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -20,15 +20,23 @@ A recursive "one task → tree of GitHub issues → agents" system. Entry point 
 
 | Agent | File | Recurses? | Writes code? | Model |
 |-------|------|-----------|--------------|-------|
-| `task-orchestrator` | `task-orchestrator.md` | no | no | `sonnet` |
+| `task-orchestrator` | `task-orchestrator.md` | no | no | `haiku` |
 | `task-decomposer`   | `task-decomposer.md`   | **yes** | no | `sonnet` |
 | `task-worker`       | `task-worker.md`       | no | **yes** (one leaf → one PR) | `opus` |
 
-**Model split (cost):** orchestrator + decomposer only read/write GitHub issues, so they
-run on **Sonnet**; only `task-worker` writes real code, so it runs on **Opus**. Each
-spawned agent re-pays the base context (system prompt + this repo's large `CLAUDE.md` +
-tool defs), so fan-out is the dominant cost — drop the issue-only agents to `haiku` for a
-cheaper (slightly blunter) split, or raise them to `opus` if decomposition quality slips.
+**Model split (#824) — tier by REASONING difficulty, not by "writes code?":** the
+naive cut ("issue-only roles → cheapest model") is wrong for the **decomposer**. Writing
+code and *reasoning* are different axes, and the decomposer is the pipeline's reasoning
+bottleneck — it applies the LEAF TEST, makes the split-vs-build call, derives coherent
+workstreams, and writes the **acceptance criteria the Opus worker builds against**. A
+blunt decomposer mis-specs the expensive worker, so it stays on **Sonnet** (at least).
+The **orchestrator** is a bounded one-shot (epic → 2–6 workstreams, once per epic), so it
+runs on **Haiku** — the genuinely zero-risk cut. The **worker** writes real code → **Opus**.
+Each spawned agent re-pays the base context (system prompt + this repo's large `CLAUDE.md`
++ tool defs), so fan-out (mostly decomposer invocations) is the dominant cost — which is
+exactly why the decomposer must be *good*, not just cheap. Open question worth measuring:
+whether the decomposer should be **raised to Opus** (and the well-specced worker dropped to
+Sonnet) — the inverse of today's split.
 
 ## The red-team agent (standalone — not part of the pipeline)
 

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -3,7 +3,7 @@ name: task-orchestrator
 layer: method
 description: Top of the recursive task-decomposition pipeline. Given a GitHub epic issue, reads the goal, splits it into 2–6 top-level workstreams as linked sub-issues, then spawns one task-decomposer per child. Invoked by the /task-decompose skill — not usually by hand.
 tools: mcp__github__issue_read, mcp__github__issue_write, mcp__github__sub_issue_write, mcp__github__add_issue_comment, mcp__github__list_issues, mcp__github__search_issues, mcp__github__get_label, mcp__github__create_pull_request, mcp__github__pull_request_read, Read, Grep, Glob, Bash, Agent
-model: sonnet
+model: haiku
 ---
 
 # Task Orchestrator


### PR DESCRIPTION
Part of #824 / #823 Tier 0. **Scoped down from the issue's original ask after a design correction (see below).**

## What changed
- `task-orchestrator` → **sonnet → haiku** — it only splits an epic into 2–6 top-level workstreams, once per epic, and writes no code. Bounded, low-stakes, genuinely zero-risk.

## Deliberately NOT changed: the decomposer
#824 originally asked to drop **both** the orchestrator *and* the decomposer to Haiku, on the logic *"issue-only roles never write code → cheapest model."* That logic is **backwards for the decomposer.** Writing code and *reasoning* are different axes:

- The **decomposer** is the pipeline's reasoning bottleneck — it applies the LEAF TEST, makes the split-vs-build call, derives coherent workstreams, handles dependency ordering (#325 foundation-first), and writes the **acceptance criteria the Opus worker builds against.** A blunt decomposer mis-specs the expensive worker → the artifact-gate catches it late → *more* cost, not less. So it stays **Sonnet** (at least).
- The **worker** writes code but executes an already-well-specified leaf → stays **Opus**.

## Open question (separate, worth measuring — not in this PR)
The corrected lens — *tier by reasoning difficulty, not "writes code?"* — raises whether the decomposer should be **raised to Opus** (and the well-specced worker dropped to Sonnet), i.e. the inverse of today's split. Captured in the `.claude/agents/CLAUDE.md` rationale; a measured experiment, not this cut.

## Verification
- `--max-turns 30` confirmed bounding `decompose-on-issue.yml` + `resume-on-comment.yml`.
- `.claude/agents/CLAUDE.md` model-split table + rationale updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)