### PR TITLE
feat(root): pi.dev telemetry convergence adapter (#944)

### DIFF
--- a/.claude/skills/loop-station/SKILL.md
+++ b/.claude/skills/loop-station/SKILL.md
@@ -104,9 +104,21 @@ Both reconstruct **2+-level recursion** (agent→agent→…) to the correct dep
 
 | file | role |
 |------|------|
-| `parse-transcripts.mjs` | parse one session → `trace.jsonl` of `{ts,kind,name,parent,depth,agentId?,durMs?}` (also importable: `parseSession()`) |
+| `parse-transcripts.mjs` | **claude harness:** parse one Claude Code session → `trace.jsonl` of `{ts,kind,name,parent,depth,agentId?,durMs?}` (also importable: `parseSession()`) |
+| `pi-telemetry.mjs` | **pi harness (#944):** adapt pi.dev telemetry (native session JSONL + subagent meta, per `writeups/architecture/pi-telemetry-schema.md`) → the SAME WS2 event shape **and** the #883 ledger slice. `buildPiTrace(dir)` / `runOutcomeToLedgerRecord(outcome)`; CLI: `node pi-telemetry.mjs <dir> [--ledger]` |
+| `pi-telemetry.test.mjs` | runs the adapter against the real captured fixtures (`pocs/loop-station/data/pi-telemetry-sample/`); asserts the ledger slice passes the real `eval-ledger/schema.mjs` validator + payload-freeness |
 | `collect-traces.mjs` | CI collector — discover the run's session across all project dirs, tag events with the run id, write one NDJSON file (meta header + tagged events) for artifact upload |
 | `lib/parse-transcripts.test.mjs` | fixtures for both layouts, 2-level recursion, payload-freeness, defensiveness |
+
+### Harness parity (#944)
+
+WS2 reads whichever harness is active. The data seam (`pocs/loop-station/scripts/prepare-data.mjs`)
+branches on `AGENT_HARNESS`: `pi` → `pi-telemetry.mjs` (live `PI_TELEMETRY_DIR` of subagent metas,
+else the committed real sample); anything else → the claude transcript parser. **One feed, two
+consumers:** the same pi telemetry yields the WS2 trace **and** the `{model,cost,turns,wall}` slice
+for the #883 run-outcome ledger — so the cost ledger *consumes* pi telemetry, it doesn't re-derive
+it. Note: pi's WS2 trace is **agent-granularity** today (one node per subagent); tool-level nesting
+arrives when pi-otel spans are actually collected (schema doc §3, not yet wired).
 
 ## Run by hand
 

--- a/.claude/skills/loop-station/pi-telemetry.mjs
+++ b/.claude/skills/loop-station/pi-telemetry.mjs
@@ -1,0 +1,238 @@
+/**
+ * pi.dev telemetry → Loop Station WS2 events + the #883 run-outcome ledger.
+ *
+ * #944 (epic #669) — the convergence adapter. Reads the telemetry surfaces pinned (from
+ * REAL captures) in writeups/architecture/pi-telemetry-schema.md and maps them to the two
+ * consumers, so a pi run feeds BOTH the trace view and the cost ledger from ONE feed:
+ *
+ *   - Loop Station WS2 trace events  { ts, kind, name, parent, depth, agentId?, durMs? }
+ *     (same shape parse-transcripts.mjs emits for the claude-code-action harness)
+ *   - #883 run-outcome LedgerRecord slice  { ts, flow, harness:'pi', model, cost_usd, turns, wall_s }
+ *     (validated by scripts/eval-ledger/schema.mjs)
+ *
+ * CAPTURED SURFACES (the primary feed — built-in, always present):
+ *   1. Native session JSONL      ~/.pi/agent/sessions/<slug>/<ts>_<id>.jsonl  (per-message usage)
+ *   2. Subagent meta JSON        <slug>/subagent-artifacts/<runId>_<agent>_<idx>_meta.json
+ * pi-otel GenAI spans (richer, tool-level nesting) are NOT collected yet — no OTLP receiver
+ * is wired — so WS2 from pi is at AGENT granularity for now (one node per subagent). When
+ * pi-otel spans are collected, tool-level children can be layered in (TODO, see schema doc §3).
+ *
+ * HARD PRIVACY RULE (parity with the WS2 transcript parser): forward names + ids + durations
+ * + token counts + cost ONLY. NEVER forward message content, task/prompt text, cwd, or tool I/O.
+ * Every mapper below picks a whitelist of fields by construction — it never spreads the source.
+ *
+ * Dependency-free (node built-ins only) so it runs in any CI step without an install — same
+ * constraint as scripts/eval-ledger/schema.mjs.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+function num(v) {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/** "anthropic/claude-haiku-4-5-20251001:high" → provider "anthropic" (null if no "/"). */
+export function providerFromModel(model) {
+  if (typeof model !== 'string' || !model.includes('/')) return null
+  return model.slice(0, model.indexOf('/')) || null
+}
+
+/** Strip the trailing ":<thinking>" qualifier pi appends to a worker's model id. */
+export function normalizeModel(model) {
+  if (typeof model !== 'string') return ''
+  const noThinking = model.includes(':') ? model.slice(0, model.lastIndexOf(':')) : model
+  return noThinking
+}
+
+/** pi exitCode → the run's own terminal verdict (NOT the ledger merge/ci state). */
+export function outcomeFromExitCode(exitCode) {
+  const n = num(exitCode)
+  if (n === null) return 'error'
+  return n === 0 ? 'success' : 'failure'
+}
+
+/**
+ * Subagent meta JSON (schema doc §2) → a PiRunOutcome. Whitelist only — `meta.task` (the
+ * full prompt) and `meta.modelAttempts[].*` content are deliberately dropped.
+ * @returns {{
+ *   runId:string, agent:string, exitCode:number, durationMs:number, toolCount:number,
+ *   timestamp:number, model:string, provider:string|null,
+ *   tokens:{input:number,output:number,cacheRead:number,cacheWrite:number,total:number},
+ *   turns:number|null, costUsd:number, harness:'pi', outcome:'success'|'failure'|'error'
+ * }}
+ */
+export function subagentMetaToRunOutcome(meta) {
+  const m = meta && typeof meta === 'object' ? meta : {}
+  const u = m.usage && typeof m.usage === 'object' ? m.usage : {}
+  const input = num(u.input) ?? 0
+  const output = num(u.output) ?? 0
+  const cacheRead = num(u.cacheRead) ?? 0
+  const cacheWrite = num(u.cacheWrite) ?? 0
+  const model = typeof m.model === 'string' ? m.model : ''
+  return {
+    runId: String(m.runId ?? ''),
+    agent: String(m.agent ?? 'unknown'),
+    exitCode: num(m.exitCode) ?? 0,
+    durationMs: num(m.durationMs) ?? 0,
+    toolCount: num(m.toolCount) ?? 0,
+    timestamp: num(m.timestamp) ?? 0,
+    model: normalizeModel(model),
+    provider: providerFromModel(model),
+    tokens: { input, output, cacheRead, cacheWrite, total: input + output + cacheRead + cacheWrite },
+    turns: num(u.turns),
+    costUsd: num(u.cost) ?? 0,
+    harness: 'pi',
+    outcome: outcomeFromExitCode(m.exitCode),
+  }
+}
+
+/**
+ * Native session JSONL (schema doc §1) → a usage rollup. Sums the assistant `message` lines'
+ * `usage` only; never reads `content`. Useful when there's no subagent meta (e.g. a single
+ * decompose run) — gives the {model, provider, tokens, cost} slice the ledger wants.
+ */
+export function sessionUsageFromJsonl(text) {
+  let model = null
+  let provider = null
+  const tokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+  let costUsd = 0
+  let messageCount = 0
+  for (const raw of String(text ?? '').split('\n')) {
+    const line = raw.trim()
+    if (!line) continue
+    let o
+    try { o = JSON.parse(line) } catch { continue }
+    if (o.type === 'model_change') {
+      if (typeof o.provider === 'string') provider = o.provider
+      if (typeof o.modelId === 'string') model = o.modelId
+      continue
+    }
+    if (o.type === 'message' && o.message && o.message.role === 'assistant') {
+      const msg = o.message
+      const u = msg.usage && typeof msg.usage === 'object' ? msg.usage : {}
+      if (typeof msg.model === 'string') model = msg.model
+      if (typeof msg.provider === 'string') provider = msg.provider
+      tokens.input += num(u.input) ?? 0
+      tokens.output += num(u.output) ?? 0
+      tokens.cacheRead += num(u.cacheRead) ?? 0
+      tokens.cacheWrite += num(u.cacheWrite) ?? 0
+      costUsd += num(u.cost && u.cost.total) ?? 0
+      messageCount++
+    }
+  }
+  tokens.total = tokens.input + tokens.output + tokens.cacheRead + tokens.cacheWrite
+  return { model, provider, tokens, costUsd, messageCount }
+}
+
+/**
+ * Subagent metas → WS2 trace events (one `agent`-kind node per subagent). Sorted by start
+ * time; each is a child of `root` at depth 0 — the spawn tree isn't in the meta alone (that
+ * needs pi-otel spans), so we don't fabricate nesting. Privacy: name = agent ROLE, never task.
+ */
+export function subagentMetasToWs2Events(metas) {
+  const list = Array.isArray(metas) ? metas : []
+  return list
+    .map((m) => subagentMetaToRunOutcome(m))
+    .sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0))
+    .map((o) => {
+      const ev = {
+        ts: new Date(o.timestamp || 0).toISOString(),
+        kind: 'agent',
+        name: o.agent,
+        parent: 'root',
+        depth: 0,
+        agentId: o.runId,
+      }
+      if (o.durationMs) ev.durMs = o.durationMs
+      return ev
+    })
+}
+
+/**
+ * PiRunOutcome → a #883 ledger record SLICE (the bits pi telemetry owns: model/cost/turns/
+ * wall). Gate/CI/terminal-outcome stay the caller's to fill from the artifact-gate + CI, per
+ * "the ledger CONSUMES pi telemetry rather than re-deriving it". Returns a plain object you
+ * pass to scripts/eval-ledger/schema.mjs `validate()` (which fills the remaining defaults).
+ */
+export function runOutcomeToLedgerRecord(outcome, opts = {}) {
+  const o = outcome || {}
+  const ts = opts.ts ?? (o.timestamp ? new Date(o.timestamp).toISOString() : new Date().toISOString())
+  const rec = {
+    ts,
+    flow: opts.flow ?? `pi-${o.agent ?? 'run'}`,
+    skill: opts.skill ?? null,
+    harness: 'pi',
+    model: o.model ?? '',
+    cost_usd: num(o.costUsd),
+    turns: num(o.turns),
+    wall_s: o.durationMs ? Math.round(o.durationMs / 1000) : null,
+    ref: opts.ref ?? null,
+  }
+  // Let the caller pass through the gate/ci/outcome verdicts it already holds.
+  if (opts.artifact_gate) rec.artifact_gate = opts.artifact_gate
+  if (opts.ci) rec.ci = opts.ci
+  if (opts.outcome) rec.outcome = opts.outcome
+  if (opts.notes) rec.notes = opts.notes
+  return rec
+}
+
+/**
+ * Read all subagent meta JSON files under a pi sessions tree (or a flat dir of *_meta.json),
+ * returning their parsed objects. Defensive: skips unreadable/invalid files. Local FS only.
+ */
+export function readSubagentMetas(dir) {
+  const out = []
+  if (!dir || !fs.existsSync(dir)) return out
+  const stack = [dir]
+  while (stack.length) {
+    const cur = stack.pop()
+    let entries
+    try { entries = fs.readdirSync(cur, { withFileTypes: true }) } catch { continue }
+    for (const e of entries) {
+      const full = path.join(cur, e.name)
+      if (e.isDirectory()) { stack.push(full); continue }
+      if (!e.name.endsWith('_meta.json') && !(e.name.endsWith('.json') && /meta/.test(e.name))) continue
+      try { out.push(JSON.parse(fs.readFileSync(full, 'utf8'))) } catch { /* skip bad file */ }
+    }
+  }
+  return out
+}
+
+/**
+ * One-shot: a pi telemetry directory → WS2 trace events (with the leading `meta` header line
+ * the data seam expects). Returns { events, meta } or null if no metas found.
+ */
+export function buildPiTrace(dir) {
+  const metas = readSubagentMetas(dir)
+  if (!metas.length) return null
+  const events = subagentMetasToWs2Events(metas)
+  return {
+    meta: { kind: 'meta', source: 'pi', harness: 'pi', eventCount: events.length },
+    events,
+  }
+}
+
+// ── CLI: `node pi-telemetry.mjs <pi-telemetry-dir> [--ledger]` ─────────────────────────────
+// Default prints WS2 trace.jsonl (meta header + events). With --ledger, prints one ledger
+// record slice per subagent (JSONL). Used by prepare-data.mjs and for manual inspection.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const dir = process.argv[2]
+  const ledger = process.argv.includes('--ledger')
+  if (!dir) {
+    console.error('usage: node pi-telemetry.mjs <pi-telemetry-dir> [--ledger]')
+    process.exit(1)
+  }
+  if (ledger) {
+    for (const m of readSubagentMetas(dir)) {
+      console.log(JSON.stringify(runOutcomeToLedgerRecord(subagentMetaToRunOutcome(m))))
+    }
+  } else {
+    const trace = buildPiTrace(dir)
+    if (!trace) { console.error('no subagent metas found'); process.exit(1) }
+    console.log(JSON.stringify(trace.meta))
+    for (const e of trace.events) console.log(JSON.stringify(e))
+  }
+}

--- a/.claude/skills/loop-station/pi-telemetry.test.mjs
+++ b/.claude/skills/loop-station/pi-telemetry.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * Tests for the pi.dev telemetry adapter (#944). Runs against the REAL captured fixtures in
+ * pocs/loop-station/data/pi-telemetry-sample/ (sanitized samples from the mac-mini, #938).
+ * Dependency-free: `node .claude/skills/loop-station/pi-telemetry.test.mjs`.
+ */
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  subagentMetaToRunOutcome,
+  sessionUsageFromJsonl,
+  subagentMetasToWs2Events,
+  runOutcomeToLedgerRecord,
+  buildPiTrace,
+  outcomeFromExitCode,
+  providerFromModel,
+  normalizeModel,
+} from './pi-telemetry.mjs'
+import { validate } from '../../../scripts/eval-ledger/schema.mjs'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const SAMPLE = path.join(HERE, '..', '..', '..', 'pocs', 'loop-station', 'data', 'pi-telemetry-sample')
+const meta = JSON.parse(fs.readFileSync(path.join(SAMPLE, 'subagent-artifacts', '8a6fa2d3_worker_0_meta.json'), 'utf8'))
+const jsonl = fs.readFileSync(path.join(SAMPLE, 'session-sample.jsonl'), 'utf8')
+
+let passed = 0
+const test = (name, fn) => { fn(); passed++; console.log(`  ✓ ${name}`) }
+
+// ── helpers ──
+test('providerFromModel splits on "/"', () => {
+  assert.equal(providerFromModel('anthropic/claude-haiku-4-5-20251001:high'), 'anthropic')
+  assert.equal(providerFromModel('claude-haiku-4-5'), null)
+})
+test('normalizeModel strips the :thinking qualifier', () => {
+  assert.equal(normalizeModel('anthropic/claude-haiku-4-5-20251001:high'), 'anthropic/claude-haiku-4-5-20251001')
+  assert.equal(normalizeModel('claude-haiku-4-5'), 'claude-haiku-4-5')
+})
+test('outcomeFromExitCode maps 0→success, else→failure', () => {
+  assert.equal(outcomeFromExitCode(0), 'success')
+  assert.equal(outcomeFromExitCode(1), 'failure')
+  assert.equal(outcomeFromExitCode(undefined), 'error')
+})
+
+// ── subagent meta → PiRunOutcome ──
+test('subagentMetaToRunOutcome maps the real worker sample', () => {
+  const o = subagentMetaToRunOutcome(meta)
+  assert.equal(o.runId, '8a6fa2d3')
+  assert.equal(o.agent, 'worker')
+  assert.equal(o.harness, 'pi')
+  assert.equal(o.provider, 'anthropic')
+  assert.equal(o.model, 'anthropic/claude-haiku-4-5-20251001') // :high stripped
+  assert.equal(o.costUsd, 0.4202159)
+  assert.equal(o.turns, 45)
+  assert.equal(o.durationMs, 192340)
+  assert.equal(o.outcome, 'success')
+  assert.equal(o.tokens.total, 459 + 9236 + 2772244 + 77082)
+})
+test('PRIVACY: the outcome carries no task/prompt/content', () => {
+  const o = subagentMetaToRunOutcome(meta)
+  const blob = JSON.stringify(o)
+  assert.ok(!('task' in o), 'task field must not be forwarded')
+  assert.ok(!/REDACTED/.test(blob), 'no redacted prompt text may leak through')
+})
+
+// ── session JSONL → usage rollup (no content) ──
+test('sessionUsageFromJsonl sums assistant usage only', () => {
+  const u = sessionUsageFromJsonl(jsonl)
+  assert.equal(u.messageCount, 1) // one assistant message in the sample
+  assert.equal(u.model, 'claude-haiku-4-5-20251001')
+  assert.equal(u.costUsd, 0.05511375)
+  assert.equal(u.tokens.cacheWrite, 43751)
+  assert.ok(!/REDACTED/.test(JSON.stringify(u)), 'no content leaks into the rollup')
+})
+
+// ── WS2 events ──
+test('subagentMetasToWs2Events emits a valid agent node', () => {
+  const events = subagentMetasToWs2Events([meta])
+  assert.equal(events.length, 1)
+  const e = events[0]
+  assert.equal(e.kind, 'agent')      // the app renders 'agent' (orange)
+  assert.equal(e.name, 'worker')
+  assert.equal(e.parent, 'root')
+  assert.equal(e.depth, 0)
+  assert.equal(e.agentId, '8a6fa2d3')
+  assert.equal(e.durMs, 192340)
+  assert.ok(typeof e.ts === 'string' && !Number.isNaN(Date.parse(e.ts)))
+})
+test('buildPiTrace reads the fixture dir and adds a meta header', () => {
+  const trace = buildPiTrace(SAMPLE)
+  assert.ok(trace, 'fixture dir should yield a trace')
+  assert.equal(trace.meta.source, 'pi')
+  assert.equal(trace.meta.eventCount, trace.events.length)
+  assert.ok(trace.events.length >= 1)
+})
+
+// ── ledger feed: the slice must pass the REAL #883 validator ──
+test('runOutcomeToLedgerRecord produces a record the #883 schema accepts', () => {
+  const o = subagentMetaToRunOutcome(meta)
+  const rec = runOutcomeToLedgerRecord(o, { flow: 'decompose-pidev', skill: 'task-decompose', ref: 'https://github.com/x/y/pull/1', artifact_gate: 'pass', ci: 'pass', outcome: 'merged' })
+  const res = validate(rec)
+  assert.ok(res.ok, 'ledger validate() must accept the mapped record: ' + JSON.stringify(res.errors))
+  assert.equal(res.record.harness, 'pi')
+  assert.equal(res.record.model, 'anthropic/claude-haiku-4-5-20251001')
+  assert.equal(res.record.cost_usd, 0.4202159)
+  assert.equal(res.record.turns, 45)
+  assert.equal(res.record.wall_s, 192) // 192340ms → 192s
+})
+
+console.log(`\npi-telemetry adapter: ${passed} tests passed`)

--- a/pocs/loop-station/data/pi-telemetry-sample/session-sample.jsonl
+++ b/pocs/loop-station/data/pi-telemetry-sample/session-sample.jsonl
@@ -1,0 +1,4 @@
+{"type":"session","version":3,"id":"019f1a4d-d255-7228-a270-fd9275877950","timestamp":"2026-06-30T20:52:15.573Z","cwd":"<REDACTED>"}
+{"type":"model_change","id":"e24ab9e1","parentId":null,"timestamp":"2026-06-30T18:09:50.428Z","provider":"anthropic","modelId":"claude-haiku-4-5"}
+{"type":"message","id":"35aedb10","parentId":"74fec097","timestamp":"2026-06-30T18:09:50.927Z","message":{"role":"user","content":[{"type":"text","text":"<REDACTED>"}],"timestamp":1782842990906}}
+{"type":"message","id":"3f10dfdb","parentId":"f5095b7e","timestamp":"2026-06-30T21:46:23.830Z","message":{"role":"assistant","content":["<REDACTED — thinking + text>"],"api":"pi-claude-cli","provider":"pi-claude-cli","model":"claude-haiku-4-5-20251001","usage":{"input":10,"output":83,"cacheRead":0,"cacheWrite":43751,"totalTokens":43844,"cost":{"input":0.00001,"output":0.000415,"cacheRead":0,"cacheWrite":0.05468875,"total":0.05511375}},"stopReason":"stop","timestamp":1782855980632}}

--- a/pocs/loop-station/data/pi-telemetry-sample/subagent-artifacts/8a6fa2d3_worker_0_meta.json
+++ b/pocs/loop-station/data/pi-telemetry-sample/subagent-artifacts/8a6fa2d3_worker_0_meta.json
@@ -1,0 +1,27 @@
+{
+  "runId": "8a6fa2d3",
+  "agent": "worker",
+  "task": "<REDACTED — full task prompt; the adapter MUST NOT forward this>",
+  "exitCode": 0,
+  "usage": {
+    "input": 459,
+    "output": 9236,
+    "cacheRead": 2772244,
+    "cacheWrite": 77082,
+    "cost": 0.4202159,
+    "turns": 45
+  },
+  "model": "anthropic/claude-haiku-4-5-20251001:high",
+  "attemptedModels": ["anthropic/claude-haiku-4-5-20251001"],
+  "modelAttempts": [
+    {
+      "model": "anthropic/claude-haiku-4-5-20251001",
+      "success": true,
+      "exitCode": 0,
+      "usage": { "input": 459, "output": 9236, "cacheRead": 2772244, "cacheWrite": 77082, "cost": 0.4202159, "turns": 45 }
+    }
+  ],
+  "durationMs": 192340,
+  "toolCount": 44,
+  "timestamp": 1782380757684
+}

--- a/pocs/loop-station/scripts/prepare-data.mjs
+++ b/pocs/loop-station/scripts/prepare-data.mjs
@@ -6,8 +6,13 @@
  * stages their output into public/data/ for the app to fetch:
  *
  *   - history.jsonl  ← the committed WS1 inventory (writeups/loop-station/)
- *   - trace.jsonl    ← WS2: reconstructed from local Claude Code transcripts if
- *                       any exist (real data), else the committed example trace.
+ *   - trace.jsonl    ← WS2, by ACTIVE HARNESS (#944, toggle parity):
+ *                       • AGENT_HARNESS=pi → pi telemetry (live PI_TELEMETRY_DIR of
+ *                         subagent metas, else the committed real pi sample) via the
+ *                         pi-telemetry.mjs adapter.
+ *                       • default (claude) → reconstructed from local Claude Code
+ *                         transcripts via parse-transcripts.mjs.
+ *                       • either way, falls back to the committed example trace.
  *
  * Runs before dev/build. Defensive: a missing source degrades to an empty/example
  * file rather than failing the build. No deps.
@@ -34,29 +39,51 @@ if (fs.existsSync(historySrc)) {
 
 // ── trace.jsonl (WS2) ─────────────────────────────────────────────────────────
 async function buildTrace() {
-  // Try the real parser on whatever transcripts this machine has.
-  try {
-    const mod = await import(
-      path.join(REPO, '.claude', 'skills', 'loop-station', 'parse-transcripts.mjs')
-    )
-    const result = mod.parseSession({})
-    if (result.events && result.events.length > 0) {
-      const meta = {
-        kind: 'meta',
-        source: 'live',
-        session: result.session,
-        layout: result.layout,
-        eventCount: result.events.length
-      }
-      const lines = [JSON.stringify(meta), ...result.events.map((e) => JSON.stringify(e))]
-      fs.writeFileSync(path.join(OUT, 'trace.jsonl'), lines.join('\n') + '\n')
-      console.error(`[prepare-data] trace.jsonl ← live session ${result.session} (${result.events.length} events)`)
-      return
-    }
-  } catch (err) {
-    console.error(`[prepare-data] live parse unavailable (${err.message}); using example`)
+  const harness = (process.env.AGENT_HARNESS || 'claude').toLowerCase()
+  const writeTrace = (meta, events, label) => {
+    const lines = [JSON.stringify(meta), ...events.map((e) => JSON.stringify(e))]
+    fs.writeFileSync(path.join(OUT, 'trace.jsonl'), lines.join('\n') + '\n')
+    console.error(`[prepare-data] trace.jsonl ← ${label} (${events.length} events)`)
   }
-  // Fallback: the committed real example (so the deployed build always has a graph).
+
+  if (harness === 'pi') {
+    // Active harness is pi → pi telemetry: a live PI_TELEMETRY_DIR of subagent metas, else
+    // the committed real sample (so a pi build still renders pi-shaped data). #944.
+    try {
+      const { buildPiTrace } = await import(
+        path.join(REPO, '.claude', 'skills', 'loop-station', 'pi-telemetry.mjs')
+      )
+      const liveDir = process.env.PI_TELEMETRY_DIR
+      const trace =
+        (liveDir && buildPiTrace(liveDir)) ||
+        buildPiTrace(path.join(POC, 'data', 'pi-telemetry-sample'))
+      if (trace && trace.events.length > 0) {
+        writeTrace(trace.meta, trace.events, liveDir ? `pi telemetry ${liveDir}` : 'committed pi sample')
+        return
+      }
+    } catch (err) {
+      console.error(`[prepare-data] pi telemetry unavailable (${err.message}); using example`)
+    }
+  } else {
+    // Default (claude harness): reconstruct from whatever Claude Code transcripts exist here.
+    try {
+      const mod = await import(
+        path.join(REPO, '.claude', 'skills', 'loop-station', 'parse-transcripts.mjs')
+      )
+      const result = mod.parseSession({})
+      if (result.events && result.events.length > 0) {
+        writeTrace(
+          { kind: 'meta', source: 'live', session: result.session, layout: result.layout, eventCount: result.events.length },
+          result.events,
+          `live session ${result.session}`
+        )
+        return
+      }
+    } catch (err) {
+      console.error(`[prepare-data] live parse unavailable (${err.message}); using example`)
+    }
+  }
+  // Shared fallback: the committed real example (so the deployed build always has a graph).
   const example = path.join(POC, 'data', 'example-trace.jsonl')
   if (fs.existsSync(example)) {
     fs.copyFileSync(example, path.join(OUT, 'trace.jsonl'))


### PR DESCRIPTION
Closes #944. Part of #669. **Stacked on #1011** (the #938 schema doc) — base auto-retargets to `main` when #1011 merges.

## What
One adapter maps a pi.dev run's native telemetry into the **two** things we observe agent runs with, from **one feed**:
- **Loop Station WS2 trace** — `{ts,kind,name,parent,depth,agentId?,durMs?}` (the same shape `parse-transcripts.mjs` emits for the claude harness).
- **#883 run-outcome ledger** — the `{model, cost_usd, turns, wall_s}` slice, so the ledger *consumes* pi telemetry instead of re-deriving it.

This is the convergence the consolidated plan (#609) calls the keystone: the observatory survives the `claude-code-action → pi` swap and gains a real cost axis.

## Built against REAL data, not guesses
The mac-mini session (#938) pinned pi's actual output shapes in `writeups/architecture/pi-telemetry-schema.md` (PR #1011). This adapter targets the **captured/primary** surfaces — native session JSONL + subagent meta — and the fixtures in `pocs/loop-station/data/pi-telemetry-sample/` are those real (sanitized) samples. The test asserts the mapped ledger record passes the **actual** `scripts/eval-ledger/schema.mjs` `validate()` (9/9 green).

## Toggle parity (#944 item 5)
`prepare-data.mjs` branches on `AGENT_HARNESS`: `pi` → pi telemetry (live `PI_TELEMETRY_DIR`, else committed sample); else → the claude transcript parser. Default deploy still renders the rich 120-event claude example until a full pi run is captured.

## Privacy (hard rule)
Mappers pick a whitelist by construction — never spread the source — so `task`/`content`/`cwd`/prompt text cannot leak. A test asserts payload-freeness.

## Honest scope / what's deferred
- **Agent-granularity WS2:** one node per subagent. Tool-level nesting needs **pi-otel spans**, which aren't collected yet (no OTLP receiver — schema doc §3). Layered in when they are.
- **CI append-to-ledger:** the `runOutcomeToLedgerRecord` feed is built + tested; wiring it as a post-run step in `decompose-on-issue-pidev.yml` lands with the **press-play run** (needs a live telemetry dir on the runner).

## 🧪 How to test
```
node .claude/skills/loop-station/pi-telemetry.test.mjs            # 9/9
AGENT_HARNESS=pi node pocs/loop-station/scripts/prepare-data.mjs  # → committed pi sample trace
node .claude/skills/loop-station/pi-telemetry.mjs pocs/loop-station/data/pi-telemetry-sample --ledger
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)