### PR TITLE
docs(root): sign-off/handoff ping is a top-level comment, not a PR review body

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -169,6 +169,12 @@ only — not visual taste (`/ui-proposal`), accessibility (`/a11y`), or security
   And **push before you block**: if you've written anything, `git push -u origin <branch>`
   first and name that branch under *State so far* — an unpushed worktree is lost on stop, a
   pushed branch is recoverable by the resuming session.
+- **The PING is a TOP-LEVEL comment, never a PR *review* body.** Post the handoff/sign-off via
+  `add_issue_comment` (a top-level issue/PR comment) — that reliably notifies. A PR **review**
+  body (state `COMMENTED`) is a weak surface the owner misses: on #846 pi buried its
+  `reply lgtm/approve` ping inside a review and it nearly went unseen. Put any detailed review
+  or analysis in its own separate artifact; the actionable ask (the handoff block + `@mention` +
+  `status:blocked`) stands alone as a top-level comment.
 - **An @mention is a request for action, not a broadcast.** Only @mention `NOTIFY_HANDLE`
   when you need the human to *do* something: answer a blocking question, give a sign-off,
   or unblock you. **Pure progress/status updates** ("spawning the worker for #NN", "wave 2

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -109,5 +109,7 @@ You may be running headless — do NOT use `AskUserQuestion` (it times out). If 
 contradictory): `add_issue_comment` on the issue with a concise question + the options
 you're weighing, **@mention the notify handle (`@pmcp` — `NOTIFY_HANDLE` in the
 task-decompose skill)** so they're notified, apply `status:blocked`, and **stop** this
-branch (don't spawn anything). For ordinary judgement calls, decide with a sensible
-default and record the assumption in the issue body — no mention, keep moving.
+branch (don't spawn anything). The ping is a **top-level** `add_issue_comment`, never a PR
+*review* body (state `COMMENTED`) — a review body doesn't reliably notify the owner (#846). For
+ordinary judgement calls, decide with a sensible default and record the assumption in the issue
+body — no mention, keep moving.

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -190,6 +190,10 @@ deploy pipeline is down). Run the **`ui-proposal`** skill with `--static`. Then:
   post-build before/after screenshot (#311) closes it.
 - **Approval signal is a reply comment** containing `approve` or `lgtm` (case-insensitive).
   A 👍 reaction or `ui-approved` label does **not** unblock the pipeline (#572).
+- **The sign-off request is a TOP-LEVEL comment.** Post it with `add_issue_comment` on the draft
+  PR/issue — **not** a PR *review* body (state `COMMENTED`), which the owner can miss (#846). The
+  detailed review (preview URL, field table, test cases) can live in the PR; the actionable
+  `@mention` + `status:blocked` ask stands alone as a top-level comment so it notifies.
 
 ## Schema sign-off gate (#314)
 

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -175,6 +175,13 @@ surfaces in the GitHub / Claude mobile app):
 - **Epic done** → when the last child merges, the verify-rollup comment on the epic
   also @mentions `NOTIFY_HANDLE` (per `github-tasks`).
 
+**Every actionable ping is a TOP-LEVEL comment.** A blocker question **or a sign-off request**
+goes out as `add_issue_comment` (a top-level issue/PR comment) — that notifies reliably.
+**Never bury the ask in a PR *review* body** (state `COMMENTED`): it's a weak surface the owner
+misses (the #846 sign-off case, where pi's `lgtm/approve` ping sat inside a review). Detailed
+review/analysis can live in its own artifact; the `@mention` + `status:blocked` ask stands alone
+on top.
+
 To change who gets pinged, edit `NOTIFY_HANDLE` here and in `.claude/agents/CLAUDE.md`.
 
 ## Notes


### PR DESCRIPTION
Closes #1023. Part of #1022 (pi parity), under #669.

## 👤 For humans
On #839, pi posted its `reply lgtm/approve` sign-off **inside a PR review body** (state `COMMENTED`) on #846 — a weak surface that's easy to miss. This codifies the convention in the four places a code-writing agent (and pi) reads: **the actionable ping (sign-off request OR block handoff) is a top-level issue/PR comment** (`add_issue_comment`, which reliably notifies); any detailed review goes in its own separate artifact. Never bury the ask in a review body.

## 🤖 For agents
- `.claude/skills/task-decompose/SKILL.md` (Notifications & async Q&A) — "Every actionable ping is a TOP-LEVEL comment" rule (this is the file pi reads via `--skill`).
- `.claude/agents/CLAUDE.md` (block-comment HANDOFF) — "The PING is a TOP-LEVEL comment, never a PR *review* body" with the #846 case.
- `.claude/agents/task-decomposer.md` (Asking the human) — ping is top-level, not a review body.
- `.claude/agents/task-worker.md` (sign-off gates' shared loop) — sign-off request is a top-level comment; the detailed review can live in the PR.

First concrete slice of the pi-parity work (#1022): one of the contract rules `--skill` doesn't carry to pi, now inlined where pi will actually see it.

## 🧪 How to test
1. Grep the four files — each states the ping is a top-level `add_issue_comment` and warns against a PR *review* body (state `COMMENTED`). `skills-and-triggers.html` is unchanged (`node scripts/gen-skills-doc.mjs --check` passes).
2. Behaviourally: the next delegate-pi sign-off/handoff lands as a top-level comment that notifies @pmcp, not inside a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
