### PR TITLE
ci(root): guard routing.yaml drift with gen-routing.mjs --check (#1029)

### DIFF
--- a/.github/workflows/routing-registry.yml
+++ b/.github/workflows/routing-registry.yml
@@ -1,0 +1,32 @@
+name: routing-registry
+
+# Keep .claude/routing.yaml, the generated writeups/architecture/routing-registry.md, AND the real
+# .claude/agents/*.md model frontmatter in sync (WS6a / #864, guard #1029). `gen-routing.mjs --check`
+# fails if the registry is stale OR if a route's tier drifts from the model an agent actually pins —
+# the exact silent drift that bit us (task-orchestrator/decomposer → opus without a routing.yaml update).
+# The generator uses only Node built-ins, so no install step is needed.
+
+on:
+  pull_request:
+    paths:
+      - '.claude/routing.yaml'
+      - '.claude/agents/**'          # an agent model change is the drift we guard against
+      - 'scripts/gen-routing.mjs'
+      - 'writeups/architecture/routing-registry.md'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/routing.yaml'
+      - '.claude/agents/**'
+      - 'scripts/gen-routing.mjs'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Verify routing registry is current + matches agent frontmatter
+        run: node scripts/gen-routing.mjs --check


### PR DESCRIPTION
Closes #1029. The #864/WS6a follow-up — a CI drift guard for the model-routing registry.

## What

`.github/workflows/routing-registry.yml`, mirroring `skills-doc.yml`: runs `node scripts/gen-routing.mjs --check` on PRs and pushes to `main`.

## Why it includes `.claude/agents/**` in the path filter

This session demonstrated the exact failure the guard prevents: `task-orchestrator`/`task-decomposer` were bumped to **opus** in their agent frontmatter over 5 days, but `routing.yaml` still said sonnet — the registry silently lied until a manual `--check` caught it. `gen-routing.mjs --check` already validates `routing.yaml`'s tiers against the real `.claude/agents/*` models, so the path filter **must** include `.claude/agents/**` — an agent model change is precisely the drift being guarded (not just edits to `routing.yaml`, the generator, or the registry md).

## Verification

- `node scripts/gen-routing.mjs --check` → `✓ routing registry current; no drift` (green on current `main`, so the guard passes today).
- Workflow YAML validated; Node built-ins only (no install step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkSarRfqYyhCnwU8yS8DwY)_