### PR TITLE
fix(root): grant frontend-review CI agent tool permissions so the gate can actually block

### DIFF
--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -52,7 +52,18 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: "--max-turns 30"
+          # --allowedTools is REQUIRED, not optional (#834). This prompt has the top-level
+          # action agent *act as* the subagent and call Bash/Write DIRECTLY (it does not spawn
+          # a sub-agent whose frontmatter tools would auto-grant). In headless CI there is no
+          # human to approve tool use, so without an explicit allowlist every Bash/Write is
+          # DENIED: the agent can read the diff and compute the right verdict but cannot persist
+          # `frontend-review-verdict.json` or post the sticky comment — it burns turns retrying
+          # denied writes, hits max_turns, and the gate step sees no verdict → fails OPEN (a
+          # silent hollow pass). Proven by the epic #834 smoke: identical verdict computed, zero
+          # bytes written. Bash covers `gh` (comment) + writing the verdict; Write/Edit for the
+          # file; Read/Grep/Glob for the scan. Bump max-turns now that turns aren't wasted on
+          # denied retries. NB: a11y.yml / red-team.yml share this exact latent bug.
+          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **frontend-review subagent** defined in `.claude/agents/frontend-review.md`.
             Input: { scope: "diff", depth: "quick", fix: false }.


### PR DESCRIPTION
## Hypothesis

**We think that** granting the frontend-review CI agent explicit tool permissions (`--allowedTools Bash,Write,Edit,Read,Grep,Glob`) **will** let it persist its verdict file and sticky comment, **and** that's what we want because without it the gate silently fails open on real violations.

## 👤 The bug (found by the epic #834 smoke)

The `frontend-review` gate merged in #845 was **fail-open on every finding**. The epic #834 smoke — a PR with a deliberate v3 `<UDropdown>` — proved it: the agent **correctly** computed the verdict (`{"highest":"critical","critical":1,...}`) and drafted the exact right sticky comment (`scratch-smoke/SmokeDropdown.vue:11`), but **wrote zero bytes to disk**, so the gate step saw no verdict file and passed the PR green.

**Root cause:** the workflow prompt has the *top-level* action agent **act as** the subagent and call `Bash`/`Write` **directly** (it doesn't spawn a sub-agent whose frontmatter tools would auto-grant). In headless CI there's no human to approve tool use, so every `Bash`/`Write` was **denied**. The agent burned all its turns retrying denied writes (`Write`, `cat >`, `printf`, `python3` …), hit `error_max_turns`, and left nothing behind. The repo's `gate-package-edits` hook was ruled out (it only blocks `packages/*`; the verdict file is at repo root).

## 🤖 The fix

`.github/workflows/frontend-review.yml`:
```diff
- claude_args: "--max-turns 30"
+ claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
```
`Bash` covers `gh` (the comment) + writing the verdict; `Write`/`Edit` for the file; `Read`/`Grep`/`Glob` for the scan. The `gate-package-edits` hook still runs, so `packages/` stays protected.

## Verification

- ✅ **Detection proven twice** — the CI agent (in the smoke run log) *and* a local run of the `frontend-review` agent both produced the identical `critical:1` verdict for the v3 `<UDropdown>`.
- ⏳ **CI red-path** — `pull_request` workflows execute from the **base branch**, so this fix only takes effect once merged to `main`. After merge I'll re-run the #834 smoke to confirm the check now goes **red** with the sticky comment.

## ⚠️ Sibling gates

`a11y.yml` and `red-team.yml` use the identical `act as … + write verdict` pattern with no `--allowedTools` — so they share this latent fail-open bug. Deliberately **not** touched here; a trivial follow-up applies the same one-line fix once this is confirmed working.

Part of #834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2Si8ZS8gx5fmZnKEgH2FW)_