### PR TITLE
feat(root): annotate skills-digest with loop-station budget (#1028 deliverable A)

### DIFF
--- a/.claude/skills/skills-digest/SKILL.md
+++ b/.claude/skills/skills-digest/SKILL.md
@@ -86,6 +86,23 @@ exists — the diagram can't silently drift from the real skill set.
 > to catch it. (Excalidraw-PNG — the `ticket-diagram` skill — remains the right tool for *per-epic
 > GitHub-mobile* status diagrams, a different surface.)
 
+## 🧮 Budget annotations (loop-station, #1028 A)
+
+When a committed **loop-station** context-budget record exists (`writeups/loop-station/history.jsonl`,
+epic #926), `gather.mjs` joins each skill's **measured token cost** and **redundancy band** onto the
+digest, and `render.mjs` surfaces:
+
+- a **header line** — total harness context budget (tokens, of which in skills), corpus redundancy %,
+  and the overall scorecard band;
+- a **per-skill token badge** — grey when in-band, **amber/red** when the scorecard flags it oversized;
+- an **`↔ overlap`** badge on skills that appear in loop-station's top restated pairs, plus a
+  **"most-overlapping skills"** callout (e.g. `a11y ↔ frontend-review 44.6%`) — the merge/trim candidates.
+
+This is the digest ↔ observatory wiring: loop-station is the **producer** (it computes tokens/redundancy);
+the digest only **reads the latest record and renders** — it never recomputes. Everything **degrades to a
+no-op** when the record is absent (no header line, no badges; the digest is unchanged). loop-station's own
+`fetch-depth`/commit-back concerns are its business; the digest just reads the committed JSONL.
+
 ## Cadence + delivery (config-as-data)
 
 Declared in `.github/digests.yml`, exactly like the other digests:

--- a/.claude/skills/skills-digest/example.data.json
+++ b/.claude/skills/skills-digest/example.data.json
@@ -9,8 +9,8 @@
       "title": "Build & generate",
       "sub": "Turn intent into code (or into issues that become code).",
       "skills": [
-        { "name": "crouton", "desc": "Collection generation workflow — schema JSON → generated CRUD.", "triggers": ["ask"] },
-        { "name": "ui-proposal", "desc": "Deploy a live staging preview for design sign-off before building UI.", "triggers": ["flow", "ask"] }
+        { "name": "crouton", "desc": "Collection generation workflow — schema JSON → generated CRUD.", "triggers": ["ask"], "budget": { "tokens": 4899, "band": "amber", "selfRedundancy": 0 } },
+        { "name": "ui-proposal", "desc": "Deploy a live staging preview for design sign-off before building UI.", "triggers": ["flow", "ask"], "budget": { "tokens": 2600, "band": "green", "selfRedundancy": 0 } }
       ]
     },
     {
@@ -18,8 +18,8 @@
       "title": "Plan & track",
       "sub": "Before code exists — issue tracking and prior-art checks.",
       "skills": [
-        { "name": "github-tasks", "desc": "Track work as GitHub issues — epics, sub-issues, labels.", "triggers": ["ask", "flow"] },
-        { "name": "skills-digest", "desc": "Monthly digest of the skills we have + what changed since last time.", "triggers": ["ask"] }
+        { "name": "github-tasks", "desc": "Track work as GitHub issues — epics, sub-issues, labels.", "triggers": ["ask", "flow"], "budget": { "tokens": 5115, "band": "amber", "selfRedundancy": 0.2 } },
+        { "name": "skills-digest", "desc": "Monthly digest of the skills we have + what changed since last time.", "triggers": ["ask"], "budget": { "tokens": 1800, "band": "green", "selfRedundancy": 0 } }
       ]
     },
     {
@@ -27,8 +27,8 @@
       "title": "Commit gates",
       "sub": "Run automatically as part of landing a change — you rarely call them by hand.",
       "skills": [
-        { "name": "sync-docs", "desc": "Update docs to match a code change before /commit.", "triggers": ["auto"] },
-        { "name": "commit", "desc": "Smart, granular conventional commits.", "triggers": ["ask"] }
+        { "name": "sync-docs", "desc": "Update docs to match a code change before /commit.", "triggers": ["auto"], "budget": { "tokens": 2400, "band": "green", "selfRedundancy": 0 } },
+        { "name": "commit", "desc": "Smart, granular conventional commits.", "triggers": ["ask"], "budget": { "tokens": 2200, "band": "green", "selfRedundancy": 0.1 } }
       ]
     }
   ],
@@ -42,6 +42,19 @@
     ],
     "removed": [
       { "name": "legacy-export" }
+    ]
+  },
+  "budget": {
+    "total": 132426,
+    "skillTokens": 93042,
+    "alwaysOn": 15702,
+    "redundancyPct": 2.8,
+    "scorecard": "amber",
+    "tokenizer": "anthropic",
+    "commit": "abc1234",
+    "generatedAt": "2026-07-01T05:00:00.000Z",
+    "topPairs": [
+      { "a": "github-tasks", "b": "skills-digest", "containment": 19.5 }
     ]
   }
 }

--- a/.claude/skills/skills-digest/gather.mjs
+++ b/.claude/skills/skills-digest/gather.mjs
@@ -15,6 +15,7 @@
  *                  Defaults to one month ago (same day-of-month) when unset.
  */
 import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { META, GROUPS, discover } from '../../../scripts/gen-skills-doc.mjs'
@@ -107,13 +108,76 @@ if (sinceRef) {
   }
 }
 
+// ── loop-station join (#1028 A) ──────────────────────────────────────────────
+// Annotate each skill with its MEASURED token cost + redundancy band from the latest
+// committed context-budget record (loop-station #926), when present. The digest stays a
+// reader/renderer — loop-station is the producer; we never recompute. Degrades to no
+// annotations when the record is absent.
+function skillNameFromPath(p) {
+  const m = String(p).match(/^\.claude\/skills\/(.+)$/)
+  if (!m) return null
+  const seg = m[1].split('/')[0]
+  if (m[1] === seg && seg.endsWith('.md')) return seg.replace(/\.md$/, '') // top-level skill.md
+  if (m[1] === `${seg}/SKILL.md`) return seg // directory skill
+  return null
+}
+function loadBudget() {
+  const p = join(ROOT, 'writeups/loop-station/history.jsonl')
+  if (!existsSync(p)) return null
+  let rec
+  try {
+    const lines = readFileSync(p, 'utf8').trim().split('\n').filter(Boolean)
+    if (!lines.length) return null
+    rec = JSON.parse(lines[lines.length - 1])
+  } catch {
+    return null
+  }
+  const bandByPath = {}
+  for (const o of rec.scorecard?.length?.oversized || []) bandByPath[o.path] = o.band
+  const self = rec.redundancy?.selfByPath || {}
+  const byName = new Map()
+  for (const a of rec.artifacts || []) {
+    if (a.kind !== 'skill') continue
+    const name = a.name || skillNameFromPath(a.path)
+    if (!name) continue
+    byName.set(name, { tokens: a.tokens, band: bandByPath[a.path] || 'green', selfRedundancy: self[a.path] ?? 0 })
+  }
+  // Top restated pairs, skill-vs-skill only, resolved to skill names (the overlap the digest cares about).
+  const topPairs = (rec.redundancy?.topPairs || [])
+    .map((pr) => ({ a: skillNameFromPath(pr.a), b: skillNameFromPath(pr.b), containment: pr.containment }))
+    .filter((pr) => pr.a && pr.b)
+    .slice(0, 3)
+  return {
+    byName,
+    summary: {
+      total: rec.totals?.tokens,
+      skillTokens: rec.totals?.byKind?.skill,
+      alwaysOn: rec.totals?.alwaysOnTokens,
+      redundancyPct: rec.redundancy?.pct,
+      scorecard: rec.scorecard?.overall,
+      tokenizer: rec.tokenizer,
+      commit: rec.commit ? String(rec.commit).slice(0, 8) : undefined,
+      generatedAt: rec.generatedAt,
+      topPairs
+    }
+  }
+}
+const budget = loadBudget()
+if (budget) {
+  for (const g of groups) for (const s of g.skills) {
+    const b = budget.byName.get(s.name)
+    if (b) s.budget = b
+  }
+}
+
 const data = {
   generatedAt: new Date().toISOString(),
   repo: REPO,
   since,
   total: skills.length,
   groups,
-  changed
+  changed,
+  budget: budget ? budget.summary : null
 }
 
 process.stdout.write(JSON.stringify(data, null, 2) + '\n')

--- a/.claude/skills/skills-digest/render.mjs
+++ b/.claude/skills/skills-digest/render.mjs
@@ -36,6 +36,11 @@ const outDir = flag('out-dir', 'writeups/reports')
 const repo = data.repo || 'repo'
 const total = data.total ?? (data.groups || []).reduce((n, g) => n + g.skills.length, 0)
 const changed = data.changed || { firstRun: true, added: [], updated: [], removed: [] }
+// loop-station budget annotations (#1028 A) — present only when the digest was gathered
+// against a committed context-budget record; every budget surface is a no-op when absent.
+const budget = data.budget || null
+const dupNames = new Set((budget?.topPairs || []).flatMap((p) => [p.a, p.b]))
+const fmtTok = (n) => (n == null ? '' : n >= 1000 ? `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k` : String(n))
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 const esc = (s) =>
@@ -60,6 +65,36 @@ const TRIG = {
 const badge = (t) => {
   const c = TRIG[t] || TRIG.ask
   return `<span style="display:inline-block;font:700 10.5px/1.4 -apple-system,Segoe UI,Roboto,sans-serif;color:${c.fg};background:${c.bg};border:1px solid ${c.bd};border-radius:999px;padding:1px 8px;margin-left:4px;white-space:nowrap;">${c.label}</span>`
+}
+
+// Measured token cost per skill (loop-station). Colour tracks the scorecard band —
+// grey (green/ok), amber/red = oversized, i.e. eating context budget.
+const BAND = {
+  green: { fg: '#64748b', bg: '#f1f5f9', bd: '#e2e8f0' },
+  amber: { fg: '#b45309', bg: '#fdecd2', bd: '#f4d29b' },
+  red: { fg: '#b91c1c', bg: '#fde8e8', bd: '#f3b4b4' }
+}
+const tokenBadge = (b) => {
+  if (!b || b.tokens == null) return ''
+  const c = BAND[b.band] || BAND.green
+  return `<span title="tokens" style="display:inline-block;font:700 10px ui-monospace,Menlo,Consolas,monospace;color:${c.fg};background:${c.bg};border:1px solid ${c.bd};border-radius:999px;padding:1px 7px;margin-left:4px;">${fmtTok(b.tokens)}</span>`
+}
+const dupBadge = (name) =>
+  dupNames.has(name)
+    ? `<span style="display:inline-block;font:700 10px -apple-system,Segoe UI,Roboto,sans-serif;color:#b45309;background:#fdecd2;border:1px solid #f4d29b;border-radius:999px;padding:1px 7px;margin-left:4px;">↔ overlap</span>`
+    : ''
+
+// Header one-liner + the "most-overlapping skills" callout — both no-op without a budget record.
+const budgetHeadline = () =>
+  budget
+    ? `<div style="color:#cdeee9;font-size:12.5px;margin-top:6px;">🧮 harness context budget: <strong style="color:#fff;">${fmtTok(budget.total)}</strong> tokens (<strong style="color:#fff;">${fmtTok(budget.skillTokens)}</strong> in skills) · ${budget.redundancyPct}% redundancy · scorecard <strong style="color:#fff;">${esc(budget.scorecard || '?')}</strong></div>`
+    : ''
+const budgetPairs = () => {
+  if (!budget || !(budget.topPairs || []).length) return ''
+  const items = budget.topPairs
+    .map((p) => `<code style="font:700 12px ui-monospace,Menlo,Consolas,monospace;">/${esc(p.a)}</code> ↔ <code style="font:700 12px ui-monospace,Menlo,Consolas,monospace;">/${esc(p.b)}</code> <strong>${p.containment}%</strong>`)
+    .join(' &nbsp;·&nbsp; ')
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 26px;"><tr><td style="padding:11px 14px;background:#fdf4e7;border:1px solid #f4d29b;border-radius:10px;color:#7c4a12;font:12.5px -apple-system,Segoe UI,Roboto,sans-serif;">⚠️ <strong>Most-overlapping skills</strong> (measured — loop-station): ${items} — candidates to merge or trim.</td></tr></table>`
 }
 
 // ── HTML ──────────────────────────────────────────────────────────────────
@@ -124,7 +159,7 @@ const flowSection = () =>
 
 const skillCard = (s) =>
   `<tr><td style="padding:11px 0;border-bottom:1px solid #eef2f7;">
-    <div style="margin-bottom:3px;"><code style="font:700 14px ui-monospace,Menlo,Consolas,monospace;color:#0f172a;">/${esc(s.name)}</code>${(s.triggers || ['ask']).map(badge).join('')}</div>
+    <div style="margin-bottom:3px;"><code style="font:700 14px ui-monospace,Menlo,Consolas,monospace;color:#0f172a;">/${esc(s.name)}</code>${(s.triggers || ['ask']).map(badge).join('')}${tokenBadge(s.budget)}${dupBadge(s.name)}</div>
     <div style="color:#64748b;font:12.5px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;">${esc(s.desc)}</div>
   </td></tr>`
 
@@ -142,9 +177,11 @@ const html = `<!DOCTYPE html>
     <div style="font:700 11px -apple-system,Segoe UI,Roboto,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:#9fe9df;">${esc(repo)} · agent flow</div>
     <div style="font:800 24px -apple-system,Segoe UI,Roboto,sans-serif;color:#ffffff;margin-top:4px;">🧩 Skills digest — ${esc(monthYear)}</div>
     <div style="color:#cdeee9;font-size:14px;margin-top:5px;"><strong style="color:#fff;">${total}</strong> skills in <code style="color:#eafcf8;">.claude/skills/</code> · grouped by job, with how each one triggers</div>
+    ${budgetHeadline()}
   </td></tr>
   <tr><td style="padding:24px 26px;">
     ${changedBand()}
+    ${budgetPairs()}
     ${flowSection()}
     ${(data.groups || []).map(groupSection).join('')}
     <p style="margin:34px 0 0;padding-top:16px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:12px;">
@@ -178,8 +215,16 @@ const txtFlow =
   ).join('\n') +
   '\n'
 
+const txtBudget = budget
+  ? `🧮 CONTEXT BUDGET: ${fmtTok(budget.total)} tokens (${fmtTok(budget.skillTokens)} in skills) · ${budget.redundancyPct}% redundancy · scorecard ${budget.scorecard || '?'}\n` +
+    ((budget.topPairs || []).length
+      ? `   most-overlapping: ${budget.topPairs.map((p) => `/${p.a} ↔ /${p.b} ${p.containment}%`).join(' · ')}\n`
+      : '')
+  : ''
 const txt =
-  `🧩 SKILLS DIGEST — ${monthYear}\n${repo} · ${total} skills\n\n` +
+  `🧩 SKILLS DIGEST — ${monthYear}\n${repo} · ${total} skills\n` +
+  txtBudget +
+  '\n' +
   txtChanged() +
   '\n' +
   txtFlow +
@@ -188,7 +233,9 @@ const txt =
     .map(
       (g, i) =>
         `${i + 1}. ${g.title.toUpperCase()} (${g.skills.length})\n   ${g.sub}\n` +
-        g.skills.map((s) => `   /${s.name}  [${(s.triggers || ['ask']).join(', ')}]\n     ${s.desc}`).join('\n')
+        g.skills
+          .map((s) => `   /${s.name}  [${(s.triggers || ['ask']).join(', ')}]${s.budget ? ` · ${fmtTok(s.budget.tokens)} tok${s.budget.band !== 'green' ? ` (${s.budget.band})` : ''}` : ''}\n     ${s.desc}`)
+          .join('\n')
     )
     .join('\n\n') +
   `\n\n${BRAND_NAME} · generated ${generated.toISOString().slice(0, 10)} by /skills-digest\n`


### PR DESCRIPTION
## 👤 For humans

Wires the two "observe the harness" tools together (deliverable **A** of #1028). The monthly **skills-digest** now shows what each skill *costs*, using **loop-station**'s measurements:

- a **header line** — total harness context budget (tokens, of which in skills), corpus redundancy %, and the overall scorecard band;
- a **per-skill token badge** — grey in-band, **amber/red** when loop-station's scorecard flags it oversized;
- an **`↔ overlap`** badge + a **"most-overlapping skills"** callout (live data: `a11y ↔ frontend-review 44.6%`) — the merge/trim candidates the digest was always *meant* to surface, now with real numbers instead of prose.

The digest stays a **reader/renderer** — loop-station computes; the digest only reads the latest committed record and renders. Everything **no-ops when the record is absent** (no header, no badges; digest unchanged).

## 🤖 For agents

- **`gather.mjs`** — reads the latest `writeups/loop-station/history.jsonl` record; joins per-skill `{tokens, band, selfRedundancy}` (skill artifacts only) onto each skill, and adds a top-level `budget` summary (`total`/`skillTokens`/`alwaysOn`/`redundancyPct`/`scorecard`/`topPairs`, skill-vs-skill pairs resolved to names). Returns `null` when the record is missing/unparseable.
- **`render.mjs`** — header budget line, per-skill `tokenBadge` (band-coloured) + `dupBadge`, the "most-overlapping" callout, and the plain-text mirror. Every budget surface is guarded on `data.budget` / `s.budget`.
- **`example.data.json`** — carries `budget` fields so `render.mjs` demonstrates the feature offline.
- **`SKILL.md`** — documents the annotation.

**Scope:** producer/reader split per #926 — no recompute in the digest. **Deliverable B** (declared `FLOWS` vs loop-station's actual WS2 trace) is **not** in this PR — it's blocked on the cross-CI trace collector #926 flagged as "remaining", so #1028 stays open after this merges.

## 🧪 How to test

1. **Live:** `node .claude/skills/skills-digest/gather.mjs > d.json && node .claude/skills/skills-digest/render.mjs d.json --out-dir /tmp/sd` → header shows `132k tokens · 2.8% redundancy · scorecard amber`; skills carry token badges (crouton/task-decompose/github-tasks amber); `a11y` + `frontend-review` show `↔ overlap` and the callout lists the pair.
2. **Offline:** render `example.data.json` → same surfaces from committed sample data.
3. **Degrades — render:** strip `budget` from the data → no header/badges, no crash.
4. **Degrades — gather:** remove `writeups/loop-station/history.jsonl` → `data.budget` is `null`, no per-skill budgets, digest otherwise unchanged.
5. `node scripts/gen-skills-doc.mjs --check` still passes.

Part of #1028. Does **not** close it (deliverable B remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFWdU19VmwjpcD97ZdEGPJ)_