### PR TITLE
fix(root): grant a11y + red-team CI agents tool permissions (same #834 fix)

### DIFF
--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -50,7 +50,11 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: "--max-turns 60"
+          # bypassPermissions REQUIRED (#834): headless CI denies un-allowlisted tools, so the
+          # deep sweep couldn't write its report, update the standing issue, or file a11y issues.
+          # Broader than the per-PR gate's allowlist because this run also files GitHub issues
+          # (MCP) + writes reports; the gate-package-edits hook still protects packages/.
+          claude_args: "--max-turns 60 --permission-mode bypassPermissions"
           prompt: |
             Run the **`/a11y`** skill (`.claude/skills/a11y/SKILL.md`) at
             **depth=deep, scope=repo**. Sweep the `vuejs-accessibility/*` eslint rules across

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -61,7 +61,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: "--max-turns 30"
+          # --allowedTools REQUIRED (#834): the prompt has the top-level agent *act as* the
+          # subagent and call Bash/Write directly; headless CI denies un-allowlisted tools, so
+          # without this the agent can't write a11y-verdict.json / post the comment → fails OPEN.
+          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **a11y subagent** defined in `.claude/agents/a11y.md`.
             Input: { scope: "diff", depth: "quick", fix: false }.

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -53,7 +53,11 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: "--max-turns 60"
+          # bypassPermissions REQUIRED (#834): headless CI denies un-allowlisted tools, so the
+          # deep sweep couldn't write its report, update the standing issue, or file security
+          # issues. Broader than the per-PR gate's allowlist because this run also files GitHub
+          # issues (MCP) + writes reports; the gate-package-edits hook still protects packages/.
+          claude_args: "--max-turns 60 --permission-mode bypassPermissions"
           prompt: |
             Run the **`/red-team`** skill (`.claude/skills/red-team/SKILL.md`) at
             **depth=deep, scope=repo**. Fan out the `red-team` subagent across the

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -53,7 +53,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: "--max-turns 30"
+          # --allowedTools REQUIRED (#834): the prompt has the top-level agent *act as* the
+          # subagent and call Bash/Write directly; headless CI denies un-allowlisted tools, so
+          # without this the agent can't write red-team-verdict.json / post the comment → fails OPEN.
+          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **red-team subagent** defined in `.claude/agents/red-team.md`.
             Input: { scope: "diff", depth: "quick" }.


### PR DESCRIPTION
Applies the **proven #834 permission fix** to the two sibling agent-gate families, which share the identical latent fail-open bug the frontend-review smoke exposed.

## Why

The frontend-review smoke (#834 → #1031) proved that a per-PR gate whose prompt has the top-level action agent *"act as"* a subagent and call `Bash`/`Write` **directly** gets those calls **denied** in headless CI (no human to approve) — so it can compute the right verdict but never write it, and the gate fails **open**. `a11y.yml` and `red-team.yml` use the exact same pattern; their `-daily` deep sweeps additionally write reports and file issues. All four were silently non-enforcing.

## The fix

- **Per-PR gates** (`a11y.yml`, `red-team.yml`) — identical to the merged frontend-review fix:
  ```
  --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob
  ```
- **Daily deep sweeps** (`a11y-daily.yml`, `red-team-daily.yml`) — broader, because they also file GitHub issues (MCP) + write reports + update a standing issue:
  ```
  --max-turns 60 --permission-mode bypassPermissions
  ```

The `gate-package-edits` hook still runs on all four, so `packages/` stays protected.

## Verification

- The mechanism is **already proven** end-to-end for the identical per-PR pattern: frontend-review went from hollow-green → **red with sticky comment** on a real violation once this exact `--allowedTools` line landed (#834 smoke on #847).
- All four workflow YAMLs parse.
- `pull_request` workflows run from the base branch, so these take effect on merge to `main` (same as #1031).

Part of #726 (a11y) and #540 (red-team).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2Si8ZS8gx5fmZnKEgH2FW)_