### PR TITLE
fix(root): make teardown-app idempotent on already-absent Worker/D1 (#1056)

### DIFF
--- a/scripts/lib/wrangler-d1.mjs
+++ b/scripts/lib/wrangler-d1.mjs
@@ -57,15 +57,31 @@ export function resolveAppDb(app, env, repoRoot) {
 /** Run `npx wrangler …` from repoRoot. Returns stdout when capture is set; throws on non-zero. */
 export function runWrangler(args, { cwd, capture = false } = {}) {
   const full = ['wrangler', ...args]
+  // stderr is ALWAYS piped (not inherited) so wrangler's real error text — e.g.
+  // "This Worker does not exist … [code: 10007]" — ends up in the thrown Error's
+  // message, where callers can classify it (see isAlreadyGone). We re-emit it live
+  // afterwards so console output is unchanged. stdout stays inherit unless captured.
   const res = spawnSync('npx', full, {
     cwd,
     encoding: 'utf8',
-    stdio: capture ? ['inherit', 'pipe', 'inherit'] : 'inherit'
+    stdio: ['inherit', capture ? 'pipe' : 'inherit', 'pipe']
   })
+  if (res.stderr) process.stderr.write(res.stderr)
   if (res.status !== 0) {
-    throw new Error(`wrangler exited with code ${res.status}: npx ${full.join(' ')}`)
+    const detail = (res.stderr ?? '').trim()
+    throw new Error(`wrangler exited with code ${res.status}: npx ${full.join(' ')}${detail ? `\n${detail}` : ''}`)
   }
   return res.stdout ?? ''
+}
+
+/**
+ * True when a wrangler delete failed only because the resource is already gone —
+ * so a re-run is idempotent, not a real failure. Matches the actual Cloudflare
+ * phrasings: Worker "does not exist … [code: 10007]", D1 "Couldn't find DB",
+ * KV "not found". A genuine error (auth 403, network) returns false.
+ */
+export function isAlreadyGone(msg) {
+  return /not found|does not exist|couldn'?t find|could not find|no such|\b10007\b/i.test(String(msg ?? ''))
 }
 
 /** Run a remote SELECT and return the first result set's rows (wrangler --json shape). */

--- a/scripts/lib/wrangler-d1.test.mjs
+++ b/scripts/lib/wrangler-d1.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * Regression for #1056 — a teardown re-run must be idempotent: an already-absent
+ * Worker/D1/KV is "already gone", not a failure. The bug was that runWrangler's
+ * thrown Error didn't carry wrangler's stderr, and the classifier missed the real
+ * Cloudflare phrasings ("Couldn't find DB", "[code: 10007]").
+ *
+ *   node --test scripts/lib/wrangler-d1.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isAlreadyGone } from './wrangler-d1.mjs'
+
+test('Worker already gone — the real CF phrasing (#1056)', () => {
+  assert.equal(isAlreadyGone('This Worker does not exist on your account. [code: 10007]'), true)
+  assert.equal(isAlreadyGone('wrangler exited with code 1: npx wrangler delete --name x\nThis Worker does not exist on your account. [code: 10007]'), true)
+})
+
+test('D1 already gone — the contraction the old regex missed (#1056)', () => {
+  assert.equal(isAlreadyGone("Couldn't find DB with name 'three-demo-staging-db'"), true)
+  assert.equal(isAlreadyGone('Could not find database'), true)
+})
+
+test('KV already gone', () => {
+  assert.equal(isAlreadyGone('KV namespace not found'), true)
+  assert.equal(isAlreadyGone('no such namespace'), true)
+})
+
+test('a genuine failure is NOT treated as already-gone', () => {
+  assert.equal(isAlreadyGone('Authentication error [code: 10000]'), false)
+  assert.equal(isAlreadyGone('A request to the Cloudflare API failed: 403 Forbidden'), false)
+  assert.equal(isAlreadyGone('connect ETIMEDOUT'), false)
+  assert.equal(isAlreadyGone(''), false)
+  assert.equal(isAlreadyGone(undefined), false)
+})

--- a/scripts/teardown-app.mjs
+++ b/scripts/teardown-app.mjs
@@ -33,7 +33,7 @@
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { createInterface } from 'node:readline'
-import { findWranglerConfig, parseJsonc, runWrangler } from './lib/wrangler-d1.mjs'
+import { findWranglerConfig, isAlreadyGone, parseJsonc, runWrangler } from './lib/wrangler-d1.mjs'
 import { readFileSync } from 'node:fs'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -139,7 +139,7 @@ function tryDelete(label, args) {
     return 'deleted'
   } catch (err) {
     const msg = String(err.message || '')
-    if (/not found|does not exist|could not find|no such/i.test(msg)) {
+    if (isAlreadyGone(msg)) {
       console.log(`    – ${label} not found (already gone)`)
       return 'absent'
     }


### PR DESCRIPTION
Closes #1056.

## 👤 For humans

Re-running an app teardown when its Cloudflare resources are already gone now reports **success** ("already gone"), not a red "failed" run. This is the exact false failure that showed up while retiring `three-demo`/`thinkgraph`/`thinkgraph-collab-worker` in #686 — the resources didn't exist, the teardown did the right thing, but the run still went red.

## 🤖 For agents

Root cause was two layers (see #1056 archaeology):
1. `scripts/lib/wrangler-d1.mjs` → `runWrangler` ran with `stdio: 'inherit'`, so wrangler's real error text (`This Worker does not exist … [code: 10007]`, `Couldn't find DB with name '…'`) streamed to the console but was **never captured** — the thrown `Error.message` was just `wrangler exited with code N: <cmd>`.
2. `scripts/teardown-app.mjs` → `tryDelete`'s idempotency regex tested that message (which never held the CF text) and also missed the `Couldn't find` contraction + `[code: 10007]`. KV escaped the bug only because `findKvId` short-circuits to `absent` before calling `tryDelete`.

**Changes:**
- `runWrangler`: pipe stderr (was inherit), re-emit it live so console UX is unchanged, and fold it into the thrown `Error`'s message so callers can classify the failure. stdout behaviour unchanged (inherit unless `capture`).
- New exported `isAlreadyGone(msg)` classifier — matches the real CF phrasings; a genuine error (auth 403 / timeout / empty) returns false.
- `tryDelete` now uses `isAlreadyGone`.
- `scripts/lib/wrangler-d1.test.mjs` — `node --test` regression (4 tests, green) over the real CF strings + the negative cases, mirroring `harness-stages.test.mjs`.

**Verified:** `node --check` both scripts; `node --test scripts/lib/wrangler-d1.test.mjs` → 4/4 pass. Scripts-only (plain `.mjs`), no app typecheck surface.

Surfaced by #686; relates to #618 (remove-app teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1WrPZTZRBLnKjzwuJXBLV)_