### PR TITLE
fix(root): brace ${NUM} before the ellipsis in standing-issue update steps

### DIFF
--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -164,7 +164,7 @@ jobs:
             echo "Creating the pi.dev standing a11y issue…"
             gh issue create --repo "$REPO" --title "$TITLE" --label a11y --label meta:agents --body-file "$BODY_FILE"
           else
-            echo "Updating pi.dev standing a11y issue #$NUM…"
+            echo "Updating pi.dev standing a11y issue #${NUM}…"
             gh issue edit "$NUM" --repo "$REPO" --body-file "$BODY_FILE"
           fi
 

--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -119,6 +119,6 @@ jobs:
             echo "Creating the standing a11y issue…"
             gh issue create --repo "$REPO" --title "$TITLE" --label a11y --body-file "$BODY_FILE"
           else
-            echo "Updating standing a11y issue #$NUM…"
+            echo "Updating standing a11y issue #${NUM}…"
             gh issue edit "$NUM" --repo "$REPO" --body-file "$BODY_FILE"
           fi

--- a/.github/workflows/eval-scoreboard.yml
+++ b/.github/workflows/eval-scoreboard.yml
@@ -76,6 +76,6 @@ jobs:
             echo "Creating the standing scoreboard issue…"
             gh issue create --repo "$REPO" --title "$TITLE" --label meta:agents --label workflow --body-file "$BODY_FILE"
           else
-            echo "Commenting on standing scoreboard issue #$NUM…"
+            echo "Commenting on standing scoreboard issue #${NUM}…"
             gh issue comment "$NUM" --repo "$REPO" --body-file "$BODY_FILE"
           fi


### PR DESCRIPTION
Closes #1068

## 👤 For humans

Three report-posting workflows (`a11y-daily-pidev`, `a11y-daily`, `eval-scoreboard`) die the **second** time they run: the "Updating standing issue #$NUM…" log line has a Unicode ellipsis glued straight onto the variable, so bash under `set -u` resolves the variable name as `NUM…` (unset) and aborts. The agent step succeeds and the report is produced — it just never gets posted. First live hit: the pi.dev a11y verification run on 2026-07-02 ([run 28577041933](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28577041933)).

## 🤖 For agents

- One-character-class fix in 3 files: `#$NUM…` → `#${NUM}…` (`a11y-daily-pidev.yml:167`, `a11y-daily.yml:122`, `eval-scoreboard.yml:79`).
- Full sweep of `.github/workflows/` for `\$[A-Za-z_]+[^\x00-\x7F]` found no other occurrences.
- Archaeology on #1068: born with the files (`00f59a30` for the pi variant), latent because only the else (issue-already-exists) branch is affected.

## 🧪 How to test

1. Merge, then re-dispatch `a11y-daily-pidev.yml` with `harness=pi` → the post step reaches "Updating pi.dev standing a11y issue #NN…" and edits the standing issue; run green end-to-end.
2. The next scheduled `a11y-daily` / `eval-scoreboard` runs **update** (not recreate) their standing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)