### PR TITLE
feat(root): wire the WS7 AGENT_HARNESS flip + /delegate-pi comment command

### DIFF
--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -2,7 +2,9 @@ name: Comment dispatch
 
 # Hand an issue to the agent pipeline by COMMENTING — mobile-friendly, no label UI.
 # Comment `/delegate` (or `/deploy`) on an issue and this applies the `delegate` label,
-# which fires decompose-on-issue.yml. Only the repo owner / members / collaborators can
+# which fires decompose-on-issue.yml. Comment `/delegate-pi` to apply `delegate-pi`
+# instead, which fires the pi.dev variant (decompose-on-issue-pidev.yml) — same gesture,
+# other harness (#1077 / #669 WS7). Only the repo owner / members / collaborators can
 # trigger it.
 #
 # AUTH (#519 WS5): the label is applied with a Nuxt Harness GitHub App installation token, so
@@ -49,16 +51,22 @@ jobs:
             const issue_number = context.payload.issue.number
             const comment_id = context.payload.comment.id
 
-            // Fire a FRESH `delegate` labeled event: decompose-on-issue only triggers on the
+            // Pick the harness label. Check `/delegate-pi` FIRST — `/delegate` is a
+            // substring of it, so the order is load-bearing (#1077).
+            const body = context.payload.comment.body || ''
+            const label = body.includes('/delegate-pi') ? 'delegate-pi' : 'delegate'
+
+            // Fire a FRESH labeled event: both decompose workflows only trigger on the
             // label being *added* (not merely present), so if it's already there, remove first.
             const cur = (context.payload.issue.labels || []).map(l => (typeof l === 'string' ? l : l.name))
-            if (cur.includes('delegate')) {
-              try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'delegate' }) } catch (e) {}
+            if (cur.includes(label)) {
+              try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label }) } catch (e) {}
             }
-            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['delegate'] })
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] })
 
             // Acknowledge so the commenter sees it registered (handy on mobile).
             try { await github.rest.reactions.createForIssueComment({ owner, repo, comment_id, content: 'rocket' }) } catch (e) {}
+            const harness = label === 'delegate-pi' ? 'pi.dev' : 'claude'
             await github.rest.issues.createComment({ owner, repo, issue_number,
-              body: `▶️ Dispatched by comment — applied \`delegate\`, the agent pipeline is picking up #${issue_number}.` })
-            core.info(`Dispatched #${issue_number} via comment.`)
+              body: `▶️ Dispatched by comment — applied \`${label}\`, the ${harness} agent pipeline is picking up #${issue_number}.` })
+            core.info(`Dispatched #${issue_number} via comment (label: ${label}).`)

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -67,17 +67,23 @@ on:
   # PROMOTED past dispatch-only (#1017): a human applying the `delegate-pi` label starts a pi
   # run. We fire on EVERY labeled event but the job `if` gates to the exact `delegate-pi` label,
   # so a worker later adding `status:in-progress` does NOT re-fire (the claude flow's #535 lesson).
+  # `opened` added for the WS7 flip (#1077): when AGENT_HARNESS=pi, an issue *created with* the
+  # plain `delegate` label must land here (the claude flow handles that shape and now yields).
   issues:
-    types: [labeled]
+    types: [labeled, opened]
 
 jobs:
   decompose-pi:
-    # Fire on EITHER: a manual dispatch opting into pi, OR the `delegate-pi` label freshly applied
-    # to an issue (#1017). The specific-label check is what stops a re-fire loop when the worker
-    # adds its own labels (#535). Anything else (other labels, AGENT_HARNESS off) → no run.
+    # Fire on: a manual dispatch opting into pi, OR the `delegate-pi` label freshly applied
+    # to an issue (#1017), OR — when the WS7 flip is ON (vars.AGENT_HARNESS == 'pi', #1077) —
+    # the same plain-`delegate` shapes the claude flow handles (which then yields via its own
+    # guard). The specific-label checks are what stop a re-fire loop when the worker adds its
+    # own labels (#535). Anything else (other labels, AGENT_HARNESS off) → no run.
     if: |
       (github.event_name == 'workflow_dispatch' && (inputs.harness == 'pi' || vars.AGENT_HARNESS == 'pi')) ||
-      (github.event_name == 'issues' && github.event.label.name == 'delegate-pi')
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'delegate-pi') ||
+      (vars.AGENT_HARNESS == 'pi' && github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'delegate') ||
+      (vars.AGENT_HARNESS == 'pi' && github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate'))
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     # No `id-token` — pi uses a provider key, not OIDC. The write scopes are for the
@@ -162,7 +168,9 @@ jobs:
           # with the issue number appended.
           PROMPT_FILE="decompose-pidev-prompt-${{ github.run_id }}.txt"
           cat > "$PROMPT_FILE" <<'PI_PROMPT'
-          You are running NON-INTERACTIVELY in CI. No human is attached and there is no terminal to read input from. NEVER pause, ask a question, or wait for confirmation, and do not invoke pi-ask-user. When a choice is ambiguous, pick the most sensible default, record the assumption in an issue or PR comment, and PROCEED. The run only succeeds if it produces a real deliverable: a PR (Closes #N), created sub-issues, or a held sign-off (status:blocked plus a review). Merely listing options or asking what to do is a FAILED run. Given that, do the following now:
+          You are running NON-INTERACTIVELY in CI. No human is attached and there is no terminal to read input from. NEVER pause, ask a question, or wait for confirmation, and do not invoke pi-ask-user. When a choice is ambiguous, pick the most sensible default, record the assumption in an issue or PR comment, and PROCEED. The run only succeeds if it produces a real deliverable: a PR (Closes #N), created sub-issues, or a held sign-off (status:blocked plus a review). Merely listing options or asking what to do is a FAILED run.
+          OPERATING CONTRACT (non-negotiable, #1022): (1) NEVER merge a pull request — not even one you opened. Open it and stop; the automerge workflow merges epic sub-PRs after CI passes. (2) Hold any sign-off as a TOP-LEVEL issue comment plus the status:blocked label — never inside a PR review body. (3) Reuse an existing epic/NNN-* branch idempotently — never create a duplicate epic branch. (4) You CANNOT modify .github/workflows/** (the App token lacks the workflows scope, by deliberate policy #1076): commit everything else, embed the needed workflow patch verbatim in the PR body under a "## Workflow patch (human applies)" heading, mention @pmcp in an issue comment, add status:blocked, and finish — that counts as a successful deliverable.
+          Given that, do the following now:
           PI_PROMPT
           printf '/task-decompose #%s\n' "$ISSUE" >> "$PROMPT_FILE"
           # Confirmed on the mac-mini (#888): pin provider + load skills via --skill.

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -13,9 +13,13 @@ jobs:
     # later label change while `delegate` happens to still be on the issue. Otherwise the
     # worker adding `status:in-progress` re-fires this workflow as claude[bot], which then
     # dies on the bot-actor guard (the mystery duplicate failures). Gate on the *added* label.
+    # AGENT_HARNESS guard (#669 WS7 / #1077): when the repo var is 'pi', this claude flow
+    # yields — the same `delegate` events are picked up by decompose-on-issue-pidev.yml
+    # instead. Unset/anything-else ⇒ claude stays the default (one-variable flip back).
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'delegate') ||
-      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate'))
+      vars.AGENT_HARNESS != 'pi' &&
+      ((github.event.action == 'labeled' && github.event.label.name == 'delegate') ||
+       (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate')))
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully


### PR DESCRIPTION
Closes #1077

## 👤 For humans

Three things, all default-preserving:

1. **`/delegate-pi` comment command** — comment it on any issue and the pi pipeline picks it up, same one-gesture flow `/delegate` has for claude (mobile-friendly, no label UI).
2. **The WS7 flip is now real** — `decompose-on-issue.yml` yields when `vars.AGENT_HARNESS == 'pi'`, and the pi variant accepts the plain `delegate` shapes in that case. Before this PR the flip variable rerouted nothing. Default stays claude; flipping (and flipping back) is one repo variable.
3. **pi's prompt now carries the operating contract** it was observed improvising on during the 2026-07-02 eval runs: never merge a PR (automerge's job), sign-offs as top-level comments, idempotent epic-branch reuse, and the freshly-decided #1076 convention — no `.github/workflows/**` edits; embed the patch in the PR body for a human and hold `status:blocked`.

## 🤖 For agents

- `comment-dispatch.yml`: `/delegate-pi` checked **before** `/delegate` (substring); label + ack derived from it.
- `decompose-on-issue.yml`: job `if` prefixed with `vars.AGENT_HARNESS != 'pi'` (unset ⇒ true ⇒ claude default).
- `decompose-on-issue-pidev.yml`: trigger `types: [labeled, opened]`; job `if` gains the two flipped-var `delegate` arms; `PI_PROMPT` gains the 4-rule `OPERATING CONTRACT` block (#1022 mitigation; #1076 convention encoded).

## 🧪 How to test

1. Comment `/delegate-pi` on a test issue → ack names the **pi.dev** pipeline, `delegate-pi` label applied by `nuxt-harness[bot]`, pi run fires.
2. Comment `/delegate` → unchanged claude flow.
3. Set repo var `AGENT_HARNESS=pi`, add `delegate` to a test issue → claude flow shows **skipped**, pi variant runs. Unset → behaviour reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)