### PR TITLE
fix(root): artifact-gate scans child issues for fresh deliverables

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -250,6 +250,49 @@ jobs:
               return
             }
 
+            // ── CHILD deliverables (#1074) ─────────────────────────────────────────────
+            // When the labeled issue is ALREADY decomposed, the correct behaviour is
+            // "resume the tree, work the remaining open leaf" — the fresh deliverable
+            // lands on a CHILD issue, invisible to the checks above (the #1050 false-fail:
+            // pi merged a real PR on child #1053 and this gate still went red). Scan the
+            // sub-issue tree for the same fresh-since-t0 signals. Only runs when the
+            // primary checks found nothing. Kept in sync with decompose-on-issue.yml.
+            let childDeliverable = ''
+            try {
+              const subs = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues', {
+                ...context.repo, issue_number, per_page: 100,
+              })
+              for (const s of subs) {
+                if (s.state === 'closed' && s.closed_at && new Date(s.closed_at).getTime() >= sinceMs) {
+                  childDeliverable = `child #${s.number} closed this run`; break
+                }
+                const tl = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                  ...context.repo, issue_number: s.number,
+                })
+                if (tl.some(e => e.event === 'cross-referenced' && e.source && e.source.issue &&
+                    e.source.issue.pull_request && new Date(e.created_at).getTime() >= sinceMs)) {
+                  childDeliverable = `PR linked to child #${s.number} this run`; break
+                }
+                const childBlocked = (s.labels || []).some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
+                if (childBlocked) {
+                  const cc = await github.paginate(github.rest.issues.listComments, {
+                    ...context.repo, issue_number: s.number, since,
+                  })
+                  if (cc.length > 0) { childDeliverable = `child #${s.number} held for sign-off this run`; break }
+                }
+              }
+            } catch (e) { core.warning(`child-deliverable check skipped: ${e.message}`) }
+            if (childDeliverable) {
+              core.info(`Artifact-gate OK for #${issue_number} via child deliverable: ${childDeliverable}`)
+              if (process.env.TRIGGER === 'issues') {
+                await github.rest.issues.createComment({
+                  ...context.repo, issue_number,
+                  body: `> 🤖 **pi.dev harness** · agent pipeline (CI · mac-mini) · _via the \`delegate-pi\` label_\n\nresumed the existing tree → ${childDeliverable}`,
+                })
+              }
+              return
+            }
+
             // ── Classify WHY there was no deliverable (#1004 piece 3) ──────────────────
             // pi emits no structured execution_file like claude-code-action — it emits the
             // plain-text run log we tee'd to PI_EXEC_LOG. Grep it for the known causes so the

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -126,6 +126,43 @@ jobs:
               return
             }
 
+            // ── (e) CHILD deliverables (#1074) ─────────────────────────────────────────
+            // When the labeled issue is ALREADY decomposed, the correct agent behaviour is
+            // "resume the tree, work the remaining open leaf" — so the fresh deliverable
+            // lands on a CHILD issue, invisible to the checks above (the #1050 false-fail:
+            // pi merged a real PR on child #1053 and the gate still went red). Scan the
+            // sub-issue tree for the same fresh-since-t0 signals. Runs ONLY when the
+            // primary checks found nothing, so the extra API calls are the exception.
+            let childDeliverable = ''
+            try {
+              const subs = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues', {
+                ...context.repo, issue_number, per_page: 100,
+              })
+              for (const s of subs) {
+                if (s.state === 'closed' && s.closed_at && new Date(s.closed_at).getTime() >= sinceMs) {
+                  childDeliverable = `child #${s.number} closed this run`; break
+                }
+                const tl = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                  ...context.repo, issue_number: s.number,
+                })
+                if (tl.some(e => e.event === 'cross-referenced' && e.source && e.source.issue &&
+                    e.source.issue.pull_request && new Date(e.created_at).getTime() >= sinceMs)) {
+                  childDeliverable = `PR linked to child #${s.number} this run`; break
+                }
+                const childBlocked = (s.labels || []).some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
+                if (childBlocked) {
+                  const cc = await github.paginate(github.rest.issues.listComments, {
+                    ...context.repo, issue_number: s.number, since,
+                  })
+                  if (cc.length > 0) { childDeliverable = `child #${s.number} held for sign-off this run`; break }
+                }
+              }
+            } catch (e) { core.warning(`child-deliverable check skipped: ${e.message}`) }
+            if (childDeliverable) {
+              core.info(`Artifact-gate OK for #${issue_number} via child deliverable: ${childDeliverable}`)
+              return
+            }
+
             // ── Classify WHY there was no deliverable, for an ACTIONABLE comment (#661) ──
             // The old message always read "narrate-the-plan-then-stop no-op" — which sent us
             // chasing the wrong thing when the real cause was a billing_error (#660). Read the


### PR DESCRIPTION
Closes #1074

## 👤 For humans

The artifact-gate false-failed the second `delegate-pi` eval run: pi correctly resumed #1050's existing WS4 tree and delivered a real, merged PR on the child (#1053 via #1071) — but the gate only inspects the *labeled* issue, so it went red and posted "the issue is underspecified" (wrong on both counts). This teaches both decompose gates to also scan the sub-issue tree for fresh deliverables before failing, so "worked the remaining open leaf" — a legitimate outcome — reads green.

## 🤖 For agents

- Both `decompose-on-issue.yml` and `decompose-on-issue-pidev.yml`, artifact-gate step: on primary-miss, paginate `sub_issues`; pass on any fresh-since-t0 child signal (closed, cross-referenced PR, or `status:blocked` + fresh comment). Kept textually in sync between the two files.
- Exception-path only (no extra API cost on normal passes); #1019's fresh-only strictness preserved — stale child PRs/closures still fail.
- pidev posts its result breadcrumb for the child-pass shape too: `resumed the existing tree → child #N …`.

## 🧪 How to test

1. Re-run the #1050 scenario (an already-decomposed parent labeled `delegate-pi`, one open child leaf) → agent works the child → gate PASSES, log names the child deliverable.
2. Regression: a run producing nothing anywhere (parent or children) still FAILS with the classified "why".

🤖 Generated with [Claude Code](https://claude.com/claude-code)