### PR TITLE
fix(root): wave scheduler — prose-only Closes matching, never close held issues

### DIFF
--- a/.github/workflows/schedule-waves.yml
+++ b/.github/workflows/schedule-waves.yml
@@ -52,15 +52,37 @@ jobs:
             // release path below. (Keeps one release codepath.)
             if (context.eventName === 'pull_request') {
               if (!context.payload.pull_request.merged) { core.info('PR closed unmerged — nothing to do.'); return }
-              const closes = [...(context.payload.pull_request.body || '').matchAll(/\bCloses\s+#(\d+)/gi)].map(x => Number(x[1]))
-              if (!closes.length) { core.info('Merged PR has no `Closes #NN` — nothing to do.'); return }
+
+              // #1021 defence-in-depth: only act on merges into the default branch or an
+              // epic/* branch — the two shapes this codepath exists for. Anything else
+              // (throwaway branches, stacked feature branches) must not close issues.
+              const base = context.payload.pull_request.base.ref
+              const defaultBranch = context.payload.repository.default_branch
+              if (base !== defaultBranch && !/^epic\//.test(base)) {
+                core.info(`PR merged into '${base}' (not ${defaultBranch}/epic/*) — not a close-driving merge.`); return
+              }
+
+              // #1021 root fix: match `Closes #NN` the way GitHub's native auto-close does —
+              // NEVER inside code. Strip fenced blocks and inline code spans first, so an
+              // illustrative "`Closes #839`" in a How-to-test line can't mis-close a live
+              // issue (the #839 incident: PR #1020's quoted example closed a real issue).
+              const raw = context.payload.pull_request.body || ''
+              const prose = raw.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '')
+              const closes = [...prose.matchAll(/\bCloses\s+#(\d+)/gi)].map(x => Number(x[1]))
+              if (!closes.length) { core.info('Merged PR has no `Closes #NN` (in prose) — nothing to do.'); return }
               for (const n of closes) {
                 try {
                   const gi = await github.rest.issues.get({ owner, repo, issue_number: n })
-                  if (gi.data.state !== 'closed') {
-                    await github.rest.issues.update({ owner, repo, issue_number: n, state: 'closed', state_reason: 'completed' })
-                    core.info(`Closed #${n} (its PR merged into the epic branch) — release runs on the issues:closed event.`)
+                  if (gi.data.state === 'closed') continue
+                  // #1035 incident: never auto-close a HELD issue. `status:blocked` means a
+                  // sign-off or human step is pending — closing it destroys the hold ("done
+                  // is signed off, not asserted"). The human closes it when the hold clears.
+                  const held = gi.data.labels.some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
+                  if (held) {
+                    core.info(`#${n} is status:blocked (held for a human) — NOT auto-closing.`); continue
                   }
+                  await github.rest.issues.update({ owner, repo, issue_number: n, state: 'closed', state_reason: 'completed' })
+                  core.info(`Closed #${n} (its PR merged into ${base}) — release runs on the issues:closed event.`)
                 } catch (e) { core.warning(`Could not close #${n}: ${e.message}`) }
               }
               return


### PR DESCRIPTION
Closes #1021

## 👤 For humans

The wave scheduler's close-on-merge parser was too greedy, with two live incidents: it closed #839 off a **backticked example** in a PR's How-to-test line, and today it closed #1035 **while the issue was `status:blocked`** — a pi run had deliberately held it for a pending human step, and the auto-close destroyed the hold. Three guards now:

1. **Prose-only matching** — fenced blocks and inline code are stripped before the `Closes #NN` regex, mirroring GitHub's native auto-close semantics.
2. **Base-branch scope** — only merges into the default branch or `epic/*` drive closes.
3. **Never close a held issue** — `status:blocked` targets are skipped with a log line; a hold is only cleared by a human ("done is signed off, not asserted").

## 🤖 For agents

- `.github/workflows/schedule-waves.yml`, `pull_request` path only; the `issues: closed` release path is untouched.
- Parser verified by replaying both incidents: PR #1020's `` `Closes #839` `` → no match; prose `Closes #1053` alongside a fenced decoy → matches exactly `[1053]`.

## 🧪 How to test

1. Merge a PR into an epic branch whose body has a real prose `Closes #N` → #N closes (unchanged happy path).
2. Body mentions `` `Closes #X` `` only in backticks/fences → #X stays open.
3. Target issue carries `status:blocked` → stays open, run log says "held for a human — NOT auto-closing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)