### PR TITLE
Outage-visible agent gates + advisor fallback, and the permission-grant standard (#1036, #1037)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -241,6 +241,24 @@ all of these by **default** — they're not optional extras; each one has burned
 - **`show_full_output: true`** — the full agent log prints inline; debugging a run must not
   require a debug re-run.
 - **Pin the action to a SHA, kept in sync** across these workflows (bump them together).
+- **The tool-permission grant that matches the workflow's shape (#834/#1036).** Headless CI has
+  no human approver, so any tool the prompt makes the *top-level* agent call directly (the
+  "act as the subagent + write the verdict / file the issue" shape) is silently **DENIED**
+  without a grant: the agent computes the right answer, persists nothing, burns turns on denied
+  retries, hits max_turns — and the gate fails **OPEN** as a hollow green. This shipped broken
+  in `frontend-review`, `a11y`, `red-team` (fixed #1031/#1033) *and* the loop-station advisor
+  (fixed #1037). Two standard forms:
+  - **Per-PR verdict gates** (`frontend-review.yml` / `a11y.yml` / `red-team.yml`):
+    `--allowedTools Bash,Write,Edit,Read,Grep,Glob` in `claude_args`.
+  - **Sweeps/advisors that file issues** (`a11y-daily.yml` / `red-team-daily.yml` /
+    `loop-station-advisor.yml`): `--permission-mode bypassPermissions`.
+  The `gate-package-edits` PreToolUse hook still guards `packages/` either way. Workflows whose
+  prompt only steers the action's built-in GitHub flows (`claude.yml`-style mention glue) don't
+  need a grant — if you omit one, say why in a workflow comment.
+- **Fail-open must be visible (#1037).** If the workflow is a verdict-gated check, pair the
+  `continue-on-error` agent step with `./.github/actions/gate-outage-check` so a no-verdict run
+  (billing / max-turns / auth / silent no-write) surfaces as a `::warning::` annotation instead
+  of a green indistinguishable from a clean scan.
 
 A new claude-action workflow that omits any of these is treated like a failing build.
 

--- a/.claude/skills/a11y/SKILL.md
+++ b/.claude/skills/a11y/SKILL.md
@@ -194,4 +194,7 @@ called out as "needs a human decision" with the reason.
   (diff-scoped, so never on the pre-existing backlog). `.github/workflows/a11y-daily.yml`
   runs `/a11y` at `depth=deep` daily — writes a report (`writeups/reports/a11y-repo-*.md`),
   updates a public standing issue, and files `a11y` issues for new confirmed criticals.
-  `/a11y` is the **on-demand** brain and human entry point for the same machinery.
+  `/a11y` is the **on-demand** brain and human entry point for the same machinery. Both
+  workflows MUST follow the **Claude-action workflow standard** in `.claude/agents/CLAUDE.md`
+  — notably the tool-permission grant (per-PR: `--allowedTools …`; daily sweep:
+  `--permission-mode bypassPermissions`), without which the gate fails open (#834/#1036).

--- a/.claude/skills/frontend-review/SKILL.md
+++ b/.claude/skills/frontend-review/SKILL.md
@@ -196,4 +196,6 @@ needs prop/slot judgment").
   `.github/workflows/frontend-review.yml` runs the subagent at `depth=quick` on a PR
   diff — posts a sticky `<!-- frontend-review -->` comment and **fails the check on a
   🔴 finding** (diff-scoped, so never on the pre-existing backlog). `/frontend-review`
-  is the **on-demand** brain and human entry point for the same machinery.
+  is the **on-demand** brain and human entry point for the same machinery. The workflow
+  MUST follow the **Claude-action workflow standard** in `.claude/agents/CLAUDE.md` —
+  notably the `--allowedTools` grant, without which the gate fails open (#834/#1036).

--- a/.claude/skills/red-team/SKILL.md
+++ b/.claude/skills/red-team/SKILL.md
@@ -101,6 +101,10 @@ of these now?"* — fixing is a separate, explicit step (this skill finds; it do
   PR diff and **fails the check on a high/critical** finding — it doesn't go through this skill.
 - **Daily** (`.github/workflows/red-team-daily.yml`) runs `depth=deep` whole-repo, posts the
   report to a standing issue, and files issues exactly as step 4 above.
+- Both workflows MUST follow the **Claude-action workflow standard** in
+  `.claude/agents/CLAUDE.md` — notably the tool-permission grant (per-PR: `--allowedTools …`;
+  daily sweep: `--permission-mode bypassPermissions`), without which the gate fails open
+  (#834/#1036).
 - **This skill** is the **on-demand** brain and the human entry point — and the reference for
   what the workflows automate.
 - It complements, not replaces, the built-in `security-review` skill (which passively reviews a

--- a/.github/actions/gate-outage-check/action.yml
+++ b/.github/actions/gate-outage-check/action.yml
@@ -1,0 +1,90 @@
+# Gate outage classifier (#1037, epic #1034).
+#
+# The agent gates are deliberately FAIL-OPEN (an agent flake must not red-flag every
+# PR), but fail-open must never be INVISIBLE: a depleted API key (billing_error) and
+# a tool-permission denial (error_max_turns) used to produce the exact same plain
+# green as a genuinely clean scan. This step makes the no-verdict case loud: it
+# classifies WHY no verdict exists — from the agent's session transcript (the same
+# source loop-station-trace reads) plus the agent step's outcome — then emits a
+# ::warning:: annotation and a step-summary block, and always exits 0.
+#
+# Shared by frontend-review.yml / a11y.yml / red-team.yml / loop-station-advisor.yml
+# so the classification logic can't drift per file. Callers pass the verdict file
+# their agent should have written; the advisor (no verdict file) omits it and gates
+# the step on its LLM step's failure instead.
+name: gate-outage-check
+description: Classify a no-verdict agent run (outage vs silent no-write) and surface it as a visible warning instead of a silent pass
+inputs:
+  gate:
+    description: Name of the gate, used in the annotation (e.g. frontend-review)
+    required: true
+  verdict-file:
+    description: >-
+      Path to the verdict file the agent should have written. If it exists the step is
+      quiet. Omit when the caller already knows the run failed (e.g. the advisor) —
+      an empty value classifies unconditionally.
+    required: false
+    default: ''
+  agent-outcome:
+    description: The claude-code-action step's `steps.<id>.outcome` (success/failure)
+    required: true
+outputs:
+  classification:
+    description: verdict-present | billing_error | error_max_turns | auth_error | agent_error | no_verdict
+    value: ${{ steps.classify.outputs.classification }}
+runs:
+  using: composite
+  steps:
+    - name: Classify no-verdict run
+      id: classify
+      shell: bash
+      env:
+        GATE: ${{ inputs.gate }}
+        VERDICT_FILE: ${{ inputs.verdict-file }}
+        AGENT_OUTCOME: ${{ inputs.agent-outcome }}
+      run: |
+        set -u
+        if [ -n "$VERDICT_FILE" ] && [ -f "$VERDICT_FILE" ]; then
+          echo "classification=verdict-present" >> "$GITHUB_OUTPUT"
+          echo "$GATE: verdict file present — agent ran and delivered. No outage."
+          exit 0
+        fi
+
+        # No verdict. Mine the newest session transcript for the failure signature;
+        # every grep is best-effort (a billing_error can kill the run before any
+        # transcript exists), falling back to the step outcome.
+        CLS=""
+        PROJECTS="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+        TRANSCRIPT=$(ls -t "$PROJECTS"/*/*.jsonl 2>/dev/null | head -1 || true)
+        if [ -n "$TRANSCRIPT" ]; then
+          if grep -qi 'credit balance is too low\|billing_error' "$TRANSCRIPT"; then CLS=billing_error
+          elif grep -q 'error_max_turns' "$TRANSCRIPT"; then CLS=error_max_turns
+          elif grep -qi 'authentication_error\|invalid x-api-key' "$TRANSCRIPT"; then CLS=auth_error
+          fi
+        fi
+        if [ -z "$CLS" ]; then
+          case "$AGENT_OUTCOME" in
+            # "Succeeded" yet wrote nothing — the #834 permission-regression signature.
+            success) CLS=no_verdict ;;
+            *)       CLS=agent_error ;;
+          esac
+        fi
+
+        case "$CLS" in
+          billing_error)   DETAIL="the Anthropic API key is out of credit (billing_error) — the agent never scanned anything" ;;
+          error_max_turns) DETAIL="the agent hit max_turns without writing a verdict — possibly burning turns on denied tool calls (check the --allowedTools grant, #834)" ;;
+          auth_error)      DETAIL="the Anthropic API rejected the key (authentication error) — the agent never scanned anything" ;;
+          no_verdict)      DETAIL="the agent step reported success but wrote no verdict — likely a tool-permission or prompt regression (the #834 fail-open signature), NOT a clean scan" ;;
+          *)               DETAIL="the agent step errored before writing a verdict" ;;
+        esac
+
+        echo "classification=$CLS" >> "$GITHUB_OUTPUT"
+        echo "::warning title=$GATE agent outage ($CLS)::$GATE produced no verdict: $DETAIL. The check passes FAIL-OPEN — this run did NOT actually scan anything."
+        {
+          echo "### ⚠️ $GATE — agent outage (\`$CLS\`)"
+          echo ""
+          echo "$DETAIL."
+          echo ""
+          echo "The gate is fail-open by design (an agent flake must not block every PR), but this green does **not** mean \"scanned and clean\" — it means \"never ran\". (#1037)"
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit 0

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -52,6 +52,7 @@ jobs:
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        id: agent
         # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
         # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found
         # nothing critical/serious, which would turn every PR red on a flake (mirrors the
@@ -102,11 +103,20 @@ jobs:
       # Ship the payload-free invocation trace for the weekly usage rollup (#1064).
       - uses: ./.github/actions/loop-station-trace
         if: always()
+      # Fail-open must be VISIBLE (#1037): when no verdict exists, classify why (billing /
+      # max-turns / auth / silent no-write) and emit a warning annotation + step summary,
+      # so a dead agent can't be mistaken for a clean scan.
+      - uses: ./.github/actions/gate-outage-check
+        if: always()
+        with:
+          gate: a11y
+          verdict-file: a11y-verdict.json
+          agent-outcome: ${{ steps.agent.outcome }}
       - name: Gate on critical/serious
         if: always()
         run: |
           if [ ! -f a11y-verdict.json ]; then
-            echo "::warning::a11y produced no verdict file — treating as inconclusive (not blocking)."
+            echo "No verdict file — outage classified by gate-outage-check above. Inconclusive pass (not blocking)."
             exit 0
           fi
           echo "Verdict: $(cat a11y-verdict.json)"

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -43,6 +43,7 @@ jobs:
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        id: agent
         # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
         # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found
         # nothing critical, which would turn every PR red on a flake (mirrors the red-team
@@ -100,11 +101,20 @@ jobs:
       # Ship the payload-free invocation trace for the weekly usage rollup (#1064).
       - uses: ./.github/actions/loop-station-trace
         if: always()
+      # Fail-open must be VISIBLE (#1037): when no verdict exists, classify why (billing /
+      # max-turns / auth / silent no-write) and emit a warning annotation + step summary,
+      # so a dead agent can't be mistaken for a clean scan.
+      - uses: ./.github/actions/gate-outage-check
+        if: always()
+        with:
+          gate: frontend-review
+          verdict-file: frontend-review-verdict.json
+          agent-outcome: ${{ steps.agent.outcome }}
       - name: Gate on critical
         if: always()
         run: |
           if [ ! -f frontend-review-verdict.json ]; then
-            echo "::warning::frontend-review produced no verdict file — treating as inconclusive (not blocking)."
+            echo "No verdict file — outage classified by gate-outage-check above. Inconclusive pass (not blocking)."
             exit 0
           fi
           echo "Verdict: $(cat frontend-review-verdict.json)"

--- a/.github/workflows/loop-station-advisor.yml
+++ b/.github/workflows/loop-station-advisor.yml
@@ -49,11 +49,19 @@ jobs:
       # recommendation issue. Pinned to the same SHA as the repo's other claude-code-action
       # workflows — bump together.
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        id: llm
         if: steps.advisor.outputs.actionable == 'true'
+        # An LLM outage must not kill the run before the deterministic fallback below —
+        # the whole point of this workflow is that actionable findings reach a human (#1037).
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: "--max-turns 12"
+          # bypassPermissions REQUIRED (#834/#1036): this prompt has the top-level agent
+          # create/update issues via tool calls directly; headless CI denies un-allowlisted
+          # tools, so without the grant the agent can't file the issue — the sweep-shaped
+          # form, same as a11y-daily.yml / red-team-daily.yml.
+          claude_args: "--max-turns 12 --permission-mode bypassPermissions"
           prompt: |
             You are the **Loop Station advisor** (#933). Read `advisor-findings.json` in
             the repo root — it lists DETERMINISTIC findings about the harness's own
@@ -84,6 +92,42 @@ jobs:
             If you POST A COMMENT (when updating), lead it with the CI provenance header:
             `> 🤖 **Claude Code** · agent pipeline (CI) · _Loop Station advisor_`
             (Issue bodies are already clearly agent-authored — no header needed there.)
+
+      # Outage visibility (#1037): the advisor's first real run died on billing_error and
+      # the actionable findings evaporated with it. When the LLM step fails, classify why
+      # (loud warning annotation + step summary)…
+      - uses: ./.github/actions/gate-outage-check
+        if: steps.advisor.outputs.actionable == 'true' && steps.llm.outcome == 'failure'
+        with:
+          gate: loop-station-advisor
+          agent-outcome: ${{ steps.llm.outcome }}
+
+      # …and still deliver: the deterministic gate already wrote advisor-findings.json, so
+      # post it raw to the advisor issue — no LLM needed for the findings to reach a human.
+      - name: Deterministic fallback — findings still reach a human
+        if: steps.advisor.outputs.actionable == 'true' && steps.llm.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          BODY_FILE=$(mktemp)
+          {
+            echo "> 🤖 **Claude Code** · agent pipeline (CI) · _Loop Station advisor — deterministic fallback (#1037)_"
+            echo ""
+            echo "The advisor's LLM step failed this week, but the deterministic gate found **actionable** findings — posting them raw so they still reach you. Human-phrased recommendations will arrive whenever the LLM step recovers; the outage is classified in [the run log]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            echo ""
+            echo '```json'
+            cat advisor-findings.json
+            echo '```'
+          } > "$BODY_FILE"
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label loop-station-advisor --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "🔭 Loop Station advisor — actionable findings (LLM outage fallback)" \
+              --label loop-station-advisor --assignee pmcp --body-file "$BODY_FILE"
+          fi
 
       # Ship the payload-free invocation trace for the weekly usage rollup (#1064).
       - uses: ./.github/actions/loop-station-trace

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -44,6 +44,7 @@ jobs:
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        id: agent
         # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
         # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found
         # nothing high/critical, which was turning every PR red on a flake (#499, #602; #603 P1).
@@ -87,11 +88,20 @@ jobs:
       # Ship the payload-free invocation trace for the weekly usage rollup (#1064).
       - uses: ./.github/actions/loop-station-trace
         if: always()
+      # Fail-open must be VISIBLE (#1037): when no verdict exists, classify why (billing /
+      # max-turns / auth / silent no-write) and emit a warning annotation + step summary,
+      # so a dead agent can't be mistaken for a clean scan.
+      - uses: ./.github/actions/gate-outage-check
+        if: always()
+        with:
+          gate: red-team
+          verdict-file: red-team-verdict.json
+          agent-outcome: ${{ steps.agent.outcome }}
       - name: Gate on high/critical
         if: always()
         run: |
           if [ ! -f red-team-verdict.json ]; then
-            echo "::warning::red-team produced no verdict file — treating as inconclusive (not blocking)."
+            echo "No verdict file — outage classified by gate-outage-check above. Inconclusive pass (not blocking)."
             exit 0
           fi
           echo "Verdict: $(cat red-team-verdict.json)"


### PR DESCRIPTION
Closes #1036, closes #1037 — the two remaining children of epic #1034 (the #1035 fixtures/smoke already landed on the epic branch via #1075/#1083; this PR is independent of that branch and targets `main` directly).

## 👤 What & why

Two failures used to look identical to a clean scan: a depleted API key (`billing_error`) and a tool-permission denial (`error_max_turns`) both produced a plain green check. And the Loop Station advisor — whose **only real run died on "Credit balance is too low"** — lost its actionable findings entirely when its LLM step failed. This PR keeps fail-open as the default (an agent flake must not block every PR) but makes it **impossible to miss**, and guarantees the advisor's findings reach a human even with a dead key.

## 🤖 What changed

**#1037 — outage visibility**
- New shared composite action **`.github/actions/gate-outage-check`**: verdict file present → quiet; missing → classifies why (`billing_error` / `error_max_turns` / `auth_error` / `agent_error` / `no_verdict`-despite-success, mined from the newest `~/.claude/projects` transcript — the same source `loop-station-trace` reads — with the agent step's outcome as fallback), then emits a `::warning::` annotation + step-summary block and always exits 0. Exposes a `classification` output.
- **`frontend-review.yml` / `a11y.yml` / `red-team.yml`**: agent step gets `id: agent`; the classifier runs before the gate step; the gate's no-verdict branch defers to it (blocking behaviour unchanged).
- **`loop-station-advisor.yml`** (the sharpest test case):
  - LLM step: `id: llm`, `continue-on-error: true`, and the **missing tool-permission grant** (`--permission-mode bypassPermissions`) — the #834 fail-open bug was live in this fourth workflow too; even with credit it likely couldn't have filed its issue.
  - On `actionable == 'true' && llm.outcome == 'failure'`: the outage classifier + a **deterministic `gh` fallback** that comments on (or creates) the `loop-station-advisor` issue with `advisor-findings.json` verbatim, assigned to @pmcp.

**#1036 — the standard**
- `.claude/agents/CLAUDE.md` → "Claude-action workflow standard": new bullet documenting the grant's two standard forms (per-PR verdict gates: `--allowedTools Bash,Write,Edit,Read,Grep,Glob`; issue-filing sweeps/advisors: `--permission-mode bypassPermissions`), the rationale (headless CI denies un-allowlisted direct tool calls → hollow green), the mention-glue exemption, and a second bullet mandating `gate-outage-check` alongside `continue-on-error`.
- Cross-refs in the CI sections of the `frontend-review` / `a11y` / `red-team` SKILL.md files.

## 🧪 How to test

1. **Classifier unit-style check (no CI needed):** the five scenarios were exercised locally by extracting the action's `run` block and driving it with fake transcripts/outcomes — `verdict-present`, `billing_error`, `error_max_turns`, `no_verdict` (step success, no file), `agent_error` all classify correctly and exit 0.
2. **Outage path in CI:** `workflow_dispatch` the advisor with a bad/empty `ANTHROPIC_API_KEY` (or wait for a genuine flake on any gate): expect a `⚠️ … agent outage (billing_error)` warning annotation + step summary instead of a plain green, and — for the advisor — a fallback comment on the `loop-station-advisor` issue carrying the raw findings JSON.
3. **Clean path:** any ordinary PR touching a `.vue` file: the gates behave exactly as before (verdict present → classifier stays quiet, severity gate unchanged).
4. **Docs:** `.claude/agents/CLAUDE.md` § "Claude-action workflow standard" now lists the grant; `grep claude_args .github/workflows/*.yml` shows every gate/sweep/advisor carrying its documented form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJhEg7WcpiyCr3vE9KJCp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJhEg7WcpiyCr3vE9KJCp)_