### PR TITLE
Land epic #1034's gate-smoke fixtures on main (epic branch → main)

### DIFF
--- a/.claude/gate-fixtures/README.md
+++ b/.claude/gate-fixtures/README.md
@@ -1,0 +1,57 @@
+# Gate smoke fixtures (#1035)
+
+**Throwaway, committed known-bad fixtures** — one per agent gate
+(`frontend-review`, `a11y`, `red-team`) — that each gate's checklist is
+guaranteed to flag 🔴. They exist to answer the #834 postmortem's headline
+lesson: a gate verified only "clean → green" is indistinguishable from a gate
+that enforces nothing. These turn that "bad → red" check into something
+committed and re-runnable instead of an ad-hoc one-off PR (the #847 smoke).
+
+## Why these live here, not as a real PR
+
+A fixture-in-a-PR smoke (like #847) is expensive to repeat — open a PR, wait
+for the gate, tear it down. Instead the fixtures are committed once, **diff-
+scope-excluded** from the real per-PR gates (see below), and exercised
+on-demand by `.github/workflows/gate-smoke.yml` (`workflow_dispatch`), which
+points each gate's subagent directly at its fixture instead of a PR diff.
+
+## Diff-scope exclusion (so these never self-flag ordinary PRs)
+
+Each real gate workflow (`frontend-review.yml`, `a11y.yml`, `red-team.yml`)
+excludes this directory from its `paths` trigger with a leading `!` entry —
+`'!.claude/gate-fixtures/**'` — so committing/touching a fixture does not
+itself trigger the real per-PR gate. The **smoke** workflow scans the fixture
+directly (not via `git diff`), so exclusion from the trigger doesn't blind it.
+
+## Fixtures
+
+| Gate | Fixture | Violation | Expected verdict |
+|------|---------|-----------|-------------------|
+| `frontend-review` | `frontend-review/SmokeDropdown.vue` | v3 component name `<UDropdown>` (v4 is `<UDropdownMenu>`) — the #847 fixture, formalized | `critical` |
+| `a11y` | `a11y/SmokeIconButton.vue` | icon-only interactive control with no accessible name, no keyboard handler, no semantic role | `critical` |
+| `red-team` | `red-team/smoke-unscoped-handler.ts` | a team-scoped-looking handler that reads a router param and queries by it directly, with **no** `resolveTeamAndCheckMembership` / auth check at all — a cross-team IDOR | `critical`/`high` |
+
+## Running the smoke
+
+- **CI (preferred):** Actions → **"Gate Smoke (known-bad fixtures)"** → *Run
+  workflow* → pick a gate (or `all`). Green means every selected gate's
+  meta-check passed (i.e. the gate actually turned red on its bad fixture).
+  A **red** smoke run means a gate failed to flag its own known-bad fixture —
+  treat that as a fail-open regression (exactly the #834 class of bug) and
+  block merges on the affected gate until fixed.
+- **Local:** `bash scripts/gate-smoke.sh <frontend-review|a11y|red-team|all>`
+  — same fixtures/expectations, useful for a quick sanity check without
+  round-tripping through Actions (it shells out to the same claude-code CLI
+  invocation the workflow uses; requires `ANTHROPIC_API_KEY` in the
+  environment).
+
+## Proving the smoke actually guards the fail-open case (#1035 acceptance)
+
+Per the issue's `## 🧪 Verify`: temporarily regress the #1031/#1033
+permission-grant fix (drop `--allowedTools` from one gate's
+`claude_args`) and re-run that gate's smoke — it must go from green to
+**red**, because the un-allowlisted agent can compute the verdict but can't
+persist it, and the smoke step should treat "the fixture wasn't clearly
+flagged" as a failure, not a silent pass. Do this by hand when validating a
+change to the permission grant; it is not run automatically on every PR
+(that would require deliberately breaking a gate in CI).

--- a/.claude/gate-fixtures/a11y/SmokeIconButton.vue
+++ b/.claude/gate-fixtures/a11y/SmokeIconButton.vue
@@ -1,0 +1,18 @@
+<!--
+  Known-bad fixture for the a11y gate smoke (#1035). An icon-only interactive
+  control with no accessible name, no keyboard handler, and no semantic role —
+  a critical/serious a11y violation (unlabeled control + non-interactive
+  element used as a button). Committed on purpose — do not "fix" this file.
+  See .claude/gate-fixtures/README.md.
+-->
+<script setup lang="ts">
+function onDelete() {
+  // no-op: this fixture only needs to exist for the gate to scan it
+}
+</script>
+
+<template>
+  <div @click="onDelete">
+    <UIcon name="i-lucide-trash-2" />
+  </div>
+</template>

--- a/.claude/gate-fixtures/frontend-review/SmokeDropdown.vue
+++ b/.claude/gate-fixtures/frontend-review/SmokeDropdown.vue
@@ -1,0 +1,15 @@
+<!--
+  Known-bad fixture for the frontend-review gate smoke (#1035, formalizing #847).
+  Deliberately uses the v3 component name <UDropdown> (v4 is <UDropdownMenu>) so
+  the gate's checklist must flag it 🔴 critical (v3-name). Committed on purpose —
+  do not "fix" this file. See .claude/gate-fixtures/README.md.
+-->
+<script setup lang="ts">
+const items = [[{ label: 'Profile' }, { label: 'Settings' }]]
+</script>
+
+<template>
+  <UDropdown :items="items">
+    <UButton label="Open" />
+  </UDropdown>
+</template>

--- a/.claude/gate-fixtures/red-team/smoke-unscoped-handler.ts
+++ b/.claude/gate-fixtures/red-team/smoke-unscoped-handler.ts
@@ -1,0 +1,24 @@
+// Known-bad fixture for the red-team gate smoke (#1035). Shaped like a real
+// team-scoped API handler (server/api/teams/[id]/orders/[orderId].get.ts) but
+// deliberately SKIPS resolveTeamAndCheckMembership and queries the child
+// resource by its id alone — a classic cross-team IDOR: team A can read team
+// B's order by guessing/enumerating orderId. No auth/session check at all.
+// Committed on purpose — do not "fix" this file, and do not wire it into any
+// real router. See .claude/gate-fixtures/README.md.
+import { defineEventHandler, getRouterParam } from 'h3'
+import { eq } from 'drizzle-orm'
+import { useDrizzle } from '../utils/drizzle'
+import { orders } from '../database/schema'
+
+export default defineEventHandler(async (event) => {
+  // BUG: trusts the URL param directly — no resolveTeamAndCheckMembership,
+  // no session check, and the query below doesn't constrain organizationId.
+  const orderId = getRouterParam(event, 'orderId')
+
+  const db = useDrizzle()
+  const order = await db.query.orders.findFirst({
+    where: eq(orders.id, orderId as string),
+  })
+
+  return order
+})

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -12,6 +12,10 @@ on:
     paths:
       # a11y lives in templates — only scan PRs that touch .vue files.
       - '**/*.vue'
+      # Known-bad smoke fixtures (#1035) are diff-scope-excluded so committing/
+      # touching them never self-flags an ordinary PR — they're exercised by
+      # gate-smoke.yml instead, which scans them directly.
+      - '!.claude/gate-fixtures/**'
 
 concurrency:
   group: a11y-${{ github.event.pull_request.number }}

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -14,6 +14,10 @@ on:
     paths:
       # Conventions live in templates — only scan PRs that touch .vue files.
       - '**/*.vue'
+      # Known-bad smoke fixtures (#1035) are diff-scope-excluded so committing/
+      # touching them never self-flags an ordinary PR — they're exercised by
+      # gate-smoke.yml instead, which scans them directly.
+      - '!.claude/gate-fixtures/**'
 
 concurrency:
   group: frontend-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/gate-smoke.yml
+++ b/.github/workflows/gate-smoke.yml
@@ -1,0 +1,122 @@
+name: Gate Smoke (known-bad fixtures)
+
+# On-demand positive-case smoke for the agent gates (#1035, postmortem of #834).
+# Each gate (frontend-review / a11y / red-team) is only ever verified "clean →
+# green" by the real per-PR workflows — this workflow proves the OTHER half:
+# "bad → red". It points each gate's subagent directly at a committed
+# known-bad fixture (.claude/gate-fixtures/<gate>/...) instead of a PR diff,
+# then asserts the resulting verdict is severe enough to have failed the real
+# gate. A fixture-in-a-PR smoke (like #847) is expensive to repeat; this is
+# the cheap, re-runnable, manual-dispatch equivalent.
+#
+# A RED run here means a gate did NOT flag its own known-bad fixture — i.e.
+# it is fail-open (the exact #834 class of bug). Treat that as a blocking
+# regression on the affected gate, not a flake.
+
+on:
+  workflow_dispatch:
+    inputs:
+      gate:
+        description: "Which gate to smoke-test"
+        type: choice
+        default: all
+        options:
+          - all
+          - frontend-review
+          - a11y
+          - red-team
+
+concurrency:
+  group: gate-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      gates: ${{ steps.plan.outputs.gates }}
+    steps:
+      - id: plan
+        run: |
+          case "${{ inputs.gate || 'all' }}" in
+            all)
+              echo 'gates=["frontend-review","a11y","red-team"]' >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "gates=[\"${{ inputs.gate }}\"]" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  smoke:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        gate: ${{ fromJson(needs.plan.outputs.gates) }}
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        if: matrix.gate == 'a11y'
+      - uses: actions/setup-node@v4
+        if: matrix.gate == 'a11y'
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install (a11y needs eslint)
+        if: matrix.gate == 'a11y'
+        run: pnpm install --frozen-lockfile
+
+      # Same engine + allowlist as the real gate workflows (#834's fix) — the
+      # smoke MUST use the identical permission grant, or it isn't testing
+      # the thing that shipped fail-open.
+      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        continue-on-error: true
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
+          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          prompt: |
+            Act as the **${{ matrix.gate }} subagent** defined in
+            `.claude/agents/${{ matrix.gate }}.md`.
+            Input: { scope: ".claude/gate-fixtures/${{ matrix.gate }}", depth: "quick", fix: false }.
+
+            Scan ONLY the file(s) under `.claude/gate-fixtures/${{ matrix.gate }}/`
+            (ignore everything else in the repo, and ignore the README.md in that
+            directory — it is documentation, not a fixture) through the checklist in
+            the agent definition. These fixtures are deliberately bad — you are
+            expected to find a real, severe violation. Do not soften or omit it.
+
+            Then write `gate-smoke-verdict.json` at the repo root, exactly:
+            `{"highest":"<none|note|warning|critical>"}` for frontend-review/a11y, or
+            `{"highest":"<none|low|medium|high|critical>"}` for red-team — using
+            the same severity vocabulary as the real gate's verdict file
+            (`frontend-review-verdict.json` / `a11y-verdict.json` /
+            `red-team-verdict.json`). Always write the file, even if you (wrongly)
+            find nothing. Do not edit the fixtures. Do not post any PR/issue
+            comments (this is a dispatch smoke, not a PR gate).
+
+      - name: Assert the gate turned RED on its known-bad fixture
+        if: always()
+        run: |
+          if [ ! -f gate-smoke-verdict.json ]; then
+            echo "::error::${{ matrix.gate }} produced NO verdict on its known-bad fixture (agent didn't run, or the permission grant is broken) — this is exactly the fail-open case. FAILING the smoke."
+            exit 1
+          fi
+          echo "Verdict: $(cat gate-smoke-verdict.json)"
+          HIGHEST=$(node -e "process.stdout.write((require('./gate-smoke-verdict.json').highest||'none').toLowerCase())")
+          case "$HIGHEST" in
+            critical|high)
+              echo "${{ matrix.gate }} correctly flagged its known-bad fixture (${HIGHEST}). Smoke passes."
+              ;;
+            *)
+              echo "::error::${{ matrix.gate }} did NOT flag its known-bad fixture as critical/high (got '${HIGHEST}') — the gate is fail-open. FAILING the smoke."
+              exit 1
+              ;;
+          esac
+

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -15,6 +15,10 @@ on:
       - 'packages/**'
       - 'apps/**'
       - 'pocs/**'
+      # Known-bad smoke fixtures (#1035) are diff-scope-excluded so committing/
+      # touching them never self-flags an ordinary PR — they're exercised by
+      # gate-smoke.yml instead, which scans them directly.
+      - '!.claude/gate-fixtures/**'
 
 concurrency:
   group: red-team-${{ github.event.pull_request.number }}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,9 @@ export default createConfigForNuxt({
       // The docs site (relocated from apps/docs) lints via its own config
       'docs/**',
       // POCs (not-yet-live) are excluded from the shared pipeline
-      'pocs/**'
+      'pocs/**',
+      // Deliberately-bad gate smoke fixtures (#1035) — never lint-clean on purpose
+      '.claude/gate-fixtures/**'
     ]
   })
   .append({

--- a/scripts/gate-smoke.sh
+++ b/scripts/gate-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Local one-command runner for the agent-gate positive-case smoke (#1035).
+#
+# Points a gate's subagent (frontend-review / a11y / red-team) at its
+# committed known-bad fixture under .claude/gate-fixtures/<gate>/ and asserts
+# the resulting verdict is severe enough to have failed the real per-PR gate.
+# This is the local mirror of .github/workflows/gate-smoke.yml — same
+# fixtures, same expectation, useful for a quick sanity check without
+# round-tripping through Actions.
+#
+# Requires: the `claude` CLI (Claude Code) on PATH and ANTHROPIC_API_KEY (or
+# an already-authenticated Claude Code session) in the environment.
+#
+# Usage:
+#   scripts/gate-smoke.sh <frontend-review|a11y|red-team|all>
+
+set -euo pipefail
+
+GATES_ALL=(frontend-review a11y red-team)
+ARG="${1:-}"
+
+if [ -z "$ARG" ]; then
+  echo "Usage: $0 <frontend-review|a11y|red-team|all>" >&2
+  exit 2
+fi
+
+if [ "$ARG" = "all" ]; then
+  GATES=("${GATES_ALL[@]}")
+else
+  GATES=("$ARG")
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "error: the 'claude' CLI is not on PATH. Install Claude Code, or run this" >&2
+  echo "smoke via Actions instead: workflow_dispatch on gate-smoke.yml." >&2
+  exit 1
+fi
+
+FAIL=0
+
+for gate in "${GATES[@]}"; do
+  case "$gate" in
+    frontend-review|a11y|red-team) ;;
+    *)
+      echo "error: unknown gate '$gate' (expected frontend-review|a11y|red-team|all)" >&2
+      exit 2
+      ;;
+  esac
+
+  echo "==> Smoking '$gate' against .claude/gate-fixtures/$gate/ ..."
+  rm -f gate-smoke-verdict.json
+
+  claude -p "Act as the ${gate} subagent defined in .claude/agents/${gate}.md.
+Input: { scope: \".claude/gate-fixtures/${gate}\", depth: \"quick\", fix: false }.
+Scan ONLY the file(s) under .claude/gate-fixtures/${gate}/ (ignore the README.md
+there and everything else in the repo) through the checklist in the agent
+definition. These fixtures are deliberately bad — you are expected to find a
+real, severe violation; do not soften or omit it. Then write
+gate-smoke-verdict.json at the repo root, exactly: {\"highest\":\"<severity>\"}
+using the same severity vocabulary as the real gate's own verdict file. Always
+write the file. Do not edit the fixtures. Do not post any comments." \
+    --allowedTools Bash,Write,Edit,Read,Grep,Glob \
+    --max-turns 40 || true
+
+  if [ ! -f gate-smoke-verdict.json ]; then
+    echo "FAIL: $gate produced no verdict on its known-bad fixture (fail-open case)." >&2
+    FAIL=1
+    continue
+  fi
+
+  HIGHEST=$(node -e "process.stdout.write((require('./gate-smoke-verdict.json').highest||'none').toLowerCase())")
+  echo "    verdict: $HIGHEST"
+  case "$HIGHEST" in
+    critical|high)
+      echo "    PASS: $gate correctly flagged its known-bad fixture."
+      ;;
+    *)
+      echo "FAIL: $gate did not flag its known-bad fixture as critical/high (got '$HIGHEST')." >&2
+      FAIL=1
+      ;;
+  esac
+  rm -f gate-smoke-verdict.json
+done
+
+exit $FAIL


### PR DESCRIPTION
Lands the epic branch for #1034 — the #1035 work (built in #1075, workflow patch applied by maintainer in #1083) that never reached `main`: all three of #1034's children are closed, but the committed known-bad fixtures and the smoke harness only existed on `epic/1034-harden-agent-gate-ci-harness` until this merges.

## 👤 What & why

The positive-case smoke for the agent gates: a committed known-bad fixture per gate (`.claude/gate-fixtures/` — a v3 `UDropdown`, an unlabeled icon-only button, a cross-team-unscoped server handler) plus the machinery to prove each gate turns **red** on its fixture — so a fail-open regression can never again look identical to a working gate.

## 🤖 What's in the diff

- `.claude/gate-fixtures/{frontend-review,a11y,red-team}/` + README — the known-bad fixtures.
- `.github/workflows/gate-smoke.yml` — dispatch smoke that runs each gate against its fixture and asserts red.
- `scripts/gate-smoke.sh` — the documented one-command local run.
- 4-line path exclusions in `frontend-review.yml` / `a11y.yml` / `red-team.yml` + `eslint.config.mjs` so the fixtures never self-flag ordinary PRs.

Merge-tested clean against current `main` (no conflicts with #1087's outage-visibility changes to the same gate workflows — different hunks).

## 🧪 How to test

1. Run `bash scripts/gate-smoke.sh` locally, or dispatch `gate-smoke.yml` — each gate must go **red** on its fixture.
2. Open any ordinary PR touching a `.vue` file — the gates must not flag the committed fixtures (path-excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJhEg7WcpiyCr3vE9KJCp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJhEg7WcpiyCr3vE9KJCp)_