### PR TITLE
Mac mini runner: security policy + fork-guard (#656) and N-runner fleet scaling (#1045)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -27,7 +27,10 @@ jobs:
     if: >
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.type != 'Bot'
-    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    # Fork PRs never land on the self-hosted box, even with AGENT_RUNNER set — this job
+    # checks out the PR's code and runs an agent (bash) over it, so a fork head means
+    # untrusted code on our hardware. Security policy: runbook §5 (#656).
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
     # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -29,7 +29,10 @@ jobs:
     if: >
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.type != 'Bot'
-    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    # Fork PRs never land on the self-hosted box, even with AGENT_RUNNER set — this job
+    # checks out the PR's code and runs an agent (bash) over it, so a fork head means
+    # untrusted code on our hardware. Security policy: runbook §5 (#656).
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
     # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -30,7 +30,10 @@ jobs:
     if: >
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.type != 'Bot'
-    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    # Fork PRs never land on the self-hosted box, even with AGENT_RUNNER set — this job
+    # checks out the PR's code and runs an agent (bash) over it, so a fork head means
+    # untrusted code on our hardware. Security policy: runbook §5 (#656).
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
     # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to

--- a/.github/workflows/schedule-waves.yml
+++ b/.github/workflows/schedule-waves.yml
@@ -28,7 +28,10 @@ permissions:
 
 jobs:
   release:
-    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    # Belt-and-braces: a closing FORK PR also fires this trigger — the job only runs
+    # repo-defined script (never PR code), but keep fork-originated events off the
+    # self-hosted box anyway. Security policy: runbook §5 (#656).
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}
     steps:
       # Mint a Nuxt Harness App installation token so the released `delegate` label is applied by
       # `nuxt-harness[bot]` → the dispatched decompose run passes the bot-actor guard via

--- a/scripts/mac-mini-runner/add-runner.sh
+++ b/scripts/mac-mini-runner/add-runner.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# add-runner.sh — register an ADDITIONAL GitHub Actions runner on the Mac mini.
+#
+# Epic #610 / issue #1045 (scale the mini to N concurrent jobs). A runner executes
+# exactly ONE job at a time — concurrency = more registered runners. This script
+# automates the per-runner dance from the runbook (§6) for runner #N on the same box:
+#
+#   ~/actions-runner-<N>/          (new install dir, reuses the first runner's tarball)
+#     ./config.sh --name mac-mini-<N> --labels mac-mini   (same label → same routing)
+#     echo "$PATH" > .path         (the launchd-minimal-PATH gotcha, runbook §2a)
+#     ./svc.sh install && start    (own launchd service, always-on)
+#
+# Usage (🖥️ on the mini, as the runner user):
+#   RUNNER_TOKEN=<fresh registration token> ./add-runner.sh <N>
+#   # e.g.  RUNNER_TOKEN=AXXXX... ./add-runner.sh 2
+#
+# The registration token comes from repo Settings → Actions → Runners → "New self-hosted
+# runner" (expires in ~1h — mint a FRESH one per runner). It is passed via env/arg only,
+# never stored. Re-running for an existing N is safe: --replace re-registers cleanly.
+#
+# Resource sizing (#1045): each slot can be a full Nuxt build / Playwright run / in-job
+# Claude agent. Default fleet = 3 on the mini — don't over-provision or the box thrashes.
+
+set -euo pipefail
+
+N="${1:-}"
+TOKEN="${RUNNER_TOKEN:-${2:-}}"
+REPO_URL="${REPO_URL:-https://github.com/FriendlyInternet/nuxt-crouton}"
+BASE_DIR="${BASE_DIR:-$HOME/actions-runner}"          # the first runner's install
+TARBALL="${TARBALL:-$BASE_DIR/actions-runner.tar.gz}" # downloaded during first setup (§1a)
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[ -n "$N" ] || die "usage: RUNNER_TOKEN=<token> $0 <N>   (N = runner number, e.g. 2)"
+case "$N" in *[!0-9]*|'') die "<N> must be a number, got '$N'";; esac
+[ "$N" -ge 2 ] || die "N starts at 2 — runner #1 is the original ~/actions-runner install"
+[ -n "$TOKEN" ] || die "no registration token — pass RUNNER_TOKEN=<token> (repo Settings → Actions → Runners → New self-hosted runner)"
+[ -f "$TARBALL" ] || die "runner tarball not found at $TARBALL — download it per runbook §1a first (or set TARBALL=)"
+
+DIR="$HOME/actions-runner-$N"
+NAME="mac-mini-$N"
+
+echo "==> Installing runner '$NAME' into $DIR"
+mkdir -p "$DIR"
+tar xzf "$TARBALL" -C "$DIR"
+
+cd "$DIR"
+
+echo "==> Registering '$NAME' (label: mac-mini) against $REPO_URL"
+./config.sh \
+  --url "$REPO_URL" \
+  --token "$TOKEN" \
+  --name "$NAME" \
+  --labels mac-mini \
+  --work _work \
+  --unattended \
+  --replace
+
+# The launchd-minimal-PATH gotcha (runbook §2a): jobs don't see Homebrew/nvm unless the
+# runner's .path file carries the interactive PATH. Prefer inheriting the first runner's
+# .path (known-good), fall back to the current shell's PATH.
+if [ -f "$BASE_DIR/.path" ]; then
+  cp "$BASE_DIR/.path" .path
+  echo "==> Copied .path from $BASE_DIR (toolchain PATH)"
+else
+  echo "$PATH" > .path
+  echo "==> Wrote current \$PATH to .path (no $BASE_DIR/.path to copy)"
+fi
+
+echo "==> Installing + starting the launchd service"
+./svc.sh install
+./svc.sh start
+./svc.sh status
+
+echo
+echo "✅ Runner '$NAME' is up. Verify: repo Settings → Actions → Runners shows '$NAME'"
+echo "   Idle with labels self-hosted, macOS, ARM64, mac-mini."
+echo "   The fleet-aware watchdog (runner-healthcheck.sh) picks it up automatically."

--- a/scripts/mac-mini-runner/runner-healthcheck.sh
+++ b/scripts/mac-mini-runner/runner-healthcheck.sh
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 #
-# runner-healthcheck.sh — watchdog for the Mac mini self-hosted GitHub Actions runner.
+# runner-healthcheck.sh — watchdog for the Mac mini self-hosted GitHub Actions runner FLEET.
 #
-# Epic #610 / issue #657 (WS5 — "keep the always-on agent loop reliable").
+# Epic #610 / issue #657 (WS5 — "keep the always-on agent loop reliable"), made
+# fleet-aware in #1045 (N same-labelled runners on the one box — one runner = one
+# concurrent job, so scaling = more registered runners, and the watchdog must notice
+# runner-2 dying even while runner-1 is fine).
 #
 # What it checks, in order:
-#   1. The runner's own launchd service (`actions.runner.*`) is loaded and has a live PID.
-#   2. That PID is actually a `Runner.Listener` process (not a zombie / wrong PID).
-#   3. The box can reach GitHub (the runner is useless if it's online but isolated).
-#   4. (best-effort) The repo's GitHub API reports >=1 ONLINE self-hosted runner.
+#   1. EVERY installed runner service (one `actions.runner.*.plist` per runner in
+#      ~/Library/LaunchAgents) is loaded in launchd with a live wrapper PID.
+#   2. Each runner's own `Runner.Listener` process exists (matched by install dir —
+#      `<dir>/bin/Runner.Listener` — so a dead listener is attributed to the right runner).
+#   3. The box can reach GitHub (the fleet is useless if it's online but isolated).
+#   4. (best-effort) The repo's GitHub API reports >= EXPECTED online runners —
+#      "expected 3, only 2 online" is a failure even though >=1 is up.
 #
-# On any failure it (a) tries to restart the runner via launchd, (b) alerts via the
-# optional ALERT_WEBHOOK (Slack/Discord-style JSON `{text}` POST), and (c) exits non-zero
-# so launchd/log readers can see the failure. A clean pass exits 0 quietly (one log line).
+# On any failure it (a) restarts the FAILED runner(s) via launchd (healthy ones are left
+# alone), (b) alerts via the optional ALERT_WEBHOOK (Slack/Discord-style JSON `{text}`
+# POST), and (c) exits non-zero so launchd/log readers can see the failure. A clean pass
+# exits 0 quietly (one log line per runner).
 #
 # This is the userspace twin of the pi runbook's "auth-retry-with-backoff" idea: the
 # launchd `KeepAlive` already restarts a crashed *process*; this watchdog catches the
@@ -22,11 +29,12 @@
 # it's a plain script — run it by hand any time to get a status read.
 #
 # ── Configuration (all optional; sensible defaults) ──────────────────────────────────
-#   RUNNER_DIR        Path to the actions-runner install.  Default: ~/actions-runner
 #   RUNNER_LABEL      Custom label we expect (informational).  Default: mac-mini
 #   GH_REPO           owner/repo for the API liveness probe.   Default: FriendlyInternet/nuxt-crouton
 #   GH_TOKEN          PAT with `repo` (or admin:org) scope for the API probe. If unset,
 #                     step 4 is skipped (steps 1–3 still run — no token needed for those).
+#   EXPECTED_RUNNERS  How many online runners step 4 requires. Default: the number of
+#                     installed runner services found on this box.
 #   ALERT_WEBHOOK     Slack/Discord-compatible incoming-webhook URL for failure alerts.
 #   LOG_FILE          Where to append logs.  Default: ~/Library/Logs/runner-watchdog.log
 #
@@ -35,12 +43,12 @@
 
 set -uo pipefail
 
-RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner}"
 RUNNER_LABEL="${RUNNER_LABEL:-mac-mini}"
 GH_REPO="${GH_REPO:-FriendlyInternet/nuxt-crouton}"
 LOG_FILE="${LOG_FILE:-$HOME/Library/Logs/runner-watchdog.log}"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
 
-# Optionally source a gitignored env file for GH_TOKEN / ALERT_WEBHOOK.
+# Optionally source a gitignored env file for GH_TOKEN / ALERT_WEBHOOK / EXPECTED_RUNNERS.
 [ -f "$HOME/.runner-watchdog.env" ] && . "$HOME/.runner-watchdog.env"
 
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -58,54 +66,71 @@ alert() {
   fi
 }
 
-# The launchd label the runner's own `./svc.sh install` creates is of the form
-# `actions.runner.<owner>-<repo>.<runnerName>`. We don't know the suffix, so match the prefix.
-runner_launchd_label() {
-  launchctl list 2>/dev/null | awk '/actions\.runner\./ {print $3; exit}'
-}
+# ── Fleet discovery ────────────────────────────────────────────────────────────────────
+# Every runner install gets its own launchd plist (`./svc.sh install` per runner, #1045's
+# add-runner.sh). The plist files are the source of truth for what SHOULD be running —
+# `launchctl list` only shows what IS loaded, so a service that fell out of launchd
+# entirely would be invisible there.
+#   label = plist filename minus .plist   (actions.runner.<owner>-<repo>.<name>)
+#   dir   = the runner install dir, extracted from the plist's runsvc.sh path
+labels=()
+dirs=()
+for plist in "$LAUNCH_AGENTS_DIR"/actions.runner.*.plist; do
+  [ -f "$plist" ] || continue
+  label="$(basename "$plist" .plist)"
+  # The svc.sh-generated plist's ProgramArguments points at <install dir>/runsvc.sh.
+  dir="$(sed -n 's|.*<string>\(/.*\)/runsvc.sh</string>.*|\1|p' "$plist" | head -1)"
+  labels+=("$label")
+  dirs+=("${dir:-}")
+done
 
 restart_runner() {
-  local label
-  label="$(runner_launchd_label)"
-  if [ -n "$label" ]; then
-    log "Restarting runner via launchctl kickstart (label=$label)…"
-    # `kickstart -k` kills then restarts the service in the GUI user's domain.
-    launchctl kickstart -k "gui/$(id -u)/$label" 2>>"$LOG_FILE" \
-      && return 0
-  fi
-  # Fallback: use the runner's own svc.sh if the label lookup failed.
-  if [ -x "$RUNNER_DIR/svc.sh" ]; then
-    log "Restarting runner via svc.sh (dir=$RUNNER_DIR)…"
-    ( cd "$RUNNER_DIR" && ./svc.sh stop; ./svc.sh start ) 2>>"$LOG_FILE" && return 0
+  local label="$1" dir="$2"
+  log "Restarting runner via launchctl kickstart (label=$label)…"
+  # `kickstart -k` kills then restarts the service in the GUI user's domain.
+  launchctl kickstart -k "gui/$(id -u)/$label" 2>>"$LOG_FILE" && return 0
+  # Fallback: use the runner's own svc.sh if kickstart failed.
+  if [ -n "$dir" ] && [ -x "$dir/svc.sh" ]; then
+    log "Restarting runner via svc.sh (dir=$dir)…"
+    ( cd "$dir" && ./svc.sh stop; ./svc.sh start ) 2>>"$LOG_FILE" && return 0
   fi
   return 1
 }
 
 fail=0
+failed_labels=()
+failed_dirs=()
 
-# ── 1+2. Is the runner service loaded and is its PID a live Runner.Listener? ──────────
-svc_label="$(runner_launchd_label)"
-if [ -z "$svc_label" ]; then
-  alert "no actions.runner.* launchd service is loaded"
+mark_failed() { fail=1; failed_labels+=("$1"); failed_dirs+=("$2"); }
+
+# ── 1+2. Per runner: service loaded with live PID, and its own Runner.Listener alive? ──
+if [ "${#labels[@]}" -eq 0 ]; then
+  alert "no actions.runner.*.plist installed under $LAUNCH_AGENTS_DIR — no runner services on this box"
   fail=1
 else
-  # `launchctl list <label>` prints a plist; the PID line is `"PID" = N;` when running.
-  # NB: launchd tracks the PID of the runner's WRAPPER (`runsvc.sh`), NOT the listener —
-  # the real `Runner.Listener` runs as a child of that wrapper. So "healthy" = the service
-  # has a live wrapper PID AND a Runner.Listener process exists somewhere. (Checking that
-  # the wrapper PID itself is a Runner.Listener is wrong — it's bash — and would restart a
-  # perfectly healthy runner every cycle.)
-  pid="$(launchctl list "$svc_label" 2>/dev/null | awk -F'= ' '/"PID"/ {gsub(/[ ;]/,"",$2); print $2}')"
-  if [ -z "$pid" ] || [ "$pid" = "-" ]; then
-    alert "runner service '$svc_label' is loaded but has no running PID"
-    fail=1
-  elif ! pgrep -f 'Runner.Listener' >/dev/null 2>&1; then
-    alert "runner service '$svc_label' is up (wrapper pid=$pid) but no Runner.Listener process exists (wedged wrapper / dead listener)"
-    fail=1
-  else
-    listener_pid="$(pgrep -f 'Runner.Listener' | head -1)"
-    log "OK: runner '$svc_label' alive (wrapper pid=$pid, listener pid=$listener_pid, label=$RUNNER_LABEL)"
-  fi
+  for i in "${!labels[@]}"; do
+    label="${labels[$i]}"; dir="${dirs[$i]}"
+    # `launchctl list <label>` prints a plist; the PID line is `"PID" = N;` when running.
+    # NB: launchd tracks the PID of the runner's WRAPPER (`runsvc.sh`), NOT the listener —
+    # the real `Runner.Listener` runs as a child of that wrapper. So "healthy" = the
+    # service has a live wrapper PID AND that runner's own Runner.Listener process exists
+    # (matched on the install dir so fleet members don't vouch for each other).
+    pid="$(launchctl list "$label" 2>/dev/null | awk -F'= ' '/"PID"/ {gsub(/[ ;]/,"",$2); print $2}')"
+    if [ -z "$pid" ] || [ "$pid" = "-" ]; then
+      alert "runner service '$label' is installed but has no running PID (not loaded or crashed)"
+      mark_failed "$label" "$dir"
+    elif [ -n "$dir" ] && ! pgrep -f "$dir/bin/Runner.Listener" >/dev/null 2>&1; then
+      alert "runner service '$label' is up (wrapper pid=$pid) but its Runner.Listener ($dir) is gone (wedged wrapper / dead listener)"
+      mark_failed "$label" "$dir"
+    elif [ -z "$dir" ] && ! pgrep -f 'Runner.Listener' >/dev/null 2>&1; then
+      # Couldn't parse the install dir from the plist — fall back to the any-listener check.
+      alert "runner service '$label' is up (wrapper pid=$pid) but no Runner.Listener process exists"
+      mark_failed "$label" "$dir"
+    else
+      listener_pid="$(pgrep -f "${dir:+$dir/bin/}Runner.Listener" | head -1)"
+      log "OK: runner '$label' alive (wrapper pid=$pid, listener pid=$listener_pid, label=$RUNNER_LABEL)"
+    fi
+  done
 fi
 
 # ── 3. Can the box reach GitHub at all? ───────────────────────────────────────────────
@@ -116,40 +141,51 @@ else
   log "OK: api.github.com reachable"
 fi
 
-# ── 4. Does the repo report a live self-hosted runner? (needs GH_TOKEN) ───────────────
-if [ -n "${GH_TOKEN:-}" ]; then
+# ── 4. Does the repo report the WHOLE fleet online? (needs GH_TOKEN) ──────────────────
+# Fleet-aware (#1045): >=1 online is NOT a pass when 3 are installed — compare against
+# EXPECTED_RUNNERS (default: the number of installed services found above).
+expected="${EXPECTED_RUNNERS:-${#labels[@]}}"
+if [ -n "${GH_TOKEN:-}" ] && [ "$expected" -gt 0 ]; then
   online="$(curl -fsS -m 15 \
     -H "Authorization: Bearer $GH_TOKEN" \
     -H "Accept: application/vnd.github+json" \
     "https://api.github.com/repos/$GH_REPO/actions/runners" 2>/dev/null \
     | grep -c '"status": *"online"')"
-  if [ "${online:-0}" -ge 1 ]; then
-    log "OK: GitHub reports $online online runner(s) for $GH_REPO"
+  if [ "${online:-0}" -ge "$expected" ]; then
+    log "OK: GitHub reports $online online runner(s) for $GH_REPO (expected >= $expected)"
   else
-    alert "GitHub API reports 0 online runners for $GH_REPO"
+    alert "GitHub API reports only ${online:-0} online runner(s) for $GH_REPO — expected $expected"
     fail=1
   fi
 else
-  log "SKIP: GH_TOKEN unset — skipping GitHub API liveness probe (steps 1–3 still ran)"
+  log "SKIP: GH_TOKEN unset — skipping GitHub API fleet probe (steps 1–3 still ran)"
 fi
 
-# ── Recover ───────────────────────────────────────────────────────────────────────────
+# ── Recover — restart only the runners that failed ────────────────────────────────────
 if [ "$fail" -ne 0 ]; then
-  if restart_runner; then
-    log "Recovery: restart issued. Re-verifying in 15s…"
-    sleep 15
-    if pgrep -f 'Runner.Listener' >/dev/null 2>&1; then
-      new_pid="$(pgrep -f 'Runner.Listener' | head -1)"
-      log "Recovery: runner back up (Runner.Listener pid=$new_pid)"
-      alert "runner was down and has been auto-restarted (listener pid=$new_pid)"
-    else
-      alert "runner restart attempted but no Runner.Listener is up — needs a human"
-    fi
+  if [ "${#failed_labels[@]}" -eq 0 ]; then
+    # A global failure (network / API count) with no specific runner to kick.
+    alert "failure without an attributable runner (network or fleet-count) — check the box"
   else
-    alert "could not restart the runner (no launchd label and no svc.sh) — needs a human"
+    for i in "${!failed_labels[@]}"; do
+      label="${failed_labels[$i]}"; dir="${failed_dirs[$i]}"
+      if restart_runner "$label" "$dir"; then
+        log "Recovery: restart issued for '$label'. Re-verifying in 15s…"
+        sleep 15
+        if pgrep -f "${dir:+$dir/bin/}Runner.Listener" >/dev/null 2>&1; then
+          new_pid="$(pgrep -f "${dir:+$dir/bin/}Runner.Listener" | head -1)"
+          log "Recovery: '$label' back up (Runner.Listener pid=$new_pid)"
+          alert "runner '$label' was down and has been auto-restarted (listener pid=$new_pid)"
+        else
+          alert "runner '$label' restart attempted but its Runner.Listener is not up — needs a human"
+        fi
+      else
+        alert "could not restart runner '$label' (kickstart and svc.sh both failed) — needs a human"
+      fi
+    done
   fi
   exit 1
 fi
 
-log "PASS: all checks green"
+log "PASS: all checks green (${#labels[@]} runner service(s))"
 exit 0

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -1,7 +1,7 @@
 # Self-Hosted Mac mini GitHub Actions Runner — Runbook
 
 **Date:** 2026-06-25
-**Status:** Active setup runbook (epic #610 / #669 — WS1/WS2/WS5)
+**Status:** Active setup runbook (epic #610 / #669 — WS1/WS2/WS4/WS5)
 **Purpose:** Stand up the Mac mini at home as an **always-on GitHub Actions self-hosted
 runner**, so the agent + deploy workflows run on our own hardware (no metered
 GitHub-hosted minutes, full control) and survive reboots, sleep, and network blips.
@@ -279,9 +279,8 @@ already read a toggle: `runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}`. A
 *not* Secrets) to send those jobs to the mini; delete the variable to fall back to
 GitHub-hosted. One variable, reversible — no workflow edits needed.
 
-> This runbook covers WS1/WS2/WS5 (register + provision + keep-alive). Wiring *more*
-> workflows to the toggle, and the fork-PR security policy (WS4), are tracked separately
-> in #610 — don't broaden `runs-on` to untrusted-triggered workflows without that policy.
+> Wiring *more* workflows to the toggle must respect the security policy in **§5** —
+> don't broaden `runs-on` to untrusted-triggered workflows without reading it first.
 
 ---
 
@@ -383,6 +382,79 @@ tail -f ~/Library/Logs/runner-watchdog.log                            # watch it
    (GitHub's runner has built-in reconnect; the watchdog's step 3 also catches a wedge).
 3. **`kill` the runner process** → KeepAlive (or, within 5 min, the watchdog) restarts it.
    `kill $(pgrep -f Runner.Listener)` then watch `./svc.sh status` / the watchdog log.
+
+---
+
+## 5. Security — a self-hosted runner on a PUBLIC repo (#656 — WS4)
+
+`nuxt-crouton` is public. A self-hosted runner that executes **untrusted fork-PR code** is
+the classic GitHub Actions footgun: the job runs arbitrary code from the PR head on *our*
+hardware, on a box that holds repo-write-capable creds and an LLM agent with `bash`.
+Reference: GitHub's [self-hosted runner hardening](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security).
+
+### The policy
+
+1. **Fork / untrusted PR CI stays on GitHub-hosted, always.** `ci.yml` and `e2e.yml` are
+   hardcoded `ubuntu-latest` and do **not** read the `AGENT_RUNNER` toggle — keep it that way.
+2. **Only trusted-event jobs may route to `mac-mini`.** A workflow may carry the
+   `AGENT_RUNNER` toggle only if every path to it is one of:
+   - a **maintainer-initiated** event (`workflow_dispatch`, `schedule`, `workflow_run` of
+     trunk workflows), or
+   - an **actor/label-gated** event (`issue_comment` / `issues` guarded on
+     `author_association` or a collaborators-only label), or
+   - a `pull_request` event whose `runs-on` expression **routes fork heads back to
+     `ubuntu-latest`** (see below).
+3. **Fork PRs never execute on the box — structurally, not by convention.** The
+   `pull_request`-triggered toggled workflows use the fork-guarded expression, so even
+   with `AGENT_RUNNER=mac-mini` set a fork PR runs GitHub-hosted:
+   ```yaml
+   runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}
+   ```
+   (For non-PR events `github.event.pull_request` is empty → falls through to the normal
+   toggle. Same shape as #347's "a push event can never set environment=production".)
+4. **Never use `pull_request_target` on a workflow that can reach `mac-mini`.** It hands
+   fork PRs a secrets-bearing context; combined with a self-hosted runner it's the worst
+   case. No workflow in the repo uses it today — keep it that way.
+5. **Comment bodies are untrusted input** even on actor-gated workflows: handle them in
+   `actions/github-script` (JS values), never interpolate `${{ github.event.comment.body }}`
+   into a `run:` shell line.
+6. **Considered & rejected:** allowing fork PRs on the mini behind a label gate →
+   ❌ one mislabel = arbitrary code on our box; not worth it (#656).
+
+### Audit of the toggled workflows (2026-07-02)
+
+Every workflow carrying `vars.AGENT_RUNNER`, its trigger, and why it's safe to route:
+
+| Workflow | Trigger | Trust gate |
+|---|---|---|
+| `a11y.yml`, `frontend-review.yml`, `red-team.yml` | `pull_request` (checks out + agents over PR code) | **fork-guarded `runs-on`** (policy §3) |
+| `schedule-waves.yml` | `issues`/`pull_request` closed | runs repo code only; fork-guarded `runs-on` as belt-and-braces |
+| `claude.yml` | `@claude` mention in issues/comments | `claude-code-action` validates the actor has **write** access before acting |
+| `comment-dispatch.yml` | `issue_comment` | `author_association` OWNER/MEMBER/COLLABORATOR |
+| `close-epic-on-comment.yml` | `issue_comment` | label-gated (`epic` + `status:ready-to-close` — labels need triage perms) + non-bot |
+| `resume-on-comment.yml` | `issue_comment` | label-gated (`status:blocked`); executes repo code only — a drive-by `lgtm` can resume a pipeline (accepted risk, same as GitHub-hosted; comment bodies handled via github-script) |
+| `decompose-on-issue.yml` / `-pidev.yml` | `issues` labeled `delegate`(-`pi`) / dispatch | applying labels needs triage perms |
+| `fix-ci-on-failure.yml` | `workflow_run` of CI/E2E | head-branch allowlist (`claude/issue-*`) + `workflow_run` executes trunk code |
+| `a11y-daily(-pidev).yml`, `red-team-daily.yml`, `gate-smoke.yml`, `eval-scoreboard.yml`, `loop-station-advisor.yml`, `sync-changelogs.yml`, `unlighthouse.yml` | `schedule` / `workflow_dispatch` | maintainer-initiated only |
+| `mac-mini-smoke.yml` | `workflow_dispatch` | maintainer-initiated (hardcoded to the box by design) |
+
+**When adding the toggle to a new workflow**, re-run this reasoning: which events can reach
+the job, who can fire them, and does the job ever check out non-trunk code? If any path is
+fork/drive-by reachable, add the fork guard or an actor gate first.
+
+### Repo settings + box hardening (⚙️ GITHUB / 🖥️ MINI — human steps)
+
+- [ ] ⚙️ **GITHUB (repo settings)** → Settings → Actions → General → *Fork pull request
+  workflows*: set **"Require approval for all outside collaborators"** (or stricter,
+  "Require approval for all external contributors"). This is defense-in-depth on top of the
+  structural guard — a fork PR then needs a human click before *any* workflow runs.
+- [ ] 🖥️ **MINI** — run the runner as a **dedicated, low-privilege macOS user** (not your
+  admin account): no sudo, no keychain full of personal creds, no SSH keys beyond what the
+  runner needs. The only standing secrets on the box are the watchdog's optional
+  `~/.runner-watchdog.env` (§4c); job secrets are injected by GitHub at runtime (§2b).
+- Network note: the runner only makes **outbound** connections (long-poll to GitHub) — no
+  inbound ports to firewall. Egress is unrestricted by default; if you later want to cap
+  what agent jobs can reach, that's an outbound-proxy/PF exercise, tracked separately.
 
 ---
 

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -325,10 +325,13 @@ Pi runbook's "auth-retry-with-backoff self-heal" idea.
 Two committed files do this:
 
 - [`scripts/mac-mini-runner/runner-healthcheck.sh`](../../scripts/mac-mini-runner/runner-healthcheck.sh)
-  — checks (1) the launchd service has a live PID, (2) that PID is a real
-  `Runner.Listener`, (3) the box can reach `api.github.com`, (4) — if a `GH_TOKEN` is
-  present — the repo's API reports ≥1 **online** runner. On any failure it restarts the
-  runner via `launchctl kickstart` (falling back to `svc.sh`), alerts via an optional
+  — **fleet-aware** (#1045): for **every** installed runner service (one
+  `actions.runner.*.plist` per runner) it checks (1) the service is loaded with a live
+  PID, (2) that runner's own `Runner.Listener` process exists, (3) the box can reach
+  `api.github.com`, (4) — if a `GH_TOKEN` is present — the repo's API reports **all
+  expected** runners online (default expected = installed count; override with
+  `EXPECTED_RUNNERS`). On failure it restarts only the failed runner(s) via `launchctl
+  kickstart` (falling back to that runner's `svc.sh`), alerts via an optional
   `ALERT_WEBHOOK`, and exits non-zero.
 - [`scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist`](../../scripts/mac-mini-runner/com.nuxtcrouton.runner-watchdog.plist)
   — a launchd agent that runs the health-check every **5 minutes**.
@@ -455,6 +458,54 @@ fork/drive-by reachable, add the fork guard or an actor gate first.
 - Network note: the runner only makes **outbound** connections (long-poll to GitHub) — no
   inbound ports to firewall. Egress is unrestricted by default; if you later want to cap
   what agent jobs can reach, that's an outbound-proxy/PF exercise, tracked separately.
+
+---
+
+## 6. Scaling to N runners — concurrent jobs on the one box (#1045)
+
+**A GitHub runner executes exactly one job at a time.** There is no "jobs per runner"
+setting — one registered runner = one launchd service = one slot. So when a long job
+(an E2E smoke, a decompose pipeline, an in-job agent session) holds the slot, every other
+`mac-mini` job queues behind it. The fix is boringly standard: **register more runners on
+the same box.** Each gets a unique `--name` (`mac-mini-2`, `mac-mini-3`, …) but the **same
+`--labels mac-mini`**, so GitHub fans `runs-on`-matched jobs across whichever slots are
+idle — no workflow changes at all.
+
+**Resource sizing:** each slot can be a full Nuxt build / Playwright run / in-job Claude
+agent at once. **Default fleet = 3** on the mini; don't over-provision or the box thrashes
+(drop to 2 if RAM says so — watch it under load).
+
+### Adding a runner
+
+⚙️ **GITHUB (repo settings)** — mint a **fresh registration token** per runner (they
+expire in ~1h and are single-use): Settings → Actions → Runners → **New self-hosted
+runner** — you only need the token from that page; the download is reused from the first
+install.
+
+🖥️ **MINI (terminal)** — folder: the repo clone (the script lives in it):
+
+```bash
+cd ~/nuxt-crouton
+RUNNER_TOKEN=<token from the UI> ./scripts/mac-mini-runner/add-runner.sh 2   # then 3, …
+```
+
+[`add-runner.sh`](../../scripts/mac-mini-runner/add-runner.sh) automates the whole §1–§2
+dance for runner N: unpacks the existing tarball into `~/actions-runner-<N>`, registers
+as `mac-mini-<N>` with the `mac-mini` label (`--replace`-safe to re-run), copies the
+first runner's **`.path`** file (the launchd-minimal-PATH gotcha, §2a), and installs +
+starts its own launchd service (`actions.runner.<owner>-<repo>.mac-mini-<N>`).
+
+The watchdog (§4c) needs **no reconfiguration** — it discovers every installed
+`actions.runner.*.plist` on each run and requires the whole fleet online.
+
+✅ **Checkpoint (#1045 acceptance):**
+1. Repo Settings → Actions → Runners shows all fleet members **Idle**, each labelled
+   `self-hosted, macOS, ARM64, mac-mini`.
+2. Dispatch 3 `mac-mini` jobs at once (e.g. re-run three PR agent-gates) → **all 3 go
+   `in_progress`**, none `queued`.
+3. `kill` one runner's `Runner.Listener` → the watchdog flags that runner (not "≥1 online
+   so fine") and restarts just it.
+4. Regression: a single dispatched job still routes to the mini as before.
 
 ---
 


### PR DESCRIPTION
Part of epic #610. Two sub-issues, one commit each — **deliberately no `Closes`**: both issues keep human checkboxes open after this merges (repo-settings flip, on-box runner registration), so they close by confirming comment, not by this PR.

## 👤 For humans

**#656 — security policy.** The repo is public. Three PR-triggered agent gates (a11y, frontend-review, red-team) check out PR code and run an LLM with bash over it — once `AGENT_RUNNER=mac-mini` is set, a fork PR would have meant arbitrary code on your hardware. Now fork PRs are structurally routed back to GitHub-hosted (same "can't happen by construction" shape as #347's prod gate), and the runbook has a `## 5. Security` section with the policy + an audit table of every toggled workflow. *The issue body's claim that no toggled workflow fires on `pull_request` was stale — the toggle spread after #655; this audit found and closed that gap.*

**#1045 — fleet scaling.** One runner = one job at a time, so everything on the mini was single-file (six jobs stacked on 2026-07-01). `add-runner.sh` registers extra same-labelled runners in one command, and the watchdog is now fleet-aware — "expected 3, only 2 online" is a failure, and it restarts just the dead one.

## 🤖 For agents

- `a11y.yml` / `frontend-review.yml` / `red-team.yml` / `schedule-waves.yml`: `runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}` — fork heads never reach `mac-mini`; non-PR events fall through to the normal toggle.
- `writeups/setup/self-hosted-mac-mini-runner.md`: new §5 (policy, audit table, human hardening steps) and §6 (scaling: unique `--name`, shared `mac-mini` label, fresh token per runner, default fleet = 3).
- `scripts/mac-mini-runner/add-runner.sh` (new, executable): installs runner N into `~/actions-runner-<N>`, registers `mac-mini-<N>` with label `mac-mini`, copies `.path` (launchd-minimal-PATH gotcha), installs its launchd service. `RUNNER_TOKEN` via env only; `--replace`-safe.
- `scripts/mac-mini-runner/runner-healthcheck.sh`: discovers every `actions.runner.*.plist`, checks each service's wrapper PID + its **own** `Runner.Listener` (matched on install dir), API probe requires `EXPECTED_RUNNERS` online (default = installed count), restarts only failed runners.

## 🧪 How to test

1. **Fork guard (structural):** on a fork PR touching a `.vue`/server file with `AGENT_RUNNER=mac-mini` set, the a11y/frontend-review/red-team jobs run on `ubuntu-latest`; a same-repo PR still routes to the mini. Expression verified to parse; semantics follow GitHub's documented `&&/||` ternary.
2. **Watchdog scripts:** `bash -n` clean; plist-dir extraction and `add-runner.sh` arg guards exercised (wrong N, missing token, missing tarball all die with the right message).
3. **On the box (after merge, human):** `RUNNER_TOKEN=<fresh> ./scripts/mac-mini-runner/add-runner.sh 2` → Runners list shows `mac-mini-2` Idle; `kill` one `Runner.Listener` → watchdog flags that runner specifically and restarts it; dispatch 3 `mac-mini` jobs → all 3 `in_progress`.

Remaining human checkboxes (kept on the issues): #656 — flip "require approval for fork PRs" in Actions settings, low-priv runner user; #1045 — register `mac-mini-2`/`-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjShyQfiXNKADjYPMwawCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjShyQfiXNKADjYPMwawCm)_