### PR TITLE
chore(root): route deploy-app.yml to the AGENT_RUNNER toggle, fork-guarded (#654)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -93,7 +93,13 @@ on:
 jobs:
   deploy:
     name: Deploy ${{ inputs.app }} (${{ inputs.environment }})
-    runs-on: ubuntu-latest
+    # Routed to the self-hosted box behind the AGENT_RUNNER toggle (#654/#658 — wrangler
+    # deploy is cross-platform Node; verified from macOS by the #654 proof run). The fork
+    # guard implements the runbook §5 policy: deploy-pocs.yml calls this on `pull_request`
+    # of pocs/**, so a fork PR must never reach the box — it routes back to GitHub-hosted
+    # structurally (fork PRs also get no secrets, but the guard keeps their code off our
+    # hardware in the first place). Delete the AGENT_RUNNER repo var to fall back.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}
     # GitHub deployment environment — kept as production/staging so any
     # environment-scoped secrets/protection from the existing setup still apply
     # (the Workers target is staging/prod independently, via inputs.environment).
@@ -112,6 +118,13 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
       - uses: actions/checkout@v4
+
+      # Hosted runners ship jq; a self-hosted mac starts bare (runbook §2a installs
+      # node/pnpm/gh/wrangler but jq wasn't on the list). Self-heals via Homebrew —
+      # already on the runner PATH through its `.path` file. No-op when jq exists.
+      - name: Ensure jq (self-hosted macOS)
+        if: runner.os == 'macOS'
+        run: command -v jq >/dev/null 2>&1 || brew install jq
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -258,9 +258,11 @@ committed file.
 
 > **macOS portability (#654 / #610 WS4 audit):** `actions/create-github-app-token` and
 > `anthropics/claude-code-action@<pinned sha>` are Node actions → run fine on macOS
-> self-hosted. The deploy workflows currently `runs-on: ubuntu-latest`; `wrangler deploy`
-> itself is cross-platform Node, so it works from macOS — verify with the #654 test below
-> before flipping any deploy job's `runs-on`.
+> self-hosted. `wrangler deploy` is cross-platform Node and was **verified from macOS by
+> the #654 proof run**, after which the reusable `deploy-app.yml` was flipped to the
+> fork-guarded `AGENT_RUNNER` toggle — deploys now route to the mini too. One macOS gap
+> surfaced: hosted runners ship `jq`, a bare mac doesn't — `deploy-app.yml` self-heals
+> with an `Ensure jq` step (`brew install jq` when missing).
 
 ✅ **Checkpoint (#654 acceptance):**
 1. Route a cheap agent workflow to the runner (set repo var `AGENT_RUNNER=mac-mini`, run
@@ -437,6 +439,7 @@ Every workflow carrying `vars.AGENT_RUNNER`, its trigger, and why it's safe to r
 | `close-epic-on-comment.yml` | `issue_comment` | label-gated (`epic` + `status:ready-to-close` — labels need triage perms) + non-bot |
 | `resume-on-comment.yml` | `issue_comment` | label-gated (`status:blocked`); executes repo code only — a drive-by `lgtm` can resume a pipeline (accepted risk, same as GitHub-hosted; comment bodies handled via github-script) |
 | `decompose-on-issue.yml` / `-pidev.yml` | `issues` labeled `delegate`(-`pi`) / dispatch | applying labels needs triage perms |
+| `deploy-app.yml` (reusable — the deploy job all `deploy-*` callers share) | `workflow_call` from push-to-main / `workflow_dispatch` callers, plus `deploy-pocs.yml` on `pull_request` of `pocs/**` | **fork-guarded `runs-on`** (policy §3) — the only fork-reachable path (a fork PR touching `pocs/**`) routes back to `ubuntu-latest`; fork PRs also receive no secrets |
 | `fix-ci-on-failure.yml` | `workflow_run` of CI/E2E | head-branch allowlist (`claude/issue-*`) + `workflow_run` executes trunk code |
 | `a11y-daily(-pidev).yml`, `red-team-daily.yml`, `gate-smoke.yml`, `eval-scoreboard.yml`, `loop-station-advisor.yml`, `sync-changelogs.yml`, `unlighthouse.yml` | `schedule` / `workflow_dispatch` | maintainer-initiated only |
 | `mac-mini-smoke.yml` | `workflow_dispatch` | maintainer-initiated (hardcoded to the box by design) |


### PR DESCRIPTION
Part of #610 — the #654 secrets-proof + the deploy-routing flip it verifies. Pre-req for the #658 end-to-end proof.

## 👤 For humans

Cloudflare deploys were the last job family still hardcoded to `ubuntu-latest`. This flips the reusable `deploy-app.yml` deploy job to the `AGENT_RUNNER` toggle, so with `AGENT_RUNNER=mac-mini` set, `deploy-pocs` / `deploy-apps` / `deploy-docs` deploys run on the Mac mini too. Delete the repo var and everything falls back to GitHub-hosted — one variable, reversible.

Safety: `deploy-pocs.yml` calls this job on `pull_request` of `pocs/**`, so the `runs-on` expression carries the runbook §5 **fork guard** — a fork PR structurally routes back to `ubuntu-latest` (and fork PRs get no secrets anyway).

**Verified before landing** (the #654 acceptance, dispatched from this branch so `main` stays untouched until proven):
- routed agent workflow with secrets on the mini: gate-smoke run [28611712318](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28611712318)
- `cf:staging` deploy of `loop-station` from the mini: deploy-pocs run [28611714321](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28611714321)

## 🤖 For agents

- `.github/workflows/deploy-app.yml`: `deploy` job `runs-on` → `${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}`; new `Ensure jq (self-hosted macOS)` step (`brew install jq` when missing — hosted runners ship jq, a bare mac doesn't).
- `writeups/setup/self-hosted-mac-mini-runner.md`: §2b macOS-portability note updated (wrangler-from-macOS verified, jq gap); §5 audit table gains the `deploy-app.yml` row.

## 🧪 How to test

1. Open the two runs linked above → the `smoke (frontend-review)` and `Deploy loop-station (staging)` jobs show runner `mac-mini`, conclusion success.
2. https://loop-station.pmcp.dev responds after the deploy.
3. Fork-guard regression: a fork PR touching `pocs/**` still schedules its deploy job on `ubuntu-latest`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtHCNa7a7xoainZpnPtN8)_