### PR TITLE
fix(root): grant @claude runs a working tool set (Write/Edit/Bash) (#658)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,10 +32,15 @@ jobs:
 
       # Pinned to commit with Claude Code 2.1.100 — fixes bun "directory mismatch" crash in 2.1.98 (v1.0.92)
       # TODO: revert to @v1 once v1.0.93+ is released
+      # --allowedTools: tag-mode (@claude) defaults to a read+git-commit-only grant (no
+      # Write/Edit/general Bash), so a mention asking for a real code change silently can't
+      # make one (#658 proof-run finding). Grant the same working set the other agent
+      # workflows use (gate-smoke.yml precedent); the actor gate (write access) still
+      # bounds who can invoke, and the action keeps WebSearch/WebFetch disallowed.
       - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 25"
+          claude_args: "--max-turns 25 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           show_full_output: true
 
       # Loop Station WS2 (#929) / usage rollup (#1064): ship this runner's


### PR DESCRIPTION
Part of #610 — unblocks the #658 proof run.

## 👤 For humans

An `@claude` mention asking for a real code change silently couldn't make one: `claude-code-action`'s tag-mode default tool grant is read-only + `git add/commit` — no `Write`, no `Edit`, no general `Bash`. Found when the dispatched build on [#1114](https://github.com/FriendlyInternet/nuxt-crouton/issues/1114) failed in ~2 minutes without touching a file (run [28614287004](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28614287004) — its `ALLOWED_TOOLS` env shows the restricted set). The same restricted-schema behaviour is what made the #1113 orchestrator report "the Agent tool is not available" and stall the delegate pipeline twice.

One line: `claude.yml` now passes the same explicit `--allowedTools Bash,Write,Edit,Read,Grep,Glob` grant that `gate-smoke.yml` already uses. The actor gate (write access required to trigger) still bounds who can invoke, and the action keeps `WebSearch`/`WebFetch` disallowed.

## 🤖 For agents

- `.github/workflows/claude.yml`: `claude_args` → `--max-turns 25 --allowedTools Bash,Write,Edit,Read,Grep,Glob`.

## 🧪 How to test

1. Comment `@claude` on an issue asking for a small file change → the run's `ALLOWED_TOOLS` includes Write/Edit/Bash and the change lands (branch/commit).
2. Regression: a non-collaborator's `@claude` mention still doesn't trigger the workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtHCNa7a7xoainZpnPtN8)_