### PR TITLE
fix(root): raise @claude job timeout to 60 min for build-class tasks (#658)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,7 +15,11 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    # 60 not 30: a build-class @claude task (scaffold a POC, pnpm install, typecheck) plus
+    # agent deliberation doesn't fit 30 min on a cold checkout — the #658 proof-run build
+    # was killed mid-work at the 30-min mark with everything unpushed. Self-hosted minutes
+    # are free; the ceiling is a runaway backstop, not a budget.
+    timeout-minutes: 60
     # NOTE: permissions MUST live at the job level. GitHub job-level `permissions` fully
     # OVERRIDES (does not merge with) any workflow-level block, so `id-token: write` has to
     # be here or the claude-code-action OIDC token request fails


### PR DESCRIPTION
Part of #610 — third pipeline defect surfaced by the #658 proof run.

## 👤 For humans

The #658 proof-run build (`@claude` scaffolding `pocs/pins` on the mini, run [28614998521](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28614998521)) was killed at the 30-minute `timeout-minutes` mark with all work unpushed. A build-class task (scaffold + `pnpm install` + typecheck + agent deliberation) legitimately needs more than 30 minutes on a cold checkout. On the self-hosted mini, minutes are free — the ceiling is a runaway backstop, not a budget.

## 🤖 For agents

- `.github/workflows/claude.yml`: `timeout-minutes` 30 → 60 on the `claude` job.

## 🧪 How to test

Re-dispatch the #1114 build via `@claude` → the run survives past 30 minutes and ends with a pushed branch + PR instead of a cancelled job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtHCNa7a7xoainZpnPtN8)_