### PR TITLE
docs(root): runbook gotcha — timeout-killed claude-code-action poisons the runner's action cache (#658)

### DIFF
--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -231,6 +231,22 @@ wrangler --version
 > rescues the direct `gh`/`wrangler` calls. (Re-run the `echo "$PATH" > .path` if you later
 > change the nvm default node version, since that dir is version-stamped.)
 
+> ⚠️ **GOTCHA — a hard-killed `claude-code-action` job can poison that runner's action
+> cache.** Found during the #658 proof run: after a `claude-code-action` session was killed
+> by `timeout-minutes` mid-work, every subsequent claude-code-action job **on that same
+> runner** crashed in ~30 s during action startup with bun's
+> `Internal error: directory mismatch for directory ".../claude-code-action/.../tsconfig.json"`
+> — before the agent even started (the loop-station trace shows `0 events`). Re-runs don't
+> help (the scheduler keeps handing the job to the same idle runner). Fix is on-box: clear
+> that runner's cached copy of the action and kick the service —
+> ```bash
+> # 🖥️ MINI — <N> is the affected runner's dir (plain ~/actions-runner for the first)
+> rm -rf ~/actions-runner/_work/_actions/anthropics
+> cd ~/actions-runner && ./svc.sh stop && ./svc.sh start
+> ```
+> The action re-downloads clean on the next job. (Hosted runners never hit this — they're
+> ephemeral; a persistent self-hosted `_work` is what lets the corruption stick.)
+
 ### 2b. Secrets
 
 ⚙️ **GITHUB (repo settings)** — nothing to run on the mini here. **GitHub repo secrets are


### PR DESCRIPTION
Part of #610 — the macOS gotcha #658 asks to be noted back into the runbook.

## 👤 For humans

After the #658 proof-run build was hard-killed by `timeout-minutes` mid-session, every later `claude-code-action` job **on that same runner** crashed in ~30 s at action startup (bun `Internal error: directory mismatch … tsconfig.json`) before the agent even started — three consecutive runs ([attempt 1](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28616959931/attempts/1), attempts 2–3 of the same run). Re-runs don't help because the scheduler keeps handing the job to the same idle runner. The fix is a one-liner on the box (clear `_work/_actions/anthropics`, restart the service) — documented in §2a.

## 🤖 For agents

- `writeups/setup/self-hosted-mac-mini-runner.md` §2a: new gotcha block — symptom (0-event runs, ~30 s bun crash), why re-runs don't help, on-box recovery commands.

## 🧪 How to test

Docs-only. After running the §2a recovery on the mini, re-dispatch the #1114 build (`@claude` mention) → the action gets past startup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtHCNa7a7xoainZpnPtN8)_