### PR TITLE
fix(root): re-pin claude-code-action to v1.0.162 across all workflows (#658)

### DIFF
--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -46,7 +46,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         id: agent
         # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
         # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,14 +34,16 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Pinned to commit with Claude Code 2.1.100 — fixes bun "directory mismatch" crash in 2.1.98 (v1.0.92)
-      # TODO: revert to @v1 once v1.0.93+ is released
+      # Pinned to v1.0.162 (Claude Code 2.1.198). Re-pinned from v1.0.92 during the #658
+      # proof run: a timeout-killed session poisoned the old pin's per-runner action cache
+      # (runbook §2a) — a NEW ref also means a fresh `_work/_actions` directory on every
+      # runner, which is the no-SSH recovery path. Keep every workflow's pin in sync.
       # --allowedTools: tag-mode (@claude) defaults to a read+git-commit-only grant (no
       # Write/Edit/general Bash), so a mention asking for a real code change silently can't
       # make one (#658 proof-run finding). Grant the same working set the other agent
       # workflows use (gate-smoke.yml precedent); the actor gate (write access) still
       # bounds who can invoke, and the action keeps WebSearch/WebFetch disallowed.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--max-turns 25 --allowedTools Bash,Write,Edit,Read,Grep,Glob"

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -45,7 +45,7 @@ jobs:
       # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
       # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
       # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         id: claude
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -126,7 +126,7 @@ jobs:
       # Anthropic terms). Pinned to the same SHA as claude.yml — keep in sync when bumping.
       # github_token is the App token so the agent's git push re-triggers CI (above).
       - if: steps.gate.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         id: agent
         # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
         # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found

--- a/.github/workflows/gate-smoke.yml
+++ b/.github/workflows/gate-smoke.yml
@@ -75,7 +75,7 @@ jobs:
       # Same engine + allowlist as the real gate workflows (#834's fix) — the
       # smoke MUST use the identical permission grant, or it isn't testing
       # the thing that shipped fail-open.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/loop-station-advisor.yml
+++ b/.github/workflows/loop-station-advisor.yml
@@ -48,7 +48,7 @@ jobs:
       # Only here does the LLM run — to turn deterministic findings into a human-readable
       # recommendation issue. Pinned to the same SHA as the repo's other claude-code-action
       # workflows — bump together.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         id: llm
         if: steps.advisor.outputs.actionable == 'true'
         # An LLM outage must not kill the run before the deterministic fallback below —

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         id: agent
         # The VERDICT FILE is the gate — NOT this step's exit code. The agent can exit non-zero
         # on `max_turns` (it flails writing the verdict / the SDK errors) even when it found

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -39,7 +39,7 @@ jobs:
       # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
       # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
       # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
-      - uses: anthropics/claude-code-action@c26cb6427d54362f5fd9834ac6818cbaaf82490a
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
Part of #610 — the **no-SSH recovery** for the #658 build-leg blocker.

## 👤 For humans

The mac-mini runner's cached copy of `claude-code-action@c26cb64…` was corrupted by the timeout-killed session (bun `directory mismatch` crash on every subsequent run — runbook §2a, PR [#1118](https://github.com/FriendlyInternet/nuxt-crouton/pull/1118)), and the box is currently unreachable for the on-disk cleanup. Self-hosted runners key their action cache by the **ref as written** (`_work/_actions/anthropics/claude-code-action/<ref>/`), so pinning a **new ref** makes every runner download a fresh, clean copy — no SSH needed.

Bonus: this clears the long-stale pin TODO ("revert once v1.0.93+ is released") — v1.0.162 (Claude Code 2.1.198) shipped Jul 1. Pinned by full commit SHA, keeping the repo's pin-by-SHA discipline.

## 🤖 For agents

- All 11 workflows using `anthropics/claude-code-action`: `c26cb6427d54362f5fd9834ac6818cbaaf82490a` (v1.0.92 / CC 2.1.100) → `6c0083bb7289c31716797a039b6367b3079cc46e` (v1.0.162 / CC 2.1.198). Pins kept in sync per the workflow comments.
- `claude.yml` pin comment rewritten (documents the fresh-cache-directory recovery property).

## 🧪 How to test

1. After merge, comment `@claude` on [#1114](https://github.com/FriendlyInternet/nuxt-crouton/issues/1114) → the action step gets past startup on the mini (no ~30 s bun crash) and the agent session starts.
2. Regression: any routed agent workflow (gate-smoke dispatch) still completes green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtHCNa7a7xoainZpnPtN8)_