### PR TITLE
feat(root): skill freshness — deterministic staleness detection for .claude/skills (#1100)

### DIFF
--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -35,6 +35,11 @@ the only thing it writes.
   isn't a currently-open epic: a closed epic left with unfinished work, or a parent missing
   the `epic` label (#980).
 - **🔀 Idle PRs** — open PRs with no activity in >N days.
+- **📚 Skill freshness** — knowledge skills (the `verified:` provenance contract, #1073/#1091)
+  whose citations drifted or whose stamp aged out, via `scripts/skill-freshness.mjs` (fs+git, no
+  LLM): a cited path that **vanished** (🔴), a cited file with commits **newer than the stamp**
+  (🟡 possibly-stale), or a stamp **> 90d old** (🔵 re-verify due). Report-only — a re-verified,
+  re-stamped skill drops off next run (#1100 WS3). Section dropped if the checker can't run.
 
 ## Pipeline (deterministic — no LLM, no secrets)
 

--- a/.claude/skills/housekeeping/gather.mjs
+++ b/.claude/skills/housekeeping/gather.mjs
@@ -20,6 +20,7 @@
 
 import { execSync } from 'node:child_process'
 import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { computeSkillFreshness } from '../../../scripts/skill-freshness.mjs'
 
 const REPO = process.env.DIGEST_REPO || 'FriendlyInternet/nuxt-crouton'
 const [OWNER, NAME] = REPO.split('/')
@@ -170,6 +171,37 @@ function loopStationBudget() {
   }
 }
 
+// ── Skill freshness (#1100 WS3) ───────────────────────────────────────────────
+// Read-only: reuse scripts/skill-freshness.mjs (fs+git, no LLM) to surface knowledge-skills
+// whose cited paths drifted or whose `verified:` stamp aged out. Returns just the flagged
+// skills + a summary so render.mjs can show a "📚 Skill freshness" band (omitted when clean).
+// Null (section dropped) if the checker throws — never blocks the rest of the digest.
+function skillFreshness() {
+  try {
+    const r = computeSkillFreshness()
+    const flagged = r.skills
+      .filter((s) => s.vanished.length || s.possiblyStale.length || s.overdue)
+      .map((s) => ({
+        name: s.name,
+        stamp: s.stamp,
+        ageDays: s.ageDays,
+        overdue: s.overdue,
+        vanished: s.vanished,
+        possiblyStale: s.possiblyStale
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+    return {
+      today: r.today,
+      staleDays: r.staleDays,
+      summary: r.summary,
+      flagged,
+      malformed: r.malformed.map((m) => ({ name: m.name, reason: m.reason }))
+    }
+  } catch {
+    return null
+  }
+}
+
 // ── Issue / PR drift (API) ───────────────────────────────────────────────────
 const COMPONENT_RE = /^(pkg|app|worker|poc):/
 
@@ -272,6 +304,7 @@ const data = {
   staleBranches: staleBranches(),
   labelCoverage: labelCoverage(),
   loopStation: loopStationBudget(),
+  skillFreshness: skillFreshness(),
   ...drift
 }
 

--- a/.claude/skills/housekeeping/render.mjs
+++ b/.claude/skills/housekeeping/render.mjs
@@ -126,6 +126,27 @@ if (data.idlePRs?.length) {
   ])
 }
 
+// 📚 Skill freshness (#1100 WS3) — knowledge skills whose cited paths drifted or whose
+// `verified:` stamp aged out. Report-only; a re-verified/re-stamped skill drops off next run.
+const sf = data.skillFreshness
+if (sf && (sf.flagged?.length || sf.malformed?.length)) {
+  const lines = [
+    `Knowledge skills (\`verified:\` provenance) that need a re-check — nothing was modified:`
+  ]
+  for (const s of sf.flagged) {
+    const tags = []
+    if (s.vanished.length) tags.push(`🔴 ${s.vanished.length} vanished`)
+    if (s.possiblyStale.length) tags.push(`🟡 ${s.possiblyStale.length} possibly-stale`)
+    if (s.overdue) tags.push(`🔵 stamp ${s.ageDays}d old`)
+    lines.push(`- \`/${s.name}\` (stamped ${s.stamp}) — ${tags.join(', ')}`)
+    for (const p of s.vanished) lines.push(`  - 🔴 vanished: \`${p}\``)
+    for (const p of s.possiblyStale) lines.push(`  - 🟡 \`${p.path}\` — changed ${p.lastCommit}, after the stamp`)
+  }
+  for (const m of sf.malformed) lines.push(`- \`/${m.name}\` — ⚠️ ${m.reason}`)
+  lines.push('', `_Re-run \`node scripts/skill-freshness.mjs --pretty\` locally; re-verify the facts, then bump the \`verified:\` stamp._`)
+  sections.push(['📚 Skill freshness', lines])
+}
+
 // Loop Station budget readout (#934, WS4) — one read-only line, always shown when
 // the inventory has produced data. Sourced from the latest committed history.jsonl
 // record (gathered, not recomputed). Omitted when WS1 hasn't run yet.

--- a/.claude/skills/skills-digest/SKILL.md
+++ b/.claude/skills/skills-digest/SKILL.md
@@ -103,6 +103,25 @@ the digest only **reads the latest record and renders** — it never recomputes.
 no-op** when the record is absent (no header line, no badges; the digest is unchanged). loop-station's own
 `fetch-depth`/commit-back concerns are its business; the digest just reads the committed JSONL.
 
+## 🪦 Dead weight — freshness × usage (#1100 WS5)
+
+The **"🪦 Dead weight"** band joins two signals to surface **retire candidates** — a knowledge
+skill that is both *stale* and *unused*:
+
+- **Freshness** from `scripts/skill-freshness.mjs` (`computeSkillFreshness()`): which provenance-
+  stamped skills have a **vanished citation** or a **`verified:` stamp aged past 90d**.
+- **Usage** from the committed **loop-station usage rollup** (`writeups/loop-station/usage.jsonl`,
+  #1064): per-skill **CI invocation counts**, gated by `usageCoverage()` (advisor.mjs).
+
+A skill that is stale (stamp overdue **or** a vanished citation) **and** has 0 CI invocations over
+the covered window becomes a **retire candidate**. It **never judges "unused" blind**: with no
+rollup (or thin coverage) `usageCoverage()` returns `judged: false`, so the band renders
+**freshness-only** and states the verdict is withheld. Counts are **pipeline scope** — interactive
+session usage isn't measured yet (#1067), so a `0` means "never fired *in CI*", not "provably dead".
+
+Like the budget band, the digest is a **reader/renderer** (freshness + usage are the producers) and
+**degrades to a no-op** — a green "✅ all N knowledge skills fresh" line — when nothing is stale.
+
 ## Cadence + delivery (config-as-data)
 
 Declared in `.github/digests.yml`, exactly like the other digests:

--- a/.claude/skills/skills-digest/example.data.json
+++ b/.claude/skills/skills-digest/example.data.json
@@ -56,5 +56,17 @@
     "topPairs": [
       { "a": "github-tasks", "b": "skills-digest", "containment": 19.5 }
     ]
+  },
+  "deadWeight": {
+    "freshness": { "scanned": 50, "tracked": 13, "malformed": 0, "vanished": 1, "possiblyStale": 2, "overdue": 2 },
+    "staleDays": 90,
+    "stale": [
+      { "name": "crouton-ci-and-deploy-map", "stamp": "2026-03-14", "ageDays": 110, "overdue": true, "vanished": 1, "possiblyStale": 0, "invocations": 0 },
+      { "name": "crouton-run-and-operate", "stamp": "2026-03-30", "ageDays": 94, "overdue": true, "vanished": 0, "possiblyStale": 1, "invocations": 6 }
+    ],
+    "coverage": { "judged": true, "coverageDays": 63, "runs": 41, "records": 9, "scope": "pipeline" },
+    "retireCandidates": [
+      { "name": "crouton-ci-and-deploy-map", "stamp": "2026-03-14", "ageDays": 110, "overdue": true, "vanished": 1, "possiblyStale": 0, "invocations": 0 }
+    ]
   }
 }

--- a/.claude/skills/skills-digest/gather.mjs
+++ b/.claude/skills/skills-digest/gather.mjs
@@ -19,6 +19,8 @@ import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { META, GROUPS, discover } from '../../../scripts/gen-skills-doc.mjs'
+import { computeSkillFreshness } from '../../../scripts/skill-freshness.mjs'
+import { usageCoverage } from '../loop-station/advisor.mjs'
 
 const REPO = process.env.DIGEST_REPO || 'FriendlyInternet/nuxt-crouton'
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..')
@@ -188,6 +190,57 @@ if (budget) {
   }
 }
 
+// ── dead-weight join (#1100 WS5) ─────────────────────────────────────────────
+// Cross the SKILL-FRESHNESS signal (scripts/skill-freshness.mjs — cited paths drifted /
+// `verified:` stamp aged out) with the USAGE rollup (writeups/loop-station/usage.jsonl, #1064)
+// to surface RETIRE CANDIDATES: a stale skill that also never fired. Honours the loop-station
+// doctrine — it NEVER judges "unused" blind: usageCoverage() gates the retire verdict, so with
+// no rollup (or thin coverage) the band renders freshness-only and says the verdict is withheld.
+// Scope is `pipeline` (CI invocations only); interactive session usage isn't measured yet (#1067),
+// so the band labels the counts as such and a 0 is "never fired IN CI", not "provably dead".
+function loadUsageRecords() {
+  const p = join(ROOT, 'writeups/loop-station/usage.jsonl')
+  if (!existsSync(p)) return []
+  try {
+    return readFileSync(p, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l))
+  } catch {
+    return []
+  }
+}
+function deadWeightJoin() {
+  let fresh
+  try {
+    fresh = computeSkillFreshness({ root: ROOT })
+  } catch {
+    return null // git/fs unavailable — drop the band rather than guess
+  }
+  const usageRecords = loadUsageRecords()
+  const coverage = usageCoverage(usageRecords)
+  const fired = {}
+  for (const u of usageRecords) for (const [name, c] of Object.entries(u?.byName || {})) fired[name] = (fired[name] || 0) + (c || 0)
+
+  // "stale" for the retire signal = the hard flags (stamp overdue OR a vanished citation).
+  // possibly-stale alone is too soft to imply retirement; it's carried as context only.
+  const stale = fresh.skills
+    .filter((s) => s.overdue || s.vanished.length)
+    .map((s) => ({
+      name: s.name,
+      stamp: s.stamp,
+      ageDays: s.ageDays,
+      overdue: s.overdue,
+      vanished: s.vanished.length,
+      possiblyStale: s.possiblyStale.length,
+      invocations: fired[s.name] ?? 0
+    }))
+    .sort((a, b) => b.ageDays - a.ageDays)
+
+  // Retire-candidate = stale AND zero invocations — ONLY when coverage lets us judge.
+  const retireCandidates = coverage.judged ? stale.filter((s) => s.invocations === 0) : []
+
+  return { freshness: fresh.summary, staleDays: fresh.staleDays, stale, coverage, retireCandidates }
+}
+const deadWeight = deadWeightJoin()
+
 const data = {
   generatedAt: new Date().toISOString(),
   repo: REPO,
@@ -195,7 +248,8 @@ const data = {
   total: skills.length,
   groups,
   changed,
-  budget: budget ? budget.summary : null
+  budget: budget ? budget.summary : null,
+  deadWeight
 }
 
 process.stdout.write(JSON.stringify(data, null, 2) + '\n')

--- a/.claude/skills/skills-digest/render.mjs
+++ b/.claude/skills/skills-digest/render.mjs
@@ -40,6 +40,8 @@ const changed = data.changed || { firstRun: true, added: [], updated: [], remove
 // against a committed context-budget record; every budget surface is a no-op when absent.
 const budget = data.budget || null
 const dupNames = new Set((budget?.topPairs || []).flatMap((p) => [p.a, p.b]))
+// Dead-weight join (#1100 WS5): freshness × usage. No-op when the gather couldn't compute it.
+const deadWeight = data.deadWeight || null
 const fmtTok = (n) => (n == null ? '' : n >= 1000 ? `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k` : String(n))
 
 // ── helpers ─────────────────────────────────────────────────────────────────
@@ -95,6 +97,51 @@ const budgetPairs = () => {
     .map((p) => `<code style="font:700 12px ui-monospace,Menlo,Consolas,monospace;">/${esc(p.a)}</code> ↔ <code style="font:700 12px ui-monospace,Menlo,Consolas,monospace;">/${esc(p.b)}</code> <strong>${p.containment}%</strong>`)
     .join(' &nbsp;·&nbsp; ')
   return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 26px;"><tr><td style="padding:11px 14px;background:#fdf4e7;border:1px solid #f4d29b;border-radius:10px;color:#7c4a12;font:12.5px -apple-system,Segoe UI,Roboto,sans-serif;">⚠️ <strong>Most-overlapping skills</strong> (measured — loop-station): ${items} — candidates to merge or trim.</td></tr></table>`
+}
+
+// Dead-weight band (#1100 WS5) — knowledge-skill freshness crossed with CI usage. Always a
+// no-op without the join; shows a green "all fresh" line when clean; lists stale skills and,
+// only when usage coverage permits, elevates the stale-AND-unused ones to retire-candidates.
+const usageNote = (cov) =>
+  cov.judged
+    ? `usage: ${cov.coverageDays}d · ${cov.runs} CI runs · pipeline scope (interactive sessions not counted, #1067)`
+    : `usage: ${esc(cov.why || 'no rollup')} — retire verdicts withheld (freshness shown alone)`
+const staleTags = (s) => {
+  const t = []
+  if (s.vanished) t.push(`🔴 ${s.vanished} vanished`)
+  if (s.overdue) t.push(`🔵 stamp ${s.ageDays}d`)
+  if (s.possiblyStale) t.push(`🟡 ${s.possiblyStale} drifted`)
+  return t.join(' · ')
+}
+const deadWeightBand = () => {
+  if (!deadWeight) return ''
+  const f = deadWeight.freshness || {}
+  const stale = deadWeight.stale || []
+  const retire = deadWeight.retireCandidates || []
+  const days = deadWeight.staleDays || 90
+  const head = `<h2 style="font:700 17px -apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;margin:4px 0 4px;">🪦 Dead weight — freshness × usage</h2>
+  <p style="color:#64748b;font-size:13px;margin:0 0 12px;">Knowledge skills (the <code>verified:</code> provenance contract) crossed with CI invocation counts. Stale <strong>and</strong> unused ⇒ a retire candidate. <span style="color:#94a3b8;">${esc(usageNote(deadWeight.coverage || { judged: false }))}</span></p>`
+  if (!stale.length) {
+    return head + `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 28px;"><tr><td style="padding:12px 14px;background:#ecfdf5;border:1px solid #a7f3d0;border-radius:10px;color:#065f46;font:13px -apple-system,Segoe UI,Roboto,sans-serif;">✅ <strong>All ${f.tracked || 0} knowledge skills fresh</strong> — verified within ${days}d, no vanished citations.</td></tr></table>`
+  }
+  const retireCallout = retire.length
+    ? `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 10px;"><tr><td style="padding:11px 14px;background:#fef2f2;border:1px solid #fecaca;border-radius:10px;color:#7f1d1d;font:12.5px -apple-system,Segoe UI,Roboto,sans-serif;">🪦 <strong>${retire.length} retire candidate${retire.length === 1 ? '' : 's'}</strong> (stale AND 0 CI invocations over the covered window): ${retire.map((s) => `<code style="font:700 12px ui-monospace,Menlo,Consolas,monospace;">/${esc(s.name)}</code>`).join(' &nbsp;·&nbsp; ')} — review to re-verify or retire.</td></tr></table>`
+    : ''
+  const rows = stale
+    .map(
+      (s) =>
+        `<tr><td style="padding:8px 14px;border-bottom:1px solid #eef2f7;background:#fff;">
+        <code style="font:700 13px ui-monospace,Menlo,Consolas,monospace;color:#0f172a;">/${esc(s.name)}</code>
+        <span style="color:#94a3b8;font-size:12px;"> · stamped ${esc(s.stamp)}</span>
+        <div style="color:#64748b;font-size:12px;margin-top:2px;">${staleTags(s)} · <strong style="color:${s.invocations === 0 ? '#b91c1c' : '#0f766e'};">${s.invocations} CI invocation${s.invocations === 1 ? '' : 's'}</strong></div>
+      </td></tr>`
+    )
+    .join('')
+  return (
+    head +
+    retireCallout +
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e2e8f0;border-radius:10px;border-collapse:separate;overflow:hidden;margin:0 0 28px;">${rows}</table>`
+  )
 }
 
 // ── HTML ──────────────────────────────────────────────────────────────────
@@ -182,6 +229,7 @@ const html = `<!DOCTYPE html>
   <tr><td style="padding:24px 26px;">
     ${changedBand()}
     ${budgetPairs()}
+    ${deadWeightBand()}
     ${flowSection()}
     ${(data.groups || []).map(groupSection).join('')}
     <p style="margin:34px 0 0;padding-top:16px;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:12px;">
@@ -221,10 +269,27 @@ const txtBudget = budget
       ? `   most-overlapping: ${budget.topPairs.map((p) => `/${p.a} ↔ /${p.b} ${p.containment}%`).join(' · ')}\n`
       : '')
   : ''
+const txtDeadWeight = (() => {
+  if (!deadWeight) return ''
+  const f = deadWeight.freshness || {}
+  const stale = deadWeight.stale || []
+  const retire = deadWeight.retireCandidates || []
+  const days = deadWeight.staleDays || 90
+  const note = usageNote(deadWeight.coverage || { judged: false }).replace(/&#?\w+;/g, '')
+  if (!stale.length) return `🪦 DEAD WEIGHT (freshness × usage): ✅ all ${f.tracked || 0} knowledge skills fresh (verified within ${days}d).\n   ${note}\n`
+  const lines = stale.map((s) => {
+    const tags = [s.vanished && `${s.vanished} vanished`, s.overdue && `stamp ${s.ageDays}d`, s.possiblyStale && `${s.possiblyStale} drifted`].filter(Boolean).join(', ')
+    return `   /${s.name} (stamped ${s.stamp}) — ${tags} · ${s.invocations} CI invocations`
+  })
+  const retireLine = retire.length ? `   RETIRE CANDIDATES (stale + 0 CI invocations): ${retire.map((s) => `/${s.name}`).join(', ')}\n` : ''
+  return `🪦 DEAD WEIGHT (freshness × usage) — ${stale.length} stale knowledge skill(s)\n   ${note}\n` + retireLine + lines.join('\n') + '\n'
+})()
 const txt =
   `🧩 SKILLS DIGEST — ${monthYear}\n${repo} · ${total} skills\n` +
   txtBudget +
   '\n' +
+  txtDeadWeight +
+  (txtDeadWeight ? '\n' : '') +
   txtChanged() +
   '\n' +
   txtFlow +

--- a/.github/workflows/skill-freshness-pr.yml
+++ b/.github/workflows/skill-freshness-pr.yml
@@ -1,0 +1,107 @@
+name: Skill freshness (PR advisory)
+
+# Advisory, NON-BLOCKING signal (#1100 WS4). When a PR changes a file that a knowledge skill
+# (the `verified:` provenance contract, #1073/#1091) cites, this posts/updates one sticky
+# comment naming those skills so the author can re-verify the facts and bump the stamp — or
+# knowingly skip it. Deterministic, NO LLM: reuses scripts/skill-freshness.mjs --cite (pure
+# token-vs-path matching). It NEVER fails the check and never mutates a skill — staleness is a
+# signal, not a build failure (the epic's rejected "blocking gate on staleness"). Mirrors the
+# sticky-upsert pattern of pipeline-pr-status.yml.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: skill-freshness-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  advise:
+    # Skip drafts and bot-authored PRs (agent/Dependabot noise).
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the base branch to diff the PR's changed files.
+          fetch-depth: 0
+
+      - name: Map changed files → citing skills
+        id: cite
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          # Changed files in this PR, base...head (three-dot = changes on the PR branch only).
+          git fetch --no-tags --depth=1 origin "$BASE" 2>/dev/null || git fetch --no-tags origin "$BASE"
+          git diff --name-only "origin/$BASE...HEAD" > changed-files.txt || true
+          echo "Changed files:"; cat changed-files.txt || true
+          # Deterministic match → JSON. Never let a match failure fail the job (advisory).
+          node scripts/skill-freshness.mjs --cite < changed-files.txt > skill-citations.json || echo '{"changed":0,"skills":[]}' > skill-citations.json
+          echo "---"; cat skill-citations.json
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const MARKER = '<!-- skill-freshness-advisory -->'
+            const HEADER = '> 🤖 **Claude Code** · agent pipeline (CI) · _skill-freshness advisory_'
+
+            const data = JSON.parse(fs.readFileSync('skill-citations.json', 'utf8'))
+            const skills = data.skills || []
+
+            // Find an existing sticky by its hidden marker.
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 })
+            const existing = comments.find((c) => (c.body || '').includes(MARKER))
+
+            // No cited files touched: clear a prior advisory if one exists, else stay silent
+            // (don't add noise to unrelated PRs).
+            if (!skills.length) {
+              if (existing) {
+                const body = [MARKER, HEADER, '', '### 📚 Skill freshness',
+                  '✅ The latest revision changes no files cited by a knowledge skill.'].join('\n')
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+              }
+              core.info('No skill-cited files changed — nothing to advise.')
+              return
+            }
+
+            const n = skills.length
+            const lines = [
+              MARKER,
+              HEADER,
+              '',
+              `### 📚 This PR changes files cited by ${n} knowledge skill${n === 1 ? '' : 's'}`,
+              '',
+              'These skills cite paths this PR touches. If the change alters what they document,',
+              '**re-verify the facts and bump the `verified:` stamp** (or knowingly skip — this is advisory):',
+              ''
+            ]
+            for (const s of skills) {
+              const cites = s.matched.map((p) => `\`${p}\``).join(', ')
+              const age = s.ageDays != null ? `, stamped ${s.stamp}` : ''
+              lines.push(`- \`/${s.name}\`${age} — cites ${cites}`)
+            }
+            lines.push(
+              '',
+              '_Advisory only — not a merge gate. After re-verifying, run `node scripts/skill-freshness.mjs --pretty` to confirm the skill reads clean._'
+            )
+            const body = lines.join('\n')
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body })
+            }
+            core.info(`Advised on ${n} skill(s).`)

--- a/scripts/skill-freshness.mjs
+++ b/scripts/skill-freshness.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Deterministic skill-freshness checker for .claude/skills/ — no LLM, no deps (epic #1100 WS2).
+ *
+ *   node scripts/skill-freshness.mjs            # concise summary, exit 0 (report-only)
+ *   node scripts/skill-freshness.mjs --pretty   # full per-skill breakdown
+ *   node scripts/skill-freshness.mjs --json      # machine-readable, for the housekeeping band
+ *   node scripts/skill-freshness.mjs --check     # exit 1 ONLY if a skill cites a VANISHED path
+ *
+ * The knowledge-skill library (#1073/#1091) is a set of dated snapshots dense with exactly the
+ * facts that drift (versions, counts, ports, paths). WS1 gave each one a machine-parseable
+ * provenance contract — a `verified: YYYY-MM-DD` stamp + a fenced re-verify bash block. This
+ * checker reads that contract and flags three kinds of drift, purely from `fs` + `git`:
+ *
+ *   • VANISHED (hard-stale)     — a cited path git history knew about but that is gone from the
+ *                                 tree now. A citation pointing at a deleted file is a broken
+ *                                 link; this is the one category `--check` will fail on.
+ *   • POSSIBLY-STALE            — a cited FILE that still exists but has commits dated newer than
+ *                                 the skill's stamp (its content may have moved on since verified).
+ *   • RE-VERIFY DUE             — the stamp itself is > STALE_DAYS (default 90d) old.
+ *
+ * "Cited repo paths" are backtick-quoted, path-shaped tokens (contain a `/` or a known source
+ * extension, no glob/placeholder chars). A token only counts as a citation if it resolves on
+ * disk OR git history knows it — that git-history gate is how we honour the WS1 rule that cited
+ * paths were "verified to exist at authoring time" WITHOUT false-positiving on the many
+ * placeholder/example/glob paths in the prose (`layers/<layer>/...`, `/api/teams/[id]/...`).
+ *
+ * Report-only by design (the epic's rejected alternatives: no blocking CI gate on age, no
+ * scheduled LLM re-audit). `computeSkillFreshness()` is exported so housekeeping/gather.mjs can
+ * surface a "📚 Skill freshness" band on the same rails (#1100 WS3).
+ *
+ * Env:
+ *   SKILL_STALE_DAYS   default 90 — stamp age (days) past which a skill is "re-verify due"
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { execSync } from 'node:child_process'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SKILLS_DIR = join(ROOT, '.claude/skills')
+const DEFAULT_STALE_DAYS = Number(process.env.SKILL_STALE_DAYS || 90)
+
+// Source-file extensions a bare backtick token must carry to be considered a repo path when it
+// has no slash. (A slash alone also qualifies — most citations are `dir/file`.)
+const EXT_RE = /\.(mjs|cjs|mts|cts|ts|tsx|js|jsx|json|jsonc|md|mdx|vue|sh|bash|yml|yaml|css|scss|sass|less|html|txt|sql|toml|env|lock)$/
+// Chars that mark a token as a glob / placeholder / example, never a literal repo path.
+const PLACEHOLDER_RE = /[<>*[\]{}()|$?!~=…\s]/
+
+// ── git helpers (repo-global answers cached across skills) ────────────────────
+const gitCache = new Map()
+function git(args, root) {
+  try {
+    return execSync(`git ${args}`, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+  } catch {
+    return ''
+  }
+}
+/** ISO date (YYYY-MM-DD) of the most recent commit touching `path`, or '' if git knows nothing. */
+function lastCommitDate(path, root) {
+  const key = `d:${path}`
+  if (gitCache.has(key)) return gitCache.get(key)
+  const out = git(`log -1 --format=%cI -- "${path}"`, root)
+  const v = out ? out.slice(0, 10) : ''
+  gitCache.set(key, v)
+  return v
+}
+/**
+ * True if git history in this (possibly shallow) clone has ever recorded `path`.
+ * `--full-history` is required: a plain `git log -- path` applies history simplification and
+ * silently drops a file that was added then later removed (TREESAME to HEAD at both ends), which
+ * is exactly the vanished-citation case we need to catch.
+ */
+function gitKnows(path, root) {
+  const key = `k:${path}`
+  if (gitCache.has(key)) return gitCache.get(key)
+  const v = git(`log --full-history --oneline -1 -- "${path}"`, root) !== ''
+  gitCache.set(key, v)
+  return v
+}
+
+// ── date helpers ──────────────────────────────────────────────────────────────
+const DAY = 86400000
+const isoDay = (d) => d.toISOString().slice(0, 10)
+const daysBetween = (a, b) => Math.floor((Date.parse(a) - Date.parse(b)) / DAY)
+
+// ── path extraction ───────────────────────────────────────────────────────────
+/**
+ * Pull candidate repo-path citations out of a SKILL.md. Tokens live in backtick spans; a span
+ * may be a whole shell command, so we split on whitespace and test each word. Returns a deduped
+ * list of concrete, path-shaped tokens (existence/history is judged later).
+ */
+export function extractCitedPaths(text) {
+  const spans = [...text.matchAll(/`([^`]+)`/g)].map((m) => m[1])
+  const seen = new Set()
+  for (const span of spans) {
+    for (const raw of span.split(/\s+/)) {
+      const tok = normalizeToken(raw)
+      if (tok) seen.add(tok)
+    }
+  }
+  return [...seen]
+}
+
+function normalizeToken(raw) {
+  // Strip markdown / prose punctuation clinging to the ends, keep internal dots+slashes.
+  let t = raw.replace(/^['"(]+/, '').replace(/[),.;:'"]+$/, '')
+  if (!t) return null
+  if (PLACEHOLDER_RE.test(t)) return null          // glob / placeholder / example
+  if (/^[@#/-]/.test(t)) return null                // npm scope, nuxt alias, absolute/route, flag
+  if (/^\.[a-z0-9]+$/i.test(t)) return null          // bare extension like `.vue`
+  const hasSlash = t.includes('/')
+  if (!hasSlash && !EXT_RE.test(t)) return null      // needs a slash OR a source extension
+  return t
+}
+
+// ── per-skill classification ──────────────────────────────────────────────────
+function parseStamp(text) {
+  const m = text.match(/^verified:\s*(\d{4}-\d{2}-\d{2})\s*$/m)
+  return m ? m[1] : null
+}
+const hasProvenanceSection = (text) => /^#{1,6}\s*Provenance and maintenance\s*$/im.test(text)
+
+function classifySkill({ name, file, text, today, staleDays, root }) {
+  const stamp = parseStamp(text)
+  // Not a provenance-carrying knowledge skill → out of scope for freshness tracking.
+  if (!stamp) {
+    return hasProvenanceSection(text)
+      ? { name, file, tracked: true, malformed: true, reason: 'Provenance section present but no parseable `verified: YYYY-MM-DD` stamp' }
+      : { name, file, tracked: false }
+  }
+
+  const ageDays = daysBetween(today, stamp)
+  const overdue = ageDays > staleDays
+
+  const vanished = []
+  const possiblyStale = []
+  let citationCount = 0
+
+  for (const path of extractCitedPaths(text)) {
+    const abs = join(root, path)
+    if (existsSync(abs)) {
+      citationCount++
+      // Directories churn constantly (a dir's "last commit" is almost always recent), so a dir
+      // is never "possibly-stale" — only a concrete FILE citation carries that signal.
+      let isFile = false
+      try { isFile = statSync(abs).isFile() } catch { /* race — treat as non-file */ }
+      if (isFile) {
+        const last = lastCommitDate(path, root)
+        if (last && last > stamp) possiblyStale.push({ path, lastCommit: last })
+      }
+    } else if (gitKnows(path, root)) {
+      // Concrete path git history recorded, now absent → the citation points at a deleted file.
+      citationCount++
+      vanished.push(path)
+    }
+    // else: never-tracked token (placeholder/example/shorthand) → not a citation, skip.
+  }
+
+  possiblyStale.sort((a, b) => a.path.localeCompare(b.path))
+  vanished.sort()
+  return { name, file, tracked: true, malformed: false, stamp, ageDays, overdue, citationCount, vanished, possiblyStale }
+}
+
+// ── discovery ─────────────────────────────────────────────────────────────────
+function discoverSkillFiles(skillsDir) {
+  const out = []
+  for (const entry of readdirSync(skillsDir)) {
+    const p = join(skillsDir, entry)
+    let st
+    try { st = statSync(p) } catch { continue }
+    if (st.isDirectory()) {
+      const f = join(p, 'SKILL.md')
+      if (existsSync(f)) out.push({ name: entry, file: f })
+    } else if (entry.endsWith('.md')) {
+      out.push({ name: entry.replace(/\.md$/, ''), file: p })
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+/**
+ * Compute skill-freshness for every provenance-stamped skill. Pure fs+git; safe to import.
+ * @param {{ root?: string, skillsDir?: string, today?: string, staleDays?: number }} [opts]
+ */
+export function computeSkillFreshness(opts = {}) {
+  const root = opts.root || ROOT
+  const skillsDir = opts.skillsDir || join(root, '.claude/skills')
+  const today = opts.today || isoDay(new Date())
+  const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS
+
+  const shallow = git('rev-parse --is-shallow-repository', root) === 'true'
+  const all = discoverSkillFiles(skillsDir).map((s) =>
+    classifySkill({ ...s, text: readFileSync(s.file, 'utf8'), today, staleDays, root })
+  )
+
+  const skills = all.filter((s) => s.tracked)
+  const malformed = skills.filter((s) => s.malformed)
+  const stamped = skills.filter((s) => !s.malformed)
+  const summary = {
+    scanned: all.length,
+    tracked: skills.length,
+    malformed: malformed.length,
+    vanished: stamped.reduce((n, s) => n + s.vanished.length, 0),
+    possiblyStale: stamped.reduce((n, s) => n + s.possiblyStale.length, 0),
+    overdue: stamped.filter((s) => s.overdue).length
+  }
+  return { today, staleDays, shallow, summary, skills: stamped, malformed }
+}
+
+const hasIssues = (s) => s.vanished.length || s.possiblyStale.length || s.overdue
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+const runDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (runDirectly) {
+  const argv = process.argv.slice(2)
+  const result = computeSkillFreshness()
+  const { today, staleDays, shallow, summary, skills, malformed } = result
+
+  if (argv.includes('--json')) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+    process.exit(0)
+  }
+
+  const flagged = skills.filter(hasIssues)
+  const pretty = argv.includes('--pretty')
+
+  console.log(`📚 Skill freshness — ${today} (stamp horizon ${staleDays}d)`)
+  console.log(
+    `   ${summary.tracked} stamped skill(s) · ${summary.vanished} vanished · ` +
+      `${summary.possiblyStale} possibly-stale · ${summary.overdue} re-verify due` +
+      (summary.malformed ? ` · ${summary.malformed} malformed` : '')
+  )
+  if (shallow && summary.vanished === 0) {
+    console.log('   ⚠️  shallow clone — vanished-path detection is limited to history in this checkout')
+  }
+
+  for (const s of malformed) console.log(`\n⚠️  /${s.name} — ${s.reason}`)
+
+  const show = pretty ? skills : flagged
+  for (const s of show) {
+    const badge = s.vanished.length ? '🔴' : s.possiblyStale.length ? '🟡' : s.overdue ? '🔵' : '🟢'
+    console.log(`\n${badge} /${s.name} — stamped ${s.stamp} (${s.ageDays}d ago), ${s.citationCount} citation(s)`)
+    if (s.overdue) console.log(`   🔵 re-verify due: stamp is ${s.ageDays}d old (> ${staleDays}d)`)
+    for (const p of s.vanished) console.log(`   🔴 vanished: \`${p}\` — cited path no longer exists`)
+    for (const { path, lastCommit } of s.possiblyStale)
+      console.log(`   🟡 possibly-stale: \`${path}\` — commit ${lastCommit} newer than stamp ${s.stamp}`)
+    if (pretty && !hasIssues(s)) console.log('   🟢 fresh')
+  }
+
+  if (!pretty && !flagged.length && !malformed.length) console.log('\n✨ All stamped skills are fresh.')
+
+  // `--check`: fail ONLY on a broken citation (vanished path). Age + drift stay signals, never a
+  // build failure — the epic explicitly rejects a blocking gate on staleness.
+  if (argv.includes('--check')) {
+    if (summary.vanished > 0) {
+      console.error(
+        `\n✗ ${summary.vanished} vanished citation(s) across ${flagged.filter((s) => s.vanished.length).length} skill(s). ` +
+          `Re-verify and re-stamp, or fix the path.`
+      )
+      process.exit(1)
+    }
+    console.log('\n✓ No broken (vanished) skill citations.')
+  }
+}

--- a/scripts/skill-freshness.mjs
+++ b/scripts/skill-freshness.mjs
@@ -6,6 +6,8 @@
  *   node scripts/skill-freshness.mjs --pretty   # full per-skill breakdown
  *   node scripts/skill-freshness.mjs --json      # machine-readable, for the housekeeping band
  *   node scripts/skill-freshness.mjs --check     # exit 1 ONLY if a skill cites a VANISHED path
+ *   git diff --name-only base...HEAD | \
+ *     node scripts/skill-freshness.mjs --cite    # JSON: which skills cite the changed paths (WS4)
  *
  * The knowledge-skill library (#1073/#1091) is a set of dated snapshots dense with exactly the
  * facts that drift (versions, counts, ports, paths). WS1 gave each one a machine-parseable
@@ -212,10 +214,68 @@ export function computeSkillFreshness(opts = {}) {
 
 const hasIssues = (s) => s.vanished.length || s.possiblyStale.length || s.overdue
 
+/**
+ * Given a set of changed repo-relative paths (e.g. a PR's diff), return the stamped skills that
+ * CITE one of them — the input to the advisory PR signal (#1100 WS4). Deterministic, no git.
+ *
+ * A skill cites a changed file when one of its extracted path tokens either exactly equals the
+ * changed path (a FILE citation) or is a directory prefix of it (a DIR citation) — but a dir
+ * token must be ≥3 segments deep so broad tokens like `packages/` or `apps/` don't firehose
+ * every PR. File vs dir is inferred from the source extension (files carry one; dir citations
+ * don't).
+ * @param {string[]} changedPaths
+ * @param {{ root?: string, skillsDir?: string, today?: string }} [opts]
+ */
+export function computeCitingSkills(changedPaths, opts = {}) {
+  const root = opts.root || ROOT
+  const skillsDir = opts.skillsDir || join(root, '.claude/skills')
+  const today = opts.today || isoDay(new Date())
+  const changed = [...new Set(changedPaths.map((p) => p.trim()).filter(Boolean))]
+
+  const segs = (t) => t.replace(/\/+$/, '').split('/').length
+  const isDirToken = (t) => !EXT_RE.test(t.replace(/\/+$/, ''))
+  const matchesToken = (cp, tok) => {
+    const t = tok.replace(/\/+$/, '')
+    if (cp === t) return true
+    return isDirToken(tok) && segs(tok) >= 3 && cp.startsWith(t + '/')
+  }
+
+  const out = []
+  for (const { name, file } of discoverSkillFiles(skillsDir)) {
+    const text = readFileSync(file, 'utf8')
+    const stamp = parseStamp(text)
+    if (!stamp) continue // only provenance-stamped skills carry a re-verify contract
+    const tokens = extractCitedPaths(text)
+    const matched = changed.filter((cp) => tokens.some((tok) => matchesToken(cp, tok)))
+    if (matched.length) out.push({ name, stamp, ageDays: daysBetween(today, stamp), matched: matched.sort() })
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/** Read newline-separated paths from stdin (for the `--cite` CI pipe). */
+function readStdinLines() {
+  try {
+    return readFileSync(0, 'utf8').split('\n').map((l) => l.trim()).filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
 // ── CLI ───────────────────────────────────────────────────────────────────────
 const runDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
 if (runDirectly) {
   const argv = process.argv.slice(2)
+
+  // --cite: map changed paths (positional args, else newline-separated stdin) → citing skills.
+  // Emits JSON for the advisory PR workflow (#1100 WS4). No git; purely token-vs-path matching.
+  if (argv.includes('--cite')) {
+    const positional = argv.filter((a) => !a.startsWith('--'))
+    const changed = positional.length ? positional : readStdinLines()
+    const skills = computeCitingSkills(changed)
+    process.stdout.write(JSON.stringify({ today: isoDay(new Date()), changed: changed.length, skills }, null, 2) + '\n')
+    process.exit(0)
+  }
+
   const result = computeSkillFreshness()
   const { today, staleDays, shallow, summary, skills, malformed } = result
 


### PR DESCRIPTION
Closes #1100

## 👤 For humans

The knowledge-skill library (#1073/#1091) is a set of dated snapshots dense with exactly the facts that drift — versions, counts, ports, paths, issue states. Nothing re-checked them against the repo, so a stale skill could actively mislead a cold session (the recurring #504 failure mode). This makes drift **visible on the rails we already read** — deterministically, with no LLM.

Three signals, computed purely from the filesystem + git against each skill's `verified:` provenance stamp:
- 🔴 **vanished** — a cited path git history knew but that's now gone (a broken citation)
- 🟡 **possibly-stale** — a cited file with commits newer than the stamp
- 🔵 **re-verify due** — the stamp itself is >90 days old

…surfaced in three places: the **housekeeping** digest, an **advisory PR comment**, and a **retire-candidate** band (stale × unused) in the monthly **skills-digest**. All report-only — staleness is a signal, never a build failure.

## 🤖 For agents — workstreams

- **WS1** (provenance contract) — already applied to the 13 crouton-* skills by PR #1091 (the test corpus).
- **WS2** — `scripts/skill-freshness.mjs`: extracts backtick, path-shaped citations; a token counts only if it resolves on disk **or** git history knows it (`git log --full-history`, so an added-then-removed file is still caught) — the deterministic proxy for "verified to exist at authoring time" that filters out glob/placeholder examples. Modes: default summary / `--pretty` / `--json` / `--check` / `--cite`. `--check` fails **only** on vanished (a broken link); age/drift stay signals. Exports `computeSkillFreshness()` + `computeCitingSkills()`.
- **WS3** — housekeeping `gather.mjs` + `render.mjs`: new "📚 Skill freshness" band, omitted when clean, null-safe.
- **WS4** — `.github/workflows/skill-freshness-pr.yml`: on `pull_request`, diffs `base...HEAD`, runs `--cite`, upserts one sticky advisory comment (exact-file or ≥3-segment dir-prefix match so `packages/`/`apps/` don't firehose). Bot-account provenance; never fails the check.
- **WS5** — skills-digest `gather.mjs` + `render.mjs`: "🪦 Dead weight" band joins freshness with the loop-station usage rollup (`usage.jsonl`, #1064). Retire candidate = (overdue ∥ vanished) AND 0 CI invocations, **only** when `usageCoverage().judged` — never judges unused blind; pipeline-scope caveat (#1067) stated on the band.

Commits kept atomic (one per workstream) for archaeology — `f5adf17` · `09fe567` · `36705d5` · `2d5a186`.

## 🧪 How to test

1. **Checker:** `node scripts/skill-freshness.mjs --pretty` → all 13 stamped skills 🟢 fresh, exit 0.
2. **Vanished:** add a backtick path to a stamped SKILL.md that git knows but is deleted (e.g. `docs/server/api/ping.get.ts`) → 🔴 vanished, and `--check` exits 1.
3. **Overdue:** set an old `verified:` date on any skill → 🔵 re-verify due.
4. **Citation match:** `git diff --name-only main...HEAD | node scripts/skill-freshness.mjs --cite` → JSON of skills citing the changed files (this PR self-fires on `crouton-config-registry` ↔ `.claude/skills/housekeeping/gather.mjs`).
5. **Housekeeping band:** inject a flagged `skillFreshness` payload into the data JSON → `render.mjs` shows the "📚 Skill freshness" section; clean payload omits it.
6. **Dead-weight band:** `node .claude/skills/skills-digest/render.mjs .claude/skills/skills-digest/example.data.json --out-dir /tmp/sd` → the "🪦 Dead weight" band with a retire candidate; on the real repo today it renders "✅ all 13 fresh · retire verdicts withheld" (no usage rollup yet).

**Not in scope (deliberate):** executing the re-verify bash blocks automatically, an LLM re-audit, and a blocking CI gate on staleness — all rejected in the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0118w8Zvz5FNf8RwANVeFkhm)_