### PR TITLE
docs(root): add the epic Decisions log convention to github-tasks

### DIFF
--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -48,13 +48,35 @@ A **"why not" is as load-bearing as a "why"** — it's the evidence the chosen p
 
 - Add a short **`Considered & rejected`** note — one line per option: `option → ❌ why not`. It lives in the **🤖 For agents** block by default (or its own small block, or a comment on the issue/epic).
 - **Required only when alternatives were actually weighed** — trivial chores opt out (same as the hypothesis framing).
-- The **epic** is the natural home for a cross-cutting "why not": post it as a comment *when the decision is made*, while the reasoning is fresh.
+- The **epic** is the natural home for a cross-cutting "why not" — record it in the epic's **Decisions log** (below), *when the decision is made*, while the reasoning is fresh.
 
 Worked example (from epic #392):
 > **Considered & rejected — E2E perf**
 > - Bump Playwright workers → ❌ the harness shares one dev server + SQLite *per job*; parallel workers race on mutated state → flaky.
 > - Shared "build packages once" prebuild job → ❌ serialises a parallel matrix; saves CI *minutes*, not wall-clock.
 > - Cache the built packages → ❌ a stale cache makes the regression smoke pass *falsely* — defeating its purpose.
+
+## The epic's Decisions log (capture the call *when it's made*)
+
+`Considered & rejected` catches the alternatives you weighed **when you write the issue**. But the decisions that leak worst are the ones made **halfway through the work** — "team-scope at the query layer", "layout composition is deterministic, not LLM", "fake the payment in the POC". At authoring time they don't exist yet, so no up-front section can catch them; by close they're lost to chat.
+
+So every epic carries a running **`## 🧭 Decisions`** log — in the epic body, or a maintained pinned comment on the epic — that you **append to the moment a real design call is made**, mid-work, while the reasoning is fresh. It's the *same reflex* as updating a POC's `HANDOFF.md` / `spec.json` at a sign-off (the `spec` skill), pointed at the epic: one concept, two homes.
+
+**The format** — newest at the bottom, one line per decision:
+
+```
+[YYYY-MM-DD] Decision → why → (Rejected: X — why not)
+```
+
+**Append-only — reversals are kept, never edited away.** This is the one deliberate difference from the POC `spec.json`, which *supersedes* (newest wins, prune the stale entry — "this is how it behaves *now*"). A decision log does the opposite: when a decision is later reversed, append a **new** line recording the reversal and the rule learned — don't touch the original. The reversal *is* the lesson, exactly as `AGENTS.md` demands ("negative results are first-class data — record the reversal and extract the rule, don't delete it"). A ledger that erases its own reversals is the re-litigation trap wearing a fresh coat.
+
+**Keep it a habit, not a gate.** Like the hypothesis framing, this is a strongly-modeled convention with a worked example — *not* a required section and *not* hook-enforced. Decision capture dies the instant it's a box you tick to unblock a merge (you get "N/A" and "see chat"). Trivial epics opt out.
+
+Worked example (a running log on an epic):
+> ## 🧭 Decisions
+> - [2026-06-14] Team-scope at the **query layer** (drizzle `where team_id`), not per-route middleware → one choke-point you can't forget to add on a new endpoint → (Rejected: per-route guard — trivially omitted on the next route added; Rejected: DB row-level security — D1/SQLite has none).
+> - [2026-06-20] POC default layout is **deterministic** (`layout-compose.ts` rules), not LLM-generated → reproducible, reviewable, no token cost on every boot → (Rejected: LLM "place the blocks" — non-deterministic and slow, can't diff two runs).
+> - [2026-06-28] **Reversed** the 06-14 call *for the reporting endpoints only*: they team-scope in **middleware** after all → their cross-collection joins made per-query scoping duplicative and error-prone → rule learned: query-layer scoping for single-collection reads, middleware for joins.
 
 ## How to test (REQUIRED on every closeable issue/PR — written for a human)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,10 @@ reveal its own gaps; running the real thing next to the contract can.
 *We think that* if X then Y · *We'll do that by* … · *We'll be right if* … · *We'll know by* …
 
 **Record what you didn't do** — when alternatives were real, a `Considered & rejected` note
-(`option → ❌ why not`) stops future-us re-litigating it.
+(`option → ❌ why not`) stops future-us re-litigating it. That note is authoring-time; the calls made
+*mid-work* go in the epic's running **Decisions log** — one dated line (`decision → why → rejected`)
+appended *when the call is made*, **append-only so reversals stay visible** (a reversed decision gets a
+new line, never an edit — the reversal is the lesson, per *Observe the harness*). It's a habit, not a gate.
 
 **Two audiences**, in this order: **👤 humans** lead — plain language, what changed + why it matters
 (a diagram only if it clarifies); **🤖 agents** — scope, exact paths/symbols, behaviour, acceptance,


### PR DESCRIPTION
Closes #1125.

## 👤 For humans

Design calls made halfway through the work used to vanish into chat. Epics now carry a running **`## 🧭 Decisions`** log you append to *the moment a call is made* — append-only, so a later reversal stays visible instead of erasing the lesson. It's a habit with a worked example, **not** a required field or a merge-blocking gate.

This extends #399 (which added the authoring-time *Considered & rejected* note) with the mid-work half that #399 couldn't catch — by definition, those decisions don't exist yet when the issue is written.

## 🤖 For agents

- **`.claude/skills/github-tasks/SKILL.md`** — new *"The epic's Decisions log"* section: format `[date] Decision → why → (Rejected: X — why not)`, the mid-work trigger (same reflex as updating a POC's `spec.json`/`HANDOFF.md` at sign-off), the append-only / keep-reversals rule, the habit-not-gate framing, and a worked example. Bridged the existing *Considered & rejected* epic bullet into it.
- **`AGENTS.md`** — extended *"Record what you didn't do"* with the mid-work living-log principle (append-only; the reversal is the lesson, per *Observe the harness*).

**Deliberate design (the `Considered & rejected` for this change):**
- No `decisions.json` structured ledger → the POC `spec.json` earns its JSON because `/graduate` walks it; an epic log has no mechanical consumer, so markdown.
- No superseding/`status` model → append-only keeps reversals visible; superseding would erase the lesson.
- No hook / required section → decision capture dies the instant it's a merge-unblocking box.

## 🧪 How to test

1. Open `.claude/skills/github-tasks/SKILL.md` → confirm the `## 🧭 Decisions` section exists with the line format, mid-work trigger, and the append-only / keep-reversals rule stated explicitly.
2. Confirm it distinguishes itself from the POC `spec.json` (append vs supersede) so the two don't blur.
3. Confirm a worked example (a real 3-line decision log) is present.
4. `node scripts/gen-skills-doc.mjs --check` passes (verified locally — no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGZ72QgVGaxte46ivRiPy5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGZ72QgVGaxte46ivRiPy5)_