### PR TITLE
docs(root): note how to scan issues without overflowing context

### DIFF
--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -154,6 +154,8 @@ Issues, sub-issues, and labels are managed through the GitHub MCP tools:
 - Link a child under a parent: `mcp__github__sub_issue_write` (`method: add`, `issue_number` = parent, `sub_issue_id` = the child's **id** from its create response — not its number).
 - Read / list: `mcp__github__issue_read`, `mcp__github__list_issues`, `mcp__github__search_issues`.
 
+**Scan without overflowing the context.** A broad `list_issues` / `search_issues` (e.g. `labels: ["epic"]`, or a keyword search with no `in:title`) can return a 90k–140k-char blob that overflows the tool result and has to be sliced out-of-band — pure wasted turns. For any repo-wide scan (the dedup and epic walk-up steps are where this bites): pass **`minimal_output: true`**, keep **`perPage` small (5–10)**, and prefer **`in:title`** filters over broad body matches. Only widen when a narrow query genuinely misses.
+
 **Labels must already exist** before you can apply them — applying an unknown label errors. New labels are added via labels-as-code (below), not by the API.
 
 **Projects v2 boards can't be created or managed via these tools** (UI-only). Tell the user to create the board in the web/iOS app; if they enable the project's "Auto-add" workflow, issues you create land on the board automatically.

--- a/.claude/skills/issue-dedup/SKILL.md
+++ b/.claude/skills/issue-dedup/SKILL.md
@@ -42,8 +42,10 @@ mcp__github__list_issues    labels: ["epic"]      # scan epic titles for overlap
 ```
 
 Run a couple of phrasings — exact-title and broad-body — and include `state:closed` in at
-least one. `search_issues` output can be large; if it overflows, narrow the query or filter
-to titles rather than dumping everything.
+least one. **Keep results in-context:** these calls overflow easily (a bare `list_issues
+labels:["epic"]` came back at ~140k chars), so pass **`minimal_output: true`**, a small
+**`perPage` (5–10)**, and prefer **`in:title`** filters — only widen if a narrow query misses.
+If output still overflows, narrow further rather than slicing the blob out-of-band.
 
 ### 3. Surface the matches to the human (number · state · why-similar)
 


### PR DESCRIPTION
Closes #1132.

## 👤 For humans

Broad GitHub issue scans — the ones the dedup gate and epic walk-up run — sometimes come back as 90k–140k-character blobs that overflow the tool result and have to be sliced apart by hand, burning turns. (Happened twice while working the parent epic #1129.) Both skills now tell you to *ask for less up front*.

## 🤖 For agents

- **`.claude/skills/github-tasks/SKILL.md`** — new bullet in *"How to create them (tools)"*: for any repo-wide `list_issues`/`search_issues`, pass `minimal_output: true`, keep `perPage` small (5–10), and prefer `in:title` over broad body matches; widen only if a narrow query misses.
- **`.claude/skills/issue-dedup/SKILL.md`** — concretised the existing overflow line in step 2 with the same params (it previously said only "narrow the query"; now it names the settings and cites the ~140k-char `list_issues labels:["epic"]` case).

Docs-only, no behaviour change.

## 🧪 How to test

1. Open `.claude/skills/github-tasks/SKILL.md` → the tools section names `minimal_output: true` + tight `perPage` + `in:title` for broad scans.
2. Open `.claude/skills/issue-dedup/SKILL.md` step 2 → the overflow guidance names the same settings.
3. `node scripts/gen-skills-doc.mjs --check` passes (verified locally — no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGZ72QgVGaxte46ivRiPy5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGZ72QgVGaxte46ivRiPy5)_