### PR TITLE
fix(root): raise @claude max-turns to 100 for build-class tasks (#658)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 25 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          claude_args: "--max-turns 100 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           show_full_output: true
 
       # Loop Station WS2 (#929) / usage rollup (#1064): ship this runner's


### PR DESCRIPTION
Part of #610 — the next #658 proof-run defect, now with a clean error name.

## 👤 For humans

With credits topped up, attempt 7 of the pins build did real work for 3m44s and then died at **"Reached maximum number of turns (25)"** (run [28653964106](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28653964106)) — 25 turns covers a Q&A reply, not a scaffold + generate + typecheck + PR build. The 60-minute job timeout (#1117) remains the cost/runaway backstop.

## 🤖 For agents

- `.github/workflows/claude.yml`: `claude_args` `--max-turns 25` → `--max-turns 100`.

## 🧪 How to test

Re-mention `@claude` on [#1114](https://github.com/FriendlyInternet/nuxt-crouton/issues/1114) → the run gets past turn 25 and ends with a pushed branch + PR into `epic/1113-pins`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtHCNa7a7xoainZpnPtN8)_