### PR TITLE
chore(root): pin claude-code-action workflows to claude-sonnet-5

### DIFF
--- a/.claude/routing.json
+++ b/.claude/routing.json
@@ -25,5 +25,5 @@
     { "flow": "prototype-example", "model": "claude-opus-4-8", "why": "exploratory prototype flow — quality over cost (replace with your real flow)" }
   ],
 
-  "_known_gaps": "The top-level workflow loop (claude.yml, decompose-on-issue.yml, fix-ci, the daily sweeps) runs on the claude-code-action DEFAULT model — UNPINNED. Pinning those is a follow-up; once pinned they become routes above."
+  "_known_gaps": "The top-level workflow loop (claude.yml, decompose-on-issue.yml, resume-on-comment, fix-ci-on-failure, a11y[-daily], frontend-review, red-team[-daily], gate-smoke, loop-station-advisor) is now PINNED to claude-sonnet-5 via `--model` in each step's claude_args (#1158, closing the earlier UNPINNED gap that let the action default to the older claude-sonnet-4-6). `--model` sets only the MAIN loop; Task-spawned sub-agents still resolve their own frontmatter model (task-worker = opus). OPEN: whether a sub-agent's `model: sonnet` frontmatter alias also resolves to sonnet-4-6 in the pinned action SHA — verify against a post-merge run's modelUsage and, if so, pin the full id in frontmatter too."
 }

--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -54,7 +54,7 @@ jobs:
           # deep sweep couldn't write its report, update the standing issue, or file a11y issues.
           # Broader than the per-PR gate's allowlist because this run also files GitHub issues
           # (MCP) + writes reports; the gate-package-edits hook still protects packages/.
-          claude_args: "--max-turns 60 --permission-mode bypassPermissions"
+          claude_args: "--model claude-sonnet-5 --max-turns 60 --permission-mode bypassPermissions"
           prompt: |
             Run the **`/a11y`** skill (`.claude/skills/a11y/SKILL.md`) at
             **depth=deep, scope=repo**. Sweep the `vuejs-accessibility/*` eslint rules across

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -72,7 +72,7 @@ jobs:
           # --allowedTools REQUIRED (#834): the prompt has the top-level agent *act as* the
           # subagent and call Bash/Write directly; headless CI denies un-allowlisted tools, so
           # without this the agent can't write a11y-verdict.json / post the comment → fails OPEN.
-          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **a11y subagent** defined in `.claude/agents/a11y.md`.
             Input: { scope: "diff", depth: "quick", fix: false }.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--max-turns 100 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          claude_args: "--model claude-sonnet-5 --max-turns 100 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           show_full_output: true
 
       # Loop Station WS2 (#929) / usage rollup (#1064): ship this runner's

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: "/task-decompose #${{ github.event.issue.number }}"
-          claude_args: "--max-turns 30"
+          claude_args: "--model claude-sonnet-5 --max-turns 30"
           show_full_output: true
           # WS5 (#535): the `delegate` label is now applied by the Nuxt Harness App, so this run is
           # actored as nuxt-harness[bot]. Allow exactly that bot past the bot-actor guard — nothing

--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
-          claude_args: "--max-turns 30"
+          claude_args: "--model claude-sonnet-5 --max-turns 30"
           show_full_output: true
           prompt: |
             CI failed on this pipeline PR — you are the fix-bot. This is auto-fix attempt

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -71,7 +71,7 @@ jobs:
           # bytes written. Bash covers `gh` (comment) + writing the verdict; Write/Edit for the
           # file; Read/Grep/Glob for the scan. Bump max-turns now that turns aren't wasted on
           # denied retries. NB: a11y.yml / red-team.yml share this exact latent bug.
-          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **frontend-review subagent** defined in `.claude/agents/frontend-review.md`.
             Input: { scope: "diff", depth: "quick", fix: false }.

--- a/.github/workflows/gate-smoke.yml
+++ b/.github/workflows/gate-smoke.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
-          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **${{ matrix.gate }} subagent** defined in
             `.claude/agents/${{ matrix.gate }}.md`.

--- a/.github/workflows/loop-station-advisor.yml
+++ b/.github/workflows/loop-station-advisor.yml
@@ -61,7 +61,7 @@ jobs:
           # create/update issues via tool calls directly; headless CI denies un-allowlisted
           # tools, so without the grant the agent can't file the issue — the sweep-shaped
           # form, same as a11y-daily.yml / red-team-daily.yml.
-          claude_args: "--max-turns 12 --permission-mode bypassPermissions"
+          claude_args: "--model claude-sonnet-5 --max-turns 12 --permission-mode bypassPermissions"
           prompt: |
             You are the **Loop Station advisor** (#933). Read `advisor-findings.json` in
             the repo root — it lists DETERMINISTIC findings about the harness's own

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -57,7 +57,7 @@ jobs:
           # deep sweep couldn't write its report, update the standing issue, or file security
           # issues. Broader than the per-PR gate's allowlist because this run also files GitHub
           # issues (MCP) + writes reports; the gate-package-edits hook still protects packages/.
-          claude_args: "--max-turns 60 --permission-mode bypassPermissions"
+          claude_args: "--model claude-sonnet-5 --max-turns 60 --permission-mode bypassPermissions"
           prompt: |
             Run the **`/red-team`** skill (`.claude/skills/red-team/SKILL.md`) at
             **depth=deep, scope=repo**. Fan out the `red-team` subagent across the

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -64,7 +64,7 @@ jobs:
           # --allowedTools REQUIRED (#834): the prompt has the top-level agent *act as* the
           # subagent and call Bash/Write directly; headless CI denies un-allowlisted tools, so
           # without this the agent can't write red-team-verdict.json / post the comment → fails OPEN.
-          claude_args: "--max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **red-team subagent** defined in `.claude/agents/red-team.md`.
             Input: { scope: "diff", depth: "quick" }.

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -47,7 +47,7 @@ jobs:
             The owner has replied to a blocking question — read the full issue comment
             thread (the latest comment is their answer), incorporate it, remove the
             `status:blocked` label, then continue via /task-decompose #${{ github.event.issue.number }}.
-          claude_args: "--max-turns 30"
+          claude_args: "--model claude-sonnet-5 --max-turns 30"
           show_full_output: true
 
       # Ship the payload-free invocation trace for the weekly usage rollup (#1064).


### PR DESCRIPTION
Closes #1158. Part of #669 (WS6 — model routing); closes the follow-up gap recorded in `.claude/routing.json` `_known_gaps` (built in #864).

## 👤 For humans

The Anthropic Console showed ~15M tokens/day on **`claude-sonnet-4-6`** — not intended. Every `anthropics/claude-code-action` step passed **no `--model`**, so it ran the action's *default* (older Sonnet) instead of Sonnet 5. Only the `pi` lane (`decompose-on-issue-pidev`) ever pinned `claude-sonnet-5`. This pins the main CI/agent lane to `claude-sonnet-5` so both lanes match.

Two things this is **not**, confirmed from the Jul-2 run records:
- **Not a runner problem.** Every LLM job ran on `runner_name: "mac-mini"` — no fallback to GitHub runners.
- **Not the daily-sweep failures.** `red-team-daily` / `a11y-daily` were fast-failing with `Credit balance is too low` (a `billing_error`), resolved out-of-band by a credit top-up — separate cause, no code change.

## 🤖 For agents — what changed

Added `--model claude-sonnet-5` to `claude_args` on all **11** claude-code-action steps:

`claude.yml` · `decompose-on-issue.yml` · `resume-on-comment.yml` · `fix-ci-on-failure.yml` · `a11y.yml` · `a11y-daily.yml` · `frontend-review.yml` · `red-team.yml` · `red-team-daily.yml` · `gate-smoke.yml` · `loop-station-advisor.yml`

- `--model` sets only the **main** loop; Task-spawned sub-agents keep their frontmatter model, so **`task-worker` stays on opus** (code-writing) and the cheap `pi` a11y sweep stays on **haiku** — only the `sonnet-4-6` leak moves to `sonnet-5`.
- Refreshed `routing.json` `_known_gaps` to record the pin; `gen-routing.mjs --check` passes (no route/tier drift).

## Open follow-up

The review sub-agents (`red-team`/`a11y`/`frontend-review`) set `model: sonnet` in frontmatter. If that alias *also* resolves to `sonnet-4-6` in the pinned action SHA (`c26cb64…`), a follow-up pins the full id in frontmatter too.

## 🧪 How to test

1. Merge → a `claude-code-action` workflow fires on the next PR / `@claude` / decompose.
2. Check that run's `modelUsage` (or the Anthropic Console the next day).
3. **Expected:** the `claude-sonnet-4-6` line collapses into `claude-sonnet-5`; `opus`/`haiku` unchanged. Any residual `sonnet-4-6` = the sub-agent frontmatter alias (the open follow-up above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9YNyHGqg4PoWYKe1uA5wW

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9YNyHGqg4PoWYKe1uA5wW)_