### PR TITLE
fix(crouton-core): make row actions visible on touch devices (#1162)

### DIFF
--- a/packages/crouton-core/app/components/DefaultCard.vue
+++ b/packages/crouton-core/app/components/DefaultCard.vue
@@ -197,7 +197,7 @@ const cardUi = computed(() => {
       v-if="!stateless"
       delete
       update
-      class="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+      class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity shrink-0"
       @delete="handleDelete"
       @update="handleEdit"
     />
@@ -256,7 +256,7 @@ const cardUi = computed(() => {
               v-if="!stateless"
               delete
               update
-              class="opacity-0 group-hover:opacity-100 transition-opacity"
+              class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity"
               @delete="handleDelete"
               @update="handleEdit"
             />
@@ -297,7 +297,7 @@ const cardUi = computed(() => {
           v-if="!stateless"
           delete
           update
-          class="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+          class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity shrink-0"
           @delete="handleDelete"
           @update="handleEdit"
         />

--- a/packages/crouton-core/app/components/KanbanColumn.vue
+++ b/packages/crouton-core/app/components/KanbanColumn.vue
@@ -231,7 +231,7 @@ const crouton = useCrouton()
           </div>
 
           <!-- Action buttons (show on hover) -->
-          <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <div class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity">
             <CroutonItemButtonsMini
               delete
               update

--- a/packages/crouton-core/app/components/TreeNode.vue
+++ b/packages/crouton-core/app/components/TreeNode.vue
@@ -450,7 +450,7 @@ onBeforeUnmount(() => {
       />
 
       <!-- Actions dropdown -->
-      <div v-if="!hideActions && !isGhost" class="opacity-0 group-hover:opacity-100 transition-opacity">
+      <div v-if="!hideActions && !isGhost" class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity">
         <UDropdownMenu
           :items="getItemActions(item)"
           :content="{ align: 'end' }"
@@ -467,7 +467,7 @@ onBeforeUnmount(() => {
       </div>
 
       <!-- Inline add dropdown (replaces full-width bar) -->
-      <div v-if="showAddButton && !isGhost" class="opacity-0 group-hover:opacity-100 transition-opacity">
+      <div v-if="showAddButton && !isGhost" class="opacity-0 group-hover:opacity-100 pointer-coarse:opacity-100 transition-opacity">
         <UDropdownMenu
           :items="getAddActions(item)"
           :content="{ align: 'end' }"


### PR DESCRIPTION
Closes #1162. Surgical bucket-A fix per the [analysis](https://github.com/FriendlyInternet/nuxt-crouton/issues/1162#issuecomment-4876875532); the remaining ~60 sites are tracked in #1163.

## 👤 For humans

Edit/delete buttons in the list/grid/cards/tree/kanban layouts only appeared on mouse hover — on phones/tablets they were permanently invisible (Tailwind v4 gates `group-hover` behind hover-capable media), making every crouton collection look read-only on mobile. Found live on pins.pmcp.dev during the #658 proof walk. Fix: the affordances stay hover-revealed on mouse devices and become always-visible on touch.

## 🤖 For agents

- `packages/crouton-core/app/components/DefaultCard.vue` (×3), `TreeNode.vue` (×2), `KanbanColumn.vue` (×1): appended `pointer-coarse:opacity-100` to each `opacity-0 group-hover:opacity-100` cluster. Pure template class change, no logic.
- Pattern precedent: `crouton-sales/Client/CategoryTabs.vue` (PR #981). `pointer-coarse:` = Tailwind v4.1 `@media (pointer: coarse)` (available via `@nuxt/ui ^4.9.0`).
- `pnpm -r --filter './apps/*' typecheck` green after the change.
- Package edit approved by @pmcp in-session (scope call on #1162: option A, crouton-core now).

## 🧪 How to test

1. After merge: refresh `epic/1113-pins` from `main` and redeploy pins (deploy-pocs dispatch) → open https://pins.pmcp.dev on a phone → each row in the list shows edit/delete buttons without any hover.
2. Desktop: hover-reveal behavior unchanged (buttons still fade in on row hover).
3. Same check applies to tree and kanban layouts in any consuming app.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtHCNa7a7xoainZpnPtN8)_