### PR TITLE
docs: align nuxt-harness marketing page with the project's strategic thesis

### DIFF
--- a/writeups/marketing/nuxt-harness.html
+++ b/writeups/marketing/nuxt-harness.html
@@ -142,6 +142,7 @@
     <a href="#what">What it is</a>
     <a href="#blocks">Building blocks</a>
     <a href="#flow">The flow</a>
+    <a href="#talk">Feedback</a>
     <a href="#why">Why</a>
   </div>
   <a class="btn btn-g" href="#start">Get started →</a>
@@ -314,6 +315,33 @@
   </div>
 </div></section>
 
+<section id="talk"><div class="wrap">
+  <div class="lead">
+    <span class="eyebrow">The conversation</span>
+    <h2>You and the agent talk <em>through the work</em></h2>
+    <p>An agent's whole life is a GitHub issue — it asks for sign-off, posts a preview, and holds for your
+      reply. The Harness gives you richer ways to answer than a text box, and richer ways for it to ask.</p>
+  </div>
+  <div class="grid">
+    <div class="cell"><div class="ic">⌖</div>
+      <h4>Annotate <span>= pin the page</span></h4>
+      <p>Click any element on the live staging preview, type a note — it lands as structured feedback
+        that names the exact source file to change. Point, don't describe. <span class="mono" style="color:var(--faint)">crouton-feedback</span></p></div>
+    <div class="cell"><div class="ic">⌸</div>
+      <h4>Console <span>= inspect anywhere</span></h4>
+      <p>An in-page devtools console (eruda), lazy-loaded on the preview — inspect the running build from
+        your phone, no laptop. Only ships when you ask for it. <span class="mono" style="color:var(--faint)">crouton-feedback</span></p></div>
+    <div class="cell"><div class="ic">▦</div>
+      <h4>Diagrams <span>= not walls of text</span></h4>
+      <p>Epic status as an Excalidraw diagram committed to the issue — renders on GitHub mobile, editable
+        in place, round-trips your edits back. <span class="mono" style="color:var(--faint)">ticket-diagram</span></p></div>
+    <div class="cell"><div class="ic">⇄</div>
+      <h4>One thread, <span>two audiences</span></h4>
+      <p>Every issue and PR speaks to <b style="color:#cdd8ea">humans</b> (plain language, what &amp; why) and
+        to <b style="color:#cdd8ea">agents</b> (paths, symbols, acceptance) — the same durable record.</p></div>
+  </div>
+</div></section>
+
 <section id="why"><div class="wrap">
   <div class="lead">
     <span class="eyebrow">Why it holds together</span>
@@ -324,7 +352,7 @@
     <div class="pillar"><h4><span class="b">⤿</span> Zero drift</h4><p>A regenerate-and-diff CI gate makes divergence impossible. No more hand-copied configs going stale.</p></div>
     <div class="pillar"><h4><span class="b">▤</span> Layered &amp; ownable</h4><p>A base Harness layer + your project layer. Local overrides survive every sync; fixes flow back upstream.</p></div>
     <div class="pillar"><h4><span class="b">◎</span> Tested by evals</h4><p>A probabilistic runtime needs gates + observation. Weekly run-log analysis is the regression suite.</p></div>
-    <div class="pillar"><h4><span class="b">⛁</span> Free on your own hardware</h4><p>Run a small local model via <b>Pi + Ollama</b> on your own box — zero per-token cost, fully private. Your stack, your model, no mandatory SaaS.</p></div>
+    <div class="pillar"><h4><span class="b">⛁</span> Sovereign by default</h4><p>The whole loop runs on <b>your own box</b> — a Mac&nbsp;mini running <b>Pi</b>, woken by GitHub Actions, driving a small local model via <b>Ollama</b>. Zero per-token cost, nothing leaves your infrastructure. Your stack, your model, no mandatory SaaS.</p></div>
     <div class="pillar"><h4><span class="b">⚑</span> Human where it counts</h4><p>It pings you only to decide — sign-offs and unblocks. Status is silent. Your attention is the scarce resource.</p></div>
   </div>
 </div></section>

--- a/writeups/marketing/nuxt-harness.html
+++ b/writeups/marketing/nuxt-harness.html
@@ -138,6 +138,7 @@
 <nav><div class="wrap">
   <div class="logo"><span class="mark">⛓</span> Nuxt&nbsp;Harness</div>
   <div class="navlinks">
+    <a href="#now">Why now</a>
     <a href="#what">What it is</a>
     <a href="#blocks">Building blocks</a>
     <a href="#flow">The flow</a>
@@ -171,6 +172,41 @@
 <span class="c-grn">✓</span> <span class="c-ink">https://my-app.pmcp.dev</span>  <span class="c-mut">auth-working, live</span></pre>
   </div>
 </div></header>
+
+<section id="now"><div class="wrap">
+  <div class="lead">
+    <span class="eyebrow">Why now</span>
+    <h2>Built for where models are <em>going</em> — not where they are</h2>
+    <p>Four bets are being made about the next few years of AI. We don't stake the Harness on any one
+      of them being right. We built it to <b style="color:#cdd8ea">win under all four — and depend on none</b>.</p>
+  </div>
+  <div class="grid">
+    <div class="cell"><div class="ic">$</div>
+      <h4>Cost is a dependency <span>— not a prediction</span></h4>
+      <p>Per-token prices fall; your <em>bill</em> rises anyway — Jevons, the frontier treadmill, and the
+        end of subsidised pricing all push it up. So we don't guess the direction. Determinism buys the
+        cheap, deflating tier — or runs local — instead of dragging every task onto the priciest model.</p></div>
+    <div class="cell"><div class="ic">◷</div>
+      <h4>Gains are slowing <span>where they were easy</span></h4>
+      <p>Pure pretraining scale is hitting a wall — which is why value migrates <em>out</em> of the model
+        and <em>into</em> the scaffold around it. The harder the model is to improve, the more the rails,
+        gates, and generators are worth.</p></div>
+    <div class="cell"><div class="ic">◇</div>
+      <h4>Open models <span>are closing the gap</span></h4>
+      <p>The frontier reaches open weights in months, not years. <b style="color:#cdd8ea">One source, any
+        runtime</b> means you drop the next good open model in without rework — the harness outlives the
+        model you started on.</p></div>
+    <div class="cell"><div class="ic">▾</div>
+      <h4>The future is smaller <span>&amp; more targeted</span></h4>
+      <p>Most agentic sub-tasks are narrow and repetitive — exactly the shape small, cheap, local models
+        do well. The harness shrinks the model's job (schema in, deterministic CRUD out) until a small one
+        can do it. A frontier model architects from a blank prompt; a 7B fills in a config and follows a skill.</p></div>
+  </div>
+  <p class="note" style="text-align:center;max-width:620px;margin:26px auto 0;">
+    The through-line: <b style="color:var(--grn-ink)">cost sovereignty, not cost prediction</b> — make the
+    prediction irrelevant. Run it on your own hardware, on your pick of model, with the rails doing the work the
+    model no longer has to.</p>
+</div></section>
 
 <section id="what"><div class="wrap">
   <div class="lead">


### PR DESCRIPTION
## 👤 For humans

The marketing page (`writeups/marketing/nuxt-harness.html`) pitched the harness as a *stack-curation* story ("best of the ecosystem, made legible to LLMs") but barely told the actual **why** behind the project — the bet on where AI is heading, and the differentiators that answer it. This PR closes that gap in three moves.

**1. New "Why now" section** — the four assumptions the project is built on (cost, diminishing returns, open models, small/targeted models), each reframed so it survives a skeptic:
- Cost is presented as **sovereignty, not prediction** — per-token prices fall, but your *bill* rises (Jevons + frontier treadmill + end of subsidies), so the harness stays *indifferent* to the direction rather than betting "prices will rise" (a claim a skeptic refutes in one line).
- Framed as *optionality*: win under all four futures, depend on none.

**2. New "The conversation" section** — finally surfaces the human↔agent communication layer, the least-marketed but most distinctive differentiator:
- **Annotate** (pin-a-comment on any live-preview element → structured feedback naming the file) and **Console** (in-page eruda) from `crouton-feedback`
- **Excalidraw** epic-status diagrams from `ticket-diagram`
- the two-audiences (human + agent) issue/PR record

**3. Elevated the sovereignty pillar** — "Free on your own hardware" → **"Sovereign by default"**, now naming the concrete topology (Mac mini running Pi, woken by GitHub Actions, small local model via Ollama) instead of leaving it a footnote.

Docs-only; no code or public-API impact. Both new sections render cleanly in the existing dark design system (verified via headless Chromium screenshot).

## 🤖 For agents

- `writeups/marketing/nuxt-harness.html`:
  - new `<section id="now">` after the hero — 4-card `.grid` (reuses `.cell`) + kicker note; "Why now" nav link
  - new `<section id="talk">` after `#flow` — 4-card `.grid`; "Feedback" nav link
  - pillar `⛁` retitled **Sovereign by default** with the Mac-mini / Pi / GitHub-Actions / Ollama topology spelled out
- No new CSS classes — all additions reuse existing `.lead` / `.grid` / `.cell` / `.pillar` / `.note` styles.

Commits: `docs(root): add "Why now" section…` (32914c4), `docs(root): surface feedback layer + sovereign topology…` (c91de7f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXHNPzwJWh2pCJvwfpjVFA)_