### PR TITLE
docs: decide-vs-ask rule in AGENTS.md (#1188)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -160,6 +160,9 @@ only — not visual taste (`/ui-proposal`), accessibility (`/a11y`), or security
   GitHub/app notification), apply `status:blocked`, and stop — the human answers by
   replying on the issue. Small ambiguities are decided with a default + a noted
   assumption (no ping). Change the handle in this file and in the task-decompose skill.
+  **When** to ask vs decide is the 3-part test in `AGENTS.md` → *Deciding vs asking* (ask only
+  when the fork is irreversible/expensive **and** not derivable **and** genuinely the human's;
+  else decide + log). Not "no assumptions" — assume the derivable/reversible, escalate the rest.
 - **A block comment is a HANDOFF, not just a question (#639).** The owner's reply spawns a
   **brand-new session** (`resume-on-comment.yml`) that has **zero memory** of your reasoning
   and checks out `main` — not your worktree, which is gone. So the blocking comment must be

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,32 @@ no `lgtm`, not done. Where the work has an enumerable contract (a behaviour spec
 comes from **comparison against the expected result**, not from re-reading the list: a list can't
 reveal its own gaps; running the real thing next to the contract can.
 
+## Deciding vs asking
+
+The sign-off gates above are *pre-declared* decision points. Most forks aren't those — they surface
+mid-work, and both extremes are wrong: "assume nothing, ask about everything" stalls an owner holding
+many async threads; "never ask" ships a confident wrong guess. So the rule is neither. **Ask only when
+all three hold:**
+
+1. **Irreversible or expensive** to undo — a destructive / data-migrating / publishing act, not
+   something a later commit quietly corrects.
+2. **Not derivable** — the answer isn't in the code, the docs, the conventions, or the issue itself,
+   and you've actually looked.
+3. **Genuinely the human's** — taste, priority, or product intent; not a mechanical choice that has a
+   defensible default.
+
+Fail any one → **decide and log**: make the call, append one dated line to the epic's Decisions log
+(append-only, so a later reversal shows as a new line), and keep moving. This replaces a blunt "no
+assumptions": the goal isn't to avoid assuming — it's to assume the *derivable and reversible* things
+and escalate *only* the rest.
+
+**When you do ask, the ask is async — never a blocking prompt.** An agent may be headless (a CI job,
+no terminal), so an in-run "ask the user" call times out or stalls the run — never use one in a
+pipeline. Instead post the ask as a comment, `@mention` the owner *only because an action is needed*,
+set `blocked`, and stop; the reply resumes a fresh run. Batch open questions into one comment rather
+than dripping pings. (The comment's *shape* — a scannable, recommendation-first handoff — is its own
+concern.)
+
 ## Issues — the unit of work
 
 - **Search before creating** — sessions are ephemeral; continue an existing epic, don't duplicate.


### PR DESCRIPTION
Closes #1188 (WS2 of epic #1182).

## 👤 For humans

"No assumptions" taken literally makes agents ask about everything, which breaks throughput when you're holding many async threads. This adds a **3-part test** for when an agent should actually stop and ask you — versus decide the reversible/derivable stuff itself and log it.

**Ask only when all three are true:** the fork is (1) irreversible or expensive to undo, **and** (2) not derivable from the code/docs/conventions/issue, **and** (3) genuinely yours to call (taste / priority / product intent). Fail any one → the agent decides and logs a line in the epic's Decisions log instead of pinging you.

The async + `@mention`-only-when-action-needed + batch-questions rules are kept. The *shape* of the ask comment (scannable, recommendation-first) is WS3 — out of scope here.

## 🤖 For agents

- **`AGENTS.md`**: new `## Deciding vs asking` section, placed between *Sign-off gates* (the pre-declared decision points) and *Issues* (it's the sibling concept — the ad-hoc mid-work fork). Stack-neutral, in the file's terse voice.
- **`.claude/agents/CLAUDE.md`**: one-line pointer from the *Async human-in-the-loop* bullet to the new rule, so the orchestrator/decomposer/worker pipeline inherits it.
- Docs-only; no gates touched, no code. Shaped by the WS1 research note (`writeups/reports/ask-human-loop-pi-research-20260706.md`).

## 🧪 How to test

- **What changed**: `AGENTS.md` carries the 3-part decide-vs-ask test; the blunt "no assumptions" framing is replaced.
- **Steps**: 1) the rule states the three conjuncts + the "decide + log" default; 2) it keeps the async-no-blocking-prompt / `@mention`-for-action / batch rules; 3) `.claude/agents/CLAUDE.md` points to it; 4) it reads stack-neutral (no Nuxt/CF-specific nouns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014vJRAbSypcM36HvHeHSBSg)_