### PR TITLE
feat: resume with the answer payload across media (#1191)

### DIFF
--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -35,6 +35,22 @@ jobs:
       - id: t0
         run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      # ── Collect the answer payload across media (WS5, #1191) ─────────────────────
+      # The owner may answer in the medium the question came in — a top-level reply, an
+      # inline PR *review* comment (e.g. on a schema `.md`), a `🎯 Preview feedback`
+      # comment, or an edited Excalidraw diagram. The resume agent only reads the top-level
+      # thread by default, so an in-medium answer would be invisible. This gathers all of
+      # them into `.resume-answer.md` for the prompt below. Dependency-free (system node +
+      # fetch); the `||` fallback guarantees the file exists so the resume never fails on it.
+      - name: Collect the answer payload
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          node scripts/resume-answer-payload.mjs "$ISSUE" > .resume-answer.md \
+            || echo '_(answer-payload collection skipped — resume from the top-level thread)_' > .resume-answer.md
+          echo "── collected answer payload ──"; cat .resume-answer.md
+
       # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
       # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
       # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
@@ -44,9 +60,14 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             Resume the task-decomposition pipeline for issue #${{ github.event.issue.number }}.
-            The owner has replied to a blocking question — read the full issue comment
-            thread (the latest comment is their answer), incorporate it, remove the
-            `status:blocked` label, then continue via /task-decompose #${{ github.event.issue.number }}.
+            The owner has replied to a blocking question. Their answer may be in the medium the
+            question came in — this run collected it across every surface into `.resume-answer.md`
+            (the latest reply, any inline PR review comments, any `🎯` preview-feedback comments,
+            and a flag if an Excalidraw diagram was edited). **Read `.resume-answer.md` first** and
+            treat it as their answer; if it flags an edited diagram, run
+            `node scripts/ticket-excalidraw-import.mjs <png>` to decode the scene before acting.
+            Then incorporate the answer, remove the `status:blocked` label, and continue via
+            /task-decompose #${{ github.event.issue.number }}.
           claude_args: "--model claude-sonnet-5 --max-turns 30"
           show_full_output: true
 

--- a/scripts/resume-answer-payload.mjs
+++ b/scripts/resume-answer-payload.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// resume-answer-payload.mjs — WS5 of epic #1182 (#1191).
+//
+// When an agent blocks with a scannable handoff (the `ask-human` skill, #1189), the owner
+// may answer *in the medium the question came in*: a top-level reply, an inline PR *review*
+// comment on a schema `.md`, a `🎯 Preview feedback` comment from crouton-feedback, or an
+// edited Excalidraw diagram. `resume-on-comment.yml` fires on the reply but, by default, the
+// resuming agent only sees the top-level thread — so an in-medium answer is invisible to it.
+//
+// This gathers the answer from EVERY surface and prints a compact markdown payload the resume
+// prompt injects, so the fresh session continues with the actual answer in context — not just
+// the trigger. Deterministic, dependency-free (Node 22 fetch + the Actions token), and it
+// NEVER throws: on any gap it degrades to a note so the resume still runs.
+//
+// Usage (from the workflow):  node scripts/resume-answer-payload.mjs <issue> > .resume-answer.md
+//   env: GITHUB_TOKEN (or GH_TOKEN), GITHUB_REPOSITORY=owner/repo
+//   arg: issue number (falls back to $ISSUE)
+
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || ''
+const repo = process.env.GITHUB_REPOSITORY || 'FriendlyInternet/nuxt-crouton'
+const [owner, name] = repo.split('/')
+const issue = Number(process.argv[2] || process.env.ISSUE || 0)
+
+const MAX = 1200 // clamp any single body so the injected payload can't blow the prompt budget
+const clip = (s) => {
+  const t = String(s || '').trim().replace(/\r/g, '')
+  return t.length > MAX ? t.slice(0, MAX) + ' …[clipped]' : t
+}
+
+async function gh(path) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      'user-agent': 'resume-answer-payload',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) throw new Error(`${res.status} ${path}`)
+  return res.json()
+}
+
+// Emit the payload + exit 0 no matter what — a missing surface must not fail the resume.
+function emit(lines) {
+  process.stdout.write(['## Answer payload (collected this run)', '', ...lines, ''].join('\n'))
+  process.exit(0)
+}
+
+if (!issue) emit(['_No issue number given — resume from the top-level thread only._'])
+if (!token) emit(['_No token available — resume from the top-level thread only._'])
+
+try {
+  const out = []
+
+  // (1) The latest human (non-bot) issue comment = the trigger / plain-text answer.
+  const comments = await gh(`/repos/${owner}/${name}/issues/${issue}/comments?per_page=100`)
+  const humanComments = comments.filter((c) => c.user && c.user.type !== 'Bot')
+  const latest = humanComments[humanComments.length - 1]
+  if (latest) {
+    out.push(`**Latest reply — @${latest.user.login}:**`, '', `> ${clip(latest.body).replace(/\n/g, '\n> ')}`, '')
+  }
+
+  // Linked PRs (via the issue timeline cross-references) — where in-medium answers live.
+  const timeline = await gh(`/repos/${owner}/${name}/issues/${issue}/timeline?per_page=100`)
+  const prNums = [
+    ...new Set(
+      timeline
+        .filter((e) => e.event === 'cross-referenced' && e.source?.issue?.pull_request)
+        .map((e) => e.source.issue.number)
+    ),
+  ]
+
+  let diagramEdited = ''
+  for (const n of prNums) {
+    // (2) Inline PR *review* comments (e.g. on a committed schema `.md`) — the resume agent
+    // does NOT read these by default; surface path + line + body.
+    let reviewComments = []
+    try {
+      reviewComments = await gh(`/repos/${owner}/${name}/pulls/${n}/comments?per_page=100`)
+    } catch {}
+    const humanReviews = reviewComments.filter((c) => c.user && c.user.type !== 'Bot')
+    if (humanReviews.length) {
+      out.push(`**PR #${n} — inline review comments:**`)
+      for (const c of humanReviews.slice(-10)) {
+        out.push(`- \`${c.path}${c.line ? ':' + c.line : ''}\` — ${clip(c.body)}`)
+      }
+      out.push('')
+    }
+
+    // (3) `🎯 Preview feedback` comments (crouton-feedback names the source file) — on the PR.
+    let prComments = []
+    try {
+      prComments = await gh(`/repos/${owner}/${name}/issues/${n}/comments?per_page=100`)
+    } catch {}
+    const feedback = prComments.filter((c) => /🎯/.test(c.body || ''))
+    if (feedback.length) {
+      out.push(`**PR #${n} — 🎯 preview feedback:**`)
+      for (const c of feedback.slice(-10)) out.push(`- ${clip(c.body)}`)
+      out.push('')
+    }
+
+    // (4) Edited-diagram flag: an Excalidraw round-trip re-attaches a PNG / bumps the
+    // `.graph.json`. Heuristic — if any surface references an excalidraw/diagram artifact,
+    // tell the resume to decode it via ticket-excalidraw-import.
+    const haystack = [...humanReviews, ...feedback].map((c) => c.body || '').join('\n')
+    if (/excalidraw|\.graph\.json|ticket-diagram|edited the diagram/i.test(haystack)) {
+      diagramEdited = `an Excalidraw diagram looks edited on PR #${n}`
+    }
+  }
+
+  out.push(
+    diagramEdited
+      ? `**Edited diagram:** ${diagramEdited} — run \`node scripts/ticket-excalidraw-import.mjs <attached-png>\` to decode the scene before acting on it.`
+      : `**Edited diagram:** none detected.`
+  )
+
+  if (out.length === 1) out.unshift('_No in-medium answer found beyond the top-level thread._', '')
+  emit(out)
+} catch (err) {
+  emit([`_Could not fully collect the answer payload (${String(err.message || err)}); resume from the top-level thread._`])
+}


### PR DESCRIPTION
Closes #1191 (WS5 — final workstream of epic #1182). The reply-in-medium loop.

## 👤 For humans

When you answer a blocked agent **in the medium the question came in** — an inline comment on a schema `.md`, pinned `🎯` feedback on a preview, an edited Excalidraw diagram — not just a text reply, the resuming session now actually *sees* that answer. Today it only reads the top-level comment thread, so an in-medium answer was invisible to it. Now "reply on the thing" works.

⚠️ **This PR includes a `.github/workflows/` change** — please give the workflow diff a deliberate look before merging (that's the CI policy #1076 in spirit: workflow edits get human eyes). Merging this PR *is* you applying it.

## 🤖 For agents

- **New `scripts/resume-answer-payload.mjs`** — gathers the answer from every surface into a compact markdown payload:
  1. the latest human (non-bot) issue reply,
  2. inline PR **review** comments (e.g. on a committed schema `.md`) — which the resume agent doesn't read by default,
  3. `🎯 Preview feedback` comments (crouton-feedback, names the source file),
  4. an **edited-Excalidraw flag** → tells the resume to `ticket-excalidraw-import` first.
  Dependency-free (Node 22 `fetch` + the Actions token); clamps each body; **never throws** — degrades to a note so the resume always runs. Verified: syntax-checks, and the no-token / no-issue paths print the graceful fallback.
- **`.github/workflows/resume-on-comment.yml`** — a *Collect the answer payload* step runs the script → `.resume-answer.md`; the resume prompt now **reads that file** and treats it as the answer (and decodes an edited diagram first). The **#572 App-token merge cascade is untouched**.

## 🧪 How to test

Needs a real blocked issue. On the next block: 1) reply with just a letter/choice → resumes with the choice in context; 2) leave an inline PR review comment on a schema `.md` → the payload surfaces it and the resume acts on it; 3) leave a `🎯` preview-feedback comment → surfaced; 4) edit the Excalidraw → payload flags it and the resume runs `ticket-excalidraw-import`; 5) approving still merges via the App token (cascade intact). Locally: `node scripts/resume-answer-payload.mjs <issue>` (with `GITHUB_TOKEN`) prints the payload; without a token it prints the graceful fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014vJRAbSypcM36HvHeHSBSg)_