### PR TITLE
docs(root): runbook §7 — interactive Claude Code under a Max subscription (#652)

### DIFF
--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -526,6 +526,40 @@ The watchdog (§4c) needs **no reconfiguration** — it discovers every installe
    so fine") and restarts just it.
 4. Regression: a single dispatched job still routes to the mini as before.
 
+## 7. Cut the Claude bill: interactive Claude Code under a Max subscription (#652)
+
+The self-hosted runner (§1–§6) cuts **GitHub Actions minutes**, not the **Claude bill** —
+the agent jobs it runs still call the metered `ANTHROPIC_API_KEY`. The lever for the Claude
+bill is different: do the **interactive** ("human in the loop") dev/agent work on the mini
+**signed in with a subscription**, so it draws on a flat-fee Max/Pro quota instead of
+per-token API billing. The always-on mini is the natural home for it.
+
+🖥️ **MINI (terminal)** — authenticate Claude Code via subscription OAuth, **not** an API key:
+
+```bash
+claude login          # opens the OAuth flow → sign in with the Max/Pro account
+# confirm: no ANTHROPIC_API_KEY in the interactive shell's env (that would force metered API)
+env | grep -i ANTHROPIC_API_KEY || echo "good — no API key, running on the subscription"
+```
+
+Verify the account is on a paid plan — the OAuth profile in `~/.claude.json` should show
+`organizationType: claude_max` (or `claude_pro`) and `billingType: stripe_subscription`.
+
+**🚫 Hard constraint — do not wire this into CI.** Subscription OAuth is for **interactive
+use only** (Anthropic Legal & Compliance terms). It must **NOT** back any unattended
+workflow. The CI agent flows (`decompose-on-issue`, `resume-on-comment`, the pi.dev
+pipeline, …) **stay on `ANTHROPIC_API_KEY`** — see the note in
+`.github/workflows/decompose-on-issue.yml`. *Considered & rejected:* pointing CI at
+`CLAUDE_CODE_OAUTH_TOKEN` for flat-fee automation → ❌ disallowed by the terms (and fragile:
+token rotation, no per-run isolation).
+
+✅ **Checkpoint (#652 acceptance):**
+1. `claude login` reports the **subscription** account (not API); no `ANTHROPIC_API_KEY` in
+   the interactive env.
+2. A real coding task is done interactively on the mini.
+3. 🌐 **Anthropic console** — the **API** usage dashboard shows **no API spend** for that
+   window (the work drew on the subscription quota instead).
+
 ---
 
 ## Three acceptance tests, in one place

--- a/writeups/setup/self-hosted-mac-mini-runner.md
+++ b/writeups/setup/self-hosted-mac-mini-runner.md
@@ -530,11 +530,23 @@ The watchdog (§4c) needs **no reconfiguration** — it discovers every installe
 
 The self-hosted runner (§1–§6) cuts **GitHub Actions minutes**, not the **Claude bill** —
 the agent jobs it runs still call the metered `ANTHROPIC_API_KEY`. The lever for the Claude
-bill is different: do the **interactive** ("human in the loop") dev/agent work on the mini
-**signed in with a subscription**, so it draws on a flat-fee Max/Pro quota instead of
-per-token API billing. The always-on mini is the natural home for it.
+bill is a different axis entirely: **auth mode, not machine.**
 
-🖥️ **MINI (terminal)** — authenticate Claude Code via subscription OAuth, **not** an API key:
+- **The cost lever is device-independent.** `claude login` is OAuth against your *account*, so
+  **interactive** ("human in the loop") Claude Code draws on your flat-fee Max/Pro quota
+  **wherever you run it** — your laptop, another Mac, Claude Code on your **phone**, *or* the
+  mini. The mini is **not** required for this, and isn't special for it: interactive work has a
+  human present by definition, and that human is wherever they are.
+- **What's actually mini-specific is the opposite half.** The always-on **runner** runs
+  **unattended**, and unattended automation must use the **API key** — never the subscription
+  (Anthropic terms; see the constraint below). "Always-on" matters for *CI*, not for
+  interactive work.
+
+So the split is: **interactive → subscription (any device)** · **runner/CI → `ANTHROPIC_API_KEY`
+(the mini)**. This section documents both so the two never get crossed.
+
+🖥️ **ANY interactive device (incl. the mini)** — authenticate Claude Code via subscription
+OAuth, **not** an API key:
 
 ```bash
 claude login          # opens the OAuth flow → sign in with the Max/Pro account
@@ -556,9 +568,10 @@ token rotation, no per-run isolation).
 ✅ **Checkpoint (#652 acceptance):**
 1. `claude login` reports the **subscription** account (not API); no `ANTHROPIC_API_KEY` in
    the interactive env.
-2. A real coding task is done interactively on the mini.
-3. 🌐 **Anthropic console** — the **API** usage dashboard shows **no API spend** for that
-   window (the work drew on the subscription quota instead).
+2. A real coding task is done interactively (on the mini or any device you're signed in on).
+3. 🌐 **Anthropic console** — the **API** usage dashboard shows **no API spend** attributable to
+   that interactive work (it drew on the subscription quota instead). Any spend on the key is
+   *automation* — the CI/runner flows — which is expected to be metered.
 
 ---
 


### PR DESCRIPTION
## 👤 For humans

The self-hosted runner work (#653/#654/#657) cut **CI minutes** — but the thing that cuts the **Claude bill** is running *interactive* work on the mini under a **Max subscription** instead of a metered API key. That rule was supposed to live in the runbook but wasn't there. This adds it as **§7**.

On-box state is already correct — verified this session:
- `organizationType: claude_max` · `default_claude_max_20x` · `billingType: stripe_subscription`
- OAuth auth, **no `ANTHROPIC_API_KEY`** in the interactive env
- Real interactive work is running under it now

## 🤖 For agents

- New §7 in `writeups/setup/self-hosted-mac-mini-runner.md`: `claude login` (OAuth) not `ANTHROPIC_API_KEY`; how to verify the plan tier; the hard constraint that CI stays on the API key (OAuth-for-automation is disallowed by terms); the #652 acceptance checklist.

## 🧪 How to test / before merging

The only #652 criterion not structurally guaranteed is **no API spend** — a 30-second check:
1. Open the Anthropic **API** usage console for today's window.
2. Confirm there's **no API spend** attributable to the interactive work on the mini (it draws on the Max quota instead — structurally guaranteed since no API key is configured).

Merging closes #652.

Closes #652