### PR TITLE
test(root): fleet concurrency smoke — prove 3 parallel mac-mini jobs (#1045)

### DIFF
--- a/.github/workflows/mac-mini-fleet-smoke.yml
+++ b/.github/workflows/mac-mini-fleet-smoke.yml
@@ -1,0 +1,42 @@
+name: Mac mini fleet concurrency smoke
+
+# Dispatch-only proof that the self-hosted `mac-mini` FLEET (epic #610 / #1045) runs jobs in
+# PARALLEL — the acceptance criterion the single mac-mini-smoke.yml can't self-prove (its
+# concurrency group serializes copies). One dispatch fans out a 3-way matrix; if the fleet has
+# 3 idle runners, all three land at once on distinct runners and hold their slot briefly so the
+# overlap is observable.
+#
+# SAFE on a public repo: workflow_dispatch only (human-with-write-access, manual) — no
+# pull_request/push trigger, so untrusted fork code can never reach the self-hosted box here.
+#
+# NB: workflow_dispatch only works once this file is on the DEFAULT branch (main).
+
+on:
+  workflow_dispatch:
+    inputs:
+      slots:
+        description: "How many parallel slots to fan out (match your fleet size)."
+        required: false
+        default: "3"
+        type: string
+
+# No cancel-in-progress group — the whole point is to let the matrix jobs overlap.
+
+jobs:
+  fan:
+    strategy:
+      fail-fast: false
+      matrix:
+        slot: [1, 2, 3]
+    runs-on: [self-hosted, mac-mini]
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Identify + hold the slot
+        run: |
+          echo "slot=${{ matrix.slot }} runner=${RUNNER_NAME:-?} host=$(hostname) started=$(date -u +%H:%M:%S)Z"
+          # Hold the slot ~25s so all three jobs are in_progress simultaneously — that overlap
+          # (three distinct RUNNER_NAMEs, none queued) is the #1045 concurrency proof.
+          sleep 25
+          echo "slot=${{ matrix.slot }} done=$(date -u +%H:%M:%S)Z"


### PR DESCRIPTION
## 👤 For humans

The fleet is live (3 runners registered + online, fleet-aware watchdog proven). This adds the one missing #1045 artifact: a workflow that proves the 3 runners run jobs **in parallel**.

## 🤖 For agents

- New `.github/workflows/mac-mini-fleet-smoke.yml`: `workflow_dispatch`, 3-way matrix on `[self-hosted, mac-mini]`, each job holds its slot ~25s (overlap = the proof), no cancel-in-progress group.

## 🧪 How to test (after merge — dispatch needs the file on main)

1. `gh workflow run mac-mini-fleet-smoke.yml`
2. Expect **3 jobs `in_progress` at once**, each on a distinct `RUNNER_NAME` (`mac-mini`, `mac-mini-2`, `mac-mini-3`), **none queued**.

Already proven live this session: 3 runners registered+online, and the fleet-aware watchdog flags+restarts a single downed runner. This closes the last criterion.

Closes #1045