### PR TITLE
chore(root): pi box config apply workflow on the mac-mini runner (#1060)

### DIFF
--- a/.github/workflows/pi-box-apply.yml
+++ b/.github/workflows/pi-box-apply.yml
@@ -1,0 +1,117 @@
+name: pi box config apply (mac-mini)
+
+# Phase 2 of #1060 — the "flip an extension from GitHub → the box updates with no manual step"
+# loop. Runs `scripts/pi-box/apply-pi-config.mjs` on the self-hosted mac-mini runner to reconcile
+# the box's real pi.dev install (`~/.pi/agent/settings.json` + globally-installed packages) to the
+# committed manifest. Phase 1 (the pinned base+deltas manifest + the idempotent apply script)
+# landed in PR #1207.
+#
+# TWO TRIGGERS:
+#   • push → main, path-filtered on the manifest/apply script — the auto loop. A merged manifest
+#     change applies to the box with zero manual steps ("We'll know by").
+#   • workflow_dispatch — a manual run, defaulting to --dry-run so a fat-finger dispatch previews
+#     the plan instead of mutating the box. Toggle dry_run off to apply; skip_base / force_base
+#     pass through to the script.
+#
+# SECURITY — SCOPED TOKEN, NOT HUMAN CREDS (#656/#670). Applying a manifest is CODE EXECUTION ON
+# THE BOX (installing an extension = supply-chain), so the trust model is:
+#   1. The manifest diff IS the supply-chain review — everything is version/SHA-pinned, reviewed
+#      in the PR, and only reaches the box AFTER merge. A `push` event fires ONLY for code already
+#      merged to main; a fork PR never runs in the base repo's context on push, so untrusted fork
+#      code can never reach the self-hosted box through this workflow (same property the
+#      mac-mini-smoke / fleet-smoke dispatch-only jobs rely on, here provided by push-after-merge).
+#   2. The runner uses the EPHEMERAL, AUTO-EXPIRING GITHUB_TOKEN scoped to `contents: read` only —
+#      NOT a PAT, NOT the Harness App token, NOT human creds. The apply performs no GitHub writes;
+#      it mutates the box locally, so read-only checkout is all it needs. The run's result is
+#      surfaced in the job summary rather than commented back, keeping the token minimal.
+#
+# NB: NO `actions/setup-node` — we resolve node/npm/pi via the runner's launchd `.path`
+# (the #654 gotcha) so we reconcile the box's REAL global `~/.pi` (the same install the
+# interactive user sees), not an ephemeral CI node prefix. On a self-hosted runner `$HOME` is the
+# box user's home, so `~/.pi/agent/settings.json` is the genuine box state.
+#
+# NB: `workflow_dispatch` only appears once this file is on the DEFAULT branch (main).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - scripts/pi-box/pi-config.manifest.json
+      - scripts/pi-box/apply-pi-config.mjs
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview the plan without touching the box (default true — flip off to apply)."
+        required: false
+        default: true
+        type: boolean
+      skip_base:
+        description: "Reconcile deltas+settings only; don't run the base installer."
+        required: false
+        default: false
+        type: boolean
+      force_base:
+        description: "Re-run the base installer even if the recorded version already matches."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # Serialize applies — never let two runs race on the same box mid-mutation. Don't cancel an
+  # in-flight apply (a half-applied box is worse than a queued one), so no cancel-in-progress.
+  group: pi-box-apply
+
+jobs:
+  apply:
+    runs-on: [self-hosted, mac-mini]
+    timeout-minutes: 15
+    # Scoped token: read-only. The apply mutates the BOX, not GitHub — it needs no write scope.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # Confirm the box toolchain resolves via `.path`, and ensure `pi` is present (the apply's
+      # add/remove/settings steps call it). If missing, install the manifest-PINNED pi version so
+      # what runs on the box matches what was reviewed.
+      - name: Preflight — toolchain + pinned pi
+        run: |
+          set -euo pipefail
+          echo "PATH=$PATH"
+          node -v
+          npm -v
+          if ! command -v pi >/dev/null 2>&1; then
+            PI_SPEC="$(node -e 'const m=require("./scripts/pi-box/pi-config.manifest.json");process.stdout.write(m.pi.package+"@"+m.pi.version)')"
+            echo "pi not on PATH — installing pinned $PI_SPEC"
+            npm i -g "$PI_SPEC"
+          fi
+          pi --version || true
+
+      - name: Apply the pi box manifest
+        env:
+          EVENT: ${{ github.event_name }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          SKIP_BASE: ${{ github.event.inputs.skip_base }}
+          FORCE_BASE: ${{ github.event.inputs.force_base }}
+        run: |
+          set -euo pipefail
+          # Plain-string flags (no bash arrays — the mac-mini's default bash is 3.2, where an empty
+          # array under `set -u` is a landmine). Simple `--flag` tokens word-split cleanly unquoted.
+          FLAGS=""
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            # A manual dispatch defaults to dry-run: only an explicit dry_run=false applies.
+            [ "${DRY_RUN:-true}" != "false" ] && FLAGS="$FLAGS --dry-run"
+            [ "${SKIP_BASE:-false}" = "true" ] && FLAGS="$FLAGS --skip-base"
+            [ "${FORCE_BASE:-false}" = "true" ] && FLAGS="$FLAGS --force-base"
+          fi
+          # A push→main is a merged, reviewed manifest change → apply for real (no flags).
+          echo "Running: node scripts/pi-box/apply-pi-config.mjs$FLAGS"
+          node scripts/pi-box/apply-pi-config.mjs $FLAGS 2>&1 | tee apply.log
+          {
+            echo "### pi box config apply — \`${EVENT}\`${FLAGS:+ (flags:$FLAGS)}"
+            echo '```'
+            cat apply.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/pi-box/README.md
+++ b/scripts/pi-box/README.md
@@ -43,9 +43,20 @@ version (`~/.pi/agent/.pi-box-base`) differs from the manifest — so a re-run w
 is a **no-op**. Flags: `--skip-base` (reconcile deltas+settings only), `--force-base`, `--settings`
 / `--base-marker` / `--manifest` (override paths, e.g. for testing against a copy).
 
-## What's not here yet (phase 2)
+## Applying from GitHub (phase 2)
 
-A `workflow_dispatch` job on the mac-mini runner that runs this apply from a manifest PR — the full
-"flip an extension from GitHub → box updates" loop (#1060 "We'll know by"). Needs a scoped token
-(not human creds — the #656/#670 lesson). Until then, apply is run on the box by hand from a merged
-manifest change.
+`.github/workflows/pi-box-apply.yml` runs this apply on the self-hosted **mac-mini** runner, so a
+manifest change lands on the box with no manual step — the full "flip an extension from GitHub → box
+updates" loop (#1060 "We'll know by"). Two triggers:
+
+- **push → `main`** (path-filtered on the manifest / apply script) — a **merged** manifest change
+  applies for real. A push fires only for already-reviewed, merged code, so untrusted fork code
+  never reaches the box; the manifest diff **is** the supply-chain review.
+- **workflow_dispatch** — a manual run, defaulting to `--dry-run` (flip `dry_run` off to apply);
+  `skip_base` / `force_base` pass through to the script.
+
+**Scoped token, not human creds (#656/#670):** applying a manifest is code execution on the box, so
+the runner uses only the ephemeral, auto-expiring `GITHUB_TOKEN` scoped to `contents: read` — no
+PAT, no Harness App token. The apply mutates the box locally (no GitHub writes); its result is shown
+in the run's job summary. No `setup-node` — node/npm/pi resolve via the runner's launchd `.path` so
+the box's **real** global `~/.pi` is reconciled, not an ephemeral CI node prefix.

--- a/scripts/pi-box/apply-pi-config.mjs
+++ b/scripts/pi-box/apply-pi-config.mjs
@@ -35,6 +35,9 @@ const manifest = loadJson(manifestPath)
 if (!manifest) die(`cannot read manifest ${manifestPath}`)
 const live = loadJson(settingsPath) || { packages: [] }
 const livePkgs = Array.isArray(live.packages) ? live.packages : []
+// Declared before planBase() runs (line ~42): a `const` read by a hoisted function is in the
+// temporal dead zone until this line executes, so it must sit above the first top-level call.
+const wantBase = manifest.base ? manifest.base.version : null
 
 log(`\n\x1b[1mpi box config apply\x1b[0m ${dry ? '(DRY RUN — no changes)' : ''}`)
 log(`manifest ${rel(manifestPath)} · settings ${rel(settingsPath)}`)
@@ -53,7 +56,6 @@ applySettings()
 log('\n✅ applied. Verify: `pi list` + `node scripts/pi-box/apply-pi-config.mjs --dry-run` (should be a no-op).')
 
 // ── planning ────────────────────────────────────────────────────────────────────────────
-const wantBase = manifest.base ? manifest.base.version : null
 function readBaseMarker() { return existsSync(markerPath) ? readFileSync(markerPath, 'utf8').trim() : null }
 function runReason(have) { return have ? `version ${have}→${wantBase}` : 'no recorded base' }
 function planBase() {


### PR DESCRIPTION
Phase 2 of #1060 — the `workflow_dispatch` + push-on-merge job that runs `scripts/pi-box/apply-pi-config.mjs` on the self-hosted **mac-mini** runner, so changing a pi.dev extension is a manifest PR that reconciles the box on merge with **no manual step** (#1060's "We'll know by"). Phase 1 (the pinned base+deltas manifest + idempotent apply script) landed in #1207.

## 👤 For humans

Right now a merged manifest change still has to be applied on the Mac by hand. This adds the last link: on merge to `main`, a workflow on the mac-mini runs the apply and the box updates itself. You can also trigger it manually — a manual run **defaults to a dry-run preview** (flip `dry_run` off to actually apply).

## 🤖 For agents

**`.github/workflows/pi-box-apply.yml`** — `runs-on: [self-hosted, mac-mini]`.

- **Triggers**: `push` → `main` path-filtered on `scripts/pi-box/pi-config.manifest.json` + `apply-pi-config.mjs` (auto-apply the reviewed+merged change) · `workflow_dispatch` (inputs: `dry_run` default **true**, `skip_base`, `force_base` — passed through to the script).
- **Scoped token, not human creds (#656/#670)**: `permissions: contents: read` only. Applying a manifest is code execution **on the box**, not on GitHub — the apply performs no GitHub writes, so the ephemeral, auto-expiring read-only `GITHUB_TOKEN` is all it needs. No PAT, no Harness App token. The run's result goes to the **job summary**, not a commented-back write.
- **Supply-chain trust**: a `push` event fires only for code **already merged** to `main`; a fork PR never runs in the base repo's context on push, so untrusted fork code can't reach the self-hosted box — the **manifest diff is the supply-chain review** (everything version/SHA-pinned). Same "self-hosted box stays off untrusted code" property the dispatch-only `mac-mini-smoke` jobs rely on, here provided by push-after-merge.
- **No `setup-node`**: node/npm/pi resolve via the runner's launchd `.path` (#654) so we reconcile the box's **real** global `~/.pi` (the install the interactive user sees), not an ephemeral CI node prefix. Preflight installs the manifest-**pinned** pi version if `pi` isn't on PATH.
- Also fixes a **temporal-dead-zone `ReferenceError`** in the phase-1 script (`const wantBase` read by a hoisted `planBase()` before its initializer ran) — it crashed on every invocation. Hoisted the declaration; verified change-detection + idempotent no-op via dry-run.

## 🧪 How to test

1. **Auto loop**: merge a one-line change to `scripts/pi-box/pi-config.manifest.json` (e.g. bump a pinned delta) → the `pi box config apply (mac-mini)` workflow runs on merge → the mac-mini's pi install reflects it; the job summary shows the plan that was applied.
2. **Manual preview**: Actions → *pi box config apply (mac-mini)* → Run workflow (leave `dry_run` on) → the summary prints the intended install/update/prune actions, box untouched. Re-run with `dry_run` off to apply.
3. **Idempotent**: a second run with no manifest change is a no-op (base up-to-date, nothing to install, settings no change).

Closes #1060