### PR TITLE
fix(root): synchronous agent spawns + diagnose fire-and-forget in the gate (#1210)

### DIFF
--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -69,6 +69,9 @@ To split:
 3. Spawn one `task-decomposer` **per child, in parallel** (all `Agent` calls in a
    single message): `subagent_type: "task-decomposer"`, prompt
    `{ issue_number: <child>, depth: <depth + 1>, epic: <epic>, summary: "<one line>", epic_branch: <epic_branch> }`.
+   **`run_in_background: false` on every call — synchronous, wait for them.** The tool defaults to
+   background; a backgrounded child dies when this one-shot job ends (#1210). "In parallel" = the
+   synchronous calls share one message, not fire-and-forget.
 4. Report the children created + that decomposers were spawned. Stop.
 
 **Dependency order (when children depend on each other).** If one child must land before a
@@ -82,6 +85,9 @@ them up). Independent children still go out in parallel.
 
 Spawn one `task-worker` via the `Agent` tool:
 - `subagent_type: "task-worker"`
+- **`run_in_background: false` — spawn SYNCHRONOUSLY and wait for the worker to finish.** The tool
+  defaults to background; a backgrounded worker is killed when this one-shot job ends, so its PR is
+  never opened and the artifact-gate fails (#1210).
 - `isolation: "worktree"` — workers run in isolated git worktrees so parallel workers
   never collide on branches/files.
 - prompt: `{ issue_number: <this issue>, epic: <epic>, epic_branch: <epic_branch> }` plus a

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -173,6 +173,9 @@ reinventing CMS bits that already shipped.
    concurrently (single message); **wave-gate** dependency-ordered children (spawn the
    foundation first; spawn dependents on a re-run once it has merged into `epic_branch`):
    - `subagent_type: "task-decomposer"`
+   - **`run_in_background: false` on every `Agent` call — spawn SYNCHRONOUSLY and wait.** The tool
+     defaults to background; a backgrounded child is killed when this one-shot job ends (#1210).
+     "Concurrently" = issue the synchronous calls in a single message, not fire-and-forget.
    - prompt: `{ issue_number: <child number>, depth: 1, epic: <epic number>, epic_branch: <epic_branch> }`
      plus a one-line summary **and the epic's design invariants** so the child has context
      without a round-trip and can't silently diverge.

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -145,6 +145,12 @@ If a leaf's work needs a workflow-file change (new trigger, path filter, job):
        **blocks the create without it** (#297).
 2. **Launch the orchestrator.** Spawn it via the `Agent` tool:
    - `subagent_type: "task-orchestrator"`
+   - **`run_in_background: false` — MANDATORY. Spawn it SYNCHRONOUSLY and wait for it to finish.**
+     The `Agent` tool defaults to background; in the one-shot CI job (`decompose-on-issue.yml`) a
+     backgrounded orchestrator is **killed when the job ends**, so the sub-issue tree never persists
+     and the artifact-gate fails the run (the #1209/#1210 fire-and-forget). **Never** end your turn
+     with "orchestration is running in the background / I'll be notified" — you will **not** be
+     re-invoked here. Hold until the orchestrator returns (sub-issues created + epic branch pushed).
    - prompt: `{ epic_issue_number: <epic number>, depth: 0 }` + a short restatement of the
      task so it doesn't need an extra read.
    - **If `#NN` is a CHILD issue (it has a `parent_issue_url`), not an epic** — e.g. someone

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -193,12 +193,22 @@ jobs:
                     action = 'Check the run log for the SDK/tooling error, fix the cause, then re-apply `delegate`.'
                   }
                 } else if (result) {
-                  // Ran to completion but produced nothing on the issue — usually an underspecified
-                  // task: the agent asked for clarification instead of building.
+                  // Ran to completion but produced nothing on the issue. DIAGNOSE the cause from the
+                  // agent's own final message — don't guess "underspecified" (#1210: that misdiagnosis
+                  // sent a human down the wrong path when the real cause was fire-and-forget).
                   const snippet = text.length > 600 ? text.slice(0, 600) + '…' : text
                   why = 'the agent finished its turn without opening a PR, creating sub-issues, or holding for sign-off'
-                  action = 'This usually means the issue is underspecified — add a concrete description + '
-                    + 'acceptance criteria so there is something to build, then re-apply `delegate`.'
+                  const backgrounded = /in the background|i['’]?ll be notified|running in the background|notified when (it|the) .*complet/i.test(text)
+                  if (backgrounded) {
+                    why = 'the agent **backgrounded its orchestration and exited** — in a one-shot CI job a '
+                      + 'backgrounded agent is killed when the job ends, so nothing persisted (fire-and-forget, #1210)'
+                    action = 'This is NOT an underspecified issue — it is a fire-and-forget bug. Spawned agents '
+                      + 'must run SYNCHRONOUSLY (`run_in_background: false`; see the `task-decompose` skill / #1210). '
+                      + 'Re-apply `delegate` once the pipeline fix is merged.'
+                  } else {
+                    action = 'This usually means the issue is underspecified — add a concrete description + '
+                      + 'acceptance criteria so there is something to build, then re-apply `delegate`.'
+                  }
                   if (snippet) why += `. Its final message was:\n\n> ${snippet.replace(/\n/g, '\n> ')}`
                 }
               }


### PR DESCRIPTION
## 👤 For humans

Surfaced by the first real `/delegate` (#1209): it built nothing because the agent backgrounded the orchestrator, and the one-shot CI job killed it — then the failure comment blamed an "underspecified issue" (wrong). Two fixes.

## 🤖 For agents

- **Fix A (root cause):** `run_in_background: false` mandated at every `Agent` spawn — `task-decompose` skill, `task-orchestrator`, `task-decomposer`. The tool now defaults to background; a backgrounded child dies when the one-shot job ends, so nothing persists.
- **Fix B (observability):** the `decompose-on-issue.yml` artifact-gate now **diagnoses** the cause from the agent's own final message — detects the fire-and-forget tell (`in the background` / `I'll be notified`) and reports that + the real fix, instead of guessing "underspecified." Regex verified against the actual #1209 messages (matches all 3, not a good "created sub-issues" message).

## 🧪 How to test

Re-`delegate` #1209 → orchestrator persists sub-issues + epic branch synchronously before the job ends → artifact-gate passes. (Doing this after merge as the live re-test.)

Closes #1210