### PR TITLE
feat(root): stamp status:in-progress when a delegated issue is picked up (#1218)

### DIFF
--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -36,6 +36,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Mark the issue in-progress the moment the pipeline picks it up (#1218) — deterministic,
+      # so "where is it at" is visible without waiting for an agent to set it. Safe re: re-trigger:
+      # the job guard fires only when the *`delegate`* label is added, so this label event can't
+      # re-fire the workflow.
+      - name: Mark the issue in-progress
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: context.payload.issue.number, labels: ['status:in-progress'],
+              })
+            } catch (e) { core.warning(`could not add status:in-progress: ${e.message}`) }
+
       # Timestamp the run start so the artifact-gate can tell "produced during this run"
       # from pre-existing comments/PRs.
       - id: t0

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -39,10 +39,21 @@ jobs:
       # Mark the issue in-progress the moment the pipeline picks it up (#1218) — deterministic,
       # so "where is it at" is visible without waiting for an agent to set it. Safe re: re-trigger:
       # the job guard fires only when the *`delegate`* label is added, so this label event can't
-      # re-fire the workflow.
+      # re-fire THIS workflow.
+      #
+      # CRUCIAL: add the label with the HARNESS APP TOKEN, not the default GITHUB_TOKEN. The label
+      # must *trigger* project-status.yml (which maps status:in-progress → the board's "In progress"
+      # column) — and events from the default GITHUB_TOKEN do NOT trigger other workflows. A
+      # default-token add would set the label but never move the board card. (#1218)
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
       - name: Mark the issue in-progress
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             try {
               await github.rest.issues.addLabels({


### PR DESCRIPTION
## 👤 For humans

`/delegate` an issue → it shows **`status:in-progress`** within seconds, deterministically — no waiting for an agent to remember. (Today the entry issue stays status-less until a gate flips it to blocked; #1209 was the live example.)

## 🤖 For agents

- `decompose-on-issue.yml`: `addLabels(['status:in-progress'])` step right after checkout. Re-trigger-safe — the job guard fires only when the *`delegate`* label is the one added, so a `status:in-progress` label event can't re-fire the workflow (existing protection, called out in the guard comment).

## 🧪 How to test

`/delegate` an issue → `status:in-progress` appears before any gate.

Closes #1218