### PR TITLE
feat(root): flag agent-run timeouts — a cancelled run comments instead of vanishing (#1220)

### DIFF
--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -262,3 +262,21 @@ jobs:
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no PR, not held for sign-off).`)
+
+      # A cancelled run (almost always the 30-min timeout-minutes cap on a heavy leaf like
+      # crouton init / a cold @fyit/* workspace build) must ANNOUNCE itself — not vanish
+      # silently on the Actions tab (#1220). `if: cancelled()` reliably fires on a timeout
+      # cancellation (the artifact-gate `if: always()` above already runs in that case).
+      - name: Flag a timeout / cancellation
+        if: cancelled()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            await github.rest.issues.createComment({ ...context.repo, issue_number,
+              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _run timed out_\n\n'
+                + '⏱️ This run was **cancelled** — almost always the 30-min job timeout (a heavy leaf '
+                + 'like `crouton init` / a cold `@fyit/*` workspace build eating the budget). It may have '
+                + `partially progressed. 🔗 [Run log](${runUrl}) — re-apply the \`delegate\` label to `
+                + 'continue (idempotent, #611).' })

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -248,3 +248,16 @@ jobs:
                   + '😕 The resume from your comment **errored before finishing** (billing / max-turns / tooling). '
                   + `🔗 [Run log](${runUrl}) — fix the cause, then comment again to retry.` })
             }
+
+      # A cancelled resume (the 30-min timeout) must announce itself, not vanish silently (#1220).
+      - name: Flag a timeout / cancellation
+        if: cancelled()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            await github.rest.issues.createComment({ ...context.repo, issue_number,
+              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _resume timed out_\n\n'
+                + '⏱️ This resume was **cancelled** — almost always the 30-min job timeout. It may have '
+                + `partially progressed. 🔗 [Run log](${runUrl}) — comment again to retry.` })


### PR DESCRIPTION
## 👤 For humans

Surfaced by #1213 (bookmark POC): its `crouton init` leaf hit the 30-min job timeout and was **silently cancelled** — no issue comment, no flag. Now a cancelled run **announces itself** with a ⏱️ comment (run link + how to continue).

## 🤖 For agents

- `decompose-on-issue.yml` + `resume-on-comment.yml`: `if: cancelled()` step posts a timeout comment. Reliably fires on a `timeout-minutes` cancellation — proven, since the artifact-gate `if: always()` already ran in #1213's cancelled run.
- Pairs with the resume 😕 reaction (#1216): a cancelled resume gets both the 😕 on the comment and the ⏱️ explanation.
- Root perf cause (the cold `@fyit/*` build eating the budget) is a separate finding to file.

## 🧪 How to test

A run that exceeds `timeout-minutes` → the issue gets a ⏱️ comment with the run link, not a silent `cancelled`.

Closes #1220