### PR TITLE
feat(crouton-cli): crouton init --poc/--out + document the scaffold recipe (#1223)

### DIFF
--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -23,6 +23,14 @@ a feature branch.
 
 ## Procedure
 
+> **Execute the documented command — don't reverse-engineer the CLI (efficiency HARD RULE, #1223).**
+> If a task has a known command, *run it*. **Scaffolding a new app/POC = `crouton init <name> --poc`**
+> (→ `pocs/<name>`, does scaffold→generate→doctor); a launched app = `crouton init <name>`. Adding a
+> collection to an existing app = `crouton config` / `generate_collection`. Do **NOT** read
+> `crouton-cli/lib/init-app.ts` / `scaffold-app.ts` to "figure out how to scaffold" — that source-dive
+> burned the entire 30-min budget on #1213 and produced nothing. Once you've read the issue + the
+> relevant skill/CLAUDE.md, **act**; a leaf that only investigates and never executes is a failed run.
+
 1. **Read the issue.** `mcp__github__issue_read` (method `get`). The acceptance criteria
    and `## 🧪 How to test` are your spec. Also read the **epic** (the `epic` number in
    your prompt) so you know the epic's stated design/invariants.

--- a/.claude/skills/crouton.md
+++ b/.claude/skills/crouton.md
@@ -210,6 +210,26 @@ For repeater fields where each item needs translations (e.g., time slots, option
 }
 ```
 
+## Scaffold a NEW app or POC — `crouton init` (run this FIRST for a new app)
+
+**Creating a new app/POC from scratch? Run ONE command — do NOT reverse-engineer the CLI.**
+`crouton init <name>` does the whole thing end-to-end (scaffold → generate → doctor → summary):
+
+```bash
+crouton init <name> --poc                     # → pocs/<name>   (the incubator — default for a new POC)
+crouton init <name>                            # → apps/<name>   (a launched app)
+crouton init <name> --out <dir>                # explicit target directory
+crouton init <name> --features bookings,pages --theme ko -d sqlite   # options
+crouton init <name> --poc --dry-run            # preview, writes nothing
+```
+
+Flags: `--poc` (→ `pocs/<name>`) · `--out <dir>` · `--features a,b,c` · `--theme <t>` · `-d sqlite|pg`
+· `--no-cf` · `--domain <zone>` · `--dry-run`. If a `crouton.config.js` already exists in the target,
+init also generates its collections. **This is the command a POC-scaffold task runs — it is not
+undocumented; don't read `init-app.ts`/`scaffold-app.ts` to figure it out (that's the #1213/#1223
+30-min timeout).** Adding a collection to an *existing* app is the separate `crouton config` /
+`generate_collection` flow below.
+
 ## Process
 
 ### Step 1: Gather Requirements

--- a/packages/crouton-cli/bin/crouton-generate.js
+++ b/packages/crouton-cli/bin/crouton-generate.js
@@ -180,6 +180,8 @@ const initCmd = defineCommand({
     dialect: { type: 'string', alias: 'd', description: 'Database dialect (sqlite or pg)', default: 'sqlite' },
     noCf: { type: 'boolean', description: 'Skip Cloudflare-specific config (wrangler.jsonc, CF stubs)' },
     domain: { type: 'string', description: 'Cloudflare zone for custom-domain routes (e.g. pmcp.dev → <app>.pmcp.dev / <app>-preview.pmcp.dev)' },
+    poc: { type: 'boolean', description: 'Scaffold into pocs/<name> (the incubator) instead of apps/<name>' },
+    out: { type: 'string', description: 'Explicit target directory (overrides --poc; default apps/<name>)' },
     dryRun: { type: 'boolean', description: 'Preview what will be generated without writing files' },
   },
   async run({ args }) {
@@ -190,12 +192,16 @@ const initCmd = defineCommand({
       ? args.features.split(',').map(f => f.trim()).filter(Boolean)
       : []
 
+    // Target: --out wins; else --poc → pocs/<name>; else the initApp default (apps/<name>).
+    const out = args.out || (args.poc ? `pocs/${args.name}` : undefined)
+
     await initApp(args.name, {
       features,
       theme: args.theme,
       dialect: args.dialect,
       cf: !args.noCf,
       domain: args.domain,
+      out,
       dryRun: args.dryRun,
     })
   }

--- a/packages/crouton-cli/lib/init-app.ts
+++ b/packages/crouton-cli/lib/init-app.ts
@@ -13,22 +13,24 @@ interface InitAppOptions {
   cf?: boolean
   domain?: string
   dryRun?: boolean
+  /** Target directory for the app. Defaults to `apps/<name>`; pass `pocs/<name>` for a POC. */
+  out?: string
 }
 
 /**
  * Run the full init pipeline: scaffold -> generate -> doctor -> summary.
  */
 export async function initApp(name: string, options: InitAppOptions = {}): Promise<void> {
-  const { features = [], theme, dialect = 'sqlite', cf = true, domain, dryRun = false } = options
+  const { features = [], theme, dialect = 'sqlite', cf = true, domain, dryRun = false, out } = options
 
-  console.log(`\n  crouton init — creating ${name}\n`)
+  console.log(`\n  crouton init — creating ${name}${out ? ` in ${out}` : ''}\n`)
 
   // ── Step 1: scaffold-app ──────────────────────────────────────────────
   console.log('  Step 1/3 — Scaffolding app...\n')
   let appDir
   try {
     const { scaffoldApp } = await import('./scaffold-app.ts')
-    const result = await scaffoldApp(name, { features, theme, dialect, cf, domain, dryRun })
+    const result = await scaffoldApp(name, { features, theme, dialect, cf, domain, dryRun, outDir: out })
     appDir = result.appDir
   } catch (error) {
     consola.error('Step 1/3 — Scaffold failed')

--- a/pocs/CLAUDE.md
+++ b/pocs/CLAUDE.md
@@ -29,6 +29,11 @@ right shape before committing to a shared API.
 
 ## Working in here
 
+- **Scaffold a new POC with ONE command — `crouton init <name> --poc`.** It scaffolds into
+  `pocs/<name>` and runs the full pipeline (scaffold → generate → doctor → summary). Don't
+  reverse-engineer the CLI from `crouton-cli/lib/*` — that's the #1213/#1223 30-min timeout. Add
+  `--features a,b,c` / `--theme <t>` / `-d sqlite|pg` as needed; `--dry-run` to preview. (Details:
+  the `crouton` skill → "Scaffold a NEW app or POC".)
 - A poc may legitimately contain feature code destined for a package — that's not a
   layering violation here the way it would be in `apps/`. The `packages/` hard gate
   still applies to actual `packages/` edits; building the *precursor* inside a poc is


### PR DESCRIPTION
## 👤 For humans

Fixes the root cause of the #1213 30-min timeout: there was **no one-command way to scaffold a POC**, so the worker reverse-engineered `init-app.ts`/`scaffold-app.ts` for 30 minutes and produced nothing. Now:

```
crouton init <name> --poc     # → pocs/<name>, end-to-end (scaffold → generate → doctor)
```

…and it's documented so the agent runs it instead of source-diving.

## 🤖 For agents

- **crouton-cli:** plumb the existing `scaffoldApp` `outDir` through `initApp` + add `--poc` (→ `pocs/<name>`) and `--out <dir>` to the `init` command. Default unchanged (`apps/<name>`). Verified via `--dry-run` for `--poc` / `--out` / default.
- **Docs:** crouton skill → new "Scaffold a NEW app or POC" section; `pocs/CLAUDE.md` → one-line recipe.
- **`task-worker.md`:** efficiency HARD RULE — run the documented command, never reverse-engineer the CLI from source (the #1213 failure).

## 🧪 How to test

```
node packages/crouton-cli/bin/crouton-generate.js init demo --poc --dry-run   # → "creating demo in pocs/demo"
node packages/crouton-cli/bin/crouton-generate.js init demo --dry-run          # → apps/demo (unchanged)
```

crouton-cli is tsx-imported at runtime (no compile step); the changed path is exercised by the dry-run above. Not an app runtime dep, so app typecheck is unaffected.

Closes #1223