### PR TITLE
feat(root): STOP+comment on unexpected failure, don't improvise (#1229)

### DIFF
--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -49,6 +49,16 @@ a feature branch.
      + **stop** (see "Asking the human"). The pipeline (epic branch + dependency order)
      is supposed to give you the prerequisite; if it's absent, the right move is to wait,
      not to invent it.
+   - **The documented/expected path fails unexpectedly ⇒ STOP (do NOT improvise) (#1229).**
+     If the command or approach the issue/skill/docs told you to run fails in a way you didn't
+     anticipate — a tool errors (e.g. `crouton init` → *"directory already exists"*), a generator
+     refuses, a step behaves differently than documented — do **NOT** improvise an alternative,
+     hand-roll what the tool was supposed to do, or grind through a workaround. That is how the
+     #1213 pi run turned a one-command scaffold into **109 turns / $4.14** of manual work that was
+     off-standard **and hid the real bug**. An unexpected failure of the *intended* path is a
+     **stop signal**, not a puzzle to solve: comment the exact error + what you tried + what you'd
+     need to proceed, `@mention` `NOTIFY_HANDLE`, set `status:blocked`, and **stop**. Bounded cost
+     (~5 turns, not 100+), the real problem surfaced for a one-time fix, no non-conformant output.
    - **Don't silently diverge from the epic's design.** If implementing the issue as
      written would contradict the epic's stated model/invariant (e.g. the epic says "use
      the generic `print_jobs` table" but the path of least resistance is to extend the old

--- a/.claude/skills/task-decompose/SKILL.md
+++ b/.claude/skills/task-decompose/SKILL.md
@@ -68,10 +68,16 @@ chose a different design. Four rules now prevent that:
    runs** — the orchestrator posts the proposed tree, @mentions `@pmcp`, blocks. Plus the
    epic→`main` PR is the integration review. Low-risk epics (`review:auto`) skip the gate.
 
-4. **Block, don't improvise (#352).** A worker that finds a prerequisite missing (a
+4. **Block, don't improvise (#352, #1229).** A worker that finds a prerequisite missing (a
    package/table/symbol a sibling owns, not yet merged) **stops and waits** — it never
    scaffolds the missing thing itself, and never silently diverges from the epic's stated
-   design invariants. Missing prerequisite = blocker, not a DIY.
+   design invariants. Missing prerequisite = blocker, not a DIY. **The same rule applies when
+   the *documented* path fails unexpectedly** — a tool errors (e.g. `crouton init` → *"directory
+   already exists"*), a generator refuses, a step behaves unlike its docs: **STOP**, comment the
+   exact error + what you tried + what you'd need, `@mention @pmcp`, set `status:blocked`, stop —
+   do **NOT** improvise an alternative or hand-roll what the tool was supposed to do. Improvising
+   turned #1213's one-command scaffold into **109 turns / $4.14** of off-standard work that hid the
+   real bug. An unexpected failure of the *intended* path is a stop signal, not a puzzle to solve.
 
 ## `.github/workflows/` boundary — embed-patch, don't block (#1076)
 


### PR DESCRIPTION
## 👤 For humans

The #1213 pi worker hit *"crouton init: directory already exists"* and **improvised a manual scaffold for 109 turns / \$4.14** instead of stopping to ask. This extends *"block, don't improvise"* to cover **unexpected failures of the documented path**, not just missing prerequisites — so an agent **stops + comments** instead of grinding an expensive, off-standard workaround that hides the real bug.

## 🤖 For agents

- `task-worker.md`: new *"documented/expected path fails unexpectedly ⇒ STOP"* bullet.
- `task-decompose` **skill**: the same rule — **load-bearing**, because the pi pipeline invokes `pi --skill .claude/skills` and does **not** load `.claude/agents/` (#1022). So the skill is the *only* place the pi worker actually reads this.

## 🧪 How to test

A fresh POC scaffold that hits the `crouton init` dir-exists wrinkle now **stops + posts a blocked comment within a few turns**, instead of improvising 100+.

Closes #1229