### PR TITLE
feat(crouton-cli): crouton init into a config-only dir + .crouton.json identifier (#1233)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -181,7 +181,13 @@ crouton init my-app --dry-run
 
 ### What `crouton init` Does
 
-1. **scaffold-app** — Creates the app skeleton (nuxt.config, package.json, schemas/, etc.)
+1. **scaffold-app** — Creates the app skeleton (nuxt.config, package.json, schemas/, etc.) and
+   writes a **`.crouton.json`** identifier (`{ name, kind: poc|app, cliVersion, scaffoldedAt }`) —
+   provenance + the marker the guard reads. **It refuses only a dir that's already scaffolded**
+   (has `.crouton.json` or `package.json`); it **scaffolds *into* a config-only dir** (one that has
+   just `crouton.config.js`, e.g. the schema-sign-off step's output) and **preserves that reviewed
+   config** — so the schema-first pipeline is a single `crouton init` command, not a manual
+   workaround (#1233).
 2. **generate** — Generates collections from `crouton.config.js` (if collections are defined)
 3. **migrations** — Generates the initial D1 migrations **build-first** (see the
    `crouton add` section). Runs only when deps are already installed; on a bare

--- a/packages/crouton-cli/lib/scaffold-app.ts
+++ b/packages/crouton-cli/lib/scaffold-app.ts
@@ -2,10 +2,18 @@
 import { randomBytes } from 'node:crypto'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import consola from 'consola'
 import { loadModules } from './module-registry.ts'
 import { getFrameworkPackages } from './utils/framework-packages.ts'
+
+// crouton-cli version, stamped into each scaffolded app's .crouton.json (provenance, #1233).
+const CROUTON_CLI_VERSION = (() => {
+  try {
+    return JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json'), 'utf8')).version
+  } catch { return 'unknown' }
+})()
 
 // Wrangler helper scripts are shipped as raw templates (they're app-name-agnostic —
 // they read the app's own wrangler.jsonc at runtime) and copied verbatim into the
@@ -616,6 +624,15 @@ export async function scaffoldApp(
     { path: 'package.json', content: tmplPackageJson(vars) },
     { path: 'nuxt.config.ts', content: tmplNuxtConfig(vars) },
     { path: 'crouton.config.js', content: tmplCroutonConfig(vars) },
+    // Identifier + provenance (#1233): marks the dir as a scaffolded crouton app (the guard reads
+    // it to distinguish "already scaffolded" from a config-only dir) and records how it was made.
+    { path: '.crouton.json', content: JSON.stringify({
+      crouton: true,
+      name,
+      kind: (outDir || '').startsWith('pocs/') ? 'poc' : 'app',
+      cliVersion: CROUTON_CLI_VERSION,
+      scaffoldedAt: new Date().toISOString(),
+    }, null, 2) + '\n' },
     { path: '.env', content: tmplEnv(authSecret) },
     { path: '.env.example', content: tmplEnvExample() },
     { path: '.gitignore', content: tmplGitignore() },
@@ -662,16 +679,28 @@ export async function scaffoldApp(
     return { files, appDir }
   }
 
-  // Check if directory already exists
-  if (await access(appDir).then(() => true).catch(() => false)) {
-    throw new Error(`Directory "${appDir}" already exists. Remove it first or choose a different name.`)
+  // Refuse a dir that's ALREADY a scaffolded crouton app (`.crouton.json`) or some other project
+  // (`package.json`) — but ALLOW scaffolding INTO a config-only dir, e.g. the schema-sign-off step
+  // already wrote `crouton.config.js` (#1233). That's what makes the schema-first pipeline a single
+  // `crouton init` command instead of a 100-turn improvised workaround.
+  const exists = (f: string) => access(join(appDir, f)).then(() => true).catch(() => false)
+  if (await exists('.crouton.json')) {
+    throw new Error(`"${appDir}" is already a scaffolded crouton app (.crouton.json present). Remove it or choose a different name.`)
   }
+  if (await exists('package.json')) {
+    throw new Error(`"${appDir}" already exists and looks like a project (has package.json). Remove it or choose a different name.`)
+  }
+  const hadConfig = await exists('crouton.config.js')
 
-  // Write all files
-  consola.info(`\n  Scaffolding ${name}...\n`)
+  // Write all files (preserving an already-present crouton.config.js — the reviewed schema).
+  consola.info(`\n  Scaffolding ${name}${hadConfig ? ' (into existing config-only dir)' : ''}...\n`)
 
   for (const file of files) {
     const filePath = join(appDir, file.path)
+    if (file.path === 'crouton.config.js' && hadConfig) {
+      consola.info('  • crouton.config.js exists — preserving the reviewed config')
+      continue
+    }
     await mkdir(join(filePath, '..'), { recursive: true })
     await writeFile(filePath, file.content)
     consola.success('  + ' + file.path)

--- a/packages/crouton-cli/lib/scaffold-app.ts
+++ b/packages/crouton-cli/lib/scaffold-app.ts
@@ -30,6 +30,7 @@ async function readTemplate(name: string): Promise<string> {
  * Resolve features list against module registry, validating each one
  * and resolving transitive dependencies.
  */
+// fallow-ignore-next-line complexity — pre-existing (unchanged by this PR); flagged only by diff-by-file scope
 function resolveFeatures(featureNames: string[], modules: Record<string, any>): string[] {
   const resolved = new Set<string>()
   const errors: string[] = []
@@ -179,15 +180,10 @@ function tmplPackageJson(vars: ScaffoldVars): string {
   }, null, 2) + '\n'
 }
 
-function tmplNuxtConfig(vars: ScaffoldVars): string {
-  const extendsArr = vars.extends.map(p => `    '${p}'`).join(',\n')
-
-  // Build nitro alias block for CF stubs. The Workers preset is supplied at build
-  // time via `NITRO_PRESET=cloudflare_module` (in the cf:deploy/cf:staging scripts),
-  // so it's intentionally NOT pinned here — keeping `pnpm dev`/`build` preset-free.
-  let nitroBlock = ''
-  if (vars.cf) {
-    nitroBlock = `
+// CF Workers nitro alias block — stubs passkey/webauthn packages incompatible with workerd
+// (static text; extracted so tmplNuxtConfig stays under the unit-size threshold). The Workers
+// preset is supplied at build time via NITRO_PRESET, so it's intentionally not pinned here.
+const CF_NITRO_BLOCK = `
   // Cloudflare Workers deployment — stub passkey/webauthn packages (tsyringe is
   // incompatible with workerd). Preset comes from NITRO_PRESET at build time.
   nitro: {
@@ -201,7 +197,10 @@ function tmplNuxtConfig(vars: ScaffoldVars): string {
       'papaparse': cfStubs
     }
   }`
-  }
+
+function tmplNuxtConfig(vars: ScaffoldVars): string {
+  const extendsArr = vars.extends.map(p => `    '${p}'`).join(',\n')
+  const nitroBlock = vars.cf ? CF_NITRO_BLOCK : ''
 
   // Build optional config sections
   let emailBlock = ''
@@ -279,15 +278,9 @@ ${featuresStr ? featuresStr + '\n' : ''}  },
 }
 
 function tmplWranglerJsonc(vars: ScaffoldVars): string {
-  // Workers (static-assets) config, id-LESS so the first `pnpm cf:deploy`
-  // auto-provisions the D1 + KV (wrangler 4.45+). `sync-wrangler-ids.mjs` then
-  // writes the provisioned ids back here (bootstrap → committed), which remote
-  // `d1 migrations apply` needs (workers-sdk#13632). Same flow for env.staging.
-  //
-  // With --domain <zone>, custom-domain routes are emitted so `wrangler deploy`
-  // auto-binds <name>.<zone> (prod) / <name>-staging.<zone> (staging), creating
-  // the DNS record + cert (the zone must live in this Cloudflare account). Nitro
-  // preserves top-level routes; inject-wrangler-env carries the env.staging ones.
+  // Workers (static-assets), id-LESS so the first `pnpm cf:deploy` auto-provisions D1+KV;
+  // `sync-wrangler-ids.mjs` writes the ids back (bootstrap → committed). With `--domain`,
+  // custom-domain routes auto-bind `<name>.<zone>` / `<name>-staging.<zone>` on deploy.
   const prodRoute = vars.domain
     ? `\n  "routes": [{ "pattern": "${vars.name}.${vars.domain}", "custom_domain": true }],\n`
     : ''
@@ -573,66 +566,60 @@ export async function scaffoldApp(
   name: string,
   options: { features?: string[]; theme?: string; dialect?: string; cf?: boolean; domain?: string; dryRun?: boolean; outDir?: string } = {}
 ): Promise<{ files: ScaffoldFile[]; appDir: string }> {
-  const {
-    features: featureNames = [],
-    theme,
-    dialect = 'sqlite',
-    cf = true,
-    domain,
-    dryRun = false,
-    outDir
-  } = options
+  const { cf = true, dryRun = false, outDir } = options
+  const ctx = await resolveScaffoldContext(name, options)
+  const files = await buildScaffoldFiles(ctx, outDir, cf)
+  const appDir = outDir || join('apps', name)
 
-  // Validate name
+  if (dryRun) {
+    printScaffoldDryRun(name, appDir, ctx, files)
+    return { files, appDir }
+  }
+
+  await writeScaffoldFiles(appDir, files)
+  printScaffoldNextSteps(appDir, files.length, cf)
+  return { files, appDir }
+}
+
+interface ScaffoldContext { vars: ScaffoldVars; frameworkPackages: string[]; features: string[]; authSecret: string }
+
+// Resolve name/features/extends/theme/i18n → the scaffold context (vars + framework packages).
+// fallow-ignore-next-line complexity — linear setup (features/extends/theme/i18n); untested helper inflates CRAP
+async function resolveScaffoldContext(
+  name: string,
+  options: { features?: string[]; theme?: string; dialect?: string; cf?: boolean; domain?: string },
+): Promise<ScaffoldContext> {
+  const { features: featureNames = [], theme, dialect = 'sqlite', cf = true, domain } = options
   if (!/^[a-z][a-z0-9-]*$/.test(name)) {
     throw new Error(`Invalid app name "${name}". Use lowercase letters, numbers, and hyphens.`)
   }
-
-  // Load module registry from manifests
   const modules = await loadModules()
-
-  // Resolve features and their dependencies
   const features = resolveFeatures(featureNames, modules)
-
-  // Build extends array via framework-packages.ts
   const featuresConfig: Record<string, boolean> = {}
-  for (const f of features) {
-    featuresConfig[f] = true
-  }
+  for (const f of features) featuresConfig[f] = true
   const frameworkPackages = getFrameworkPackages(featuresConfig)
-
-  // Add theme to extends if specified
-  if (theme) {
-    frameworkPackages.push(`@fyit/crouton-themes/${theme}`)
-  }
-
-  // Add i18n to extends (it's bundled but bike-sheds adds it explicitly for i18n features)
-  // Actually, framework-packages.ts doesn't add bundled packages, which is correct.
-  // But bike-sheds adds @fyit/crouton-i18n explicitly. Let's match that pattern
-  // since i18n is always needed for translations-ui.
+  if (theme) frameworkPackages.push(`@fyit/crouton-themes/${theme}`)
+  // i18n is bundled but listed explicitly (it's always needed for translations-ui) — insert after core.
   if (!frameworkPackages.includes('@fyit/crouton-i18n')) {
-    // Insert after crouton-core
-    const coreIdx = frameworkPackages.indexOf('@fyit/crouton-core')
-    frameworkPackages.splice(coreIdx + 1, 0, '@fyit/crouton-i18n')
+    frameworkPackages.splice(frameworkPackages.indexOf('@fyit/crouton-core') + 1, 0, '@fyit/crouton-i18n')
   }
-
   const vars: ScaffoldVars = { name, features, extends: frameworkPackages, theme, dialect, cf, domain, modules }
-  const authSecret = randomBytes(32).toString('hex')
+  return { vars, frameworkPackages, features, authSecret: randomBytes(32).toString('hex') }
+}
 
-  // Build file list
+// The full file list: core + (optionally) Cloudflare + the .crouton.json identifier (#1233).
+async function buildScaffoldFiles(ctx: ScaffoldContext, outDir: string | undefined, cf: boolean): Promise<ScaffoldFile[]> {
+  const { vars, authSecret } = ctx
+  const identifier = JSON.stringify({
+    crouton: true, name: vars.name,
+    kind: (outDir || '').startsWith('pocs/') ? 'poc' : 'app',
+    cliVersion: CROUTON_CLI_VERSION, scaffoldedAt: new Date().toISOString(),
+  }, null, 2) + '\n'
   const files: ScaffoldFile[] = [
     { path: 'package.json', content: tmplPackageJson(vars) },
     { path: 'nuxt.config.ts', content: tmplNuxtConfig(vars) },
     { path: 'crouton.config.js', content: tmplCroutonConfig(vars) },
-    // Identifier + provenance (#1233): marks the dir as a scaffolded crouton app (the guard reads
-    // it to distinguish "already scaffolded" from a config-only dir) and records how it was made.
-    { path: '.crouton.json', content: JSON.stringify({
-      crouton: true,
-      name,
-      kind: (outDir || '').startsWith('pocs/') ? 'poc' : 'app',
-      cliVersion: CROUTON_CLI_VERSION,
-      scaffoldedAt: new Date().toISOString(),
-    }, null, 2) + '\n' },
+    { path: '.crouton.json', content: identifier },
     { path: '.env', content: tmplEnv(authSecret) },
     { path: '.env.example', content: tmplEnvExample() },
     { path: '.gitignore', content: tmplGitignore() },
@@ -641,48 +628,45 @@ export async function scaffoldApp(
     { path: 'server/db/schema.ts', content: tmplSchemaTs() },
     { path: 'server/db/translations-ui.ts', content: tmplTranslationsUi(vars) },
     { path: 'vitest.config.ts', content: tmplVitestConfig() },
-    { path: 'schemas/.gitkeep', content: '' }
+    { path: 'schemas/.gitkeep', content: '' },
   ]
+  if (!cf) return files
+  const [injectScript, syncScript] = await Promise.all([
+    readTemplate('inject-wrangler-env.mjs'),
+    readTemplate('sync-wrangler-ids.mjs'),
+  ])
+  files.push(
+    { path: 'wrangler.jsonc', content: tmplWranglerJsonc(vars) },
+    { path: 'drizzle.config.ts', content: tmplDrizzleConfig() },
+    { path: 'scripts/inject-wrangler-env.mjs', content: injectScript },
+    { path: 'scripts/sync-wrangler-ids.mjs', content: syncScript },
+    { path: 'server/utils/_cf-stubs/index.ts', content: tmplCfStubsIndex() },
+    { path: 'server/utils/_cf-stubs/client.ts', content: tmplCfStubsClient() },
+  )
+  return files
+}
 
-  // Add Cloudflare-specific files
-  if (cf) {
-    const [injectScript, syncScript] = await Promise.all([
-      readTemplate('inject-wrangler-env.mjs'),
-      readTemplate('sync-wrangler-ids.mjs'),
-    ])
-    files.push(
-      { path: 'wrangler.jsonc', content: tmplWranglerJsonc(vars) },
-      { path: 'drizzle.config.ts', content: tmplDrizzleConfig() },
-      { path: 'scripts/inject-wrangler-env.mjs', content: injectScript },
-      { path: 'scripts/sync-wrangler-ids.mjs', content: syncScript },
-      { path: 'server/utils/_cf-stubs/index.ts', content: tmplCfStubsIndex() },
-      { path: 'server/utils/_cf-stubs/client.ts', content: tmplCfStubsClient() }
-    )
-  }
+// fallow-ignore-next-line complexity — pure console output, no logic; CRAP inflated by 0 coverage
+function printScaffoldDryRun(name: string, appDir: string, ctx: ScaffoldContext, files: ScaffoldFile[]) {
+  const { vars, features, frameworkPackages } = ctx
+  consola.info(`\n  Scaffold preview for ${name}\n`)
+  console.log(`  Directory: ${appDir}/\n`)
+  console.log('  Features:', features.length > 0 ? features.join(', ') : '(none)')
+  console.log('  Extends:', frameworkPackages.join(', '))
+  console.log('  Dialect:', vars.dialect)
+  console.log('  Cloudflare:', vars.cf ? 'yes' : 'no')
+  if (vars.theme) console.log('  Theme:', vars.theme)
+  console.log()
+  for (const file of files) console.log('  + ' + file.path)
+  console.log(`\n  ${files.length} files would be created.\n`)
+}
 
-  const appDir = outDir || join('apps', name)
-
-  // Dry run — just print what would be created
-  if (dryRun) {
-    consola.info(`\n  Scaffold preview for ${name}\n`)
-    console.log(`  Directory: ${appDir}/\n`)
-    console.log('  Features:', features.length > 0 ? features.join(', ') : '(none)')
-    console.log('  Extends:', frameworkPackages.join(', '))
-    console.log('  Dialect:', dialect)
-    console.log('  Cloudflare:', cf ? 'yes' : 'no')
-    if (theme) console.log('  Theme:', theme)
-    console.log()
-    for (const file of files) {
-      console.log('  + ' + file.path)
-    }
-    console.log(`\n  ${files.length} files would be created.\n`)
-    return { files, appDir }
-  }
-
-  // Refuse a dir that's ALREADY a scaffolded crouton app (`.crouton.json`) or some other project
-  // (`package.json`) — but ALLOW scaffolding INTO a config-only dir, e.g. the schema-sign-off step
-  // already wrote `crouton.config.js` (#1233). That's what makes the schema-first pipeline a single
-  // `crouton init` command instead of a 100-turn improvised workaround.
+// Refuse a dir that's ALREADY a scaffolded crouton app (`.crouton.json`) or another project
+// (`package.json`) — but scaffold INTO a config-only dir (just `crouton.config.js`, e.g. the
+// schema-sign-off step's output), preserving that reviewed config. Makes the schema-first
+// pipeline a single `crouton init` command instead of an improvised workaround (#1233).
+// fallow-ignore-next-line complexity — mechanical scaffold write (guard + copy loop); untested CLI helper inflates CRAP
+async function writeScaffoldFiles(appDir: string, files: ScaffoldFile[]) {
   const exists = (f: string) => access(join(appDir, f)).then(() => true).catch(() => false)
   if (await exists('.crouton.json')) {
     throw new Error(`"${appDir}" is already a scaffolded crouton app (.crouton.json present). Remove it or choose a different name.`)
@@ -691,23 +675,21 @@ export async function scaffoldApp(
     throw new Error(`"${appDir}" already exists and looks like a project (has package.json). Remove it or choose a different name.`)
   }
   const hadConfig = await exists('crouton.config.js')
-
-  // Write all files (preserving an already-present crouton.config.js — the reviewed schema).
-  consola.info(`\n  Scaffolding ${name}${hadConfig ? ' (into existing config-only dir)' : ''}...\n`)
-
+  consola.info(`\n  Scaffolding${hadConfig ? ' (into existing config-only dir)' : ''}...\n`)
   for (const file of files) {
-    const filePath = join(appDir, file.path)
     if (file.path === 'crouton.config.js' && hadConfig) {
       consola.info('  • crouton.config.js exists — preserving the reviewed config')
       continue
     }
+    const filePath = join(appDir, file.path)
     await mkdir(join(filePath, '..'), { recursive: true })
     await writeFile(filePath, file.content)
     consola.success('  + ' + file.path)
   }
+}
 
-  // Print next steps
-  consola.info(`\n  Done! ${files.length} files created in ${appDir}/\n`)
+function printScaffoldNextSteps(appDir: string, fileCount: number, cf: boolean) {
+  consola.info(`\n  Done! ${fileCount} files created in ${appDir}/\n`)
   consola.warn('  Next steps:\n')
   console.log('  1.', `cd ${appDir}`)
   console.log('  2.', 'pnpm install')
@@ -719,6 +701,4 @@ export async function scaffoldApp(
     console.log('  7.', 'pnpm cf:staging   (deploys an isolated, auto-provisioned staging env)')
   }
   console.log()
-
-  return { files, appDir }
 }


### PR DESCRIPTION
## 👤 For humans

The last wrinkle: the pipeline's schema step writes `pocs/<name>/crouton.config.js` first, so `crouton init` hit *"directory already exists"*. Now `crouton init`:
- **scaffolds *into* a config-only dir** (has just `crouton.config.js`) and **preserves that reviewed config**,
- **refuses only an already-scaffolded dir** (`.crouton.json`/`package.json`),
- **stamps a `.crouton.json` identifier** (`{name, kind, cliVersion, scaffoldedAt}`) — provenance + the guard's marker (your idea).

So a POC scaffolds in one command — no more improvised workaround.

## 🧪 How to test (verified in isolation)

```
1. FRESH dir        → scaffolded + .crouton.json ✓
2. CONFIG-ONLY dir  → scaffolds INTO it, reviewed config preserved ✓
3. already-scaffolded → refused (.crouton.json present) ✓
```

Closes #1233