### PR TITLE
chore(root): fallow complexity gate advisory via health-baseline ratchet (#1236)

### DIFF
--- a/.fallow-health-baseline.json
+++ b/.fallow-health-baseline.json
@@ -1,0 +1,8186 @@
+{
+  "finding_counts": {
+    "apps/fanfare/app/pages/admin/[team]/sales/events/index.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/app/pages/index.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId]/move.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/pages/collections/pages/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "apps/fanfare/layers/pages/collections/pages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/categories/server/api/teams/[id]/sales-categories/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/categories/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/fanfare/layers/sales/collections/categories/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/clients/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/clients/server/api/teams/[id]/sales-clients/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/clients/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "apps/fanfare/layers/sales/collections/clients/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/events/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/events/server/api/teams/[id]/sales-events/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/events/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "apps/fanfare/layers/sales/collections/events/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/eventsettings/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/eventsettings/server/api/teams/[id]/sales-eventsettings/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/eventsettings/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/fanfare/layers/sales/collections/eventsettings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/kdsbumps/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/kdsbumps/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/kdsbumps/server/api/teams/[id]/sales-kdsbumps/index.get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/kdsbumps/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/fanfare/layers/sales/collections/kdsbumps/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/locations/server/api/teams/[id]/sales-locations/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/locations/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/fanfare/layers/sales/collections/locations/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orderitems/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orderitems/server/api/teams/[id]/sales-orderitems/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orderitems/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orderitems/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orders/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orders/server/api/teams/[id]/sales-orders/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orders/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/fanfare/layers/sales/collections/orders/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printers/server/api/teams/[id]/sales-printers/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printers/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printers/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printqueues/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printqueues/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printqueues/server/api/teams/[id]/sales-printqueues/index.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printqueues/server/database/queries.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/fanfare/layers/sales/collections/printqueues/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/products/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/products/app/components/Option/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/products/app/components/Option/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/products/server/api/teams/[id]/sales-products/index.get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/products/server/api/teams/[id]/sales-products/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/layers/sales/collections/products/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/fanfare/layers/sales/collections/products/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/fanfare/scripts/sync-wrangler-ids.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/app/components/CategorizeCategorizeLayoutsCard.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/app/components/NotionCardNode.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/app/pages/admin/[team]/categorize.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 4
+      },
+      "crap_high": {
+        "count": 9
+      },
+      "crap_moderate": {
+        "count": 6
+      }
+    },
+    "apps/triage/layers/categorize/collections/categorize-layouts/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/collections/categorize-layouts/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/triage/layers/categorize/collections/categorize-layouts/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/server/api/teams/[id]/notion/database/[databaseId]/categorize.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/server/api/teams/[id]/notion/database/[databaseId]/pages.get.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/server/api/teams/[id]/notion/database/[databaseId]/property.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/categorize/server/api/teams/[id]/notion/databases.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId]/move.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/pages/collections/pages/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/triage/layers/pages/collections/pages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/accounts/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/accounts/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/triage/layers/triage/collections/accounts/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/discussions/app/components/List.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/discussions/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/discussions/server/database/queries.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/triage/layers/triage/collections/discussions/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/flows/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/flows/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/flows/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/triage/layers/triage/collections/flows/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/inputs/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/inputs/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/triage/layers/triage/collections/inputs/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/jobs/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/jobs/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/jobs/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/triage/layers/triage/collections/jobs/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/messages/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "apps/triage/layers/triage/collections/messages/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/triage/layers/triage/collections/messages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/outputs/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/outputs/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/outputs/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/triage/layers/triage/collections/outputs/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/tasks/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/tasks/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/triage/layers/triage/collections/tasks/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/users/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/layers/triage/collections/users/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "apps/triage/layers/triage/collections/users/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/triage/scripts/sync-wrangler-ids.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/bookings/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/bookings/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/bookings/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/bookings/collections/bookings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/emaillogs/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/emaillogs/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/bookings/collections/emaillogs/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/emailtemplates/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/bookings/collections/emailtemplates/server/api/teams/[id]/bookings-emailtemplates/[emailtemplateId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/emailtemplates/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/bookings/collections/emailtemplates/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/app/components/BlockedDate/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/app/components/BlockedDate/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/app/components/Slot/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/app/components/Slot/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/server/api/teams/[id]/bookings-locations/[locationId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/server/database/queries.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/bookings/collections/locations/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/settings/app/components/Group/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/settings/app/components/Group/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/settings/app/components/Statuse/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/settings/app/components/Statuse/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/settings/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/bookings/collections/settings/server/database/queries.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/bookings/collections/settings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/crouton/collections/assets/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/crouton/collections/assets/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/crouton/collections/assets/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId]/move.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/layers/pages/collections/pages/server/database/queries.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "apps/velo/layers/pages/collections/pages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/scripts/sync-wrangler-ids.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/server/api/seed/index.post.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/server/api/seed/pages-fix.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/server/api/seed/velosolidaire.post.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "apps/velo/server/plugins/auto-seed-bookings.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "docs/app/app.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "docs/app/components/AppFooter.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "docs/app/components/AppHeader.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "docs/app/components/changelog/PackageFilter.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "docs/app/components/changelog/ReleaseCard.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "docs/app/error.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "docs/app/pages/[...slug].vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "docs/app/pages/changelogs/index.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "docs/scripts/sync-changelogs.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "docs/server/api/changelogs/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "docs/server/mcp/tools/get-page.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "docs/server/mcp/tools/list-sections.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "docs/server/mcp/tools/validate-schema.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "docs/server/routes/raw/[...slug].md.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/minimal/layers/main/collections/items/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/minimal/layers/main/collections/items/server/api/teams/[id]/main-items/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/minimal/layers/main/collections/items/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/minimal/layers/main/collections/items/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-assets/layers/main/collections/items/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-assets/layers/main/collections/items/server/api/teams/[id]/main-items/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-assets/layers/main/collections/items/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-assets/layers/main/collections/items/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/bookings/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/bookings/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/bookings/server/api/teams/[id]/bookings-bookings/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/bookings/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/bookings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/app/components/BlockedDate/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/app/components/BlockedDate/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/app/components/Slot/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/app/components/Slot/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/server/api/teams/[id]/bookings-locations/[locationId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/server/api/teams/[id]/bookings-locations/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/server/database/queries.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/locations/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/app/components/Group/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/app/components/Group/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/app/components/Status/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/app/components/Status/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/server/api/teams/[id]/bookings-settings/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/server/database/queries.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-bookings/layers/bookings/collections/settings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/main/collections/items/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/main/collections/items/server/api/teams/[id]/main-items/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-bookings/layers/main/collections/items/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-bookings/layers/main/collections/items/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-collab/layers/main/collections/items/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-collab/layers/main/collections/items/server/api/teams/[id]/main-items/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-collab/layers/main/collections/items/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-collab/layers/main/collections/items/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-devtools/layers/main/collections/items/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-devtools/layers/main/collections/items/server/api/teams/[id]/main-items/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-devtools/layers/main/collections/items/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-devtools/layers/main/collections/items/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/items/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/items/server/api/teams/[id]/main-items/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/items/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/items/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/venues/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/venues/server/api/teams/[id]/main-venues/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/venues/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-maps/layers/main/collections/venues/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/main/collections/items/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/main/collections/items/server/api/teams/[id]/main-items/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/main/collections/items/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-pages/layers/main/collections/items/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId]/move.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-pages/layers/pages/collections/pages/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "fixtures/with-pages/layers/pages/collections/pages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/categories/server/api/teams/[id]/sales-categories/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/categories/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/categories/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/clients/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/clients/server/api/teams/[id]/sales-clients/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/clients/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/clients/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/events/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/events/server/api/teams/[id]/sales-events/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/events/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/events/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/eventsettings/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/eventsettings/server/api/teams/[id]/sales-eventsettings/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/eventsettings/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/eventsettings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/kdsbumps/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/kdsbumps/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/kdsbumps/server/api/teams/[id]/sales-kdsbumps/index.get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/kdsbumps/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/kdsbumps/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/locations/server/api/teams/[id]/sales-locations/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/locations/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/locations/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orderitems/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orderitems/server/api/teams/[id]/sales-orderitems/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orderitems/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orderitems/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orders/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orders/server/api/teams/[id]/sales-orders/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orders/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/orders/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printers/server/api/teams/[id]/sales-printers/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printers/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printers/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printqueues/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printqueues/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printqueues/server/api/teams/[id]/sales-printqueues/index.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printqueues/server/database/queries.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/printqueues/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/products/app/components/List.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/products/app/components/Option/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/products/app/components/Option/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/products/server/api/teams/[id]/sales-products/index.get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/products/server/api/teams/[id]/sales-products/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/products/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "fixtures/with-sales/layers/sales/collections/products/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "fixtures/with-sales/server/api/_seed.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/Admin/Dashboard.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/Admin/StatsCard.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/Admin/TeamList.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/Admin/UserList.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/TeamColorSwatchPicker.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/TeamDomainSettings.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-admin/app/components/TeamFaviconSettings.vue": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/TeamSiteInfoSettings.vue": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/components/TeamThemeSettings.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/composables/useAdminTeams.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/composables/useAdminUsers.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/composables/useTeamFavicon.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/composables/useTeamTheme.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/middleware/super-admin.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/middleware/team-admin.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/[team]/index.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/[team]/team.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/[team]/team/domains.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/[team]/team/email-templates.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/[team]/team/look-and-feel.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/[team]/team/redirects.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/[team]/team/settings.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/admin/index.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/super-admin/index.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/super-admin/teams.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/pages/super-admin/users.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/app/plugins/team-theme.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/impersonate/start.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/impersonate/status.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/impersonate/stop.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/stats.get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/teams/index.get.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/users/ban.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/users/create.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/api/admin/users/index.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-admin/server/utils/admin.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/app/components/AIPageGenerator.vue": {
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-ai/app/components/AITranslateButton.vue": {
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-ai/app/components/Chatbox.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/app/components/Message.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/app/composables/useChat.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-ai/app/composables/useCompletion.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/app/composables/useTranslationSuggestion.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/server/api/ai/generate-email-template.post.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/server/api/ai/generate-page.post.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/server/api/ai/translate-blocks.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/server/api/ai/translate.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-ai/server/utils/index.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-ai/shared/utils/ai-providers.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-assets/app/components/AssetTile.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-assets/app/components/Card.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-assets/app/components/Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-assets/app/components/FormUpdate.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-assets/app/components/Picker.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-assets/app/components/Uploader.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-assets/app/composables/useAssetUpload.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-assets/app/utils/asset.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-assets/crouton.manifest.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/app/components/BlockCanvas.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/app/components/BlockDetail.vue": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/app/components/BlockPalette.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/app/components/GeneratePanel.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/app/components/PresenceIndicator.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/app/composables/useAtelierScaffold.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-atelier/app/pages/admin/[team]/atelier/[id].vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/app/pages/admin/[team]/atelier/index.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-atelier/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-audio/app/components/Controls.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-audio/app/composables/useAudioPlayer.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Account/DeleteAccount.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Account/LinkedAccounts.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/components/Account/PasskeyManager.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Account/PasswordForm.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/components/Account/ProfileForm.vue": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-auth/app/components/Account/Sessions.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/components/Account/Settings.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Account/TwoFactorSetup.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Admin/EmailLogs.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Auth/ForgotPasswordForm.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Auth/LoginForm.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Auth/OAuthButtons.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Auth/RegisterForm.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Auth/RouteModal.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-auth/app/components/Auth/TwoFactorForm.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/components/Error/AuthErrorAlert.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Loading/AuthGuard.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/components/Loading/AuthSkeleton.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Sidebar/AuthSidebar.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Sidebar/TeamSection.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Sidebar/UserMenu.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Team/CreateForm.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Team/DeleteConfirm.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Team/Invitations.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/components/Team/MemberRow.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-auth/app/components/Team/Members.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/components/Team/Settings.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/components/Team/Switcher.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/composables/useAuth.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/composables/useScopedAccess.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/composables/useSession.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "complexity_moderate": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-auth/app/composables/useTeam.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/composables/useTeamContext.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/composables/useUserMenuItems.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/middleware/auth.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/middleware/guest.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/middleware/team-context.global.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/pages/auth/accept-invitation/[id].vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/pages/auth/magic-link.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/pages/auth/verify-email.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/plugins/auth-401-redirect.client.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/plugins/auth-client.client.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/plugins/auth-modal-router.client.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/plugins/team-context.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/app/utils/errors.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/app/utils/security.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/module.ts": {
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/scripts/migrate.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/auth/[...all].ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/auth/invitations/[id].get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/auth/invitations/[id]/resend.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/auth/scoped-access/mint.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/auth/scoped-access/redeem.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/teams/[id]/domains/[domainId].delete.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/teams/[id]/domains/[domainId]/verify.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/teams/[id]/email-logs/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/api/teams/[id]/email-logs/stats.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/lib/auth.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-auth/server/middleware/team-context.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/plugins/auth-email-logger.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/plugins/auth-init.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/plugins/team-init.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-auth/server/utils/team.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/ActivityTimeline.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/BlockedDateInput.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/components/Blocks/BookingBlockRender.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/Blocks/BookingBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/BookingCard.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/BookingCreateCard.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/components/Calendar.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/components/Layout/Locations.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/components/List.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-bookings/app/components/LocationCard.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/components/LocationForm.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/OpenDaysPicker.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/Panel.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 4
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/components/PanelFilters.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/PanelMap.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/ScheduleGrid.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/components/Slot/Indicator.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/components/WeekStrip.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingAvailability.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingCart.ts": {
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingCartStorage.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingEmail.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingMonthlyLimit.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingOptions.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingSlots.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-bookings/app/composables/useBookingsList.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-bookings/app/composables/useScheduleRules.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 3
+      }
+    },
+    "packages/crouton-bookings/app/pages/admin/[team]/bookings/email-logs.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/app/pages/admin/[team]/bookings/email-templates.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 3
+      }
+    },
+    "packages/crouton-bookings/app/pages/admin/[team]/bookings/index.vue": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/admin-bookings.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/availability.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/bookings/[bookingId]/index.patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/bookings/[bookingId]/resend-email.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/customer-bookings-batch.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/customer-bookings.get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/customer-locations.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/monthly-booking-count.get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-bookings/server/utils/email-service.ts": {
+      "complexity_critical": {
+        "count": 4
+      },
+      "crap_critical": {
+        "count": 5
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-charts/app/components/Blocks/ChartBlockRender.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-charts/app/components/Blocks/ChartBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-charts/app/components/Blocks/ChartPresetPicker.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-charts/app/components/Widget.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-charts/app/composables/useCollectionChart.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/bin/crouton-generate.js": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/add-events.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/add-module.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/db-pull.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/deploy-check.ts": {
+      "crap_critical": {
+        "count": 3
+      }
+    },
+    "packages/crouton-cli/lib/doctor.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-cli/lib/generate-collection.ts": {
+      "complexity_critical": {
+        "count": 5
+      },
+      "crap_critical": {
+        "count": 9
+      },
+      "crap_high": {
+        "count": 6
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-cli/lib/generators/api-test.ts": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/generators/collection-readme.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/generators/collection-seed-fixture.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/generators/collection-test.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/generators/collection-types-registry.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/generators/database-queries.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-cli/lib/generators/database-schema.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/generators/field-components.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/generators/form-component.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "complexity_moderate": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/generators/list-component.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/init-app.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/install-crouton.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/install-modules.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/rollback-bulk.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/rollback-collection.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/rollback-interactive.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/seed-app.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/seed-translations.ts": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-cli/lib/templates/deploy-workflow.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/templates/wrangler/sync-wrangler-ids.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/config-builder.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/css-setup.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/detect-package-manager.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/utils/dialects.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/framework-packages.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/generate-migrations.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/helpers.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/i18n-schema.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/layer-config.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/layer-discovery.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/load-fields.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/manifest-loader.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-cli/lib/utils/manifest-merge.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/module-detector.ts": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-cli/lib/utils/parse-app-config.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-cli/lib/utils/update-app-config.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-cli/lib/utils/update-nuxt-config.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-cli/lib/utils/update-schema-index.ts": {
+      "crap_critical": {
+        "count": 4
+      }
+    },
+    "packages/crouton-cli/lib/utils/validate-config.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/components/CollabCursors.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/components/CollabEditingBadge.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/components/CollabPresence.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/components/CollabStatus.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-collab/app/composables/useCollabConnection.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/composables/useCollabEditor.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/composables/useCollabLocalizedContent.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-collab/app/composables/useCollabPresence.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/composables/useCollectionSyncSignal.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/app/composables/useFormCollabPresence.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-collab/server/durable-objects/CollabRoom.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/server/routes/api/collab/[roomId]/users.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-collab/server/routes/api/collab/[roomId]/ws.ts": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 4
+      }
+    },
+    "packages/crouton-collab/worker-template/src/index.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/app.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/AdminSidebar.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-core/app/components/AdminStatusBar.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/AppearanceSwitcher.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Calendar.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Collection.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "packages/crouton-core/app/components/CollectionViewer.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/ConfirmButton.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ContentArticle.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ContentPage.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/DefaultCard.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/DeleteButton.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/DependentFieldCardMini.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Detail.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-core/app/components/DetailLayout.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/DraggableItem.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/DraggableList.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/DropZone.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ExportButton.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormActionButton.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormColorPicker.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormDependentButtonGroup.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormDependentSelectOption.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/FormDynamicLoader.vue": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormExpandableSlideOver.vue": {
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/FormLayout.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormOptionsSelect.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/FormReferenceSelect.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormRepeater.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/FormTranslatableOptionItem.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-core/app/components/IconPicker.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ImportPreviewModal.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ItemButtonsMini.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ItemCardMini.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ItemCardSmall.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ItemDependentField.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Kanban.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/KanbanColumn.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/Loading.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/OptionsFieldCardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/RedirectsForm.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/SetupDashboard/CollectionCard.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/SetupDashboard/ConfigViewer.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/SetupDashboard/Index.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/ShortcutHint.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Table.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/TableHeader.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Tree.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/TreeNode.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-core/app/components/TreeView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/UsersAvatarUpload.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/UsersCardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/components/Workspace.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/WorkspaceEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/WorkspaceLayout.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/WorkspaceSidebar.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/stubs/CroutonEditorPreview.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/components/stubs/CroutonMapsPreview.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useAdminStatusBar.ts": {
+      "complexity_moderate": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/composables/useCollectionExport.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useCollectionImport.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/app/composables/useCollectionMutation.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useCrouton.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useCroutonApps.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useCroutonCollectionsNav.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useCroutonShortcuts.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useDisplayConfig.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useImageCrop.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useKanban.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useNotify.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/composables/useTableColumns.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/error.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/pages/admin/[team]/crouton/[collection].vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/pages/index.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/app/plugins/component-warmup.client.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/modules/ensure-hub-blob.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/modules/ipx-blob.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/nuxt.config.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/scripts/sync-stub.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/server/api/crouton/setup/stats.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/api/teams/[id]/settings/site.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/api/teams/[id]/settings/site.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/api/teams/[id]/settings/theme.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/api/upload-image.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/database/queries/redirects.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/server/middleware/redirects.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/utils/createExternalCollectionHandler.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/utils/encryption.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-core/server/utils/redirectCache.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/utils/scaffold-pipeline.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/server/utils/tiptap-renderer.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/shared/seed/runner.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-core/shared/seed/sql.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/ChatPanel.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/CollectionEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/FieldRow.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/GenerationSummary.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/IntakeSummaryCard.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/ReviewPanel.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/SeedDataPanel.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/components/ValidationChecklist.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/composables/useAppScaffold.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-designer/app/composables/useCollectionDesignPrompt.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-designer/app/composables/useCollectionEditor.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/composables/useFieldTypes.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/composables/useIntakePrompt.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-designer/app/composables/useReviewPrompt.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/composables/useSchemaExport.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/composables/useSchemaValidation.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/composables/useSeedDataPrompt.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/pages/admin/[team]/designer/[id].vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-designer/app/pages/admin/[team]/designer/index.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/app/utils/promptFormatting.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/server/api/ai/designer-chat.post.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-designer/server/api/scaffold-app.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/module.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/client/app.js": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "packages/crouton-devtools/src/runtime/client/template.html": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server-rpc/endpoints.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server-rpc/events.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server-rpc/eventsHealth.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server-rpc/executeRequest.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server-rpc/operations.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server-rpc/systemOperations.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server/plugins/operationTracker.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server/plugins/reviewAlias.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server/utils/operationStore.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-devtools/src/runtime/server/utils/systemOperationStore.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-editor/app/components/Blocks.vue": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 3
+      }
+    },
+    "packages/crouton-editor/app/components/Preview.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-editor/app/components/Simple.vue": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-editor/app/components/Variables.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-editor/app/components/WithPreview.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-editor/crouton.manifest.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-email/server/emails/TeamInvite.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-email/server/plugins/auth-email-listener.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-email/server/utils/email.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-email/server/utils/resolve-email-settings.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-email/server/utils/senders.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-email/server/utils/template-renderer.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/components/CroutonActivityFilters.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/components/CroutonActivityLog.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/components/CroutonActivityTimeline.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/components/CroutonActivityTimelineItem.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/components/CroutonEventChangesTable.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/components/CroutonEventDetail.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/composables/useCroutonEventTracker.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/composables/useCroutonEvents.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/composables/useCroutonEventsExport.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/plugins/event-listener.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/app/utils/event-display.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/server/api/teams/[teamId]/crouton-operations/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/server/plugins/operation-listener.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/server/utils/cleanup.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-events/server/utils/event-filters.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-feedback/src/module.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-feedback/src/runtime/components/AnnotateOverlay.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-feedback/src/runtime/components/ChangelogOverlay.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-feedback/src/runtime/components/FeedbackLauncher.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-feedback/src/runtime/composables/useAnnotate.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-feedback/src/runtime/server/api/feedback.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/components/Flow.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 5
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 9
+      }
+    },
+    "packages/crouton-flow/app/components/Node.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-flow/app/components/PageNode.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/components/Workspace/Sidebar.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowContainerDetection.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowDragDrop.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowEphemeralData.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowGroupManager.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowLayout.ts": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowPositionStore.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowPositionSync.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowSync.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/app/composables/useFlowSyncBridge.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-flow/app/pages/admin/[team]/flows.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-flow/server/api/crouton-flow/teams/[id]/flows/[flowId].patch.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/server/api/crouton-flow/teams/[id]/flows/[flowId]/positions.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-flow/server/api/crouton-flow/teams/[id]/flows/index.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/components/DevModeToggle.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-i18n/app/components/Display.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-i18n/app/components/Input.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/components/InputWithEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/components/LanguageSwitcherIsland.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/components/ListCards.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-i18n/app/components/UiForm.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/components/UiList.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 4
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/composables/useAiTranslation.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/composables/useFieldGroups.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-i18n/app/composables/useFieldTransforms.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-i18n/app/composables/useLocaleLayout.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/composables/useT.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/app/composables/useTranslationFields.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-i18n/cli/seed.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-i18n/config-utils.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-i18n/server/api/seed/translations-ui.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/server/api/teams/[id]/settings/translations.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/server/api/teams/[id]/settings/translations.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/server/api/teams/[id]/translations-ui/[translationId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/server/api/teams/[id]/translations-ui/index.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-i18n/server/utils/serverTranslations.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-i18n/server/utils/translationsQueries.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-layout/app/components/Layout.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/components/LayoutBreakpointAuthor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/components/LayoutComposeCanvas.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/components/LayoutComposePane.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/components/LayoutEditorPane.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/components/LayoutRenderer.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/components/LayoutResponsiveRenderer.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/components/LayoutZoomShell.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/composables/useCroutonComposeGestures.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/composables/useCroutonLayoutStore.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/composables/useLayoutFlip.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/utils/layout-serialize.ts": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/utils/layout-snap.ts": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-layout/app/utils/layout-tree.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/app/components/Blocks/CollectionMapBlockRender.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-maps/app/components/Blocks/CollectionMapBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/app/components/Blocks/MapBlockRender.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/app/components/Blocks/MapBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/app/components/Map.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-maps/app/components/Marker.vue": {
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-maps/app/components/Popup.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/app/components/Preview.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/app/composables/useGeocode.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-maps/app/composables/useMapConfig.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/crouton.manifest.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-maps/server/api/maps/geocode.get.ts": {
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-mcp-toolkit/server/api/teams/[id]/mcp-tokens/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp-toolkit/server/mcp/resources/collection-schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp-toolkit/server/mcp/tools/create-item.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp-toolkit/server/mcp/tools/list-items.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp-toolkit/server/utils/mcp-auth.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp-toolkit/server/utils/mcp-collections.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp/src/tools/design-schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp/src/tools/dry-run.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp/src/tools/generate.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp/src/tools/rollback.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp/src/tools/validate-schema.ts": {
+      "complexity_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp/src/utils/cli.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-mcp/src/utils/fs.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/BlockContent.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/ButtonRowEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/CardsEditor.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/FileEditor.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/ImageEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/LinksEditor.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/LogosEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/TeamMemberPicker.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Properties/VideoEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/ButtonRowBlock.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/CardGridBlock.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/CollectionBlock.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/ContactBlock.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/EmbedBlock.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/FaqBlock.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/GalleryBlock.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/HeroBlock.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/ImageBlock.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/LogoBlock.vue": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/MailingBlock.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/PaneBlock.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/StatsBlock.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/TwoColumnBlock.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Render/VideoBlock.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/AddonBlockView.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/ButtonRowBlockView.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/CTABlockView.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/CardGridBlockView.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/CollectionBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/ContactBlockView.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/EmbedBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/FaqBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/FileBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/GalleryBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/HeroBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/ImageBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/LogoBlockView.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/MailingBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/QrCodeBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/SectionBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/SeparatorBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/StatsBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/TwoColumnBlockView.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Blocks/Views/VideoBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Card.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/CollectionBinderRenderer.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 7
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/CollectionPageRenderer.vue": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/BlockEditor.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/BlockEditorWithPreview.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/BlockPropertyPanel.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/BlockToolbar.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/LayoutPicker.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/PageTypePicker.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/SeoPreview.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/SettingsPanel.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Editor/Toolbar.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Footer.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/FooterRenderer.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Nav.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/components/Renderer.vue": {
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-pages/app/components/ScopedAccessGate.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/components/Workspace/Editor.vue": {
+      "complexity_critical": {
+        "count": 4
+      },
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 6
+      },
+      "crap_high": {
+        "count": 5
+      },
+      "crap_moderate": {
+        "count": 9
+      }
+    },
+    "packages/crouton-pages/app/components/Workspace/Sidebar.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-pages/app/composables/useDomainContext.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/composables/useFooterPage.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/composables/useLocalizedSlug.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/composables/useNavigation.ts": {
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-pages/app/composables/usePageLink.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/composables/usePageTypes.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/composables/useReorderMode.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/editor/extensions/addon-block-factory.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/editor/extensions/image-block.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/editor/extensions/page-blocks.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/editor/extensions/video-block.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/app/layouts/public.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/pages/[team]/[locale]/[...slug].vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "packages/crouton-pages/app/utils/content-detector.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/app/utils/page-path.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/nuxt.config.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/seed/index.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/server/api/public/[team]/[collection].get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/server/api/public/[team]/[collection]/[itemId].get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/server/api/teams/[id]/pages.get.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-pages/server/api/teams/[id]/pages/[...slug].get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/server/api/teams/[id]/pages/[pageId]/access-code.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/server/plugins/domain-resolver.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-pages/server/plugins/single-team-rewrite.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-printing/server/api/crouton-printing/events/[eventId]/browser-print-jobs/[jobId]/fail.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-printing/server/api/crouton-printing/events/[eventId]/browser-print-jobs/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-printing/server/api/print-server/jobs/[jobId]/fail.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-printing/server/plugins/escpos-drainer.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-printing/server/utils/print-job-queue.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-printing/server/utils/print-server-auth.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-printing/server/utils/receipt-formatter.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/ChartBlockRender.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/ChartBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/ClientsView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/EventWorkspaceRender.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/EventWorkspaceView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/KitchenDisplayRender.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/KitchenDisplayView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/LiveDashboardRender.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/LiveDashboardView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/OrdersView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/PrintBridgeRender.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/PrintBridgeView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/ProductMatrixRender.vue": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Blocks/ProductMatrixView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/CategoryForm.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Client/Cart.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Client/CategoryTabs.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Client/OrderInterface.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Client/ProductList.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Client/ProductOptionsSelect.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Client/Selector.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Dashboard/SalesSummary.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/ClientsPanel.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/OrderItems.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/PrintersTab.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/SettingsListCard.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-sales/app/components/EventWorkspace/Shell.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/LocationForm.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Pos/OrdersList.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Pos/Panel.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-sales/app/components/PrinterForm.vue": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/PrintqueuesCard.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/ProductForm.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/app/components/Settings/PrintPreviewModal.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/components/Sync/Status.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/composables/useHelperAuth.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-sales/app/composables/usePosOrder.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/app/composables/usePrintWatcher.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/events/[eventId]/display-jobs/index.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/events/[eventId]/kds-bump.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/events/[eventId]/orders/[orderId]/print-status.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/events/[eventId]/orders/[orderId]/print.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/events/[eventId]/orders/index.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/product-day-matrix.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/units-per-product-day.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/admin-helper-token.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/clients/[clientId]/end-receipt.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/duplicate.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/retry-failed.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/receipt-settings.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/plugins/cloud-sync-pusher.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/server/plugins/scoped-access.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-sales/server/utils/client-tab.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/utils/cloud-sync-pusher.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/utils/generate-print-queues.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/utils/printing-reactions.ts": {
+      "complexity_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/utils/sync-ingest.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-sales/server/utils/sync-status.ts": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-themes/themes/components/ThemeCompactPicker.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-themes/themes/components/ThemeSwitcher.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-themes/themes/composables/useThemeSwitcher.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-three/app/components/Blocks/ModelBlockView.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-three/app/composables/useThreeControls.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/AiConfig.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/app/components/Blocks/TriageBlockRender.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/Blocks/TriageBlockView.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/FeedItem.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/Panel.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 6
+      }
+    },
+    "packages/crouton-triage/app/components/PipelineBuilder.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-triage/app/components/flows/AccountManager.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "packages/crouton-triage/app/components/flows/AccountPicker.vue": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/app/components/flows/InputManager.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-triage/app/components/flows/OutputManager.vue": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 5
+      }
+    },
+    "packages/crouton-triage/app/components/shared/DomainPicker.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/usermappings/FigmaUserDiscovery.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/usermappings/NotionUserDiscovery.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/usermappings/NotionUserPicker.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/usermappings/SlackUserDiscovery.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/usermappings/UserMappingDrawer.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/components/usermappings/UserMappingTable.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/composables/useTriageConnectedAccounts.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/composables/useTriageFeed.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/app/composables/useTriageFieldMapping.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/composables/useTriageNotionSchema.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/composables/useTriageOAuth.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/composables/useTriagePromptPreview.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/pages/admin/[team]/triage.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/app/pages/admin/[team]/triage/inbox.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 6
+      }
+    },
+    "packages/crouton-triage/app/pages/admin/[team]/triage/jobs.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/adapters/figma.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 3
+      }
+    },
+    "packages/crouton-triage/server/adapters/notion.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 4
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/adapters/slack.ts": {
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 4
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/oauth/slack/callback.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/oauth/slack/install.get.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/accounts/[accountId]/verify.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/accounts/connect.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/ai/suggest-icons.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/discussions/[discussionId]/retry.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/discussions/process.post.ts": {
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/notion/schema/[databaseId].get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/notion/test-connection.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/notion/users.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/slack/users.get.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/user-mappings/bulk-import.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/webhooks/figma-email.post.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/webhooks/notion-input.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/webhooks/notion.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/webhooks/resend.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/server/api/crouton-triage/webhooks/slack.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/services/ai.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/server/services/notion.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 4
+      },
+      "crap_high": {
+        "count": 5
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/services/processor.ts": {
+      "complexity_critical": {
+        "count": 4
+      },
+      "crap_critical": {
+        "count": 6
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "packages/crouton-triage/server/services/reply-generator.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/services/userMapping.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/server/utils/emailClassifier.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/emailParser.ts": {
+      "complexity_high": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/server/utils/emoji-converter.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/field-mapping.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/logger.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/rateLimit.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/resendEmail.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/retry.ts": {
+      "complexity_high": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/securityCheck.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/server/utils/tokenResolver.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton-triage/server/utils/webhookSecurity.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "packages/crouton-triage/shared/utils/field-mapping.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "packages/crouton/src/module.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/agendas/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/agendas/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/agendas/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/agendas/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/articles/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/articles/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/articles/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 6
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/articles/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/articles/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/categories/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/categories/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/categories/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/categories/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/tags/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/tags/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/tags/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/content/collections/tags/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/crouton/collections/assets/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/crouton/collections/assets/server/api/teams/[id]/crouton-assets/[assetId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/crouton/collections/assets/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/alexdeforce/layers/crouton/collections/assets/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId]/move.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/pages/collections/pages/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "pocs/alexdeforce/layers/pages/collections/pages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/site/app/components/ArticleCard.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/site/app/components/Sidebar.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/site/app/pages/agenda/index.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/site/app/pages/archive/[category]/index.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/layers/site/app/pages/index.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/server/api/seed/content.post.ts": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 4
+      }
+    },
+    "pocs/alexdeforce/server/api/seed/fix-image-nodes.post.ts": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/server/api/seed/fix-slugs.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/server/api/seed/images.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/alexdeforce/server/api/seed/pages.post.ts": {
+      "complexity_critical": {
+        "count": 4
+      },
+      "crap_critical": {
+        "count": 4
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/bookings/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/bookings/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/bookings/server/api/teams/[id]/bookings-bookings/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/bookings/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/bookings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/app/components/BlockedDate/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/app/components/BlockedDate/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/app/components/Slot/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/app/components/Slot/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/server/api/teams/[id]/bookings-locations/[locationId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/server/api/teams/[id]/bookings-locations/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/server/database/queries.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/locations/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/app/components/Group/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/app/components/Group/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/app/components/Status/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/app/components/Status/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/server/api/teams/[id]/bookings-settings/index.get.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/server/database/queries.ts": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "pocs/booking-demo/layers/bookings/collections/settings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/scripts/sync-wrangler-ids.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/booking-demo/server/plugins/auto-seed-bookings.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 4
+      },
+      "crap_moderate": {
+        "count": 3
+      }
+    },
+    "pocs/crouton-builder-demo/app/components/SpikeFocusShell.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/crouton-builder-demo/app/components/SpikeListBlock.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/app/components/SpikePageCard.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/app/components/SpikePagePreview.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/app/composables/useSpikeMagic.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/crouton-builder-demo/app/pages/hide-recipes.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/app/pages/spike-app.vue": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 8
+      },
+      "crap_moderate": {
+        "count": 5
+      }
+    },
+    "pocs/crouton-builder-demo/app/utils/spike-layout.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/crouton-builder-demo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId]/move.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/layers/pages/collections/pages/server/database/queries.ts": {
+      "crap_high": {
+        "count": 3
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/crouton-builder-demo/layers/pages/collections/pages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/scripts/sync-wrangler-ids.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder-demo/server/api/spike-magic-ai.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder/app/components/BuilderBlock.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder/app/pages/builder/[pageId].vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder/app/pages/builder/index.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/crouton-builder/server/api/builder/post-layout.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/app/components/PublicWerkvergunningForm.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/app/components/SignaturePad.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/settings/app/components/Recipient/CardMini.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/settings/app/components/Recipient/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/settings/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/settings/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/settings/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/Cable/CardMini.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/Cable/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/List.vue": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/Photo/CardMini.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/Photo/Input.vue": {
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/Photo/Select.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/server/api/teams/[id]/kvr-werkvergunningens/[werkvergunningenId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/server/api/teams/[id]/kvr-werkvergunningens/[werkvergunningenId]/resend.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/server/database/queries.ts": {
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/server/api/public/kvr/submit.post.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/server/api/public/kvr/upload.post.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/server/utils/public-token.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/kvr/server/utils/send-werkvergunning-email.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/loop-station/app/components/BudgetTrend.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/loop-station/app/components/InventoryTable.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/loop-station/app/components/LoopGraph.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/loop-station/app/components/TraceTimeline.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/loop-station/app/composables/useLoopData.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/loop-station/app/pages/index.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/loop-station/scripts/prepare-data.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/pins/layers/main/collections/pins/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/pins/scripts/sync-wrangler-ids.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/app/components/ContentAteliersDetail.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/app/components/SiteFooter.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/app/components/SiteHeader.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/ateliers/app/components/List.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/ateliers/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/ateliers/server/api/teams/[id]/content-ateliers/[atelierId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/ateliers/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 6
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/ateliers/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/ateliers/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/categories/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/categories/server/api/teams/[id]/content-categories/[categorieId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/categories/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/categories/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/categories/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/downloads/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/downloads/server/api/teams/[id]/content-downloads/[downloadId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/downloads/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/downloads/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/downloads/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/locations/app/components/_Form.vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/locations/server/api/teams/[id]/content-locations/[locationId].patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/locations/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/locations/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/locations/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/news/app/components/_Form.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/news/server/api/teams/[id]/content-news/[newId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/news/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/news/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/news/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/persons/app/components/_Form.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/persons/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/persons/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/content/collections/persons/server/database/seed.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/crouton/collections/assets/server/api/teams/[id]/crouton-assets/[assetId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/crouton/collections/assets/server/database/queries.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/crouton/collections/assets/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId]/move.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/index.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/reorder.patch.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/pages/collections/pages/server/database/queries.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 4
+      }
+    },
+    "pocs/sintlukas/layers/pages/collections/pages/server/database/schema.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/app/components/AtelierCard.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/app/components/LocationCard.vue": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/app/components/PersonCard.vue": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/app/pages/[locale]/aanbod/[slug].vue": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/app/pages/[locale]/aanbod/index.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/app/pages/[locale]/academie.vue": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/app/pages/[locale]/contact.vue": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/site/app/pages/[locale]/index.vue": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/layers/site/server/api/public/ateliers.get.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/layers/site/server/api/public/ateliers/[slug].get.ts": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/scripts/seed-images.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/server/api/seed/content.post.ts": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 4
+      },
+      "crap_high": {
+        "count": 2
+      }
+    },
+    "pocs/sintlukas/server/api/seed/images.post.ts": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/server/api/seed/pages.post.ts": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "pocs/sintlukas/server/api/teams/[id]/content-ateliers/index.get.ts": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/app-shots.mjs": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/check-docs.mjs": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "scripts/db-clone.mjs": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      }
+    },
+    "scripts/db-counts.mjs": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "scripts/eval-ledger/append.mjs": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "scripts/eval-ledger/schema.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/eval-ledger/scoreboard.mjs": {
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/gen-package-catalog.mjs": {
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "scripts/gen-routing.mjs": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "scripts/gen-skills-doc.mjs": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/harness-layers.mjs": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/harness-stages.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/label-ready-epics.mjs": {
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "scripts/lib/drawio.mjs": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "scripts/lib/excalidraw-png.mjs": {
+      "crap_critical": {
+        "count": 1
+      }
+    },
+    "scripts/lib/excalidraw.mjs": {
+      "complexity_critical": {
+        "count": 3
+      },
+      "crap_critical": {
+        "count": 5
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/lib/wrangler-d1.mjs": {
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/seed-review-login.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "scripts/skill-freshness.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "scripts/smoke-deployed.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 3
+      },
+      "crap_high": {
+        "count": 2
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    },
+    "scripts/teardown-app.mjs": {
+      "complexity_critical": {
+        "count": 1
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      }
+    },
+    "scripts/validate-field-types-sync.mjs": {
+      "complexity_critical": {
+        "count": 2
+      },
+      "crap_critical": {
+        "count": 2
+      },
+      "crap_high": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
+      }
+    },
+    "workers/ticket-editor/src/index.ts": {
+      "crap_critical": {
+        "count": 1
+      },
+      "crap_moderate": {
+        "count": 2
+      }
+    }
+  },
+  "runtime_coverage_findings": [],
+  "target_keys": [
+    "packages/crouton-pages/app/editor/extensions/page-blocks.ts:dead code",
+    "packages/crouton-pages/app/composables/useNavigation.ts:high impact",
+    "packages/crouton-triage/server/adapters/index.ts:dead code",
+    "packages/crouton-triage/server/services/reply-generator.ts:dead code",
+    "packages/crouton-triage/server/services/processor.ts:complexity",
+    "packages/crouton-pages/app/editor/extensions/block-commands.ts:dead code",
+    "packages/crouton-triage/server/services/userMapping.ts:dead code",
+    "packages/crouton-i18n/app/composables/useEntityTranslations.ts:high impact",
+    "packages/crouton-pages/app/composables/usePageLink.ts:high impact",
+    "pocs/crouton-builder-demo/app/pages/spike-app.vue:complexity",
+    "pocs/alexdeforce/layers/content/collections/agendas/server/database/schema.ts:high impact",
+    "packages/crouton-i18n/app/components/ListCards.vue:untested risk",
+    "apps/velo/layers/bookings/collections/locations/app/composables/useBookingsLocations.ts:dead code",
+    "packages/crouton-layout/app/utils/layout-tree.ts:high impact",
+    "packages/crouton-core/app/composables/useCrouton.ts:complexity",
+    "scripts/lib/wrangler-d1.mjs:high impact",
+    "packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue:untested risk",
+    "packages/crouton-pages/app/composables/useFooterPage.ts:untested risk",
+    "apps/triage/layers/triage/collections/jobs/server/database/schema.ts:high impact",
+    "packages/crouton-pages/app/components/CollectionBinderRenderer.vue:complexity",
+    "packages/crouton-bookings/app/composables/useBookingsList.ts:high impact",
+    "packages/crouton-bookings/app/composables/useScheduleRules.ts:untested risk",
+    "packages/crouton-cli/lib/utils/helpers.ts:high impact",
+    "packages/crouton-designer/app/composables/useSchemaValidation.ts:complexity",
+    "packages/crouton-layout/app/components/LayoutRenderer.vue:complexity",
+    "pocs/booking-demo/layers/bookings/collections/locations/app/composables/useBookingsLocations.ts:dead code",
+    "packages/crouton-triage/server/adapters/figma.ts:dead code",
+    "apps/triage/layers/triage/collections/outputs/server/database/schema.ts:high impact",
+    "packages/crouton-core/server/utils/tiptap-renderer.ts:complexity",
+    "apps/fanfare/layers/sales/collections/events/server/database/schema.ts:high impact",
+    "packages/crouton-layout/app/utils/layout-responsive.ts:high impact",
+    "packages/crouton-bookings/app/composables/useBookingSlots.ts:high impact",
+    "fixtures/with-sales/layers/sales/collections/products/server/database/schema.ts:high impact",
+    "packages/crouton-cli/lib/generators/database-schema.ts:complexity",
+    "apps/triage/layers/triage/collections/discussions/server/database/schema.ts:high impact",
+    "fixtures/with-sales/layers/sales/collections/clients/server/database/schema.ts:high impact",
+    "packages/crouton-bookings/app/components/BookingCreateCard.vue:complexity",
+    "pocs/kvr/layers/kvr/collections/settings/server/database/schema.ts:high impact",
+    "fixtures/with-sales/layers/sales/collections/events/server/database/schema.ts:high impact",
+    "apps/fanfare/layers/sales/collections/products/server/database/schema.ts:high impact",
+    "packages/crouton-sales/app/components/PrintqueuesCard.vue:untested risk",
+    "packages/crouton-triage/app/composables/useTriageFeed.ts:untested risk",
+    "apps/fanfare/layers/sales/collections/clients/server/database/schema.ts:high impact",
+    "packages/crouton-assets/app/utils/asset.ts:high impact",
+    "apps/velo/layers/bookings/collections/settings/server/database/schema.ts:high impact",
+    "packages/crouton-designer/app/components/ReviewPanel.vue:complexity",
+    "pocs/alexdeforce/layers/content/collections/articles/server/database/schema.ts:high impact",
+    "pocs/loop-station/app/composables/useLoopData.ts:high impact",
+    "apps/triage/layers/triage/collections/flows/server/database/schema.ts:high impact",
+    "apps/velo/layers/bookings/collections/bookings/server/database/schema.ts:high impact",
+    "packages/crouton-triage/server/adapters/notion.ts:dead code",
+    "packages/crouton-triage/server/services/ai.ts:dead code",
+    "pocs/crouton-builder-demo/app/components/SpikeBlockNode.vue:complexity",
+    "packages/crouton-pages/app/components/Nav.vue:complexity",
+    "packages/crouton-pages/app/components/Blocks/Views/ContactBlockView.vue:untested risk",
+    "packages/crouton-cli/lib/generate-collection.ts:complexity",
+    "packages/crouton-pages/app/components/Workspace/Editor.vue:complexity",
+    "packages/crouton-admin/app/components/TeamDomainSettings.vue:complexity",
+    "pocs/crouton-builder-demo/app/composables/useSpikeMagic.ts:untested risk",
+    "packages/crouton-core/app/components/Detail.vue:complexity",
+    "packages/crouton-sales/app/components/EventWorkspace/OrderItems.vue:complexity",
+    "pocs/crouton-builder/app/pages/builder/[pageId].vue:complexity",
+    "packages/crouton-triage/server/services/notion.ts:complexity",
+    "packages/crouton-designer/app/composables/useSchemaExport.ts:complexity",
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/customer-bookings-batch.post.ts:complexity",
+    "pocs/crouton-builder-demo/app/components/SpikeFocusShell.vue:complexity",
+    "packages/crouton-auth/app/middleware/team-context.global.ts:complexity",
+    "packages/crouton-printing/server/utils/receipt-formatter.ts:complexity",
+    "packages/crouton-sales/app/components/Client/Cart.vue:complexity",
+    "packages/crouton-i18n/app/components/Input.vue:complexity",
+    "packages/crouton-bookings/app/components/BookingCard.vue:complexity",
+    "packages/crouton-bookings/app/components/LocationForm.vue:complexity",
+    "packages/crouton-editor/app/components/Preview.vue:complexity",
+    "apps/triage/layers/categorize/server/api/teams/[id]/notion/database/[databaseId]/pages.get.ts:complexity",
+    "packages/crouton-maps/app/components/Blocks/CollectionMapBlockRender.vue:untested risk",
+    "packages/crouton-auth/server/database/schema/auth.ts:circular dependency",
+    "packages/crouton-layout/app/components/LayoutResponsiveRenderer.vue:complexity",
+    "packages/crouton-flow/app/components/Flow.vue:complexity",
+    "pocs/sintlukas/server/api/seed/images.post.ts:complexity",
+    "packages/crouton-pages/app/components/Blocks/Views/LogoBlockView.vue:complexity",
+    "packages/crouton-pages/server/api/teams/[id]/pages/[...slug].get.ts:complexity",
+    "packages/crouton-bookings/server/utils/email-service.ts:complexity",
+    "packages/crouton-sales/app/components/Client/OrderInterface.vue:complexity",
+    "packages/crouton-bookings/app/components/ScheduleGrid.vue:complexity",
+    "packages/crouton-designer/app/components/FieldRow.vue:complexity",
+    "scripts/harness-stages.mjs:untested risk",
+    "scripts/lib/excalidraw.mjs:complexity",
+    "packages/crouton-auth/server/database/schema/user-profile.ts:circular dependency",
+    "packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue:complexity",
+    "packages/crouton-auth/app/components/Team/Members.vue:complexity",
+    "packages/crouton-auth/app/components/Auth/RouteModal.vue:complexity",
+    "packages/crouton-collab/app/components/CollabEditingBadge.vue:complexity",
+    "packages/crouton-layout/app/components/Layout.vue:complexity",
+    "packages/crouton-cli/lib/add-module.ts:complexity",
+    "packages/crouton-mcp/src/tools/validate-schema.ts:complexity",
+    "apps/triage/layers/categorize/app/pages/admin/[team]/categorize.vue:complexity",
+    "packages/crouton-cli/lib/utils/validate-config.ts:complexity",
+    "packages/crouton-designer/app/components/CollectionEditor.vue:complexity",
+    "docs/app/pages/[...slug].vue:untested risk",
+    "packages/crouton-bookings/app/components/List.vue:complexity",
+    "packages/crouton-designer/app/components/GenerationSummary.vue:complexity",
+    "packages/crouton-sales/app/components/Client/ProductList.vue:complexity",
+    "packages/crouton-assets/app/components/FormUpdate.vue:complexity",
+    "packages/crouton-cli/lib/utils/module-detector.ts:complexity",
+    "packages/crouton-core/app/components/Collection.vue:complexity",
+    "packages/crouton-admin/app/pages/admin/index.vue:complexity",
+    "packages/crouton-cli/lib/utils/manifest-merge.ts:complexity",
+    "packages/crouton-triage/server/api/crouton-triage/oauth/slack/callback.get.ts:complexity",
+    "packages/crouton-core/app/components/DefaultCard.vue:complexity",
+    "packages/crouton-layout/app/components/LayoutBreakpointAuthor.vue:complexity",
+    "pocs/sintlukas/server/api/seed/content.post.ts:complexity",
+    "packages/crouton-core/app/components/stubs/CroutonEditorPreview.vue:untested risk",
+    "packages/crouton-pages/server/api/teams/[id]/pages.get.ts:complexity",
+    "packages/crouton-admin/app/middleware/team-admin.ts:complexity",
+    "packages/crouton-triage/app/components/PipelineBuilder.vue:complexity",
+    "apps/velo/server/api/seed/velosolidaire.post.ts:complexity",
+    "packages/crouton-cli/lib/generators/form-component.ts:complexity",
+    "packages/crouton-cli/lib/utils/layer-config.ts:complexity",
+    "pocs/alexdeforce/server/api/seed/fix-image-nodes.post.ts:complexity",
+    "packages/crouton-bookings/app/components/ActivityTimeline.vue:complexity",
+    "apps/velo/server/api/seed/index.post.ts:complexity",
+    "packages/crouton-triage/app/components/Panel.vue:complexity",
+    "packages/crouton-sales/app/components/EventWorkspace/Shell.vue:complexity",
+    "pocs/alexdeforce/server/api/seed/images.post.ts:complexity",
+    "packages/crouton-pages/app/components/Blocks/Properties/LogosEditor.vue:complexity",
+    "packages/crouton-triage/app/pages/admin/[team]/triage/jobs.vue:complexity",
+    "pocs/alexdeforce/server/api/seed/pages.post.ts:complexity",
+    "scripts/teardown-app.mjs:complexity",
+    "scripts/smoke-deployed.mjs:untested risk",
+    "packages/crouton-devtools/src/runtime/server-rpc/eventsHealth.ts:complexity",
+    "pocs/kvr/layers/kvr/collections/werkvergunningens/app/components/_Form.vue:complexity",
+    "pocs/alexdeforce/server/api/seed/content.post.ts:complexity",
+    "apps/triage/layers/triage/collections/discussions/app/components/_Form.vue:complexity",
+    "packages/crouton-core/app/components/ImportPreviewModal.vue:complexity",
+    "scripts/seed-review-login.mjs:complexity",
+    "packages/crouton-bookings/app/components/Calendar.vue:complexity",
+    "packages/crouton-designer/app/components/IntakeSummaryCard.vue:complexity",
+    "packages/crouton-pages/app/components/Editor/BlockPropertyPanel.vue:complexity",
+    "packages/crouton-triage/app/components/flows/OutputManager.vue:complexity",
+    "packages/crouton-i18n/app/components/InputWithEditor.vue:complexity",
+    "scripts/db-clone.mjs:complexity",
+    "packages/crouton-i18n/app/components/UiList.vue:complexity",
+    "packages/crouton-pages/app/components/Blocks/Properties/ButtonRowEditor.vue:complexity",
+    "packages/crouton-sales/app/components/EventWorkspace/ClientsPanel.vue:complexity",
+    "packages/crouton-bookings/app/pages/admin/[team]/bookings/email-templates.vue:complexity",
+    "packages/crouton-triage/server/api/crouton-triage/webhooks/notion-input.post.ts:complexity",
+    "apps/fanfare/scripts/sync-wrangler-ids.mjs:complexity",
+    "apps/triage/scripts/sync-wrangler-ids.mjs:complexity",
+    "apps/velo/scripts/sync-wrangler-ids.mjs:complexity",
+    "docs/server/mcp/tools/validate-schema.ts:complexity",
+    "packages/crouton-bookings/app/components/PanelFilters.vue:complexity",
+    "packages/crouton-cli/lib/templates/wrangler/sync-wrangler-ids.mjs:complexity",
+    "packages/crouton-pages/app/components/Blocks/Properties/ImageEditor.vue:complexity",
+    "pocs/booking-demo/scripts/sync-wrangler-ids.mjs:complexity",
+    "pocs/crouton-builder-demo/scripts/sync-wrangler-ids.mjs:complexity",
+    "pocs/pins/scripts/sync-wrangler-ids.mjs:complexity",
+    "packages/crouton-pages/app/components/Blocks/Render/ContactBlock.vue:complexity",
+    "packages/crouton/src/module.ts:complexity",
+    "packages/crouton-events/app/components/CroutonEventChangesTable.vue:complexity",
+    "packages/crouton-triage/app/pages/admin/[team]/triage/inbox.vue:complexity",
+    "packages/crouton-atelier/app/components/GeneratePanel.vue:complexity",
+    "packages/crouton-bookings/server/api/crouton-bookings/teams/[id]/availability.get.ts:complexity",
+    "pocs/kvr/server/utils/send-werkvergunning-email.ts:complexity",
+    "packages/crouton-sales/app/components/Blocks/PrintBridgeRender.vue:complexity",
+    "scripts/validate-field-types-sync.mjs:complexity",
+    "packages/crouton-pages/app/components/Blocks/Properties/VideoEditor.vue:complexity",
+    "packages/crouton-triage/server/api/crouton-triage/teams/[id]/notion/schema/[databaseId].get.ts:complexity",
+    "packages/crouton-triage/app/components/usermappings/SlackUserDiscovery.vue:complexity",
+    "packages/crouton-triage/app/components/usermappings/NotionUserDiscovery.vue:complexity",
+    "packages/crouton-triage/app/components/flows/InputManager.vue:complexity",
+    "packages/crouton-cli/lib/seed-translations.ts:complexity"
+  ]
+}

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -94,6 +94,16 @@
       "fixtures/**" // throwaway generated e2e apps — duplication is by design
     ]
   },
+  // Complexity/unit-size (CRAP, big functions) is advisory, not walling (#1235/#1236).
+  // fallow bundles dead-code + complexity + duplication into ONE audit pass/fail with no
+  // per-category "warn" switch — so we snapshot today's complexity and gate only on findings
+  // WORSE than the snapshot: touching a legacy big function passes, NEW mess is still blocked,
+  // dead-code + duplication stay strict. Regenerate the ratchet as we burn legacy down:
+  //   npx fallow health --save-baseline .fallow-health-baseline.json
+  // (kept at repo root, not .fallow/, because fallow self-ignores its .fallow/ cache dir.)
+  "audit": {
+    "healthBaseline": ".fallow-health-baseline.json"
+  },
   "rules": {
     "unused-dependencies": "warn"
   }


### PR DESCRIPTION
Closes #1236 · part of #1235

## 👤 For humans
Touching an old file that contains a big/tangled function no longer blocks your PR — fallow's **complexity** check is now advisory for *existing* code. **Dead code and duplication still block**, and writing **brand-new** tangled code **still blocks** (so the mess can't grow). As we burn down legacy complexity (#1235), regenerate the snapshot to ratchet the bar down.

## 🤖 For agents — this is a RESHAPE of #1236
The issue's prescribed fix — set `complexity` + `unit-size` to `warn` in `.fallowrc.json`'s `rules` block — is a **verified no-op**: those are fallow *health metrics*, **not** `rules` keys (absent from the rules enum). `fallow audit` bundles dead-code + complexity + duplication into **one pass/fail verdict** with no per-category severity and no `--skip`/`--only` (both exit 2).

**Real mechanism (Option 1 — ratchet):**
- `.fallowrc.json` → `audit.healthBaseline: ".fallow-health-baseline.json"`
- `.fallow-health-baseline.json` — committed snapshot from `fallow health --save-baseline`
- Audit gates only on complexity findings **worse than the snapshot**; inherited/touched-legacy findings pass. Dead-code + dupes are unbaselined → stay strict.
- Baseline lives at repo root (not `.fallow/`, which fallow self-ignores via a nested `.fallow/.gitignore *`).

## 🧪 How to test
Against the CI-pinned `fallow@2.104.0`, verified all four:
| Change | Verdict |
|---|---|
| Touch a legacy >60-LOC function (comment append) | ✅ PASS (exit 0) |
| Introduce a brand-new tangled function | 🚫 FAIL (exit 1) |
| Introduce new dead code | 🚫 FAIL (exit 1) |
| Clean/no-op change | ✅ PASS (exit 0) |

**Merge this first** — it's the enabler for the #1235 burn-down (WS2–5). Regenerate the baseline after complexity-reducing work lands to lock the gains in.