### PR TITLE
refactor: burn down the 12 worst >120-LOC functions in packages/ (batch 1) (#1237)

### DIFF
--- a/packages/crouton-auth/app/composables/useSession.ts
+++ b/packages/crouton-auth/app/composables/useSession.ts
@@ -18,6 +18,7 @@
  * </script>
  * ```
  */
+import type { Ref } from 'vue'
 import type { Session, User, Team } from '../../types'
 import { useAuthClientSafe } from '../../types/auth-client'
 
@@ -26,13 +27,29 @@ export interface SessionData {
   user: User
 }
 
-export function useSession() {
-  const authClient = useAuthClientSafe()
-  const config = useRuntimeConfig()
-  const debug = (config.public?.crouton?.auth as { debug?: boolean } | undefined)?.debug ?? false
-  const headers = import.meta.server ? useRequestHeaders() : undefined
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyRef = Ref<any>
 
-  // Shared state using useState (works in components, middleware, plugins)
+/**
+ * Everything the session helpers need: the auth client, request context,
+ * and the shared refs. Helpers receive the refs themselves (never `.value`)
+ * so reactivity is preserved.
+ */
+interface SessionContext {
+  authClient: ReturnType<typeof useAuthClientSafe>
+  debug: boolean
+  headers: ReturnType<typeof useRequestHeaders> | undefined
+  sessionState: AnyRef
+  userState: AnyRef
+  activeOrgState: AnyRef
+  userProfileState: AnyRef
+  isPendingState: Ref<boolean>
+  errorState: Ref<Error | null>
+  isListening: Ref<boolean>
+}
+
+// Shared state using useState (works in components, middleware, plugins)
+function createSessionState() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sessionState = useState<any>('crouton-auth-session', () => null)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,201 +64,231 @@ export function useSession() {
   // Track if we've set up the signal listener (once per app)
   const isListening = useState('crouton-auth-listening', () => false)
 
-  // Fetch session from Better Auth
-  async function fetchSession(): Promise<void> {
+  return {
+    sessionState,
+    userState,
+    activeOrgState,
+    userProfileState,
+    isPendingState,
+    errorState,
+    isListening
+  }
+}
+
+// Server-side session fetch: authClient is not available (client-only plugin), use $fetch directly
+async function fetchSessionOnServer(ctx: SessionContext): Promise<void> {
+  const { debug, headers, sessionState, userState } = ctx
+
+  const requestHeaders = headers ?? {}
+  const data = await ($fetch as (url: string, opts?: Record<string, unknown>) => Promise<{ session: unknown; user: unknown } | null>)(
+    '/api/auth/get-session',
+    { headers: requestHeaders }
+  ).catch(() => null)
+
+  sessionState.value = data?.session ?? null
+  userState.value = data?.user ?? null
+
+  if (debug) {
+    console.log('[@crouton/auth] useSession: server fetched', {
+      hasSession: !!data?.session,
+      user: (data?.user as Record<string, unknown> | null)?.email ?? null
+    })
+  }
+}
+
+// Client-side session fetch: use Better Auth client
+async function fetchSessionOnClient(ctx: SessionContext): Promise<void> {
+  const { authClient, debug, headers, sessionState, userState, errorState } = ctx
+
+  if (!authClient) return
+
+  const { data, error } = await authClient.getSession({
+    fetchOptions: { headers }
+  })
+
+  if (error) {
     if (debug) {
-      console.log('[@crouton/auth] useSession: fetching session...')
+      console.log('[@crouton/auth] useSession: fetch error', error)
     }
+    errorState.value = new Error(error.message ?? 'Session error')
+    sessionState.value = null
+    userState.value = null
+  } else {
+    sessionState.value = data?.session ?? null
+    userState.value = data?.user ?? null
 
-    isPendingState.value = true
-    errorState.value = null
-
-    try {
-      if (import.meta.server) {
-        // Server-side: authClient is not available (client-only plugin), use $fetch directly
-        const requestHeaders = headers ?? {}
-        const data = await ($fetch as (url: string, opts?: Record<string, unknown>) => Promise<{ session: unknown; user: unknown } | null>)(
-          '/api/auth/get-session',
-          { headers: requestHeaders }
-        ).catch(() => null)
-
-        sessionState.value = data?.session ?? null
-        userState.value = data?.user ?? null
-
-        if (debug) {
-          console.log('[@crouton/auth] useSession: server fetched', {
-            hasSession: !!data?.session,
-            user: (data?.user as Record<string, unknown> | null)?.email ?? null
-          })
-        }
-      } else {
-        // Client-side: use Better Auth client
-        if (!authClient) return
-
-        const { data, error } = await authClient.getSession({
-          fetchOptions: { headers }
-        })
-
-        if (error) {
-          if (debug) {
-            console.log('[@crouton/auth] useSession: fetch error', error)
-          }
-          errorState.value = new Error(error.message ?? 'Session error')
-          sessionState.value = null
-          userState.value = null
-        } else {
-          sessionState.value = data?.session ?? null
-          userState.value = data?.user ?? null
-
-          if (debug) {
-            console.log('[@crouton/auth] useSession: fetched', {
-              hasSession: !!data?.session,
-              user: data?.user?.email ?? null
-            })
-          }
-        }
-      }
-    } catch (err) {
-      console.error('[@crouton/auth] useSession: fetch failed', err)
-      errorState.value = err instanceof Error ? err : new Error('Session fetch failed')
-      sessionState.value = null
-      userState.value = null
-    } finally {
-      isPendingState.value = false
+    if (debug) {
+      console.log('[@crouton/auth] useSession: fetched', {
+        hasSession: !!data?.session,
+        user: data?.user?.email ?? null
+      })
     }
   }
+}
 
-  // Fetch active organization
-  // If no active org is set (400 error), try to find and set one automatically
-  async function fetchActiveOrg(): Promise<void> {
-    // Don't fetch org data if user is not authenticated (prevents 401 console errors)
-    if (!userState.value) return
-    if (!authClient?.organization?.getFullOrganization) return
+// Fetch session from Better Auth
+async function fetchSession(ctx: SessionContext): Promise<void> {
+  const { debug, sessionState, userState, isPendingState, errorState } = ctx
 
-    try {
-      const { data, error } = await authClient.organization.getFullOrganization({
+  if (debug) {
+    console.log('[@crouton/auth] useSession: fetching session...')
+  }
+
+  isPendingState.value = true
+  errorState.value = null
+
+  try {
+    if (import.meta.server) {
+      await fetchSessionOnServer(ctx)
+    } else {
+      await fetchSessionOnClient(ctx)
+    }
+  } catch (err) {
+    console.error('[@crouton/auth] useSession: fetch failed', err)
+    errorState.value = err instanceof Error ? err : new Error('Session fetch failed')
+    sessionState.value = null
+    userState.value = null
+  } finally {
+    isPendingState.value = false
+  }
+}
+
+// Fetch active organization
+// If no active org is set (400 error), try to find and set one automatically
+async function fetchActiveOrg(ctx: SessionContext): Promise<void> {
+  const { authClient, debug, headers, userState, activeOrgState } = ctx
+
+  // Don't fetch org data if user is not authenticated (prevents 401 console errors)
+  if (!userState.value) return
+  if (!authClient?.organization?.getFullOrganization) return
+
+  try {
+    const { data, error } = await authClient.organization.getFullOrganization({
+      fetchOptions: { headers }
+    })
+
+    if (error || !data) {
+      // No active org set - try to find and set one (personal/single-tenant mode)
+      if (debug) {
+        console.log('[@crouton/auth] useSession: no active org, trying to find one...')
+      }
+      await trySetDefaultOrg(ctx)
+      return
+    }
+
+    activeOrgState.value = data
+
+    if (debug) {
+      console.log('[@crouton/auth] useSession: fetched active org', {
+        org: data?.slug ?? null
+      })
+    }
+  } catch (err) {
+    if (debug) {
+      console.log('[@crouton/auth] useSession: getFullOrganization failed, trying to find org', err)
+    }
+    // Try to find and set an org
+    await trySetDefaultOrg(ctx)
+  }
+}
+
+// Try to find and set a default organization (for personal/single-tenant modes)
+async function trySetDefaultOrg(ctx: SessionContext): Promise<void> {
+  const { authClient, debug, headers, userState, activeOrgState } = ctx
+
+  // Don't try to set org if user is not authenticated (prevents 401 console errors)
+  if (!userState.value) return
+  if (!authClient?.organization) return
+
+  try {
+    // List user's organizations
+    const { data: orgs } = await authClient.organization.list({
+      fetchOptions: { headers }
+    })
+
+    if (debug) {
+      console.log('[@crouton/auth] useSession: found orgs', orgs?.length ?? 0)
+    }
+
+    if (orgs && orgs.length > 0) {
+      // Set the first org as active
+      const firstOrg = orgs[0]!
+      await authClient.organization.setActive({
+        organizationId: firstOrg.id
+      })
+
+      if (debug) {
+        console.log('[@crouton/auth] useSession: set active org to', firstOrg.slug)
+      }
+
+      // Now fetch the full org data
+      const { data: fullOrg } = await authClient.organization.getFullOrganization({
         fetchOptions: { headers }
       })
 
-      if (error || !data) {
-        // No active org set - try to find and set one (personal/single-tenant mode)
-        if (debug) {
-          console.log('[@crouton/auth] useSession: no active org, trying to find one...')
-        }
-        await trySetDefaultOrg()
-        return
-      }
-
-      activeOrgState.value = data
-
-      if (debug) {
-        console.log('[@crouton/auth] useSession: fetched active org', {
-          org: data?.slug ?? null
-        })
-      }
-    } catch (err) {
-      if (debug) {
-        console.log('[@crouton/auth] useSession: getFullOrganization failed, trying to find org', err)
-      }
-      // Try to find and set an org
-      await trySetDefaultOrg()
+      activeOrgState.value = fullOrg ?? null
     }
+  } catch (err) {
+    if (debug) {
+      console.log('[@crouton/auth] useSession: failed to set default org', err)
+    }
+    activeOrgState.value = null
   }
+}
 
-  // Try to find and set a default organization (for personal/single-tenant modes)
-  async function trySetDefaultOrg(): Promise<void> {
-    // Don't try to set org if user is not authenticated (prevents 401 console errors)
-    if (!userState.value) return
-    if (!authClient?.organization) return
+// Fetch user profile (locale, timezone, etc.) — separate from session
+async function fetchUserProfile(ctx: SessionContext): Promise<void> {
+  const { debug, headers, userState, userProfileState } = ctx
 
-    try {
-      // List user's organizations
-      const { data: orgs } = await authClient.organization.list({
-        fetchOptions: { headers }
+  if (!userState.value) return
+
+  try {
+    const profile = await $fetch('/api/users/me/profile', {
+      headers: headers as Record<string, string> | undefined,
+    })
+    userProfileState.value = profile
+
+    // Auto-apply saved locale on login
+    if (import.meta.client && profile && (profile as Record<string, unknown>).locale) {
+      try {
+        const { setLocale } = useI18n()
+        setLocale((profile as Record<string, unknown>).locale as any)
+      } catch {
+        // i18n not available — skip
+      }
+    }
+
+    if (debug) {
+      console.log('[@crouton/auth] useSession: fetched user profile', {
+        locale: (profile as Record<string, unknown>)?.locale ?? null,
       })
-
-      if (debug) {
-        console.log('[@crouton/auth] useSession: found orgs', orgs?.length ?? 0)
-      }
-
-      if (orgs && orgs.length > 0) {
-        // Set the first org as active
-        const firstOrg = orgs[0]!
-        await authClient.organization.setActive({
-          organizationId: firstOrg.id
-        })
-
-        if (debug) {
-          console.log('[@crouton/auth] useSession: set active org to', firstOrg.slug)
-        }
-
-        // Now fetch the full org data
-        const { data: fullOrg } = await authClient.organization.getFullOrganization({
-          fetchOptions: { headers }
-        })
-
-        activeOrgState.value = fullOrg ?? null
-      }
-    } catch (err) {
-      if (debug) {
-        console.log('[@crouton/auth] useSession: failed to set default org', err)
-      }
-      activeOrgState.value = null
     }
+  } catch {
+    // Profile not found or endpoint not available — that's fine
+    userProfileState.value = null
   }
+}
 
-  // Fetch user profile (locale, timezone, etc.) — separate from session
-  async function fetchUserProfile(): Promise<void> {
-    if (!userState.value) return
+// Update user profile fields
+async function updateUserProfileImpl(ctx: SessionContext, data: { locale?: string | null }): Promise<void> {
+  if (!ctx.userState.value) return
 
-    try {
-      const profile = await $fetch('/api/users/me/profile', {
-        headers: headers as Record<string, string> | undefined,
-      })
-      userProfileState.value = profile
-
-      // Auto-apply saved locale on login
-      if (import.meta.client && profile && (profile as Record<string, unknown>).locale) {
-        try {
-          const { setLocale } = useI18n()
-          setLocale((profile as Record<string, unknown>).locale as any)
-        } catch {
-          // i18n not available — skip
-        }
-      }
-
-      if (debug) {
-        console.log('[@crouton/auth] useSession: fetched user profile', {
-          locale: (profile as Record<string, unknown>)?.locale ?? null,
-        })
-      }
-    } catch {
-      // Profile not found or endpoint not available — that's fine
-      userProfileState.value = null
-    }
+  try {
+    const profile = await $fetch('/api/users/me/profile', {
+      method: 'PATCH',
+      body: data,
+    })
+    ctx.userProfileState.value = profile
+  } catch (err) {
+    console.warn('[@crouton/auth] useSession: failed to update user profile', err)
   }
+}
 
-  // Update user profile fields
-  async function updateUserProfile(data: { locale?: string | null }): Promise<void> {
-    if (!userState.value) return
+// Set up the client signal listener (once per app lifecycle) + initial fetches,
+// and the server-side one-time SSR fetch
+function setupSessionSync(ctx: SessionContext): void {
+  const { authClient, debug, userState, isPendingState, isListening } = ctx
 
-    try {
-      const profile = await $fetch('/api/users/me/profile', {
-        method: 'PATCH',
-        body: data,
-      })
-      userProfileState.value = profile
-    } catch (err) {
-      console.warn('[@crouton/auth] useSession: failed to update user profile', err)
-    }
-  }
-
-  // Convenience: update user locale
-  async function updateUserLocale(locale: string): Promise<void> {
-    return updateUserProfile({ locale })
-  }
-
-  // Set up signal listener on client (once per app lifecycle)
   if (import.meta.client && authClient && !isListening.value) {
     isListening.value = true
 
@@ -258,19 +305,19 @@ export function useSession() {
         console.log('[@crouton/auth] useSession: session signal received')
       }
 
-      await fetchSession()
+      await fetchSession(ctx)
       // Only fetch org and profile if user is authenticated (prevents 401 console errors)
       if (userState.value) {
-        await fetchActiveOrg()
-        await fetchUserProfile()
+        await fetchActiveOrg(ctx)
+        await fetchUserProfile(ctx)
       }
     })
 
     // Initial fetch - only fetch org and profile if session exists
-    fetchSession().then(() => {
+    fetchSession(ctx).then(() => {
       if (userState.value) {
-        fetchActiveOrg()
-        fetchUserProfile()
+        fetchActiveOrg(ctx)
+        fetchUserProfile(ctx)
       }
     })
   }
@@ -279,16 +326,62 @@ export function useSession() {
   if (import.meta.server && isPendingState.value) {
     // Use callOnce to avoid duplicate fetches during SSR
     callOnce('crouton-auth-ssr-fetch', async () => {
-      await fetchSession()
+      await fetchSession(ctx)
       // Only fetch org and profile if user is authenticated (prevents 401 console errors)
       if (userState.value) {
-        await fetchActiveOrg()
-        await fetchUserProfile()
+        await fetchActiveOrg(ctx)
+        await fetchUserProfile(ctx)
       }
     })
   }
+}
 
-  // Computed accessors for cleaner API
+// Normalize the raw Better Auth organization payload into a Team
+function mapActiveOrganization(rawOrg: unknown): Team {
+  const org = rawOrg as {
+    id: string
+    name: string
+    slug: string
+    logo?: string | null
+    metadata?: string | Record<string, unknown> | null
+    personal?: boolean | number | null
+    isDefault?: boolean | number | null
+    ownerId?: string | null
+    createdAt: string | Date
+  }
+
+  // Parse metadata if it's a string
+  let metadata: Record<string, unknown> = {}
+  if (org.metadata) {
+    try {
+      metadata = typeof org.metadata === 'string' ? JSON.parse(org.metadata) : org.metadata
+    } catch {
+      metadata = {}
+    }
+  }
+
+  // SQLite returns 0/1 for booleans
+  const isPersonal = org.personal === true || org.personal === 1 || metadata.personal === true
+  const isDefaultOrg = org.isDefault === true || org.isDefault === 1 || metadata.isDefault === true
+
+  return {
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+    logo: org.logo ?? null,
+    metadata,
+    personal: isPersonal,
+    isDefault: isDefaultOrg,
+    ownerId: org.ownerId ?? (metadata.ownerId as string | undefined),
+    createdAt: new Date(org.createdAt),
+    updatedAt: new Date(org.createdAt)
+  }
+}
+
+// Computed accessors for cleaner API
+function createSessionComputeds(ctx: SessionContext) {
+  const { sessionState, userState, activeOrgState, userProfileState, isPendingState, errorState } = ctx
+
   const session = computed<Session | null>(() => {
     if (!sessionState.value) return null
     const s = sessionState.value as Record<string, unknown>
@@ -321,44 +414,7 @@ export function useSession() {
 
   const activeOrganization = computed<Team | null>(() => {
     if (!activeOrgState.value) return null
-    const org = activeOrgState.value as {
-      id: string
-      name: string
-      slug: string
-      logo?: string | null
-      metadata?: string | Record<string, unknown> | null
-      personal?: boolean | number | null
-      isDefault?: boolean | number | null
-      ownerId?: string | null
-      createdAt: string | Date
-    }
-
-    // Parse metadata if it's a string
-    let metadata: Record<string, unknown> = {}
-    if (org.metadata) {
-      try {
-        metadata = typeof org.metadata === 'string' ? JSON.parse(org.metadata) : org.metadata
-      } catch {
-        metadata = {}
-      }
-    }
-
-    // SQLite returns 0/1 for booleans
-    const isPersonal = org.personal === true || org.personal === 1 || metadata.personal === true
-    const isDefaultOrg = org.isDefault === true || org.isDefault === 1 || metadata.isDefault === true
-
-    return {
-      id: org.id,
-      name: org.name,
-      slug: org.slug,
-      logo: org.logo ?? null,
-      metadata,
-      personal: isPersonal,
-      isDefault: isDefaultOrg,
-      ownerId: org.ownerId ?? (metadata.ownerId as string | undefined),
-      createdAt: new Date(org.createdAt),
-      updatedAt: new Date(org.createdAt)
-    }
+    return mapActiveOrganization(activeOrgState.value)
   })
 
   const userLocale = computed<string | null>(() => {
@@ -378,27 +434,76 @@ export function useSession() {
     }
   })
 
+  // Raw active org state (includes members from getFullOrganization)
+  const activeOrgRaw = computed(() => activeOrgState.value)
+
+  return {
+    session,
+    user,
+    activeOrganization,
+    userLocale,
+    isPending,
+    error,
+    isAuthenticated,
+    sessionData,
+    activeOrgRaw
+  }
+}
+
+export function useSession() {
+  const authClient = useAuthClientSafe()
+  const config = useRuntimeConfig()
+  const debug = (config.public?.crouton?.auth as { debug?: boolean } | undefined)?.debug ?? false
+  const headers = import.meta.server ? useRequestHeaders() : undefined
+
+  const ctx: SessionContext = {
+    authClient,
+    debug,
+    headers,
+    ...createSessionState()
+  }
+
+  setupSessionSync(ctx)
+
+  const {
+    session,
+    user,
+    activeOrganization,
+    userLocale,
+    isPending,
+    error,
+    isAuthenticated,
+    sessionData,
+    activeOrgRaw
+  } = createSessionComputeds(ctx)
+
   // Methods
   async function refresh(): Promise<void> {
     if (debug) {
       console.log('[@crouton/auth] useSession: refresh called')
     }
-    await fetchSession()
-    await fetchActiveOrg()
+    await fetchSession(ctx)
+    await fetchActiveOrg(ctx)
   }
 
   async function clear(): Promise<void> {
     if (authClient) {
       await authClient.signOut()
     }
-    sessionState.value = null
-    userState.value = null
-    activeOrgState.value = null
-    userProfileState.value = null
+    ctx.sessionState.value = null
+    ctx.userState.value = null
+    ctx.activeOrgState.value = null
+    ctx.userProfileState.value = null
   }
 
-  // Raw active org state (includes members from getFullOrganization)
-  const activeOrgRaw = computed(() => activeOrgState.value)
+  async function updateUserProfile(data: { locale?: string | null }): Promise<void> {
+    return updateUserProfileImpl(ctx, data)
+  }
+
+  // Convenience: update user locale
+  async function updateUserLocale(locale: string): Promise<void> {
+    return updateUserProfile({ locale })
+  }
 
   return {
     // Raw data (for advanced use)

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -439,6 +439,172 @@ async function createDatabaseTable(config: { name: string; layer: string; fields
   }
 }
 
+// Build the Zod fields-schema body shared by the composable and the server
+// endpoints — regular + translatable fields, the hierarchy parentId, and the
+// translations record with its default-locale required-fields refinement.
+function buildFieldsSchema(params: {
+  fields: Field[]
+  config: Record<string, any> | null
+  hierarchy: HierarchyConfig
+  cases: any
+  layerCamelCase: string
+}): string {
+  const { fields, config, hierarchy, cases, layerCamelCase } = params
+  const translatableFieldNames = config?.translations?.collections?.[cases.plural] || []
+  const hierarchyFieldNames = hierarchy?.enabled ? ['parentId', 'path', 'depth', 'order'] : []
+  const regularFieldsSchema = fields
+    .filter(f => f.name !== 'id' && !translatableFieldNames.includes(f.name) && !hierarchyFieldNames.includes(f.name))
+    .map((f) => {
+      const isDependentField = (f.meta?.dependsOn && f.meta?.dependsOnCollection) || f.meta?.displayAs === 'slotButtonGroup'
+      const hasRepeaterProperties = f.type === 'repeater' && (f.meta?.translatableProperties || f.meta?.properties)
+      let baseZod = isDependentField ? 'z.array(z.string())' : f.zod
+      // Dates arrive as ISO strings (forms/JSON) — coerce so validation accepts them.
+      if (f.type === 'date') baseZod = 'z.coerce.date()'
+      if (hasRepeaterProperties) {
+        const { pascalCase: fieldPascalCase } = toCase(f.name)
+        const itemSchemaName = `${layerCamelCase}${cases.pascalCasePlural}${fieldPascalCase}ItemSchema`
+        baseZod = `z.array(${itemSchemaName})`
+      }
+      if (f.meta?.required) {
+        if (isDependentField) {
+          return `${f.name}: ${baseZod}.min(1, '${f.name} is required')`
+        } else if (f.type === 'date') {
+          // z.coerce.date() (no Zod-3 `required_error`, which is invalid in Zod 4)
+          return `${f.name}: ${baseZod}`
+        } else if (f.type === 'string' || f.type === 'text') {
+          return `${f.name}: ${baseZod}.min(1, '${f.name} is required')`
+        } else if (f.type === 'number' || f.type === 'decimal') {
+          return `${f.name}: ${baseZod}`
+        } else if (f.type === 'boolean') {
+          return `${f.name}: ${baseZod}`
+        } else if (f.type === 'json') {
+          return `${f.name}: ${baseZod}`
+        } else if (f.type === 'repeater') {
+          return `${f.name}: ${baseZod}`
+        } else {
+          return `${f.name}: ${baseZod}`
+        }
+      } else {
+        // json commonly arrives as null (empty config/metadata) — allow it.
+        const suffix = (f.meta?.nullable || f.type === 'json' || f.type === 'date') ? '.nullish()' : '.optional()'
+        return `${f.name}: ${baseZod}${suffix}`
+      }
+    })
+  const translatableFieldsSchema = fields
+    .filter(f => translatableFieldNames.includes(f.name))
+    .map(f => `${f.name}: ${f.zod}.optional()`)
+  let allFieldsSchema = [...regularFieldsSchema, ...translatableFieldsSchema].join(',\n  ')
+  if (hierarchy?.enabled) {
+    const hierarchySchemaField = `parentId: z.string().nullable().optional()`
+    allFieldsSchema = allFieldsSchema ? `${allFieldsSchema},\n  ${hierarchySchemaField}` : hierarchySchemaField
+  }
+  if (translatableFieldNames.length > 0) {
+    const translatableFields = fields.filter(f => translatableFieldNames.includes(f.name))
+    const requiredTranslatableFields = translatableFields.filter(f => f.meta?.required)
+    const translationsFieldSchema = translatableFields.map((f) => {
+      if (f.meta?.required) {
+        return `      ${f.name}: z.string().min(1, '${f.name.charAt(0).toUpperCase() + f.name.slice(1)} is required')`
+      } else {
+        return `      ${f.name}: z.string().optional()`
+      }
+    }).join(',\n')
+    // Validate the app's default locale (not a hardcoded 'en') — single-language
+    // apps (e.g. defaultLocale: 'nl') must validate that locale, not English.
+    const defaultLocale = config?.defaultLocale || 'en'
+    const requiredFieldsCheck = requiredTranslatableFields.length > 0
+      ? `.refine(
+    (translations) => translations.${defaultLocale} && ${requiredTranslatableFields.map(f => `translations.${defaultLocale}.${f.name}`).join(' && ')},
+    { message: 'Translations for ${requiredTranslatableFields.map(f => f.name).join(', ')} (${defaultLocale}) are required' }
+  )`
+      : ''
+    return `${allFieldsSchema},\n  translations: z.record(
+    z.string(),
+    z.object({
+${translationsFieldSchema}
+    })
+  )${requiredFieldsCheck}`
+  }
+  return allFieldsSchema
+}
+
+// Build the default-values object body for the generated form state.
+function buildFieldsDefault(params: {
+  fields: Field[]
+  config: Record<string, any> | null
+  hierarchy: HierarchyConfig
+  cases: any
+}): string {
+  const { fields, config, hierarchy, cases } = params
+  const hierarchyDefaultNames = hierarchy?.enabled ? ['parentId', 'path', 'depth', 'order'] : []
+  let fieldDefaults = fields.filter(f => f.name !== 'id' && !hierarchyDefaultNames.includes(f.name)).map((f) => {
+    const isDependentField = (f.meta?.dependsOn && f.meta?.dependsOnCollection) || f.meta?.displayAs === 'slotButtonGroup'
+    if (isDependentField) {
+      return `${f.name}: null`
+    }
+    return `${f.name}: ${f.default}`
+  }).join(',\n    ')
+  if (hierarchy?.enabled) {
+    fieldDefaults = fieldDefaults ? `${fieldDefaults},\n    parentId: null` : 'parentId: null'
+  }
+  const hasTranslations = config?.translations?.collections?.[cases.plural]?.length > 0
+  return hasTranslations ? `${fieldDefaults},\n    translations: {}` : fieldDefaults
+}
+
+// Build the table-columns array body for the generated list component.
+function buildFieldsColumns(fields: Field[], config: Record<string, any> | null, cases: any): string {
+  const baseColumns = fields.map(f =>
+    `{ accessorKey: '${f.name}', header: '${f.name.charAt(0).toUpperCase() + f.name.slice(1)}' }`
+  ).join(',\n  ')
+  const hasTranslations = config?.translations?.collections?.[cases.plural]?.length > 0
+  const translationsColumn = hasTranslations
+    ? ',\n  { accessorKey: \'translations\', header: \'Translations\' }'
+    : ''
+  return baseColumns + translationsColumn
+}
+
+// Build the TypeScript interface body for the generated types.ts, keeping the
+// optional/null-ness of each property in sync with the Zod schema.
+function buildFieldsTypes(params: {
+  fields: Field[]
+  config: Record<string, any> | null
+  hierarchy: HierarchyConfig
+  cases: any
+}): string {
+  const { fields, config, hierarchy, cases } = params
+  const translatableFieldNames = config?.translations?.collections?.[cases.plural] || []
+  const typeLines = fields.filter(f => f.name !== 'id').map((f) => {
+    const isDependentField = (f.meta?.dependsOn && f.meta?.dependsOnCollection) || f.meta?.displayAs === 'slotButtonGroup'
+    let tsType = isDependentField ? 'string[] | null' : f.tsType
+    if (f.meta?.required) {
+      // Required ⇒ the zod schema enforces a present, non-null value, so the
+      // interface must not widen to null (some tsTypes, e.g. date, default to
+      // `T | null`). Otherwise FormData/New<Type> reject the validated body.
+      tsType = tsType.replace(/\s*\|\s*null\b/g, '')
+    } else if ((f.meta?.nullable || f.type === 'json') && !tsType.includes('null')) {
+      // Non-required json/nullable fields are `.nullish()` in the zod schema
+      // (the body may be null) — the interface must allow null to match.
+      tsType += ' | null'
+    }
+    // Translatable fields are validated as optional in the zod schema (the real
+    // value lives in translations.<locale>; the root column is a cache/fallback) —
+    // keep the interface optional to match, otherwise New<Type> rejects the body.
+    const optional = !f.meta?.required || translatableFieldNames.includes(f.name)
+    return `${f.name}${optional ? '?' : ''}: ${tsType}`
+  })
+  // Hierarchy system fields (parentId/path/depth/order) live in the DB schema and
+  // are set by the generated POST endpoint, but aren't declared collection fields —
+  // include them so New<Type> (used by create*) accepts them.
+  if (hierarchy?.enabled) {
+    typeLines.push(
+      `${hierarchy.parentField || 'parentId'}?: string | null`,
+      `${hierarchy.pathField || 'path'}?: string`,
+      `${hierarchy.depthField || 'depth'}?: number`,
+      `${hierarchy.orderField || 'order'}?: number`
+    )
+  }
+  return typeLines.join('\n  ')
+}
+
 function buildGeneratorData(params: {
   layer: string
   collection: string
@@ -460,145 +626,13 @@ function buildGeneratorData(params: {
     .map((part, index) => index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1))
     .join('')
 
-  const fieldsSchema = (() => {
-    const translatableFieldNames = config?.translations?.collections?.[cases.plural] || []
-    const hierarchyFieldNames = hierarchy?.enabled ? ['parentId', 'path', 'depth', 'order'] : []
-    const regularFieldsSchema = fields
-      .filter(f => f.name !== 'id' && !translatableFieldNames.includes(f.name) && !hierarchyFieldNames.includes(f.name))
-      .map((f) => {
-        const isDependentField = (f.meta?.dependsOn && f.meta?.dependsOnCollection) || f.meta?.displayAs === 'slotButtonGroup'
-        const hasRepeaterProperties = f.type === 'repeater' && (f.meta?.translatableProperties || f.meta?.properties)
-        let baseZod = isDependentField ? 'z.array(z.string())' : f.zod
-        // Dates arrive as ISO strings (forms/JSON) — coerce so validation accepts them.
-        if (f.type === 'date') baseZod = 'z.coerce.date()'
-        if (hasRepeaterProperties) {
-          const { pascalCase: fieldPascalCase } = toCase(f.name)
-          const itemSchemaName = `${layerCamelCase}${cases.pascalCasePlural}${fieldPascalCase}ItemSchema`
-          baseZod = `z.array(${itemSchemaName})`
-        }
-        if (f.meta?.required) {
-          if (isDependentField) {
-            return `${f.name}: ${baseZod}.min(1, '${f.name} is required')`
-          } else if (f.type === 'date') {
-            // z.coerce.date() (no Zod-3 `required_error`, which is invalid in Zod 4)
-            return `${f.name}: ${baseZod}`
-          } else if (f.type === 'string' || f.type === 'text') {
-            return `${f.name}: ${baseZod}.min(1, '${f.name} is required')`
-          } else if (f.type === 'number' || f.type === 'decimal') {
-            return `${f.name}: ${baseZod}`
-          } else if (f.type === 'boolean') {
-            return `${f.name}: ${baseZod}`
-          } else if (f.type === 'json') {
-            return `${f.name}: ${baseZod}`
-          } else if (f.type === 'repeater') {
-            return `${f.name}: ${baseZod}`
-          } else {
-            return `${f.name}: ${baseZod}`
-          }
-        } else {
-          // json commonly arrives as null (empty config/metadata) — allow it.
-          const suffix = (f.meta?.nullable || f.type === 'json' || f.type === 'date') ? '.nullish()' : '.optional()'
-          return `${f.name}: ${baseZod}${suffix}`
-        }
-      })
-    const translatableFieldsSchema = fields
-      .filter(f => translatableFieldNames.includes(f.name))
-      .map(f => `${f.name}: ${f.zod}.optional()`)
-    let allFieldsSchema = [...regularFieldsSchema, ...translatableFieldsSchema].join(',\n  ')
-    if (hierarchy?.enabled) {
-      const hierarchySchemaField = `parentId: z.string().nullable().optional()`
-      allFieldsSchema = allFieldsSchema ? `${allFieldsSchema},\n  ${hierarchySchemaField}` : hierarchySchemaField
-    }
-    if (translatableFieldNames.length > 0) {
-      const translatableFields = fields.filter(f => translatableFieldNames.includes(f.name))
-      const requiredTranslatableFields = translatableFields.filter(f => f.meta?.required)
-      const translationsFieldSchema = translatableFields.map((f) => {
-        if (f.meta?.required) {
-          return `      ${f.name}: z.string().min(1, '${f.name.charAt(0).toUpperCase() + f.name.slice(1)} is required')`
-        } else {
-          return `      ${f.name}: z.string().optional()`
-        }
-      }).join(',\n')
-      // Validate the app's default locale (not a hardcoded 'en') — single-language
-      // apps (e.g. defaultLocale: 'nl') must validate that locale, not English.
-      const defaultLocale = config?.defaultLocale || 'en'
-      const requiredFieldsCheck = requiredTranslatableFields.length > 0
-        ? `.refine(
-    (translations) => translations.${defaultLocale} && ${requiredTranslatableFields.map(f => `translations.${defaultLocale}.${f.name}`).join(' && ')},
-    { message: 'Translations for ${requiredTranslatableFields.map(f => f.name).join(', ')} (${defaultLocale}) are required' }
-  )`
-        : ''
-      return `${allFieldsSchema},\n  translations: z.record(
-    z.string(),
-    z.object({
-${translationsFieldSchema}
-    })
-  )${requiredFieldsCheck}`
-    }
-    return allFieldsSchema
-  })()
+  const fieldsSchema = buildFieldsSchema({ fields, config, hierarchy, cases, layerCamelCase })
 
-  const fieldsDefault = (() => {
-    const hierarchyDefaultNames = hierarchy?.enabled ? ['parentId', 'path', 'depth', 'order'] : []
-    let fieldDefaults = fields.filter(f => f.name !== 'id' && !hierarchyDefaultNames.includes(f.name)).map((f) => {
-      const isDependentField = (f.meta?.dependsOn && f.meta?.dependsOnCollection) || f.meta?.displayAs === 'slotButtonGroup'
-      if (isDependentField) {
-        return `${f.name}: null`
-      }
-      return `${f.name}: ${f.default}`
-    }).join(',\n    ')
-    if (hierarchy?.enabled) {
-      fieldDefaults = fieldDefaults ? `${fieldDefaults},\n    parentId: null` : 'parentId: null'
-    }
-    const hasTranslations = config?.translations?.collections?.[cases.plural]?.length > 0
-    return hasTranslations ? `${fieldDefaults},\n    translations: {}` : fieldDefaults
-  })()
+  const fieldsDefault = buildFieldsDefault({ fields, config, hierarchy, cases })
 
-  const fieldsColumns = (() => {
-    const baseColumns = fields.map(f =>
-      `{ accessorKey: '${f.name}', header: '${f.name.charAt(0).toUpperCase() + f.name.slice(1)}' }`
-    ).join(',\n  ')
-    const hasTranslations = config?.translations?.collections?.[cases.plural]?.length > 0
-    const translationsColumn = hasTranslations
-      ? ',\n  { accessorKey: \'translations\', header: \'Translations\' }'
-      : ''
-    return baseColumns + translationsColumn
-  })()
+  const fieldsColumns = buildFieldsColumns(fields, config, cases)
 
-  const fieldsTypes = (() => {
-    const translatableFieldNames = config?.translations?.collections?.[cases.plural] || []
-    const typeLines = fields.filter(f => f.name !== 'id').map((f) => {
-      const isDependentField = (f.meta?.dependsOn && f.meta?.dependsOnCollection) || f.meta?.displayAs === 'slotButtonGroup'
-      let tsType = isDependentField ? 'string[] | null' : f.tsType
-      if (f.meta?.required) {
-        // Required ⇒ the zod schema enforces a present, non-null value, so the
-        // interface must not widen to null (some tsTypes, e.g. date, default to
-        // `T | null`). Otherwise FormData/New<Type> reject the validated body.
-        tsType = tsType.replace(/\s*\|\s*null\b/g, '')
-      } else if ((f.meta?.nullable || f.type === 'json') && !tsType.includes('null')) {
-        // Non-required json/nullable fields are `.nullish()` in the zod schema
-        // (the body may be null) — the interface must allow null to match.
-        tsType += ' | null'
-      }
-      // Translatable fields are validated as optional in the zod schema (the real
-      // value lives in translations.<locale>; the root column is a cache/fallback) —
-      // keep the interface optional to match, otherwise New<Type> rejects the body.
-      const optional = !f.meta?.required || translatableFieldNames.includes(f.name)
-      return `${f.name}${optional ? '?' : ''}: ${tsType}`
-    })
-    // Hierarchy system fields (parentId/path/depth/order) live in the DB schema and
-    // are set by the generated POST endpoint, but aren't declared collection fields —
-    // include them so New<Type> (used by create*) accepts them.
-    if (hierarchy?.enabled) {
-      typeLines.push(
-        `${hierarchy.parentField || 'parentId'}?: string | null`,
-        `${hierarchy.pathField || 'path'}?: string`,
-        `${hierarchy.depthField || 'depth'}?: number`,
-        `${hierarchy.orderField || 'order'}?: number`
-      )
-    }
-    return typeLines.join('\n  ')
-  })()
+  const fieldsTypes = buildFieldsTypes({ fields, config, hierarchy, cases })
 
   // Repeater fields with properties reference a named item schema (e.g.
   // `...SlotItemSchema`) in fieldsSchema. The composable exports those, but
@@ -632,12 +666,33 @@ ${translationsFieldSchema}
   }
 }
 
-async function writeScaffold({ layer, collection, fields, dialect, autoRelations, dryRun, noDb, force = false, noTranslations = false, config = null, collectionConfig = null, hierarchy: hierarchyFlag = false, seed = false, seedCount = 25, noTests = false }: WriteScaffoldOptions): Promise<void> {
-  const cases = toCase(collection)
-  const base = path.resolve('layers', layer, 'collections', cases.plural)
+// ---------------------------------------------------------------------------
+// writeScaffold helpers — one per scaffold step
+// ---------------------------------------------------------------------------
 
+interface GeneratedFile {
+  path: string
+  content: string
+}
+
+interface HierarchyConfig {
+  enabled: boolean
+  parentField?: string
+  orderField?: string
+  pathField?: string
+  depthField?: string
+}
+
+interface SortableConfig {
+  enabled: boolean
+  orderField?: string
+}
+
+// Resolve the structural options (hierarchy / sortable / collab) from the
+// collection config or CLI flag.
+function resolveStructureConfig(collectionConfig: Record<string, any> | null, hierarchyFlag: boolean): { hierarchy: HierarchyConfig; sortable: SortableConfig; collab: { enabled: boolean } } {
   // Detect hierarchy configuration from collection config or CLI flag
-  const hierarchy = collectionConfig?.hierarchy === true || hierarchyFlag === true
+  const hierarchy: HierarchyConfig = collectionConfig?.hierarchy === true || hierarchyFlag === true
     ? {
         enabled: true,
         parentField: 'parentId',
@@ -656,7 +711,7 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
         : { enabled: false })
 
   // Detect sortable configuration (simpler than hierarchy, just needs order field for drag-and-drop)
-  const sortable = collectionConfig?.sortable === true
+  const sortable: SortableConfig = collectionConfig?.sortable === true
     ? {
         enabled: true,
         orderField: collectionConfig.orderField || 'order'
@@ -673,8 +728,24 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     ? { enabled: true }
     : { enabled: false }
 
-  // Handle translation configuration
-  // Priority: 1) field-level meta.translatable, 2) collection-level translatable, 3) config.translations.collections
+  return { hierarchy, sortable, collab }
+}
+
+// Handle translation configuration.
+// Priority: 1) field-level meta.translatable, 2) collection-level translatable, 3) config.translations.collections
+// Returns the (possibly created or replaced) config object; when translatable
+// fields are found, the existing config's translations map is updated in place
+// so the caller's config object observes the merged field list.
+function resolveTranslationConfig(params: {
+  fields: Field[]
+  config: Record<string, any> | null
+  collectionConfig: Record<string, any> | null
+  noTranslations: boolean
+  plural: string
+}): Record<string, any> | null {
+  const { fields, collectionConfig, noTranslations, plural } = params
+  let { config } = params
+
   if (!noTranslations) {
     // Check for field-level translatable markers (meta.translatable: true)
     const fieldLevelTranslatable = fields
@@ -694,7 +765,7 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     }
 
     // Get config-level translatable fields
-    const configLevelTranslatable = config?.translations?.collections?.[cases.plural] || []
+    const configLevelTranslatable = config?.translations?.collections?.[plural] || []
 
     // Merge all sources (field-level takes precedence, then collection-level, then config-level)
     const allTranslatableFields = [...new Set([
@@ -714,7 +785,7 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
       if (!config.translations.collections) {
         config.translations.collections = {}
       }
-      config.translations.collections[cases.plural] = allTranslatableFields
+      config.translations.collections[plural] = allTranslatableFields
 
       // Log the source of translatable fields
       if (fieldLevelTranslatable.length > 0) {
@@ -735,7 +806,12 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     }
   }
 
-  // Check for required modules/dependencies
+  return config
+}
+
+// Check for required modules/dependencies; aborts (exit 1) when dependencies
+// are missing and --force is not set.
+async function ensureRequiredDependencies(config: Record<string, any> | null, noTranslations: boolean, force: boolean): Promise<void> {
   console.log('↻ Checking for required dependencies...')
   const dependencies = await detectRequiredDependencies({
     ...config,
@@ -757,13 +833,24 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     // Ensure layers are extended in nuxt.config
     await ensureLayersExtended(dependencies.layers)
   }
+}
 
-  // Prepare data for all generators
-  // Typed as Record<string, any> so contribution results can be attached dynamically
-  const data: Record<string, any> = buildGeneratorData({ layer, collection, fields, hierarchy, sortable, collab, config, collectionConfig })
-  const { layerPascalCase, layerCamelCase } = data
+// Manifest-driven detection + contributions: compute detection results, run the
+// relevant packages' contribution functions, and attach the merged form/list
+// enhancements to the generator data. Returns the (possibly updated)
+// collectionConfig — a package contribution can auto-detect the form component.
+async function applyManifestEnhancements(params: {
+  data: Record<string, any>
+  fields: Field[]
+  config: Record<string, any> | null
+  collectionConfig: Record<string, any> | null
+  dialect: string
+  collection: string
+}): Promise<Record<string, any> | null> {
+  const { data, fields, config, dialect, collection } = params
+  let { collectionConfig } = params
+  const { layerCamelCase } = data
 
-  // ── Manifest-driven detection + contributions ──────────────────────────────
   // Discover manifests (cached after first call) and compute detection results
   const manifests = await discoverManifests()
   const detectors = await getGeneratorDetectors(manifests)
@@ -809,83 +896,101 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
   const translatableFieldNames = config?.translations?.collections?.[toCase(collection).plural] || []
   data.formEnhancements = runFormContributions(contributions, data, dialect)
   data.listEnhancements = runListContributions(contributions, data, translatableFieldNames)
-  // ── End manifest-driven section ────────────────────────────────────────────
 
-  if (dryRun) {
-    const apiPath = `${layer}-${cases.plural}`
-    console.log('DRY RUN - Would generate:')
-    if (hierarchy.enabled) {
-      console.log(`\n🌳 HIERARCHY ENABLED - Additional files will be generated:`)
-      console.log(`   • Database fields: parentId, path, depth, order`)
-      console.log(`   • Tree queries: getTreeData(), updatePosition(), reorderSiblings()`)
-      console.log(`   • API endpoints: [id]/move.patch.ts, reorder.patch.ts`)
-      console.log(`   • Form: Parent picker component\n`)
-    }
-    if (!collectionConfig?.formComponent) {
-      console.log(`• ${base}/app/components/Form.vue`)
-    } else {
-      console.log(`• Form.vue skipped (using ${collectionConfig.formComponent})`)
-    }
-    console.log(`• ${base}/app/components/List.vue`)
+  return collectionConfig
+}
 
-    // Show repeater components
-    const repeaterFields = fields.filter(f => f.type === 'repeater')
-    const repeaterComponents = new Set()
-    for (const field of repeaterFields) {
-      const componentName = field.meta?.repeaterComponent
-      if (componentName && !repeaterComponents.has(componentName)) {
-        repeaterComponents.add(componentName)
-        console.log(`• ${base}/app/components/${componentName}.vue [PLACEHOLDER]`)
-      }
-    }
+// Print the dry-run plan (what would be generated) without writing anything.
+function printDryRunPlan(params: {
+  base: string
+  layer: string
+  cases: any
+  layerPascalCase: string
+  hierarchy: HierarchyConfig
+  collectionConfig: Record<string, any> | null
+  fields: Field[]
+  seed: boolean
+  seedCount: number
+  noTests: boolean
+  noDb: boolean
+}): void {
+  const { base, layer, cases, layerPascalCase, hierarchy, collectionConfig, fields, seed, seedCount, noTests, noDb } = params
+  const apiPath = `${layer}-${cases.plural}`
+  console.log('DRY RUN - Would generate:')
+  if (hierarchy.enabled) {
+    console.log(`\n🌳 HIERARCHY ENABLED - Additional files will be generated:`)
+    console.log(`   • Database fields: parentId, path, depth, order`)
+    console.log(`   • Tree queries: getTreeData(), updatePosition(), reorderSiblings()`)
+    console.log(`   • API endpoints: [id]/move.patch.ts, reorder.patch.ts`)
+    console.log(`   • Form: Parent picker component\n`)
+  }
+  if (!collectionConfig?.formComponent) {
+    console.log(`• ${base}/app/components/Form.vue`)
+  } else {
+    console.log(`• Form.vue skipped (using ${collectionConfig.formComponent})`)
+  }
+  console.log(`• ${base}/app/components/List.vue`)
 
-    console.log(`• ${base}/app/composables/use${layerPascalCase}${cases.pascalCasePlural}.ts`)
-    console.log(`• ${base}/server/api/teams/[id]/${apiPath}/index.get.ts`)
-    console.log(`• ${base}/server/api/teams/[id]/${apiPath}/index.post.ts`)
-    console.log(`• ${base}/server/api/teams/[id]/${apiPath}/[${cases.camelCase}Id].patch.ts`)
-    console.log(`• ${base}/server/api/teams/[id]/${apiPath}/[${cases.camelCase}Id].delete.ts`)
-    if (hierarchy.enabled) {
-      console.log(`• ${base}/server/api/teams/[id]/${apiPath}/[${cases.camelCase}Id]/move.patch.ts`)
-      console.log(`• ${base}/server/api/teams/[id]/${apiPath}/reorder.patch.ts`)
+  // Show repeater components
+  const repeaterFields = fields.filter(f => f.type === 'repeater')
+  const repeaterComponents = new Set()
+  for (const field of repeaterFields) {
+    const componentName = field.meta?.repeaterComponent
+    if (componentName && !repeaterComponents.has(componentName)) {
+      repeaterComponents.add(componentName)
+      console.log(`• ${base}/app/components/${componentName}.vue [PLACEHOLDER]`)
     }
-    console.log(`• ${base}/server/database/queries.ts`)
-    console.log(`• ${base}/server/database/schema.ts`)
-    if (seed) {
-      console.log(`• ${base}/server/database/seed.ts (${seedCount} records)`)
-    }
-    console.log(`• ${base}/types.ts`)
-    if (!noTests) {
-      console.log(`• ${base}/${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
-      console.log(`• ${base}/${layerPascalCase}${cases.pascalCasePlural}.api.test.ts (route handlers)`)
-    }
-    console.log(`• ${base}/nuxt.config.ts`)
-    console.log(`• layers/${layer}/nuxt.config.ts (layer root config)`)
-    console.log(`• nuxt.config.ts (root config - add layer to extends)`)
-    if (!noDb) {
-      console.log(`• Would update server/db/schema.ts`)
-      console.log(`• Would generate database migration`)
-    }
-
-    if (repeaterComponents.size > 0) {
-      console.log(`\n• Would generate ${repeaterComponents.size} placeholder repeater component(s):`)
-      repeaterComponents.forEach((name) => {
-        console.log(`   - ${name}.vue`)
-      })
-    }
-    return
   }
 
-  // Create directories
-  // Use layer-prefixed API path
-  // For system collections, use simplified naming without layer prefix
-  let apiPath
+  console.log(`• ${base}/app/composables/use${layerPascalCase}${cases.pascalCasePlural}.ts`)
+  console.log(`• ${base}/server/api/teams/[id]/${apiPath}/index.get.ts`)
+  console.log(`• ${base}/server/api/teams/[id]/${apiPath}/index.post.ts`)
+  console.log(`• ${base}/server/api/teams/[id]/${apiPath}/[${cases.camelCase}Id].patch.ts`)
+  console.log(`• ${base}/server/api/teams/[id]/${apiPath}/[${cases.camelCase}Id].delete.ts`)
+  if (hierarchy.enabled) {
+    console.log(`• ${base}/server/api/teams/[id]/${apiPath}/[${cases.camelCase}Id]/move.patch.ts`)
+    console.log(`• ${base}/server/api/teams/[id]/${apiPath}/reorder.patch.ts`)
+  }
+  console.log(`• ${base}/server/database/queries.ts`)
+  console.log(`• ${base}/server/database/schema.ts`)
+  if (seed) {
+    console.log(`• ${base}/server/database/seed.ts (${seedCount} records)`)
+  }
+  console.log(`• ${base}/types.ts`)
+  if (!noTests) {
+    console.log(`• ${base}/${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
+    console.log(`• ${base}/${layerPascalCase}${cases.pascalCasePlural}.api.test.ts (route handlers)`)
+  }
+  console.log(`• ${base}/nuxt.config.ts`)
+  console.log(`• layers/${layer}/nuxt.config.ts (layer root config)`)
+  console.log(`• nuxt.config.ts (root config - add layer to extends)`)
+  if (!noDb) {
+    console.log(`• Would update server/db/schema.ts`)
+    console.log(`• Would generate database migration`)
+  }
+
+  if (repeaterComponents.size > 0) {
+    console.log(`\n• Would generate ${repeaterComponents.size} placeholder repeater component(s):`)
+    repeaterComponents.forEach((name) => {
+      console.log(`   - ${name}.vue`)
+    })
+  }
+}
+
+// Resolve the collection's API path segment.
+// For system collections, use simplified naming without layer prefix.
+function resolveApiPath(layer: string, collection: string, cases: any): string {
   if (layer.startsWith('crouton-')) {
     // System collection: use crouton-<collection_name> format
     // e.g., crouton-events + collectionEvents -> crouton-collection-events
-    apiPath = toSnakeCase(`crouton_${collection}`).replace(/_/g, '-')
-  } else {
-    apiPath = `${layer}-${cases.plural}`
+    return toSnakeCase(`crouton_${collection}`).replace(/_/g, '-')
   }
+  // Use layer-prefixed API path
+  return `${layer}-${cases.plural}`
+}
+
+// Create the collection's directory structure.
+async function createCollectionDirs(base: string, apiPath: string, hierarchy: HierarchyConfig, cases: any): Promise<void> {
   const dirs = [
     path.join(base, 'app', 'components'),
     path.join(base, 'app', 'composables'),
@@ -903,10 +1008,42 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
   }
 
   console.log('✓ Directory structure created')
+}
 
-  // Generate all files using modules
+// Map every configured collection name to its layer (used by the queries
+// generator to resolve cross-collection references).
+function buildCollectionLayerMap(config: Record<string, any> | null): Map<string, string> {
+  const map = new Map<string, string>()
+  if (config?.targets) {
+    for (const t of config.targets) {
+      for (const c of t.collections) {
+        map.set(c.toLowerCase(), t.layer)
+      }
+    }
+  }
+  return map
+}
+
+// Build the core file set every collection gets: components, composable, CRUD
+// endpoints (+ hierarchy/sortable endpoints), queries, schema, types, the layer
+// nuxt.config and README.
+function buildCoreScaffoldFiles(params: {
+  base: string
+  apiPath: string
+  data: Record<string, any>
+  config: Record<string, any> | null
+  collectionConfig: Record<string, any> | null
+  dialect: string
+  layer: string
+  cases: any
+  layerPascalCase: string
+  hierarchy: HierarchyConfig
+  sortable: SortableConfig
+}): GeneratedFile[] {
+  const { base, apiPath, data, config, collectionConfig, dialect, layer, cases, layerPascalCase, hierarchy, sortable } = params
+
   // All endpoints now use @crouton/auth for team-based authentication
-  const files = [
+  const files: GeneratedFile[] = [
     // Only generate Form.vue if no custom formComponent specified
     ...(collectionConfig?.formComponent ? [] : [{
       path: path.join(base, 'app', 'components', '_Form.vue'),
@@ -938,17 +1075,7 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     },
     {
       path: path.join(base, 'server', 'database', 'queries.ts'),
-      content: generateQueries(data, config, layer, (() => {
-        const map = new Map<string, string>()
-        if (config?.targets) {
-          for (const t of config.targets) {
-            for (const c of t.collections) {
-              map.set(c.toLowerCase(), t.layer)
-            }
-          }
-        }
-        return map
-      })())
+      content: generateQueries(data, config, layer, buildCollectionLayerMap(config))
     },
     {
       path: path.join(base, 'server', 'database', 'schema.ts'),
@@ -988,8 +1115,14 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     })
   }
 
-  // Detect repeater fields and generate field components
-  // These are the source fields that other collections will depend on
+  return files
+}
+
+// Detect repeater fields and generate their field components (Input / Select /
+// CardMini). These are the source fields that other collections will depend on.
+// Creates each field's component folder as a side effect.
+async function buildRepeaterComponentFiles(base: string, fields: Field[], data: Record<string, any>): Promise<GeneratedFile[]> {
+  const files: GeneratedFile[] = []
   const repeaterFields = fields.filter(f => f.type === 'repeater')
   const generatedFieldComponents = new Set()
 
@@ -1023,6 +1156,21 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     }
   }
 
+  return files
+}
+
+// Build the seed artifacts: the optional drizzle-seed seed.ts (--seed) and the
+// always-emitted editable seed.json fixture (#298).
+function buildSeedFiles(params: {
+  base: string
+  data: Record<string, any>
+  config: Record<string, any> | null
+  seed: boolean
+  seedCount: number
+}): GeneratedFile[] {
+  const { base, data, config, seed, seedCount } = params
+  const files: GeneratedFile[] = []
+
   // Generate seed file if --seed flag is enabled
   if (seed) {
     files.push({
@@ -1048,37 +1196,54 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     console.log(`  Generating seed.json (${seedFixture.rows.length} sample rows)`)
   }
 
+  return files
+}
+
+// Build the per-collection tests — the schema-smoke test (#785) and the API
+// route handler test (#791). Caller gates on --no-tests.
+function buildCollectionTestFiles(params: {
+  base: string
+  data: Record<string, any>
+  config: Record<string, any> | null
+  cases: any
+  layerPascalCase: string
+}): GeneratedFile[] {
+  const { base, data, config, cases, layerPascalCase } = params
+  const files: GeneratedFile[] = []
+
   // Emit a schema-smoke test next to the collection (#785) — on by default,
   // suppressed by --no-tests. Runtime-free (zod only): asserts the generated
   // Zod schema accepts a valid record and rejects an invalid one. The e2e
   // fixture smoke owns boot + CRUD; this is the unit-level complement.
-  if (!noTests) {
-    files.push({
-      path: path.join(base, `${layerPascalCase}${cases.pascalCasePlural}.test.ts`),
-      content: generateCollectionTest(data, config),
-    })
-    console.log(`  Generating ${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
+  files.push({
+    path: path.join(base, `${layerPascalCase}${cases.pascalCasePlural}.test.ts`),
+    content: generateCollectionTest(data, config),
+  })
+  console.log(`  Generating ${layerPascalCase}${cases.pascalCasePlural}.test.ts (schema smoke)`)
 
-    // Emit the API route handler test (#791) — the depth deferred from #788.
-    // Drives the generated handlers with mocked team-auth + queries and a fake
-    // H3 event to cover team-scoping (unauth → rejected; queries called with the
-    // resolved team id) and error paths (invalid body → rejected, missing id →
-    // 400, not-found → 404). Same --no-tests gate.
-    files.push({
-      path: path.join(base, `${layerPascalCase}${cases.pascalCasePlural}.api.test.ts`),
-      content: generateApiTest(data, config),
-    })
-    console.log(`  Generating ${layerPascalCase}${cases.pascalCasePlural}.api.test.ts (route handlers)`)
-  }
+  // Emit the API route handler test (#791) — the depth deferred from #788.
+  // Drives the generated handlers with mocked team-auth + queries and a fake
+  // H3 event to cover team-scoping (unauth → rejected; queries called with the
+  // resolved team id) and error paths (invalid body → rejected, missing id →
+  // 400, not-found → 404). Same --no-tests gate.
+  files.push({
+    path: path.join(base, `${layerPascalCase}${cases.pascalCasePlural}.api.test.ts`),
+    content: generateApiTest(data, config),
+  })
+  console.log(`  Generating ${layerPascalCase}${cases.pascalCasePlural}.api.test.ts (route handlers)`)
 
-  // Write all files
-  for (const file of files) {
-    await fsp.writeFile(file.path, file.content, 'utf8')
-    console.log(`  ✓ ${path.relative(base, file.path)}`)
-  }
+  return files
+}
 
-  // Note: team-auth utility is now provided by @fyit/crouton package
-  // No need to generate it per-layer
+// Update the layer root nuxt.config (extend the new collection, wire i18n when
+// translations are enabled) and add the layer to the root nuxt.config extends.
+async function updateLayerAndRootConfigs(params: {
+  layer: string
+  collection: string
+  config: Record<string, any> | null
+  cases: any
+}): Promise<void> {
+  const { layer, collection, config, cases } = params
 
   // Check if we're using translations
   const hasTranslations = config?.translations?.collections?.[cases.plural]?.length > 0
@@ -1107,17 +1272,16 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     console.error(`! Could not update root nuxt.config.ts: ${nuxtResult.reason}`)
     console.log(`  Please manually add './layers/${layer}' to the extends array`)
   }
+}
 
-  // Create database table if requested
-  if (!noDb) {
-    await createDatabaseTable({ name: collection, layer, fields, force })
-
-    // Always export i18n schema since crouton-i18n is bundled with @fyit/crouton
-    console.log(`↻ Ensuring translations_ui table...`)
-    await exportI18nSchema(force)
-  }
-
-  // Update collection registry
+// Register the collection in the app.config crouton collections registry.
+async function registerCollectionInAppConfig(params: {
+  layer: string
+  cases: any
+  layerPascalCase: string
+  layerCamelCase: string
+}): Promise<void> {
+  const { layer, cases, layerPascalCase, layerCamelCase } = params
   const collectionKey = `${layerCamelCase}${cases.pascalCasePlural}`
   const configExportName = `${layerCamelCase}${cases.pascalCasePlural}Config`
   const registryPath = await resolveAppConfigPath()
@@ -1135,6 +1299,69 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
   } else {
     console.error(`Failed to update registry: ${registryResult.reason}`)
   }
+}
+
+async function writeScaffold({ layer, collection, fields, dialect, autoRelations, dryRun, noDb, force = false, noTranslations = false, config = null, collectionConfig = null, hierarchy: hierarchyFlag = false, seed = false, seedCount = 25, noTests = false }: WriteScaffoldOptions): Promise<void> {
+  const cases = toCase(collection)
+  const base = path.resolve('layers', layer, 'collections', cases.plural)
+
+  // Detect structural options (hierarchy / sortable / collab)
+  const { hierarchy, sortable, collab } = resolveStructureConfig(collectionConfig, hierarchyFlag)
+
+  // Handle translation configuration
+  config = resolveTranslationConfig({ fields, config, collectionConfig, noTranslations, plural: cases.plural })
+
+  // Check for required modules/dependencies
+  await ensureRequiredDependencies(config, noTranslations, force)
+
+  // Prepare data for all generators
+  // Typed as Record<string, any> so contribution results can be attached dynamically
+  const data: Record<string, any> = buildGeneratorData({ layer, collection, fields, hierarchy, sortable, collab, config, collectionConfig })
+  const { layerPascalCase, layerCamelCase } = data
+
+  // Manifest-driven detection + contributions (may auto-detect the form component)
+  collectionConfig = await applyManifestEnhancements({ data, fields, config, collectionConfig, dialect, collection })
+
+  if (dryRun) {
+    printDryRunPlan({ base, layer, cases, layerPascalCase, hierarchy, collectionConfig, fields, seed, seedCount, noTests, noDb })
+    return
+  }
+
+  // Create directories
+  const apiPath = resolveApiPath(layer, collection, cases)
+  await createCollectionDirs(base, apiPath, hierarchy, cases)
+
+  // Generate all files using modules
+  const files: GeneratedFile[] = [
+    ...buildCoreScaffoldFiles({ base, apiPath, data, config, collectionConfig, dialect, layer, cases, layerPascalCase, hierarchy, sortable }),
+    ...await buildRepeaterComponentFiles(base, fields, data),
+    ...buildSeedFiles({ base, data, config, seed, seedCount }),
+    ...(noTests ? [] : buildCollectionTestFiles({ base, data, config, cases, layerPascalCase }))
+  ]
+
+  // Write all files
+  for (const file of files) {
+    await fsp.writeFile(file.path, file.content, 'utf8')
+    console.log(`  ✓ ${path.relative(base, file.path)}`)
+  }
+
+  // Note: team-auth utility is now provided by @fyit/crouton package
+  // No need to generate it per-layer
+
+  // Update the layer root + root nuxt.config (and i18n locale files when needed)
+  await updateLayerAndRootConfigs({ layer, collection, config, cases })
+
+  // Create database table if requested
+  if (!noDb) {
+    await createDatabaseTable({ name: collection, layer, fields, force })
+
+    // Always export i18n schema since crouton-i18n is bundled with @fyit/crouton
+    console.log(`↻ Ensuring translations_ui table...`)
+    await exportI18nSchema(force)
+  }
+
+  // Update collection registry
+  await registerCollectionInAppConfig({ layer, cases, layerPascalCase, layerCamelCase })
 
   // Record generation history for DevTools Generators tab
   if (!dryRun) {
@@ -1162,60 +1389,59 @@ interface PostGenerationOptions {
   force: boolean
 }
 
-async function runPostGeneration(opts: PostGenerationOptions): Promise<void> {
-  const { allCollections, config, dryRun, noDb, force } = opts
+// Batch database setup: update the schema index for every generated collection,
+// ensure the i18n schema, and run the database migration once.
+async function runBatchDatabaseSetup(allCollections: Array<{ name: string; layer: string; fields: Field[] }>, force: boolean): Promise<void> {
+  console.log(`\n${'═'.repeat(60)}`)
+  console.log(`  DATABASE SETUP`)
+  console.log(`${'═'.repeat(60)}\n`)
+  console.log(`Updating schema index for ${allCollections.length} collections...`)
 
-  // Update schema index for all collections and run migration once (unless disabled)
-  if (!noDb && !dryRun && allCollections.length > 0) {
-    console.log(`\n${'═'.repeat(60)}`)
-    console.log(`  DATABASE SETUP`)
-    console.log(`${'═'.repeat(60)}\n`)
-    console.log(`Updating schema index for ${allCollections.length} collections...`)
-
-    // Update schema index for each collection
-    for (const col of allCollections) {
-      const { exportName: colExportName, importPath: colImportPath, schemaIndexPath: colSchemaIndexPath } = buildSchemaExportNames(col.name, col.layer)
-      const colSchemaResult = await addNamedSchemaExport(colSchemaIndexPath, colExportName, colImportPath, force)
-      if (!colSchemaResult.added && colSchemaResult.reason !== 'already exported') {
-        console.error(`  ✗ Failed to update schema index for ${col.name}: ${colSchemaResult.reason}`)
-      }
-    }
-
-    // Always export i18n schema since crouton-i18n is bundled with @fyit/crouton
-    // Note: exportI18nSchema() already calls registerTranslationsUiCollection() internally
-    console.log(`\n↻ Ensuring translations_ui table...`)
-    await exportI18nSchema(force)
-
-    // Run database migration once for all collections
-    console.log(`\nRunning database migration...`)
-    console.log(`Command: npx nuxt db generate (30s timeout)`)
-
-    try {
-      const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('Command timed out after 30 seconds')), 30000)
-      })
-
-      const { stdout, stderr } = await Promise.race([
-        execAsync('npx nuxt db generate'),
-        timeoutPromise
-      ])
-
-      if (stderr && !stderr.includes('Warning')) {
-        console.error(`⚠ Warnings:`, stderr)
-      }
-      console.log(`\n✓ Database migration generated successfully`)
-    } catch (execError: any) {
-      if (execError.message.includes('timed out')) {
-        console.error(`\n✗ Database migration timed out after 30 seconds`)
-        console.error(`  Check server/db/schema.ts for conflicts`)
-      } else {
-        console.error(`\n✗ Failed to run database migration:`, execError.message)
-      }
-      console.log(`\nManual command: npx nuxt db generate\n`)
+  // Update schema index for each collection
+  for (const col of allCollections) {
+    const { exportName: colExportName, importPath: colImportPath, schemaIndexPath: colSchemaIndexPath } = buildSchemaExportNames(col.name, col.layer)
+    const colSchemaResult = await addNamedSchemaExport(colSchemaIndexPath, colExportName, colImportPath, force)
+    if (!colSchemaResult.added && colSchemaResult.reason !== 'already exported') {
+      console.error(`  ✗ Failed to update schema index for ${col.name}: ${colSchemaResult.reason}`)
     }
   }
 
-  // Setup CSS @source directive for Tailwind
+  // Always export i18n schema since crouton-i18n is bundled with @fyit/crouton
+  // Note: exportI18nSchema() already calls registerTranslationsUiCollection() internally
+  console.log(`\n↻ Ensuring translations_ui table...`)
+  await exportI18nSchema(force)
+
+  // Run database migration once for all collections
+  console.log(`\nRunning database migration...`)
+  console.log(`Command: npx nuxt db generate (30s timeout)`)
+
+  try {
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('Command timed out after 30 seconds')), 30000)
+    })
+
+    const { stdout, stderr } = await Promise.race([
+      execAsync('npx nuxt db generate'),
+      timeoutPromise
+    ])
+
+    if (stderr && !stderr.includes('Warning')) {
+      console.error(`⚠ Warnings:`, stderr)
+    }
+    console.log(`\n✓ Database migration generated successfully`)
+  } catch (execError: any) {
+    if (execError.message.includes('timed out')) {
+      console.error(`\n✗ Database migration timed out after 30 seconds`)
+      console.error(`  Check server/db/schema.ts for conflicts`)
+    } else {
+      console.error(`\n✗ Failed to run database migration:`, execError.message)
+    }
+    console.log(`\nManual command: npx nuxt db generate\n`)
+  }
+}
+
+// Setup the CSS @source directive for Tailwind.
+async function setupTailwindCss(): Promise<void> {
   console.log(`\n${'═'.repeat(60)}`)
   console.log(`  TAILWIND CSS SETUP`)
   console.log(`${'═'.repeat(60)}\n`)
@@ -1234,62 +1460,378 @@ async function runPostGeneration(opts: PostGenerationOptions): Promise<void> {
     console.log(`\n⚠️  Could not automatically setup CSS @source directive`)
     displayManualCssSetupInstructions()
   }
+}
 
-  // Generate type registry for type-safe CRUD composables
+// Generate the type registry (type-safe CRUD composables) and the server-side
+// query registry (lazy-loaded query lookups). Shared by the config batch
+// post-generation and the single-collection runGenerate.
+async function generateRegistryFiles(): Promise<void> {
+  console.log(`\n${'═'.repeat(60)}`)
+  console.log(`  TYPE REGISTRY`)
+  console.log(`${'═'.repeat(60)}\n`)
+
+  try {
+    const registryResult = await generateCollectionTypesRegistry(process.cwd())
+    console.log(`✓ Generated type registry with ${registryResult.collectionsCount} collection(s)`)
+    console.log(`  → ${registryResult.outputPath}`)
+  } catch (error: any) {
+    console.log(`⚠ Could not generate type registry: ${error.message}`)
+  }
+
+  // Generate server-side query registry for lazy-loaded query lookups
+  console.log(`\n${'═'.repeat(60)}`)
+  console.log(`  QUERY REGISTRY`)
+  console.log(`${'═'.repeat(60)}\n`)
+
+  try {
+    const queryRegistryResult = await generateQueryRegistryFile(process.cwd())
+    console.log(`✓ Generated query registry with ${queryRegistryResult.collectionsCount} collection(s)`)
+    console.log(`  → ${queryRegistryResult.outputPath}`)
+  } catch (error: any) {
+    console.log(`⚠ Could not generate query registry: ${error.message}`)
+  }
+}
+
+// Deterministic default layout (#709): arrange the generated collections into
+// a viable `layout_configs` tree the POC boots with (seeded by crouton-seed).
+async function composeDefaultLayoutStep(allCollections: Array<{ name: string; layer: string; fields: Field[] }>, config: Record<string, any>): Promise<void> {
+  console.log(`\n${'═'.repeat(60)}`)
+  console.log(`  DEFAULT LAYOUT`)
+  console.log(`${'═'.repeat(60)}\n`)
+
+  try {
+    const { writeDefaultLayout } = await import('./compose-layout.ts')
+    const layoutResult = await writeDefaultLayout({
+      allCollections,
+      features: config.features,
+      cwd: process.cwd(),
+    })
+    if (layoutResult.written) {
+      console.log(`✓ Composed default layout (${layoutResult.pattern}${layoutResult.viable ? ', viable' : ', NOT viable — review minWidths'})`)
+      console.log(`  → ${layoutResult.path}`)
+    } else {
+      console.log(`⚠ Skipped default layout (${layoutResult.reason})`)
+    }
+  } catch (error: any) {
+    console.log(`⚠ Could not compose default layout: ${error.message}`)
+  }
+}
+
+async function runPostGeneration(opts: PostGenerationOptions): Promise<void> {
+  const { allCollections, config, dryRun, noDb, force } = opts
+
+  // Update schema index for all collections and run migration once (unless disabled)
+  if (!noDb && !dryRun && allCollections.length > 0) {
+    await runBatchDatabaseSetup(allCollections, force)
+  }
+
+  // Setup CSS @source directive for Tailwind
+  await setupTailwindCss()
+
+  // Generate the type/query registries and the default layout
   if (!dryRun) {
-    console.log(`\n${'═'.repeat(60)}`)
-    console.log(`  TYPE REGISTRY`)
-    console.log(`${'═'.repeat(60)}\n`)
-
-    try {
-      const registryResult = await generateCollectionTypesRegistry(process.cwd())
-      console.log(`✓ Generated type registry with ${registryResult.collectionsCount} collection(s)`)
-      console.log(`  → ${registryResult.outputPath}`)
-    } catch (error: any) {
-      console.log(`⚠ Could not generate type registry: ${error.message}`)
-    }
-
-    // Generate server-side query registry for lazy-loaded query lookups
-    console.log(`\n${'═'.repeat(60)}`)
-    console.log(`  QUERY REGISTRY`)
-    console.log(`${'═'.repeat(60)}\n`)
-
-    try {
-      const queryRegistryResult = await generateQueryRegistryFile(process.cwd())
-      console.log(`✓ Generated query registry with ${queryRegistryResult.collectionsCount} collection(s)`)
-      console.log(`  → ${queryRegistryResult.outputPath}`)
-    } catch (error: any) {
-      console.log(`⚠ Could not generate query registry: ${error.message}`)
-    }
-
-    // Deterministic default layout (#709): arrange the generated collections into
-    // a viable `layout_configs` tree the POC boots with (seeded by crouton-seed).
-    console.log(`\n${'═'.repeat(60)}`)
-    console.log(`  DEFAULT LAYOUT`)
-    console.log(`${'═'.repeat(60)}\n`)
-
-    try {
-      const { writeDefaultLayout } = await import('./compose-layout.ts')
-      const layoutResult = await writeDefaultLayout({
-        allCollections,
-        features: config.features,
-        cwd: process.cwd(),
-      })
-      if (layoutResult.written) {
-        console.log(`✓ Composed default layout (${layoutResult.pattern}${layoutResult.viable ? ', viable' : ', NOT viable — review minWidths'})`)
-        console.log(`  → ${layoutResult.path}`)
-      } else {
-        console.log(`⚠ Skipped default layout (${layoutResult.reason})`)
-      }
-    } catch (error: any) {
-      console.log(`⚠ Could not compose default layout: ${error.message}`)
-    }
+    await generateRegistryFiles()
+    await composeDefaultLayoutStep(allCollections, config)
   }
 
   console.log(`\n${'═'.repeat(60)}`)
   console.log(`  ALL DONE!`)
   console.log(`${'═'.repeat(60)}\n`)
   console.log(`Next step: Restart your Nuxt dev server\n`)
+}
+
+// ---------------------------------------------------------------------------
+// runConfig helpers — one per config-run stage
+// ---------------------------------------------------------------------------
+
+// Load the crouton config via c12, resolve the config directory, and fold the
+// CLI flags / --only filter into it. Exits when no config file is found.
+async function loadAndPrepareConfig(options: RunConfigOptions): Promise<Record<string, any>> {
+  // Resolve configPath to absolute so c12 can locate it and _configDir is always correct
+  const resolvedConfigPath = options.configPath
+    ? path.resolve(process.cwd(), options.configPath)
+    : undefined
+  const configCwd = resolvedConfigPath ? path.dirname(resolvedConfigPath) : process.cwd()
+
+  const { config } = await loadConfig({
+    name: 'crouton',
+    cwd: configCwd,
+    configFile: resolvedConfigPath || undefined,
+    defaults: {
+      dialect: 'sqlite',
+      features: {},
+      flags: {}
+    }
+  })
+
+  if (!config || (Object.keys(config).length === 0)) {
+    console.error(`\n❌ Config file not found\n`)
+    process.exit(1)
+  }
+
+  // Store config file directory for downstream path resolution (fieldsFile in collections)
+  // Always derived from the resolved config path, not process.cwd()
+  config._configDir = resolvedConfigPath
+    ? path.dirname(resolvedConfigPath)
+    : (config._configFile ? path.dirname(config._configFile) : process.cwd())
+
+  // Merge CLI flags into config.flags (CLI flags override config file)
+  if (!config.flags) config.flags = {}
+  if (options.force) config.flags.force = true
+  if (options.dryRun) config.flags.dryRun = true
+  if (options.noTests) config.flags.noTests = true
+
+  // Single-collection filter
+  const onlyCollection = options.only || null
+  if (onlyCollection) {
+    console.log(`\n📌 Generating only: ${onlyCollection}\n`)
+  }
+  config._onlyCollection = onlyCollection
+
+  return config
+}
+
+// Sync framework packages in the root nuxt.config extends for enabled features.
+async function syncFeaturePackages(config: Record<string, any>): Promise<void> {
+  if (!config.features) return
+
+  console.log('\n' + '═'.repeat(60))
+  console.log('  FRAMEWORK PACKAGES')
+  console.log('═'.repeat(60) + '\n')
+  console.log('↻ Syncing framework packages...')
+  const nuxtConfigPath = path.resolve('nuxt.config.ts')
+  const result = await syncFrameworkPackages(nuxtConfigPath, config.features)
+  if (result.synced) {
+    console.log(`✓ Synced ${result.packages.length} framework packages to extends`)
+    result.packages.forEach(pkg => console.log(`  • ${pkg}`))
+  } else {
+    console.log(`⚠ Could not sync framework packages: ${result.reason}`)
+  }
+}
+
+// Persist prompted feature configs: runtimeConfig into nuxt.config.ts and the
+// feature's config object back into crouton.config.js.
+async function persistPromptedConfigs(
+  promptedConfigs: import('./utils/manifest-merge.ts').PromptedConfig[],
+  config: Record<string, any>
+): Promise<void> {
+  const nuxtConfigPath = path.resolve('nuxt.config.ts')
+
+  for (const pc of promptedConfigs) {
+    // Write runtimeConfig to nuxt.config.ts
+    if (pc.runtimeConfig) {
+      const rtResult = await addRuntimeConfig(nuxtConfigPath, pc.runtimeConfig.server, pc.runtimeConfig.public)
+      if (rtResult.added) {
+        console.log(`  ✓ Added runtimeConfig for ${pc.featureKey}`)
+      }
+    }
+  }
+
+  // Persist feature config back to crouton.config.js
+  const configFilePath = config._configDir
+    ? path.resolve(config._configDir, 'crouton.config.js')
+    : path.resolve('crouton.config.js')
+
+  try {
+    const { readFile, writeFile } = await import('node:fs/promises')
+    const configContent = await readFile(configFilePath, 'utf-8')
+    let updated = configContent
+
+    for (const pc of promptedConfigs) {
+      // Replace `featureKey: true` with the config object
+      // Match patterns like `bookings: true` (with optional trailing comma)
+      const boolPattern = new RegExp(`(${pc.featureKey}\\s*:\\s*)true`, 'g')
+      const configStr = JSON.stringify(pc.configObject, null, 2)
+        .replace(/\n/g, '\n    ') // indent to match config file nesting
+      updated = updated.replace(boolPattern, `$1${configStr}`)
+    }
+
+    if (updated !== configContent) {
+      await writeFile(configFilePath, updated, 'utf-8')
+      console.log(`  ✓ Updated ${path.basename(configFilePath)} with feature configs`)
+    }
+  } catch {
+    // Config file may not exist or not be writable — non-fatal
+  }
+}
+
+// Auto-merge package manifest collections for enabled features
+// (may prompt interactively for manifest configuration options).
+async function autoMergeFeatureCollections(config: Record<string, any>, options: RunConfigOptions): Promise<void> {
+  if (!config.features || options.noAutoMerge) return
+
+  const { mergeManifestCollections } = await import('./utils/manifest-merge.ts')
+  const mergeResult = await mergeManifestCollections(config)
+  const promptedConfigs: import('./utils/manifest-merge.ts').PromptedConfig[] = mergeResult.promptedConfigs
+
+  if (mergeResult.merged > 0) {
+    console.log('\n' + '═'.repeat(60))
+    console.log('  PACKAGE COLLECTIONS (auto-merged)')
+    console.log('═'.repeat(60))
+    mergeResult.collections.forEach(c =>
+      console.log(`  + ${c.layer}/${c.name} (from @fyit/crouton-${c.feature})`)
+    )
+    if (mergeResult.skipped.length > 0) {
+      console.log(`\n  Already in config: ${mergeResult.skipped.join(', ')}`)
+    }
+  }
+
+  // Persist prompted configs: update nuxt.config.ts runtimeConfig + crouton.config.js
+  if (promptedConfigs.length > 0 && !options.dryRun) {
+    await persistPromptedConfigs(promptedConfigs, config)
+  }
+}
+
+// Generate one collection entry from the enhanced config format. Returns the
+// entry to track for the batch db:generate, or null when the collection has no
+// fields file.
+async function generateConfigEntry(params: {
+  layer: string
+  collectionName: string
+  collectionConfig: Record<string, any> | undefined
+  config: Record<string, any>
+  typeMapping: any
+}): Promise<{ name: string; layer: string; fields: Field[] } | null> {
+  const { layer, collectionName, collectionConfig, config, typeMapping } = params
+
+  if (!collectionConfig?.fieldsFile) {
+    console.error(`Error: No fields file found for collection '${collectionName}'`)
+    return null
+  }
+
+  console.log(`\n${'─'.repeat(60)}`)
+  console.log(`Generating ${layer}/${collectionName}`)
+  console.log(`${'─'.repeat(60)}`)
+  console.log(`Schema: ${collectionConfig.fieldsFile}`)
+  if (collectionConfig.hierarchy) {
+    console.log(`Hierarchy: enabled`)
+  }
+
+  // Resolve fieldsFile path relative to config directory if needed
+  const resolvedFieldsFile = config._configDir && !path.isAbsolute(collectionConfig.fieldsFile)
+    ? path.resolve(config._configDir, collectionConfig.fieldsFile)
+    : collectionConfig.fieldsFile
+  const fields = await loadFields(resolvedFieldsFile, typeMapping)
+
+  // Check if this collection has translations
+  // Generate files but skip database creation (we'll do it in batch at the end)
+  // Determine seed settings from collection config or global config
+  const collectionSeed = collectionConfig?.seed === true
+    ? { count: config?.seed?.defaultCount || 25 }
+    : typeof collectionConfig?.seed === 'object'
+      ? collectionConfig.seed
+      : null
+
+  await writeScaffold({
+    layer,
+    collection: collectionName,
+    fields,
+    dialect: config.dialect || 'pg',
+    autoRelations: config.flags?.autoRelations || false,
+    dryRun: config.flags?.dryRun || false,
+    noDb: true, // Skip individual db:generate
+    force: config.flags?.force || false,
+    noTranslations: config.flags?.noTranslations || false,
+    config: config,
+    collectionConfig: collectionConfig, // Pass individual collection config for hierarchy detection
+    seed: !!collectionSeed,
+    seedCount: collectionSeed?.count || config?.seed?.defaultCount || 25,
+    noTests: config.flags?.noTests || collectionConfig?.tests === false || false
+  })
+
+  return { name: collectionName, layer, fields }
+}
+
+// Enhanced config format (collections[] + targets[]): generate every configured
+// collection, then run the batch post-generation steps.
+async function runEnhancedConfigFormat(config: Record<string, any>, typeMapping: any): Promise<void> {
+  if (!config.targets || !config.collections) {
+    console.error('Error: Invalid config file - missing targets or collections')
+    process.exit(1)
+  }
+
+  // Create a map of collection names to their full config (including fieldsFile, hierarchy, etc.)
+  const collectionConfigMap: Record<string, any> = {}
+  for (const col of config.collections) {
+    collectionConfigMap[col.name] = col
+  }
+
+  // Track all collections for batch db:generate
+  const allCollections: Array<{ name: string; layer: string; fields: Field[] }> = []
+
+  // Process each target
+  for (const target of config.targets) {
+    for (const collectionName of target.collections) {
+      // Skip if --only flag is set and this isn't the target collection
+      if (config._onlyCollection && collectionName !== config._onlyCollection) {
+        continue
+      }
+
+      const generated = await generateConfigEntry({
+        layer: target.layer,
+        collectionName,
+        collectionConfig: collectionConfigMap[collectionName],
+        config,
+        typeMapping
+      })
+      if (generated) {
+        allCollections.push(generated)
+      }
+    }
+  }
+
+  await runPostGeneration({
+    allCollections,
+    config,
+    dryRun: config.flags?.dryRun || false,
+    noDb: config.flags?.noDb || false,
+    force: config.flags?.force || false,
+  })
+}
+
+// Original simple config format (schemaPath + targets[]): every target collection
+// shares the one schema; then run the batch post-generation steps.
+async function runSimpleConfigFormat(config: Record<string, any>, typeMapping: any): Promise<void> {
+  const fields = await loadFields(config.schemaPath, typeMapping)
+
+  // Track all collections for batch db:generate
+  const allCollections: Array<{ name: string; layer: string; fields: Field[] }> = []
+
+  // Process each target
+  for (const target of config.targets) {
+    for (const collection of target.collections) {
+      console.log(`\nGenerating collection '${collection}' in layer '${target.layer}'...`)
+
+      // Check for global seed settings (this code path doesn't have per-collection config)
+      const globalSeed = config?.seed?.enabled === true || config?.flags?.seed === true
+
+      await writeScaffold({
+        layer: target.layer,
+        collection,
+        fields,
+        dialect: config.dialect || 'pg',
+        autoRelations: config.flags?.autoRelations || false,
+        dryRun: config.flags?.dryRun || false,
+        noDb: true, // Skip individual db:generate
+        force: config.flags?.force || false,
+        noTranslations: config.flags?.noTranslations || false,
+        config: config,
+        seed: globalSeed,
+        seedCount: config?.seed?.defaultCount || 25,
+        noTests: config.flags?.noTests || false
+      })
+
+      allCollections.push({ name: collection, layer: target.layer, fields })
+    }
+  }
+
+  await runPostGeneration({
+    allCollections,
+    config,
+    dryRun: config.flags?.dryRun || false,
+    noDb: config.flags?.noDb || false,
+    force: config.flags?.force || false,
+  })
 }
 
 /**
@@ -1299,268 +1841,80 @@ export async function runConfig(options: RunConfigOptions = {}): Promise<void> {
   try {
     const typeMapping = await loadTypeMapping()
 
-    // Resolve configPath to absolute so c12 can locate it and _configDir is always correct
-    const resolvedConfigPath = options.configPath
-      ? path.resolve(process.cwd(), options.configPath)
-      : undefined
-    const configCwd = resolvedConfigPath ? path.dirname(resolvedConfigPath) : process.cwd()
+    // Load the config file and fold CLI flags / the --only filter into it
+    const config = await loadAndPrepareConfig(options)
 
-    const { config } = await loadConfig({
-      name: 'crouton',
-      cwd: configCwd,
-      configFile: resolvedConfigPath || undefined,
-      defaults: {
-        dialect: 'sqlite',
-        features: {},
-        flags: {}
-      }
-    })
+    // Validate configuration before proceeding
+    const validation = await validateConfig(config)
 
-    if (!config || (Object.keys(config).length === 0)) {
-      console.error(`\n❌ Config file not found\n`)
+    if (!validation.valid) {
+      console.error('\n⛔ Cannot proceed with generation due to validation errors\n')
       process.exit(1)
     }
 
-    // Store config file directory for downstream path resolution (fieldsFile in collections)
-    // Always derived from the resolved config path, not process.cwd()
-    config._configDir = resolvedConfigPath
-      ? path.dirname(resolvedConfigPath)
-      : (config._configFile ? path.dirname(config._configFile) : process.cwd())
+    // Sync framework packages based on features config
+    await syncFeaturePackages(config)
 
-    // Merge CLI flags into config.flags (CLI flags override config file)
-    if (!config.flags) config.flags = {}
-    if (options.force) config.flags.force = true
-    if (options.dryRun) config.flags.dryRun = true
-    if (options.noTests) config.flags.noTests = true
+    // Auto-merge package manifest collections for enabled features
+    await autoMergeFeatureCollections(config, options)
 
-    // Single-collection filter
-    const onlyCollection = options.only || null
-    if (onlyCollection) {
-      console.log(`\n📌 Generating only: ${onlyCollection}\n`)
+    // Handle both config formats
+    if (config.collections && config.targets) {
+      // Enhanced config format with collections array
+      await runEnhancedConfigFormat(config, typeMapping)
+    } else if (config.targets && config.schemaPath) {
+      // Original simple config format
+      await runSimpleConfigFormat(config, typeMapping)
+    } else {
+      console.error('Error: Invalid config file')
+      console.error('Config must have either:')
+      console.error('  1. collections[] and targets[] (enhanced format)')
+      console.error('  2. schemaPath and targets[] (simple format)')
+      process.exit(1)
     }
-    config._onlyCollection = onlyCollection
-
-      // Validate configuration before proceeding
-      const validation = await validateConfig(config)
-
-      if (!validation.valid) {
-        console.error('\n⛔ Cannot proceed with generation due to validation errors\n')
-        process.exit(1)
-      }
-
-      // Sync framework packages based on features config
-      if (config.features) {
-        console.log('\n' + '═'.repeat(60))
-        console.log('  FRAMEWORK PACKAGES')
-        console.log('═'.repeat(60) + '\n')
-        console.log('↻ Syncing framework packages...')
-        const nuxtConfigPath = path.resolve('nuxt.config.ts')
-        const result = await syncFrameworkPackages(nuxtConfigPath, config.features)
-        if (result.synced) {
-          console.log(`✓ Synced ${result.packages.length} framework packages to extends`)
-          result.packages.forEach(pkg => console.log(`  • ${pkg}`))
-        } else {
-          console.log(`⚠ Could not sync framework packages: ${result.reason}`)
-        }
-      }
-
-      // Auto-merge package manifest collections for enabled features
-      // (may prompt interactively for manifest configuration options)
-      let promptedConfigs: import('./utils/manifest-merge.ts').PromptedConfig[] = []
-      if (config.features && !options.noAutoMerge) {
-        const { mergeManifestCollections } = await import('./utils/manifest-merge.ts')
-        const mergeResult = await mergeManifestCollections(config)
-        promptedConfigs = mergeResult.promptedConfigs
-
-        if (mergeResult.merged > 0) {
-          console.log('\n' + '═'.repeat(60))
-          console.log('  PACKAGE COLLECTIONS (auto-merged)')
-          console.log('═'.repeat(60))
-          mergeResult.collections.forEach(c =>
-            console.log(`  + ${c.layer}/${c.name} (from @fyit/crouton-${c.feature})`)
-          )
-          if (mergeResult.skipped.length > 0) {
-            console.log(`\n  Already in config: ${mergeResult.skipped.join(', ')}`)
-          }
-        }
-
-        // Persist prompted configs: update nuxt.config.ts runtimeConfig + crouton.config.js
-        if (promptedConfigs.length > 0 && !options.dryRun) {
-          const nuxtConfigPath = path.resolve('nuxt.config.ts')
-
-          for (const pc of promptedConfigs) {
-            // Write runtimeConfig to nuxt.config.ts
-            if (pc.runtimeConfig) {
-              const rtResult = await addRuntimeConfig(nuxtConfigPath, pc.runtimeConfig.server, pc.runtimeConfig.public)
-              if (rtResult.added) {
-                console.log(`  ✓ Added runtimeConfig for ${pc.featureKey}`)
-              }
-            }
-          }
-
-          // Persist feature config back to crouton.config.js
-          const configFilePath = config._configDir
-            ? path.resolve(config._configDir, 'crouton.config.js')
-            : path.resolve('crouton.config.js')
-
-          try {
-            const { readFile, writeFile } = await import('node:fs/promises')
-            const configContent = await readFile(configFilePath, 'utf-8')
-            let updated = configContent
-
-            for (const pc of promptedConfigs) {
-              // Replace `featureKey: true` with the config object
-              // Match patterns like `bookings: true` (with optional trailing comma)
-              const boolPattern = new RegExp(`(${pc.featureKey}\\s*:\\s*)true`, 'g')
-              const configStr = JSON.stringify(pc.configObject, null, 2)
-                .replace(/\n/g, '\n    ') // indent to match config file nesting
-              updated = updated.replace(boolPattern, `$1${configStr}`)
-            }
-
-            if (updated !== configContent) {
-              await writeFile(configFilePath, updated, 'utf-8')
-              console.log(`  ✓ Updated ${path.basename(configFilePath)} with feature configs`)
-            }
-          } catch {
-            // Config file may not exist or not be writable — non-fatal
-          }
-        }
-      }
-
-      // Handle both config formats
-      if (config.collections && config.targets) {
-        // Enhanced config format with collections array
-        if (!config.targets || !config.collections) {
-          console.error('Error: Invalid config file - missing targets or collections')
-          process.exit(1)
-        }
-
-        // Create a map of collection names to their full config (including fieldsFile, hierarchy, etc.)
-        const collectionConfigMap = {}
-        for (const col of config.collections) {
-          collectionConfigMap[col.name] = col
-        }
-
-        // Track all collections for batch db:generate
-        const allCollections = []
-
-        // Process each target
-        for (const target of config.targets) {
-          for (const collectionName of target.collections) {
-            // Skip if --only flag is set and this isn't the target collection
-            if (config._onlyCollection && collectionName !== config._onlyCollection) {
-              continue
-            }
-
-            const collectionConfig = collectionConfigMap[collectionName]
-            if (!collectionConfig?.fieldsFile) {
-              console.error(`Error: No fields file found for collection '${collectionName}'`)
-              continue
-            }
-
-            console.log(`\n${'─'.repeat(60)}`)
-            console.log(`Generating ${target.layer}/${collectionName}`)
-            console.log(`${'─'.repeat(60)}`)
-            console.log(`Schema: ${collectionConfig.fieldsFile}`)
-            if (collectionConfig.hierarchy) {
-              console.log(`Hierarchy: enabled`)
-            }
-
-            // Resolve fieldsFile path relative to config directory if needed
-            const resolvedFieldsFile = config._configDir && !path.isAbsolute(collectionConfig.fieldsFile)
-              ? path.resolve(config._configDir, collectionConfig.fieldsFile)
-              : collectionConfig.fieldsFile
-            const fields = await loadFields(resolvedFieldsFile, typeMapping)
-
-            // Check if this collection has translations
-            // Generate files but skip database creation (we'll do it in batch at the end)
-            // Determine seed settings from collection config or global config
-            const collectionSeed = collectionConfig?.seed === true
-              ? { count: config?.seed?.defaultCount || 25 }
-              : typeof collectionConfig?.seed === 'object'
-                ? collectionConfig.seed
-                : null
-
-            await writeScaffold({
-              layer: target.layer,
-              collection: collectionName,
-              fields,
-              dialect: config.dialect || 'pg',
-              autoRelations: config.flags?.autoRelations || false,
-              dryRun: config.flags?.dryRun || false,
-              noDb: true, // Skip individual db:generate
-              force: config.flags?.force || false,
-              noTranslations: config.flags?.noTranslations || false,
-              config: config,
-              collectionConfig: collectionConfig, // Pass individual collection config for hierarchy detection
-              seed: !!collectionSeed,
-              seedCount: collectionSeed?.count || config?.seed?.defaultCount || 25,
-              noTests: config.flags?.noTests || collectionConfig?.tests === false || false
-            })
-
-            allCollections.push({ name: collectionName, layer: target.layer, fields })
-          }
-        }
-
-        await runPostGeneration({
-          allCollections,
-          config,
-          dryRun: config.flags?.dryRun || false,
-          noDb: config.flags?.noDb || false,
-          force: config.flags?.force || false,
-        })
-      } else if (config.targets && config.schemaPath) {
-        // Original simple config format
-        const fields = await loadFields(config.schemaPath, typeMapping)
-
-        // Track all collections for batch db:generate
-        const allCollections = []
-
-        // Process each target
-        for (const target of config.targets) {
-          for (const collection of target.collections) {
-            console.log(`\nGenerating collection '${collection}' in layer '${target.layer}'...`)
-
-            // Check for global seed settings (this code path doesn't have per-collection config)
-            const globalSeed = config?.seed?.enabled === true || config?.flags?.seed === true
-
-            await writeScaffold({
-              layer: target.layer,
-              collection,
-              fields,
-              dialect: config.dialect || 'pg',
-              autoRelations: config.flags?.autoRelations || false,
-              dryRun: config.flags?.dryRun || false,
-              noDb: true, // Skip individual db:generate
-              force: config.flags?.force || false,
-              noTranslations: config.flags?.noTranslations || false,
-              config: config,
-              seed: globalSeed,
-              seedCount: config?.seed?.defaultCount || 25,
-              noTests: config.flags?.noTests || false
-            })
-
-            allCollections.push({ name: collection, layer: target.layer, fields })
-          }
-        }
-
-        await runPostGeneration({
-          allCollections,
-          config,
-          dryRun: config.flags?.dryRun || false,
-          noDb: config.flags?.noDb || false,
-          force: config.flags?.force || false,
-        })
-      } else {
-        console.error('Error: Invalid config file')
-        console.error('Config must have either:')
-        console.error('  1. collections[] and targets[] (enhanced format)')
-        console.error('  2. schemaPath and targets[] (simple format)')
-        process.exit(1)
-      }
   } catch (error: any) {
     console.error('Error:', error.message)
     process.exit(1)
+  }
+}
+
+// Validate the single-collection CLI arguments: the schema file exists, the
+// cwd is writable, and (unless --force) required dependencies are present.
+async function validateGenerateArgs(args: Record<string, any>): Promise<void> {
+  console.log('\n📋 Validating CLI arguments...\n')
+
+  // Check schema file exists
+  const schemaPath = path.resolve(args.fieldsFile)
+  try {
+    await fsp.access(schemaPath)
+    console.log(`✓ Schema file found: ${args.fieldsFile}`)
+  } catch {
+    console.error(`\n❌ Schema file not found: ${args.fieldsFile}\n`)
+    process.exit(1)
+  }
+
+  // Check for write permissions
+  try {
+    await fsp.access(process.cwd(), fsp.constants.W_OK)
+    console.log(`✓ Write permissions verified`)
+  } catch {
+    console.error(`\n❌ No write permissions in current directory\n`)
+    process.exit(1)
+  }
+
+  // Check dependencies unless force flag
+  if (!args.force) {
+    const dependencies = await detectRequiredDependencies()
+
+    if (dependencies.missing.length > 0) {
+      console.log('\n⚠️  Missing dependencies detected:')
+      displayMissingDependencies(dependencies)
+
+      if (!args.force) {
+        console.log('\nUse --force to skip this check or run:')
+        console.log('  crouton install\n')
+      }
+    }
   }
 }
 
@@ -1587,41 +1941,7 @@ export async function runGenerate(options: RunGenerateOptions = {}): Promise<voi
     }
 
     // Validate CLI arguments
-    console.log('\n📋 Validating CLI arguments...\n')
-
-    // Check schema file exists
-    const schemaPath = path.resolve(args.fieldsFile)
-    try {
-      await fsp.access(schemaPath)
-      console.log(`✓ Schema file found: ${args.fieldsFile}`)
-    } catch {
-      console.error(`\n❌ Schema file not found: ${args.fieldsFile}\n`)
-      process.exit(1)
-    }
-
-    // Check for write permissions
-    try {
-      await fsp.access(process.cwd(), fsp.constants.W_OK)
-      console.log(`✓ Write permissions verified`)
-    } catch {
-      console.error(`\n❌ No write permissions in current directory\n`)
-      process.exit(1)
-    }
-
-    // Check dependencies unless force flag
-    if (!args.force) {
-      const dependencies = await detectRequiredDependencies()
-
-      if (dependencies.missing.length > 0) {
-        console.log('\n⚠️  Missing dependencies detected:')
-        displayMissingDependencies(dependencies)
-
-        if (!args.force) {
-          console.log('\nUse --force to skip this check or run:')
-          console.log('  crouton install\n')
-        }
-      }
-    }
+    await validateGenerateArgs(args)
 
     console.log(`\n📦 Will generate:`)
     console.log(`  Layer: ${args.layer}`)
@@ -1647,32 +1967,9 @@ export async function runGenerate(options: RunGenerateOptions = {}): Promise<voi
     // Proceed with generation
     await writeScaffold({ ...args, fields })
 
-    // Generate type registry for type-safe CRUD composables
+    // Generate the type + query registries for type-safe CRUD composables
     if (!args.dryRun) {
-      console.log(`\n${'═'.repeat(60)}`)
-      console.log(`  TYPE REGISTRY`)
-      console.log(`${'═'.repeat(60)}\n`)
-
-      try {
-        const registryResult = await generateCollectionTypesRegistry(process.cwd())
-        console.log(`✓ Generated type registry with ${registryResult.collectionsCount} collection(s)`)
-        console.log(`  → ${registryResult.outputPath}`)
-      } catch (error: any) {
-        console.log(`⚠ Could not generate type registry: ${error.message}`)
-      }
-
-      // Generate server-side query registry
-      console.log(`\n${'═'.repeat(60)}`)
-      console.log(`  QUERY REGISTRY`)
-      console.log(`${'═'.repeat(60)}\n`)
-
-      try {
-        const queryRegistryResult = await generateQueryRegistryFile(process.cwd())
-        console.log(`✓ Generated query registry with ${queryRegistryResult.collectionsCount} collection(s)`)
-        console.log(`  → ${queryRegistryResult.outputPath}`)
-      } catch (error: any) {
-        console.log(`⚠ Could not generate query registry: ${error.message}`)
-      }
+      await generateRegistryFiles()
 
       // Print .env hints for prompted configurations
       if (promptedConfigs.length > 0) {

--- a/packages/crouton-cli/lib/generators/database-queries.ts
+++ b/packages/crouton-cli/lib/generators/database-queries.ts
@@ -1,49 +1,57 @@
 // Generator for database queries
 import { toKebabCase, pascal } from '../utils/helpers.ts'
 
-// Helper to generate tree-specific queries when hierarchy is enabled
-function generateTreeQueries(data: Record<string, any>, tableName: string, prefixedPascalCase: string, prefixedPascalCasePlural: string, camelCasePlural: string): string {
-  const hierarchy = data.hierarchy
-  if (!hierarchy || !hierarchy.enabled) {
-    return ''
-  }
+// Shared context for the tree-query template builders below
+interface TreeQueryContext {
+  tableName: string
+  prefixedPascalCase: string
+  prefixedPascalCasePlural: string
+  camelCasePlural: string
+  parentField: string
+  pathField: string
+  depthField: string
+  orderField: string
+}
 
-  // Get field names with defaults
-  const parentField = hierarchy.parentField || 'parentId'
-  const pathField = hierarchy.pathField || 'path'
-  const depthField = hierarchy.depthField || 'depth'
-  const orderField = hierarchy.orderField || 'order'
-
-  // Note: Type assertions (as any) are used throughout to handle drizzle-orm version mismatches
-  // that can occur in monorepo setups. This is a pragmatic solution that allows the generated
-  // code to work across different drizzle-orm versions.
-
+// Section banner + the TreeItem interface shared by the tree query templates
+function buildTreeQueriesHeader(ctx: TreeQueryContext): string {
   return `
 
 // Tree hierarchy queries (auto-generated when hierarchy: true)
-// Type: ${prefixedPascalCase} with hierarchy fields
+// Type: ${ctx.prefixedPascalCase} with hierarchy fields
 
 interface TreeItem {
   id: string
-  ${pathField}: string
-  ${depthField}: number
-  ${orderField}: number
+  ${ctx.pathField}: string
+  ${ctx.depthField}: number
+  ${ctx.orderField}: number
   [key: string]: any
+}`
 }
 
-export async function getTreeData${prefixedPascalCasePlural}(teamId: string) {
+// getTreeData* — fetch the whole team-scoped tree ordered by path + order
+function buildTreeGetDataQuery(ctx: TreeQueryContext): string {
+  return `
+
+export async function getTreeData${ctx.prefixedPascalCasePlural}(teamId: string) {
   const db = useDB()
 
-  const ${camelCasePlural} = await (db as any)
+  const ${ctx.camelCasePlural} = await (db as any)
     .select()
-    .from(tables.${tableName})
-    .where(eq(tables.${tableName}.teamId, teamId))
-    .orderBy(tables.${tableName}.${pathField}, tables.${tableName}.${orderField})
+    .from(tables.${ctx.tableName})
+    .where(eq(tables.${ctx.tableName}.teamId, teamId))
+    .orderBy(tables.${ctx.tableName}.${ctx.pathField}, tables.${ctx.tableName}.${ctx.orderField})
 
-  return ${camelCasePlural} as TreeItem[]
+  return ${ctx.camelCasePlural} as TreeItem[]
+}`
 }
 
-export async function updatePosition${prefixedPascalCase}(
+// updatePosition* — move a node to a new parent/order, recomputing path + depth
+// for the node and all of its descendants
+function buildTreeUpdatePositionQuery(ctx: TreeQueryContext): string {
+  return `
+
+export async function updatePosition${ctx.prefixedPascalCase}(
   teamId: string,
   id: string,
   newParentId: string | null,
@@ -54,18 +62,18 @@ export async function updatePosition${prefixedPascalCase}(
   // Get the current item to find its path
   const [current] = await (db as any)
     .select()
-    .from(tables.${tableName})
+    .from(tables.${ctx.tableName})
     .where(
       and(
-        eq(tables.${tableName}.id, id),
-        eq(tables.${tableName}.teamId, teamId)
+        eq(tables.${ctx.tableName}.id, id),
+        eq(tables.${ctx.tableName}.teamId, teamId)
       )
     ) as TreeItem[]
 
   if (!current) {
     throw createError({
       status: 404,
-      statusText: '${prefixedPascalCase} not found'
+      statusText: '${ctx.prefixedPascalCase} not found'
     })
   }
 
@@ -76,51 +84,51 @@ export async function updatePosition${prefixedPascalCase}(
   if (newParentId) {
     const [parent] = await (db as any)
       .select()
-      .from(tables.${tableName})
+      .from(tables.${ctx.tableName})
       .where(
         and(
-          eq(tables.${tableName}.id, newParentId),
-          eq(tables.${tableName}.teamId, teamId)
+          eq(tables.${ctx.tableName}.id, newParentId),
+          eq(tables.${ctx.tableName}.teamId, teamId)
         )
       ) as TreeItem[]
 
     if (!parent) {
       throw createError({
         status: 400,
-        statusText: 'Parent ${prefixedPascalCase} not found'
+        statusText: 'Parent ${ctx.prefixedPascalCase} not found'
       })
     }
 
     // Prevent moving item to its own descendant
-    if (parent.${pathField}.startsWith(current.${pathField})) {
+    if (parent.${ctx.pathField}.startsWith(current.${ctx.pathField})) {
       throw createError({
         status: 400,
         statusText: 'Cannot move item to its own descendant'
       })
     }
 
-    newPath = \`\${parent.${pathField}}\${id}/\`
-    newDepth = parent.${depthField} + 1
+    newPath = \`\${parent.${ctx.pathField}}\${id}/\`
+    newDepth = parent.${ctx.depthField} + 1
   } else {
     newPath = \`/\${id}/\`
     newDepth = 0
   }
 
-  const oldPath = current.${pathField}
+  const oldPath = current.${ctx.pathField}
 
   // Update the item itself
   const [updated] = await (db as any)
-    .update(tables.${tableName})
+    .update(tables.${ctx.tableName})
     .set({
-      ${parentField}: newParentId,
-      ${pathField}: newPath,
-      ${depthField}: newDepth,
-      ${orderField}: newOrder
+      ${ctx.parentField}: newParentId,
+      ${ctx.pathField}: newPath,
+      ${ctx.depthField}: newDepth,
+      ${ctx.orderField}: newOrder
     })
     .where(
       and(
-        eq(tables.${tableName}.id, id),
-        eq(tables.${tableName}.teamId, teamId)
+        eq(tables.${ctx.tableName}.id, id),
+        eq(tables.${ctx.tableName}.teamId, teamId)
       )
     )
     .returning()
@@ -130,35 +138,40 @@ export async function updatePosition${prefixedPascalCase}(
     // Get all descendants
     const descendants = await (db as any)
       .select()
-      .from(tables.${tableName})
+      .from(tables.${ctx.tableName})
       .where(
         and(
-          eq(tables.${tableName}.teamId, teamId),
-          sql\`\${tables.${tableName}.${pathField}} LIKE \${oldPath + '%'} AND \${tables.${tableName}.id} != \${id}\`
+          eq(tables.${ctx.tableName}.teamId, teamId),
+          sql\`\${tables.${ctx.tableName}.${ctx.pathField}} LIKE \${oldPath + '%'} AND \${tables.${ctx.tableName}.id} != \${id}\`
         )
       ) as TreeItem[]
 
     // Update each descendant's path and depth
     for (const descendant of descendants) {
-      const descendantNewPath = descendant.${pathField}.replace(oldPath, newPath)
-      const depthDiff = newDepth - current.${depthField}
+      const descendantNewPath = descendant.${ctx.pathField}.replace(oldPath, newPath)
+      const depthDiff = newDepth - current.${ctx.depthField}
 
       await (db as any)
-        .update(tables.${tableName})
+        .update(tables.${ctx.tableName})
         .set({
-          ${pathField}: descendantNewPath,
-          ${depthField}: descendant.${depthField} + depthDiff
+          ${ctx.pathField}: descendantNewPath,
+          ${ctx.depthField}: descendant.${ctx.depthField} + depthDiff
         })
-        .where(eq(tables.${tableName}.id, descendant.id))
+        .where(eq(tables.${ctx.tableName}.id, descendant.id))
     }
   }
 
   return updated
+}`
 }
 
-export async function reorderSiblings${prefixedPascalCasePlural}(
+// reorderSiblings* — sequential per-row order updates (hierarchy variant)
+function buildTreeReorderSiblingsQuery(ctx: TreeQueryContext): string {
+  return `
+
+export async function reorderSiblings${ctx.prefixedPascalCasePlural}(
   teamId: string,
-  updates: { id: string; ${orderField}: number }[]
+  updates: { id: string; ${ctx.orderField}: number }[]
 ) {
   const db = useDB()
 
@@ -166,12 +179,12 @@ export async function reorderSiblings${prefixedPascalCasePlural}(
 
   for (const update of updates) {
     const [updated] = await (db as any)
-      .update(tables.${tableName})
-      .set({ ${orderField}: update.${orderField} })
+      .update(tables.${ctx.tableName})
+      .set({ ${ctx.orderField}: update.${ctx.orderField} })
       .where(
         and(
-          eq(tables.${tableName}.id, update.id),
-          eq(tables.${tableName}.teamId, teamId)
+          eq(tables.${ctx.tableName}.id, update.id),
+          eq(tables.${ctx.tableName}.teamId, teamId)
         )
       )
       .returning()
@@ -183,6 +196,35 @@ export async function reorderSiblings${prefixedPascalCasePlural}(
 
   return results
 }`
+}
+
+// Helper to generate tree-specific queries when hierarchy is enabled
+function generateTreeQueries(data: Record<string, any>, tableName: string, prefixedPascalCase: string, prefixedPascalCasePlural: string, camelCasePlural: string): string {
+  const hierarchy = data.hierarchy
+  if (!hierarchy || !hierarchy.enabled) {
+    return ''
+  }
+
+  // Get field names with defaults
+  const ctx: TreeQueryContext = {
+    tableName,
+    prefixedPascalCase,
+    prefixedPascalCasePlural,
+    camelCasePlural,
+    parentField: hierarchy.parentField || 'parentId',
+    pathField: hierarchy.pathField || 'path',
+    depthField: hierarchy.depthField || 'depth',
+    orderField: hierarchy.orderField || 'order'
+  }
+
+  // Note: Type assertions (as any) are used throughout to handle drizzle-orm version mismatches
+  // that can occur in monorepo setups. This is a pragmatic solution that allows the generated
+  // code to work across different drizzle-orm versions.
+
+  return buildTreeQueriesHeader(ctx)
+    + buildTreeGetDataQuery(ctx)
+    + buildTreeUpdatePositionQuery(ctx)
+    + buildTreeReorderSiblingsQuery(ctx)
 }
 
 // Helper to generate reorder-only queries when sortable is enabled (without full hierarchy)
@@ -302,40 +344,22 @@ function detectReferenceFields(data: Record<string, any>, config: Record<string,
   return { singleReferences, arrayReferences }
 }
 
-export function generateQueries(data: Record<string, any>, config: Record<string, any> | null = null, currentLayer: string = '', collectionLayerMap: Map<string, string> = new Map()): string {
-  const { singular, camelCase, camelCasePlural, plural, pascalCase, pascalCasePlural, layer, layerPascalCase } = data
-  // Use layer-prefixed table name to match schema export
-  // Convert layer to camelCase to ensure valid JavaScript identifier
-  const layerCamelCase = layer
+// Convert a layer name to camelCase to ensure a valid JavaScript identifier
+// (e.g. my-app_core -> myAppCore)
+function toLayerCamelCase(layer: string): string {
+  return layer
     .split(/[-_]/)
     .map((part, index) => index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1))
     .join('')
+}
 
-  // Resolve target layer camelCase for a collection — uses collectionLayerMap so cross-layer
-  // refs (e.g. contacts in people layer) produce the correct table name (peopleContacts, not
-  // projectsContacts). Falls back to current layer for unresolved collections.
-  const getTargetLayerCamelCase = (collectionName: string): string => {
-    const targetLayer = collectionLayerMap.get(collectionName.toLowerCase())
-    if (!targetLayer) return layerCamelCase
-    return targetLayer
-      .split(/[-_]/)
-      .map((part, index) => index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1))
-      .join('')
-  }
-  // Use pascalCasePlural which properly handles hyphens (e.g., email-templates -> EmailTemplates)
-  const tableName = `${layerCamelCase}${pascalCasePlural}`
-  const prefixedPascalCase = `${layerPascalCase}${pascalCase}`
-  const prefixedPascalCasePlural = `${layerPascalCase}${pascalCasePlural}`
-  const typesPath = '../../types'
-
-  // Detect reference fields for LEFT JOINs and post-query processing
-  const { singleReferences, arrayReferences } = detectReferenceFields(data, config)
-
-  // Foreign-key fields usable to scope getAll* (e.g. ?eventId=...). Excludes the
-  // owner/createdBy/updatedBy user refs — only real FK columns (eventId, categoryId, …).
-  const filterFields = singleReferences.filter(r => !r.isUserReference).map(r => r.fieldName)
-
-  // Generate imports for referenced schemas
+// Generate imports for referenced schemas (external, cross-layer, or same-layer)
+function buildSchemaImports(
+  singleReferences: Record<string, any>[],
+  arrayReferences: Record<string, any>[],
+  currentLayer: string,
+  collectionLayerMap: Map<string, string>
+): string {
   let schemaImports = ''
   const allReferences = [...singleReferences, ...arrayReferences]
   const uniqueCollections = [...new Set(allReferences.map(r => r.targetCollection))]
@@ -366,7 +390,15 @@ export function generateQueries(data: Record<string, any>, config: Record<string
     }
   })
 
-  // Build SELECT clause with joins (only for single references)
+  return schemaImports
+}
+
+// Build SELECT clause with joins (only for single references)
+function buildSelectJoins(
+  singleReferences: Record<string, any>[],
+  tableName: string,
+  getTargetLayerCamelCase: (collectionName: string) => string
+): { selectClause: string; leftJoins: string; aliasDefinitions: string } {
   let selectClause = ''
   let leftJoins = ''
   let aliasDefinitions = ''
@@ -431,11 +463,15 @@ export function generateQueries(data: Record<string, any>, config: Record<string
     }`
   }
 
-  // Detect JSON/repeater fields that need parsing
-  const jsonFields = detectJsonFields(data)
+  return { selectClause, leftJoins, aliasDefinitions }
+}
 
-  // Generate post-query processing code for JSON fields (repeater, json types)
-  // These fields come back as strings from SQLite and need to be parsed
+// Generate post-query processing code for JSON fields (repeater, json types)
+// These fields come back as strings from SQLite and need to be parsed
+function buildJsonFieldProcessing(
+  jsonFields: { fieldName: string; fieldType: string; defaultValue: string }[],
+  camelCasePlural: string
+): string {
   let jsonFieldProcessing = ''
   if (jsonFields.length > 0) {
     const fieldParsers = jsonFields.map(field => `
@@ -458,8 +494,15 @@ export function generateQueries(data: Record<string, any>, config: Record<string
   })
 `
   }
+  return jsonFieldProcessing
+}
 
-  // Generate post-query processing code for array references
+// Generate post-query processing code for array references
+function buildArrayRefProcessing(
+  arrayReferences: Record<string, any>[],
+  camelCasePlural: string,
+  getTargetLayerCamelCase: (collectionName: string) => string
+): string {
   let postQueryProcessing = ''
   if (arrayReferences.length > 0) {
     // Group array references by target collection for efficient querying
@@ -539,13 +582,252 @@ export function generateQueries(data: Record<string, any>, config: Record<string
   }
 `
   }
+  return postQueryProcessing
+}
+
+// getAll* options bag: optional FK filters (e.g. ?eventId=) + optional limit/offset
+// pagination. When `limit` is provided the function returns { items, total }
+// (total via a parallel count(*)); otherwise it returns the bare array — so
+// existing non-paginated callers are unaffected (enforced by the overloads).
+function buildGetAllOpts(filterFields: string[], tableName: string): { overload1Opts: string; overload2Opts: string; implOpts: string; filterConditions: string } {
+  const fkTypeFields = filterFields.map(f => `${f}?: string`).join('; ')
+  return {
+    overload1Opts: `opts?: {${fkTypeFields ? ` ${fkTypeFields} ` : ''}}`,
+    overload2Opts: `opts: {${fkTypeFields ? ` ${fkTypeFields};` : ''} limit: number; offset?: number }`,
+    implOpts: `opts: {${fkTypeFields ? ` ${fkTypeFields};` : ''} limit?: number; offset?: number } = {}`,
+    filterConditions: filterFields
+      .map(f => `\n  if (opts.${f}) conditions.push(eq(tables.${tableName}.${f}, opts.${f}))`)
+      .join('')
+  }
+}
+
+// Shared context for the CRUD query template builders below
+interface QueryTemplateContext {
+  tableName: string
+  prefixedPascalCase: string
+  prefixedPascalCasePlural: string
+  camelCase: string
+  camelCasePlural: string
+  useMetadata: boolean
+  typesPath: string
+  ascImport: string
+  schemaImports: string
+  aliasDefinitions: string
+  selectExpr: string
+  leftJoins: string
+  orderByClause: string
+  jsonFieldProcessing: string
+  postQueryProcessing: string
+  overload1Opts: string
+  overload2Opts: string
+  implOpts: string
+  filterConditions: string
+}
+
+// Imports + schema imports header of the generated queries file
+function buildFileHeader(ctx: QueryTemplateContext): string {
+  // `sql` is always needed now — getAll* runs a count(*) for pagination totals.
+  const sqlImport = ', sql'
+  return `// Generated with JSON field post-processing support (v2025-01-11)
+import { eq, and${ctx.useMetadata ? ', desc' : ''}${ctx.ascImport}, inArray${sqlImport} } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/sqlite-core'
+import * as tables from './schema'
+import type { ${ctx.prefixedPascalCase}, New${ctx.prefixedPascalCase} } from '${ctx.typesPath}'
+${ctx.schemaImports}`
+}
+
+// getAll* — team-scoped list with FK filters, joins, post-processing, and the
+// opt-in pagination overloads ({ items, total } when `limit` is passed)
+function buildGetAllQuery(ctx: QueryTemplateContext): string {
+  return `
+// Overload order matters: the paginated signature (required \`limit\`) must come
+// first so non-paginated calls fall through to the array overload.
+export async function getAll${ctx.prefixedPascalCasePlural}(teamId: string, ${ctx.overload2Opts}): Promise<{ items: any[]; total: number }>
+export async function getAll${ctx.prefixedPascalCasePlural}(teamId: string, ${ctx.overload1Opts}): Promise<any[]>
+export async function getAll${ctx.prefixedPascalCasePlural}(teamId: string, ${ctx.implOpts}) {
+  const db = useDB()
+${ctx.aliasDefinitions}  const conditions = [eq(tables.${ctx.tableName}.teamId, teamId)]${ctx.filterConditions}
+  const whereExpr = and(...conditions)
+
+  let listQuery = (db as any)
+    .select(${ctx.selectExpr})
+    .from(tables.${ctx.tableName})${ctx.leftJoins}
+    .where(whereExpr)${ctx.orderByClause ? `
+    .orderBy(${ctx.orderByClause})` : ''}
+
+  if (opts.limit != null) {
+    listQuery = listQuery.limit(opts.limit).offset(opts.offset ?? 0)
+  }
+
+  const ${ctx.camelCasePlural} = await listQuery
+${ctx.jsonFieldProcessing}${ctx.postQueryProcessing}
+  if (opts.limit != null) {
+    const [countRow] = await (db as any)
+      .select({ count: sql\`count(*)\` })
+      .from(tables.${ctx.tableName})
+      .where(whereExpr)
+    return { items: ${ctx.camelCasePlural}, total: Number(countRow?.count ?? 0) }
+  }
+
+  return ${ctx.camelCasePlural}
+}`
+}
+
+// get*ByIds — team-scoped bulk fetch by id list (same joins/post-processing)
+function buildGetByIdsQuery(ctx: QueryTemplateContext): string {
+  return `
+
+export async function get${ctx.prefixedPascalCasePlural}ByIds(teamId: string, ${ctx.camelCase}Ids: string[]) {
+  const db = useDB()
+${ctx.aliasDefinitions}
+  const ${ctx.camelCasePlural} = await (db as any)
+    .select(${ctx.selectExpr})
+    .from(tables.${ctx.tableName})${ctx.leftJoins}
+    .where(
+      and(
+        eq(tables.${ctx.tableName}.teamId, teamId),
+        inArray(tables.${ctx.tableName}.id, ${ctx.camelCase}Ids)
+      )
+    )${ctx.orderByClause ? `
+    .orderBy(${ctx.orderByClause})` : ''}
+${ctx.jsonFieldProcessing}${ctx.postQueryProcessing}
+  return ${ctx.camelCasePlural}
+}`
+}
+
+// create* — plain insert returning the created row
+function buildCreateQuery(ctx: QueryTemplateContext): string {
+  return `
+
+export async function create${ctx.prefixedPascalCase}(data: New${ctx.prefixedPascalCase}) {
+  const db = useDB()
+
+  const [${ctx.camelCase}] = await (db as any)
+    .insert(tables.${ctx.tableName})
+    .values(data)
+    .returning()
+
+  return ${ctx.camelCase}
+}`
+}
+
+// update* — team-scoped update with owner check (admins bypass) + 404 guard
+function buildUpdateQuery(ctx: QueryTemplateContext): string {
+  return `
+
+export async function update${ctx.prefixedPascalCase}(
+  recordId: string,
+  teamId: string,
+  userId: string,
+  updates: Partial<${ctx.prefixedPascalCase}>,
+  options?: { role?: string }
+) {
+  const db = useDB()
+  const isAdmin = options?.role === 'admin' || options?.role === 'owner'
+
+  const conditions = [
+    eq(tables.${ctx.tableName}.id, recordId),
+    eq(tables.${ctx.tableName}.teamId, teamId),
+  ]
+  if (!isAdmin) {
+    conditions.push(eq(tables.${ctx.tableName}.owner, userId))
+  }
+
+  const [${ctx.camelCase}] = await (db as any)
+    .update(tables.${ctx.tableName})
+    .set({
+      ...updates,${ctx.useMetadata ? `
+      updatedBy: userId` : ''}
+    })
+    .where(and(...conditions))
+    .returning()
+
+  if (!${ctx.camelCase}) {
+    throw createError({
+      status: 404,
+      statusText: '${ctx.prefixedPascalCase} not found or unauthorized'
+    })
+  }
+
+  return ${ctx.camelCase}
+}`
+}
+
+// delete* — team-scoped delete with owner check (admins bypass) + 404 guard
+function buildDeleteQuery(ctx: QueryTemplateContext): string {
+  return `
+
+export async function delete${ctx.prefixedPascalCase}(
+  recordId: string,
+  teamId: string,
+  userId: string,
+  options?: { role?: string }
+) {
+  const db = useDB()
+  const isAdmin = options?.role === 'admin' || options?.role === 'owner'
+
+  const conditions = [
+    eq(tables.${ctx.tableName}.id, recordId),
+    eq(tables.${ctx.tableName}.teamId, teamId),
+  ]
+  if (!isAdmin) {
+    conditions.push(eq(tables.${ctx.tableName}.owner, userId))
+  }
+
+  const [deleted] = await (db as any)
+    .delete(tables.${ctx.tableName})
+    .where(and(...conditions))
+    .returning()
+
+  if (!deleted) {
+    throw createError({
+      status: 404,
+      statusText: '${ctx.prefixedPascalCase} not found or unauthorized'
+    })
+  }
+
+  return { success: true }
+}`
+}
+
+export function generateQueries(data: Record<string, any>, config: Record<string, any> | null = null, currentLayer: string = '', collectionLayerMap: Map<string, string> = new Map()): string {
+  const { singular, camelCase, camelCasePlural, plural, pascalCase, pascalCasePlural, layer, layerPascalCase } = data
+  // Use layer-prefixed table name to match schema export
+  // Convert layer to camelCase to ensure valid JavaScript identifier
+  const layerCamelCase = toLayerCamelCase(layer)
+
+  // Resolve target layer camelCase for a collection — uses collectionLayerMap so cross-layer
+  // refs (e.g. contacts in people layer) produce the correct table name (peopleContacts, not
+  // projectsContacts). Falls back to current layer for unresolved collections.
+  const getTargetLayerCamelCase = (collectionName: string): string => {
+    const targetLayer = collectionLayerMap.get(collectionName.toLowerCase())
+    if (!targetLayer) return layerCamelCase
+    return toLayerCamelCase(targetLayer)
+  }
+  // Use pascalCasePlural which properly handles hyphens (e.g., email-templates -> EmailTemplates)
+  const tableName = `${layerCamelCase}${pascalCasePlural}`
+  const prefixedPascalCase = `${layerPascalCase}${pascalCase}`
+  const prefixedPascalCasePlural = `${layerPascalCase}${pascalCasePlural}`
+  const typesPath = '../../types'
+
+  // Detect reference fields for LEFT JOINs and post-query processing
+  const { singleReferences, arrayReferences } = detectReferenceFields(data, config)
+
+  // Foreign-key fields usable to scope getAll* (e.g. ?eventId=...). Excludes the
+  // owner/createdBy/updatedBy user refs — only real FK columns (eventId, categoryId, …).
+  const filterFields = singleReferences.filter(r => !r.isUserReference).map(r => r.fieldName)
+
+  const schemaImports = buildSchemaImports(singleReferences, arrayReferences, currentLayer, collectionLayerMap)
+  const { selectClause, leftJoins, aliasDefinitions } = buildSelectJoins(singleReferences, tableName, getTargetLayerCamelCase)
+
+  // Post-query processing for JSON/repeater fields and array references
+  const jsonFieldProcessing = buildJsonFieldProcessing(detectJsonFields(data), camelCasePlural)
+  const postQueryProcessing = buildArrayRefProcessing(arrayReferences, camelCasePlural, getTargetLayerCamelCase)
 
   // Check if hierarchy or sortable is enabled for import modifications
   const hasHierarchy = data.hierarchy && data.hierarchy.enabled
   const hasSortable = data.sortable && data.sortable.enabled
   const useMetadata = config?.flags?.useMetadata ?? true
-  // `sql` is always needed now — getAll* runs a count(*) for pagination totals.
-  const sqlImport = ', sql'
   const ascImport = (hasHierarchy || hasSortable) ? ', asc' : ''
   const orderField = hasSortable ? (data.sortable.orderField || 'order') : 'order'
   const orderByClause = hasSortable
@@ -563,151 +845,36 @@ export function generateQueries(data: Record<string, any>, config: Record<string
   // (hierarchy already includes reorderSiblings, so we skip to avoid duplicate exports)
   const sortableQueries = hasHierarchy ? '' : generateSortableQueries(data, tableName, prefixedPascalCasePlural)
 
-  // getAll* options bag: optional FK filters (e.g. ?eventId=) + optional limit/offset
-  // pagination. When `limit` is provided the function returns { items, total }
-  // (total via a parallel count(*)); otherwise it returns the bare array — so
-  // existing non-paginated callers are unaffected (enforced by the overloads below).
-  const fkTypeFields = filterFields.map(f => `${f}?: string`).join('; ')
-  const overload1Opts = `opts?: {${fkTypeFields ? ` ${fkTypeFields} ` : ''}}`
-  const overload2Opts = `opts: {${fkTypeFields ? ` ${fkTypeFields};` : ''} limit: number; offset?: number }`
-  const implOpts = `opts: {${fkTypeFields ? ` ${fkTypeFields};` : ''} limit?: number; offset?: number } = {}`
-  const filterConditions = filterFields
-    .map(f => `\n  if (opts.${f}) conditions.push(eq(tables.${tableName}.${f}, opts.${f}))`)
-    .join('')
-  const selectExpr = selectClause ? `${selectClause} as any` : '()'
+  const { overload1Opts, overload2Opts, implOpts, filterConditions } = buildGetAllOpts(filterFields, tableName)
 
-  return `// Generated with JSON field post-processing support (v2025-01-11)
-import { eq, and${useMetadata ? ', desc' : ''}${ascImport}, inArray${sqlImport} } from 'drizzle-orm'
-import { alias } from 'drizzle-orm/sqlite-core'
-import * as tables from './schema'
-import type { ${prefixedPascalCase}, New${prefixedPascalCase} } from '${typesPath}'
-${schemaImports}
-// Overload order matters: the paginated signature (required \`limit\`) must come
-// first so non-paginated calls fall through to the array overload.
-export async function getAll${prefixedPascalCasePlural}(teamId: string, ${overload2Opts}): Promise<{ items: any[]; total: number }>
-export async function getAll${prefixedPascalCasePlural}(teamId: string, ${overload1Opts}): Promise<any[]>
-export async function getAll${prefixedPascalCasePlural}(teamId: string, ${implOpts}) {
-  const db = useDB()
-${aliasDefinitions}  const conditions = [eq(tables.${tableName}.teamId, teamId)]${filterConditions}
-  const whereExpr = and(...conditions)
-
-  let listQuery = (db as any)
-    .select(${selectExpr})
-    .from(tables.${tableName})${leftJoins}
-    .where(whereExpr)${orderByClause ? `
-    .orderBy(${orderByClause})` : ''}
-
-  if (opts.limit != null) {
-    listQuery = listQuery.limit(opts.limit).offset(opts.offset ?? 0)
+  const ctx: QueryTemplateContext = {
+    tableName,
+    prefixedPascalCase,
+    prefixedPascalCasePlural,
+    camelCase,
+    camelCasePlural,
+    useMetadata,
+    typesPath,
+    ascImport,
+    schemaImports,
+    aliasDefinitions,
+    selectExpr: selectClause ? `${selectClause} as any` : '()',
+    leftJoins,
+    orderByClause,
+    jsonFieldProcessing,
+    postQueryProcessing,
+    overload1Opts,
+    overload2Opts,
+    implOpts,
+    filterConditions
   }
 
-  const ${camelCasePlural} = await listQuery
-${jsonFieldProcessing}${postQueryProcessing}
-  if (opts.limit != null) {
-    const [countRow] = await (db as any)
-      .select({ count: sql\`count(*)\` })
-      .from(tables.${tableName})
-      .where(whereExpr)
-    return { items: ${camelCasePlural}, total: Number(countRow?.count ?? 0) }
-  }
-
-  return ${camelCasePlural}
-}
-
-export async function get${prefixedPascalCasePlural}ByIds(teamId: string, ${camelCase}Ids: string[]) {
-  const db = useDB()
-${aliasDefinitions}
-  const ${camelCasePlural} = await (db as any)
-    .select(${selectClause ? `${selectClause} as any` : '()'})
-    .from(tables.${tableName})${leftJoins}
-    .where(
-      and(
-        eq(tables.${tableName}.teamId, teamId),
-        inArray(tables.${tableName}.id, ${camelCase}Ids)
-      )
-    )${orderByClause ? `
-    .orderBy(${orderByClause})` : ''}
-${jsonFieldProcessing}${postQueryProcessing}
-  return ${camelCasePlural}
-}
-
-export async function create${prefixedPascalCase}(data: New${prefixedPascalCase}) {
-  const db = useDB()
-
-  const [${camelCase}] = await (db as any)
-    .insert(tables.${tableName})
-    .values(data)
-    .returning()
-
-  return ${camelCase}
-}
-
-export async function update${prefixedPascalCase}(
-  recordId: string,
-  teamId: string,
-  userId: string,
-  updates: Partial<${prefixedPascalCase}>,
-  options?: { role?: string }
-) {
-  const db = useDB()
-  const isAdmin = options?.role === 'admin' || options?.role === 'owner'
-
-  const conditions = [
-    eq(tables.${tableName}.id, recordId),
-    eq(tables.${tableName}.teamId, teamId),
-  ]
-  if (!isAdmin) {
-    conditions.push(eq(tables.${tableName}.owner, userId))
-  }
-
-  const [${camelCase}] = await (db as any)
-    .update(tables.${tableName})
-    .set({
-      ...updates,${useMetadata ? `
-      updatedBy: userId` : ''}
-    })
-    .where(and(...conditions))
-    .returning()
-
-  if (!${camelCase}) {
-    throw createError({
-      status: 404,
-      statusText: '${prefixedPascalCase} not found or unauthorized'
-    })
-  }
-
-  return ${camelCase}
-}
-
-export async function delete${prefixedPascalCase}(
-  recordId: string,
-  teamId: string,
-  userId: string,
-  options?: { role?: string }
-) {
-  const db = useDB()
-  const isAdmin = options?.role === 'admin' || options?.role === 'owner'
-
-  const conditions = [
-    eq(tables.${tableName}.id, recordId),
-    eq(tables.${tableName}.teamId, teamId),
-  ]
-  if (!isAdmin) {
-    conditions.push(eq(tables.${tableName}.owner, userId))
-  }
-
-  const [deleted] = await (db as any)
-    .delete(tables.${tableName})
-    .where(and(...conditions))
-    .returning()
-
-  if (!deleted) {
-    throw createError({
-      status: 404,
-      statusText: '${prefixedPascalCase} not found or unauthorized'
-    })
-  }
-
-  return { success: true }
-}${treeQueries}${sortableQueries}`
+  return buildFileHeader(ctx)
+    + buildGetAllQuery(ctx)
+    + buildGetByIdsQuery(ctx)
+    + buildCreateQuery(ctx)
+    + buildUpdateQuery(ctx)
+    + buildDeleteQuery(ctx)
+    + treeQueries
+    + sortableQueries
 }

--- a/packages/crouton-cli/lib/generators/form-component.ts
+++ b/packages/crouton-cli/lib/generators/form-component.ts
@@ -79,10 +79,302 @@ function formatOptionLabel(value: unknown): string {
     .replace(/\b\w/g, char => char.toUpperCase())
 }
 
-export function generateFormComponent(data: Record<string, any>, config: Record<string, any> = {}): string {
-  const { pascalCase, pascalCasePlural, layerPascalCase, layerCamelCase, fields, singular, plural, layer, hierarchy } = data
-  const prefixedPascalCase = `${layerPascalCase}${pascalCase}`
-  const prefixedPascalCasePlural = `${layerPascalCase}${pascalCasePlural}`
+// Helper to resolve component names (handles component aliasing)
+function resolveComponentName(componentName: string): string {
+  // Transform EditorSimple to CroutonEditorSimple to match actual registration
+  if (componentName === 'EditorSimple') {
+    return 'CroutonEditorSimple'
+  }
+  // Transform ColorPicker to CroutonFormColorPicker (popover-based picker with presets)
+  if (componentName === 'ColorPicker') {
+    return 'CroutonFormColorPicker'
+  }
+  return componentName
+}
+
+// ── i18n field labels ──────────────────────────────────────────────────────
+// Field labels resolve through useT() so they can be translated/overridden per
+// team, with a humanized fallback so untranslated keys still render readable text.
+// Key convention: `{layer}.{plural}.fields.{fieldName}` (seed these in your locales).
+function createLabelAttr(fieldsI18nPrefix: string) {
+  return (field: Record<string, any>, fallbackOverride?: string): string => {
+    const fallback = fallbackOverride ?? field.meta?.label ?? humanizeFieldName(field.name)
+    return `:label="t('${fieldsI18nPrefix}.${field.name}', '${escapeLabel(fallback)}')"`
+  }
+}
+
+// ── Field markup rendering ─────────────────────────────────────────────────
+// Per-collection values the module-scope field/group renderers need (so they
+// don't close over generateFormComponent locals).
+interface FieldMarkupContext {
+  layerCamelCase: string
+  layerPascalCase: string
+  pascalCasePlural: string
+  formEnhancements: Record<string, any>
+  labelAttr: (field: Record<string, any>, fallbackOverride?: string) => string
+}
+
+// Field with a custom component specified in meta (e.g. EditorSimple)
+function renderCustomComponentField(field: Record<string, any>, ctx: FieldMarkupContext): string {
+  const componentName = resolveComponentName(field.meta.component)
+  return `        <UFormField ${ctx.labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <${componentName} v-model="state.${field.name}" />
+        </UFormField>`
+}
+
+// Dependent field (slotButtonGroup): options load from another field's selected value
+function renderDependentField(field: Record<string, any>, ctx: FieldMarkupContext): string {
+  const dependsOn = field.meta.dependsOn
+  const dependsOnField = field.meta.dependsOnField
+  const dependsOnCollection = field.meta.dependsOnCollection
+
+  // Resolve the collection name with layer prefix
+  const refCases = toCase(dependsOnCollection)
+  const resolvedCollection = `${ctx.layerCamelCase}${refCases.pascalCasePlural}`
+
+  // Determine dependent label (capitalize first letter)
+  const dependentLabel = dependsOn.charAt(0).toUpperCase() + dependsOn.slice(1)
+
+  return `        <UFormField ${ctx.labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonFormDependentFieldLoader
+            v-model="state.${field.name}"
+            :dependent-value="state.${dependsOn}"
+            dependent-collection="${resolvedCollection}"
+            dependent-field="${dependsOnField}"
+            dependent-label="${dependentLabel}"
+          />
+        </UFormField>`
+}
+
+// Static options select field (inline meta.options array → `${name}Options` const in the script)
+function renderInlineOptionsField(field: Record<string, any>, ctx: FieldMarkupContext): string {
+  return `        <UFormField ${ctx.labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <USelect
+            v-model="state.${field.name}"
+            :items="${field.name}Options"
+            class="w-full"
+            size="xl"
+          />
+        </UFormField>`
+}
+
+// Options select field backed by an options collection (admin-configurable dropdown)
+function renderOptionsCollectionField(field: Record<string, any>, ctx: FieldMarkupContext): string {
+  const optionsCollection = field.meta.optionsCollection
+  const optionsField = field.meta.optionsField
+  const creatable = field.meta.creatable !== false // Default to true
+
+  // Resolve the collection name with layer prefix
+  // If optionsCollection already starts with layer prefix, use as-is
+  // Otherwise add the layer prefix (for backwards compatibility with short names like "settings")
+  let resolvedOptionsCollection
+  if (optionsCollection.startsWith(ctx.layerCamelCase)) {
+    // Already has prefix (e.g., "bookingsSettings")
+    resolvedOptionsCollection = optionsCollection
+  } else {
+    // Add prefix (e.g., "settings" -> "bookingsSettings")
+    const refCases = toCase(optionsCollection)
+    resolvedOptionsCollection = `${ctx.layerCamelCase}${refCases.pascalCasePlural}`
+  }
+
+  return `        <UFormField ${ctx.labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonFormOptionsSelect
+            v-model="state.${field.name}"
+            options-collection="${resolvedOptionsCollection}"
+            options-field="${optionsField}"
+            ${ctx.labelAttr(field)}${!creatable
+              ? `
+            :creatable="false"`
+              : ''}
+          />
+        </UFormField>`
+}
+
+// Reference field (has refTarget): read-only card, multi-select or single reference select
+function renderReferenceField(field: Record<string, any>, ctx: FieldMarkupContext): string {
+  let resolvedCollection
+
+  // Check refScope to determine how to resolve the reference
+  if (field.refScope === 'adapter') {
+    // Adapter-scoped reference: use target as-is (no layer prefix)
+    // These are managed by connector packages (e.g., @fyit/crouton-supersaas)
+    resolvedCollection = field.refTarget
+  } else {
+    // Local layer reference: add layer prefix
+    const refCases = toCase(field.refTarget)
+    resolvedCollection = `${ctx.layerCamelCase}${refCases.pascalCasePlural}`
+  }
+
+  // Check if this is a read-only reference field
+  if (field.meta?.readOnly) {
+    return `        <UFormField ${ctx.labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonItemCardMini
+            v-if="state.${field.name}"
+            :id="state.${field.name}"
+            collection="${resolvedCollection}"
+          />
+          <span v-else class="text-gray-400 text-sm">Not set</span>
+        </UFormField>`
+  }
+
+  // Build optional label-key and filter-fields props when labelField is specified
+  const labelField = field.meta?.labelField
+  const labelKeyAttr = labelField && labelField !== 'title'
+    ? `\n            label-key="${labelField}"\n            :filter-fields="['${labelField}']"`
+    : ''
+
+  // Check if this is an array type (multi-select reference)
+  if (field.type === 'array') {
+    return `        <UFormField ${ctx.labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonFormReferenceSelect
+            v-model="state.${field.name}"
+            collection="${resolvedCollection}"
+            ${ctx.labelAttr(field)}${labelKeyAttr}
+            multiple
+          />
+        </UFormField>`
+  }
+
+  return `        <UFormField ${ctx.labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonFormReferenceSelect
+            v-model="state.${field.name}"
+            collection="${resolvedCollection}"
+            ${ctx.labelAttr(field)}${labelKeyAttr}
+          />
+        </UFormField>`
+}
+
+// Fallback rendering keyed on the field's (canonical) type
+function renderDefaultTypeField(field: Record<string, any>, ctx: FieldMarkupContext): string {
+  const { labelAttr } = ctx
+
+  // Image field type — base fallback uses CroutonImageUpload (crouton-assets contribution overrides with CroutonAssetsPicker)
+  if (field.type === 'image') {
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonImageUpload
+            v-model="state.${field.name}"
+            :crop="true"
+          />
+        </UFormField>`
+  }
+
+  // File field type — base fallback uses CroutonImageUpload
+  if (field.type === 'file') {
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonImageUpload
+            v-model="state.${field.name}"
+          />
+        </UFormField>`
+  }
+
+  // Default component selection based on field type
+  if (field.type === 'text') {
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <UTextarea v-model="state.${field.name}" class="w-full" size="xl" />
+        </UFormField>`
+  } else if (field.type === 'boolean') {
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <UCheckbox v-model="state.${field.name}" />
+        </UFormField>`
+  } else if (field.type === 'number' || field.type === 'decimal') {
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <UInputNumber v-model="state.${field.name}" class="w-full" />
+        </UFormField>`
+  } else if (field.type === 'date') {
+    const pickerProp = field.meta?.picker ? ' picker' : ''
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonCalendar v-model:date="state.${field.name}"${pickerProp} />
+        </UFormField>`
+  } else if (field.type === 'repeater') {
+    // Use the field's Input component from the field components folder
+    const fieldCases = toCase(field.name)
+    const componentName = `${ctx.layerPascalCase}${ctx.pascalCasePlural}${fieldCases.pascalCase}Input`
+    const addLabel = field.meta?.addLabel || 'Add Item'
+    const sortable = field.meta?.sortable !== false // Default to true
+
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <CroutonFormRepeater
+            v-model="state.${field.name}"
+            component-name="${componentName}"
+            add-label="${addLabel}"
+            ${sortable ? ':sortable="true"' : ':sortable="false"'}
+          />
+        </UFormField>`
+  } else if (field.type === 'json') {
+    // JSON field - use textarea with JSON serialization
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <UTextarea
+            :model-value="typeof state.${field.name} === 'string' ? state.${field.name} : JSON.stringify(state.${field.name}, null, 2)"
+            @update:model-value="(val) => { try { state.${field.name} = val ? JSON.parse(val) : {} } catch (e) { console.error('Invalid JSON:', e) } }"
+            class="w-full font-mono text-sm"
+            :rows="8"
+            placeholder="Enter JSON object"
+          />
+        </UFormField>`
+  } else if (field.type === 'array' && !field.refTarget) {
+    // Array field without refTarget - use textarea with array handling
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <UTextarea
+            :model-value="Array.isArray(state.${field.name}) ? state.${field.name}.join('\\n') : ''"
+            @update:model-value="(val) => state.${field.name} = val ? val.split('\\n').filter(Boolean) : []"
+            class="w-full"
+            :rows="6"
+            placeholder="Enter one value per line"
+          />
+          <p class="text-sm text-gray-500 mt-1">Enter one value per line</p>
+        </UFormField>`
+  } else {
+    return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
+          <UInput v-model="state.${field.name}" class="w-full" size="xl" />
+        </UFormField>`
+  }
+}
+
+// Render the form markup for one field, dispatching to the renderer matching its
+// meta/type shape. Order matters: contribution overrides win, then explicit
+// component/display hints, then references, then type-based defaults.
+function generateFieldMarkup(field: Record<string, any>, ctx: FieldMarkupContext): string {
+  // ── Contribution override takes priority ─────────────────────────────
+  const override = ctx.formEnhancements.fieldOverrides?.[field.name]
+  if (override !== undefined) {
+    // Empty string means hide the field; otherwise use the override template
+    return override
+  }
+
+  // Check if a custom component is specified in meta
+  if (field.meta?.component) {
+    return renderCustomComponentField(field, ctx)
+  }
+
+  // Check if this is a dependent field
+  if (field.meta?.displayAs === 'slotButtonGroup' && field.meta?.dependsOn && field.meta?.dependsOnField && field.meta?.dependsOnCollection) {
+    return renderDependentField(field, ctx)
+  }
+
+  // Check if this is a static options select field (inline meta.options array)
+  if (field.meta?.displayAs === 'optionsSelect' && Array.isArray(field.meta?.options) && !field.meta?.optionsCollection) {
+    return renderInlineOptionsField(field, ctx)
+  }
+
+  // Check if this is an options select field (admin-configurable dropdown)
+  if (field.meta?.displayAs === 'optionsSelect' && field.meta?.optionsCollection && field.meta?.optionsField) {
+    return renderOptionsCollectionField(field, ctx)
+  }
+
+  // Check if this is a reference field (has refTarget)
+  if (field.refTarget) {
+    return renderReferenceField(field, ctx)
+  }
+
+  return renderDefaultTypeField(field, ctx)
+}
+
+// ── Field analysis ─────────────────────────────────────────────────────────
+// Derive the field partitions and feature flags the generator branches on:
+// hierarchy handling, translatable vs regular fields, contribution exclusions,
+// and the display / inline-options lists.
+function analyzeFields(data: Record<string, any>, config: Record<string, any>) {
+  const { fields, plural, hierarchy } = data
 
   // Check for hierarchy support
   const hasHierarchy = hierarchy?.enabled === true
@@ -137,267 +429,31 @@ export function generateFormComponent(data: Record<string, any>, config: Record<
       && !f.meta?.optionsCollection
   )
 
-  // Helper to resolve component names (handles component aliasing)
-  const resolveComponentName = (componentName) => {
-    // Transform EditorSimple to CroutonEditorSimple to match actual registration
-    if (componentName === 'EditorSimple') {
-      return 'CroutonEditorSimple'
-    }
-    // Transform ColorPicker to CroutonFormColorPicker (popover-based picker with presets)
-    if (componentName === 'ColorPicker') {
-      return 'CroutonFormColorPicker'
-    }
-    return componentName
+  return {
+    hasHierarchy,
+    parentField,
+    translatableFieldNames,
+    hasTranslations,
+    translatableFields,
+    regularFields,
+    hasDateFields,
+    formEnhancements,
+    excludedFieldNames,
+    fieldsToDisplay,
+    fieldsWithInlineOptions
   }
+}
 
-  // ── i18n field labels ──────────────────────────────────────────────────────
-  // Field labels resolve through useT() so they can be translated/overridden per
-  // team, with a humanized fallback so untranslated keys still render readable text.
-  // Key convention: `{layer}.{plural}.fields.{fieldName}` (seed these in your locales).
-  const fieldsI18nPrefix = `${layer}.${plural}.fields`
-  const labelAttr = (field, fallbackOverride?: string): string => {
-    const fallback = fallbackOverride ?? field.meta?.label ?? humanizeFieldName(field.name)
-    return `:label="t('${fieldsI18nPrefix}.${field.name}', '${escapeLabel(fallback)}')"`
-  }
-
-  const generateFieldMarkup = (field) => {
-    // ── Contribution override takes priority ─────────────────────────────
-    const override = formEnhancements.fieldOverrides?.[field.name]
-    if (override !== undefined) {
-      // Empty string means hide the field; otherwise use the override template
-      return override
-    }
-
-    const fieldName = field.name.charAt(0).toUpperCase() + field.name.slice(1)
-
-    // Check if a custom component is specified in meta
-    if (field.meta?.component) {
-      const componentName = resolveComponentName(field.meta.component)
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <${componentName} v-model="state.${field.name}" />
-        </UFormField>`
-    }
-
-    // Check if this is a dependent field
-    if (field.meta?.displayAs === 'slotButtonGroup' && field.meta?.dependsOn && field.meta?.dependsOnField && field.meta?.dependsOnCollection) {
-      const dependsOn = field.meta.dependsOn
-      const dependsOnField = field.meta.dependsOnField
-      const dependsOnCollection = field.meta.dependsOnCollection
-
-      // Resolve the collection name with layer prefix
-      const refCases = toCase(dependsOnCollection)
-      const resolvedCollection = `${layerCamelCase}${refCases.pascalCasePlural}`
-
-      // Determine dependent label (capitalize first letter)
-      const dependentLabel = dependsOn.charAt(0).toUpperCase() + dependsOn.slice(1)
-
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonFormDependentFieldLoader
-            v-model="state.${field.name}"
-            :dependent-value="state.${dependsOn}"
-            dependent-collection="${resolvedCollection}"
-            dependent-field="${dependsOnField}"
-            dependent-label="${dependentLabel}"
-          />
-        </UFormField>`
-    }
-
-    // Check if this is a static options select field (inline meta.options array)
-    if (field.meta?.displayAs === 'optionsSelect' && Array.isArray(field.meta?.options) && !field.meta?.optionsCollection) {
-      const label = field.meta.label || fieldName
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <USelect
-            v-model="state.${field.name}"
-            :items="${field.name}Options"
-            class="w-full"
-            size="xl"
-          />
-        </UFormField>`
-    }
-
-    // Check if this is an options select field (admin-configurable dropdown)
-    if (field.meta?.displayAs === 'optionsSelect' && field.meta?.optionsCollection && field.meta?.optionsField) {
-      const optionsCollection = field.meta.optionsCollection
-      const optionsField = field.meta.optionsField
-      const label = field.meta.label || fieldName
-      const creatable = field.meta.creatable !== false // Default to true
-
-      // Resolve the collection name with layer prefix
-      // If optionsCollection already starts with layer prefix, use as-is
-      // Otherwise add the layer prefix (for backwards compatibility with short names like "settings")
-      let resolvedOptionsCollection
-      if (optionsCollection.startsWith(layerCamelCase)) {
-        // Already has prefix (e.g., "bookingsSettings")
-        resolvedOptionsCollection = optionsCollection
-      } else {
-        // Add prefix (e.g., "settings" -> "bookingsSettings")
-        const refCases = toCase(optionsCollection)
-        resolvedOptionsCollection = `${layerCamelCase}${refCases.pascalCasePlural}`
-      }
-
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonFormOptionsSelect
-            v-model="state.${field.name}"
-            options-collection="${resolvedOptionsCollection}"
-            options-field="${optionsField}"
-            ${labelAttr(field)}${!creatable
-              ? `
-            :creatable="false"`
-              : ''}
-          />
-        </UFormField>`
-    }
-
-    // Check if this is a reference field (has refTarget)
-    if (field.refTarget) {
-      let resolvedCollection
-
-      // Check refScope to determine how to resolve the reference
-      if (field.refScope === 'adapter') {
-        // Adapter-scoped reference: use target as-is (no layer prefix)
-        // These are managed by connector packages (e.g., @fyit/crouton-supersaas)
-        resolvedCollection = field.refTarget
-      } else {
-        // Local layer reference: add layer prefix
-        const refCases = toCase(field.refTarget)
-        resolvedCollection = `${layerCamelCase}${refCases.pascalCasePlural}`
-      }
-
-      // Check if this is a read-only reference field
-      if (field.meta?.readOnly) {
-        return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonItemCardMini
-            v-if="state.${field.name}"
-            :id="state.${field.name}"
-            collection="${resolvedCollection}"
-          />
-          <span v-else class="text-gray-400 text-sm">Not set</span>
-        </UFormField>`
-      }
-
-      // Build optional label-key and filter-fields props when labelField is specified
-      const labelField = field.meta?.labelField
-      const labelKeyAttr = labelField && labelField !== 'title'
-        ? `\n            label-key="${labelField}"\n            :filter-fields="['${labelField}']"`
-        : ''
-
-      // Check if this is an array type (multi-select reference)
-      if (field.type === 'array') {
-        return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonFormReferenceSelect
-            v-model="state.${field.name}"
-            collection="${resolvedCollection}"
-            ${labelAttr(field)}${labelKeyAttr}
-            multiple
-          />
-        </UFormField>`
-      }
-
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonFormReferenceSelect
-            v-model="state.${field.name}"
-            collection="${resolvedCollection}"
-            ${labelAttr(field)}${labelKeyAttr}
-          />
-        </UFormField>`
-    }
-
-    // Image field type — base fallback uses CroutonImageUpload (crouton-assets contribution overrides with CroutonAssetsPicker)
-    if (field.type === 'image') {
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonImageUpload
-            v-model="state.${field.name}"
-            :crop="true"
-          />
-        </UFormField>`
-    }
-
-    // File field type — base fallback uses CroutonImageUpload
-    if (field.type === 'file') {
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonImageUpload
-            v-model="state.${field.name}"
-          />
-        </UFormField>`
-    }
-
-    // Default component selection based on field type
-    if (field.type === 'text') {
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <UTextarea v-model="state.${field.name}" class="w-full" size="xl" />
-        </UFormField>`
-    } else if (field.type === 'boolean') {
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <UCheckbox v-model="state.${field.name}" />
-        </UFormField>`
-    } else if (field.type === 'number' || field.type === 'decimal') {
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <UInputNumber v-model="state.${field.name}" class="w-full" />
-        </UFormField>`
-    } else if (field.type === 'date') {
-      const pickerProp = field.meta?.picker ? ' picker' : ''
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonCalendar v-model:date="state.${field.name}"${pickerProp} />
-        </UFormField>`
-    } else if (field.type === 'repeater') {
-      // Use the field's Input component from the field components folder
-      const fieldCases = toCase(field.name)
-      const componentName = `${layerPascalCase}${pascalCasePlural}${fieldCases.pascalCase}Input`
-      const addLabel = field.meta?.addLabel || 'Add Item'
-      const sortable = field.meta?.sortable !== false // Default to true
-
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <CroutonFormRepeater
-            v-model="state.${field.name}"
-            component-name="${componentName}"
-            add-label="${addLabel}"
-            ${sortable ? ':sortable="true"' : ':sortable="false"'}
-          />
-        </UFormField>`
-    } else if (field.type === 'json') {
-      // JSON field - use textarea with JSON serialization
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <UTextarea
-            :model-value="typeof state.${field.name} === 'string' ? state.${field.name} : JSON.stringify(state.${field.name}, null, 2)"
-            @update:model-value="(val) => { try { state.${field.name} = val ? JSON.parse(val) : {} } catch (e) { console.error('Invalid JSON:', e) } }"
-            class="w-full font-mono text-sm"
-            :rows="8"
-            placeholder="Enter JSON object"
-          />
-        </UFormField>`
-    } else if (field.type === 'array' && !field.refTarget) {
-      // Array field without refTarget - use textarea with array handling
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <UTextarea
-            :model-value="Array.isArray(state.${field.name}) ? state.${field.name}.join('\\n') : ''"
-            @update:model-value="(val) => state.${field.name} = val ? val.split('\\n').filter(Boolean) : []"
-            class="w-full"
-            :rows="6"
-            placeholder="Enter one value per line"
-          />
-          <p class="text-sm text-gray-500 mt-1">Enter one value per line</p>
-        </UFormField>`
-    } else {
-      return `        <UFormField ${labelAttr(field)} name="${field.name}" class="not-last:pb-4">
-          <UInput v-model="state.${field.name}" class="w-full" size="xl" />
-        </UFormField>`
-    }
-  }
-
-  // Generate parent picker section for hierarchy-enabled collections
-  // This uses CroutonFormParentSelect which excludes self and descendants
-  const parentPickerSection = hasHierarchy
-    ? `
-        <UFormField :label="t('crouton.form.parent', 'Parent')" name="${parentField}" class="not-last:pb-4">
-          <CroutonFormParentSelect
-            v-model="state.${parentField}"
-            collection="${layerCamelCase}${pascalCasePlural}"
-            :current-id="state.id"
-            :label="t('crouton.form.parent', 'Parent')"
-          />
-        </UFormField>`
-    : ''
-
+// ── Group assembly ─────────────────────────────────────────────────────────
+// Group the displayable fields by area (main/sidebar) and then by group,
+// ensuring groups that have contribution injections exist in the maps
+// (e.g. the coordinate field's group may be filtered out but we still need to inject the map)
+function buildFieldGroups(
+  fieldsToDisplay: Record<string, any>[],
+  fields: Record<string, any>[],
+  excludedFieldNames: Set<string>,
+  formEnhancements: Record<string, any>
+) {
   // Group fields by area and then by group
   const mainFields = fieldsToDisplay.filter(f => !f.meta?.area || f.meta.area === 'main')
   const sidebarFields = fieldsToDisplay.filter(f => f.meta?.area === 'sidebar')
@@ -405,8 +461,6 @@ export function generateFormComponent(data: Record<string, any>, config: Record<
   const mainGroups = groupFieldsByGroup(mainFields)
   const sidebarGroups = groupFieldsByGroup(sidebarFields)
 
-  // Ensure groups that have contribution injections exist in the map
-  // (e.g. the coordinate field's group may be filtered out but we still need to inject the map)
   for (const groupName of Object.keys(formEnhancements.groupInjections || {})) {
     if (!mainGroups.has(groupName === '' ? null : groupName) && !sidebarGroups.has(groupName === '' ? null : groupName)) {
       // Check if the excluded field that belonged to this group was main or sidebar
@@ -420,51 +474,49 @@ export function generateFormComponent(data: Record<string, any>, config: Record<
     }
   }
 
-  // Determine if we should use tabs (multiple main groups)
-  const useTabs = mainGroups.size > 1
-  // Sidebar is shown if there are sidebar fields OR if hierarchy is enabled (for parent picker)
-  const hasSidebar = sidebarGroups.size > 0 || hasHierarchy
+  return { mainGroups, sidebarGroups }
+}
 
-  // Generate navigation items from main groups
-  const navigationItems = useTabs
-    ? Array.from(mainGroups.keys()).map(groupName => ({
-        label: humanizeGroupName(groupName),
-        value: groupName || 'general'
-      }))
-    : []
+// Helper to generate a group section with flex layout
+function buildGroupSection(groupName: string | null, groupFields: Record<string, any>[], showConditionally: boolean, ctx: FieldMarkupContext): string {
+  const groupValue = groupName || 'general'
+  const fieldsMarkup = groupFields.map(field => generateFieldMarkup(field, ctx)).join('\n')
 
-  // Helper to generate a group section with flex layout
-  const generateGroupSection = (groupName, groupFields, showConditionally = false) => {
-    const title = humanizeGroupName(groupName)
-    const groupValue = groupName || 'general'
-    const fieldsMarkup = groupFields.map(generateFieldMarkup).join('\n')
+  // Inject contribution-provided content after this group
+  const groupKey = groupName || ''
+  const groupInjection = ctx.formEnhancements.groupInjections?.[groupKey] || ''
 
-    // Inject contribution-provided content after this group
-    const groupKey = groupName || ''
-    const groupInjection = formEnhancements.groupInjections?.[groupKey] || ''
+  const conditionalWrapper = showConditionally
+    ? `      <div v-show="!tabs || activeSection === '${groupValue}'" class="flex flex-col gap-4 p-1">\n`
+    : `      <div class="flex flex-col gap-4 p-1">\n`
 
-    const conditionalWrapper = showConditionally
-      ? `      <div v-show="!tabs || activeSection === '${groupValue}'" class="flex flex-col gap-4 p-1">\n`
-      : `      <div class="flex flex-col gap-4 p-1">\n`
-
-    return `${conditionalWrapper}${fieldsMarkup}${groupInjection}
+  return `${conditionalWrapper}${fieldsMarkup}${groupInjection}
       </div>`
-  }
+}
 
-  // Generate main area groups
-  const mainAreaMarkup = Array.from(mainGroups.entries())
-    .map(([groupName, groupFields]) => generateGroupSection(groupName, groupFields, useTabs))
-    .join('\n\n')
+// ── Template section builders ──────────────────────────────────────────────
 
-  // Generate sidebar area groups
-  const sidebarAreaMarkup = hasSidebar
-    ? Array.from(sidebarGroups.entries())
-        .map(([groupName, groupFields]) => generateGroupSection(groupName, groupFields, false))
-        .join('\n\n')
+// Generate parent picker section for hierarchy-enabled collections
+// This uses CroutonFormParentSelect which excludes self and descendants
+function buildParentPickerSection(hasHierarchy: boolean, parentField: string, layerCamelCase: string, pascalCasePlural: string): string {
+  return hasHierarchy
+    ? `
+        <UFormField :label="t('crouton.form.parent', 'Parent')" name="${parentField}" class="not-last:pb-4">
+          <CroutonFormParentSelect
+            v-model="state.${parentField}"
+            collection="${layerCamelCase}${pascalCasePlural}"
+            :current-id="state.id"
+            :label="t('crouton.form.parent', 'Parent')"
+          />
+        </UFormField>`
     : ''
+}
 
+// Add CroutonI18nInput if there are translatable fields
+// Use fallback to empty string to ensure string type compatibility
+function buildTranslationField(hasTranslations: boolean, translatableFieldNames: string[], translatableFields: Record<string, any>[], plural: string): string {
   // Build fieldComponents map for translatable fields with custom components
-  const fieldComponentsMap = {}
+  const fieldComponentsMap: Record<string, string> = {}
   translatableFields.forEach((field) => {
     if (field.meta?.component) {
       fieldComponentsMap[field.name] = resolveComponentName(field.meta.component)
@@ -472,9 +524,7 @@ export function generateFormComponent(data: Record<string, any>, config: Record<
   })
   const hasFieldComponents = Object.keys(fieldComponentsMap).length > 0
 
-  // Add CroutonI18nInput if there are translatable fields
-  // Use fallback to empty string to ensure string type compatibility
-  const translationField = hasTranslations
+  return hasTranslations
     ? `
 
       <CroutonI18nInput
@@ -493,49 +543,13 @@ export function generateFormComponent(data: Record<string, any>, config: Record<
         :label="t('crouton.form.translations', 'Translations')"
       />`
     : ''
+}
 
-  // Generate initial state fields with proper defaults (excluding id)
-  const stateFields = fields.filter(field => field.name !== 'id').map((field) => {
-    // Dependent fields need to default to null (CroutonFormDependentFieldLoader expects null or array)
-    if (field.meta?.dependsOn || field.meta?.displayAs === 'slotButtonGroup') {
-      return `  ${field.name}: null`
-    }
+// ── Script section builders ────────────────────────────────────────────────
 
-    // Array fields should default to [] or null
-    if (field.type === 'array') {
-      // Check if it's a reference field that might be nullable
-      if (field.refTarget) {
-        return `  ${field.name}: []`
-      }
-      return `  ${field.name}: []`
-    }
-
-    const defaultVal = field.type === 'boolean'
-      ? 'false'
-      : field.type === 'number' || field.type === 'decimal'
-        ? '0'
-        : field.type === 'date'
-          ? 'null'
-          : field.type === 'repeater' ? '[]' : '\'\''
-    return `  ${field.name}: ${defaultVal}`
-  }).join(',\n')
-
-  // Add translations to state if needed
-  const translationsState = hasTranslations ? ',\n  translations: {}' : ''
-
-  // Add hierarchy fields to state if needed (parentId, path, depth, order are auto-generated)
-  const hierarchyState = hasHierarchy
-    ? `,
-  ${parentField}: null,
-  ${hierarchy.pathField || 'path'}: '/',
-  ${hierarchy.depthField || 'depth'}: 0,
-  ${hierarchy.orderField || 'order'}: 0`
-    : ''
-
-  const typesPath = '../../types'
-
-  // Generate navigation items array for the template
-  const navigationItemsCode = useTabs
+// Generate navigation items array for the template (tabbed forms)
+function buildNavigationItemsCode(useTabs: boolean, navigationItems: Array<{ label: string, value: string }>): string {
+  return useTabs
     ? `const navigationItems = [
   ${navigationItems.map(item => `{ label: '${item.label}', value: '${item.value}' }`).join(',\n  ')}
 ]
@@ -543,9 +557,11 @@ export function generateFormComponent(data: Record<string, any>, config: Record<
 const tabs = ref(true)
 const activeSection = ref('${navigationItems[0]?.value || 'general'}')`
     : 'const tabs = ref(false)'
+}
 
-  // Generate inline options arrays for static USelect fields
-  const inlineOptionsCode = fieldsWithInlineOptions.length > 0
+// Generate inline options arrays for static USelect fields
+function buildInlineOptionsCode(fieldsWithInlineOptions: Record<string, any>[]): string {
+  return fieldsWithInlineOptions.length > 0
     ? fieldsWithInlineOptions.map((field) => {
         const options = field.meta.options
         const optionsArray = options.map((opt) => {
@@ -558,10 +574,12 @@ const activeSection = ref('${navigationItems[0]?.value || 'general'}')`
         return `const ${field.name}Options = [\n${optionsArray}\n]`
       }).join('\n\n')
     : ''
+}
 
-  // Generate field-to-group mapping for error tracking
+// Generate field-to-group mapping for error tracking
+function buildFieldToGroupCode(useTabs: boolean, mainGroups: Map<string | null, Record<string, any>[]>): string {
   const fieldGroupMapping = useTabs ? mainGroups : new Map()
-  const fieldToGroupCode = useTabs
+  return useTabs
     ? `
 // Map field names to their tab groups for error tracking
 const fieldToGroup: Record<string, string> = {
@@ -572,10 +590,10 @@ ${Array.from(fieldGroupMapping.entries())
   .join(',\n')}
 }`
     : ''
+}
 
-  // Generate error tracking code (only if tabs are used)
-  const errorTrackingCode = useTabs
-    ? `
+// Error tracking code (only emitted if tabs are used)
+const ERROR_TRACKING_CODE = `
 // Track validation errors for tab indicators
 const validationErrors = ref<Array<{ name: string; message: string }>>([])
 
@@ -602,16 +620,89 @@ const tabErrorCounts = computed(() => {
 const switchToTab = (tabValue: string) => {
   activeSection.value = tabValue
 }`
+
+// Hierarchy defaults snippet: new items get parentId/path/depth/order seeded
+function buildHierarchyDefaultsCode(hasHierarchy: boolean, hierarchy: Record<string, any>, parentField: string): string {
+  return hasHierarchy
+    ? `
+// Hierarchy defaults for new items (parentId, path, depth, order)
+const hierarchyDefaults = {
+  ${parentField}: null,
+  ${hierarchy.pathField || 'path'}: '/',
+  ${hierarchy.depthField || 'depth'}: 0,
+  ${hierarchy.orderField || 'order'}: 0
+}`
     : ''
+}
 
-  // Contribution script additions (geocoding, etc.)
-  const scriptAdditions = (formEnhancements.scriptAdditions || []).join('\n')
+// Date-hydration snippet: convert stored ISO strings to Date objects when editing
+function buildDateInitCode(hasDateFields: boolean, regularFields: Record<string, any>[]): string {
+  return hasDateFields
+    ? `
 
-  // Generate AI context header
-  const apiPath = `${layer}-${plural}`
-  const aiHeader = generateAIHeader(data, apiPath)
+// Convert date strings to Date objects for date fields during editing
+if (props.action === 'update' && props.activeItem?.id) {${regularFields
+  .filter(f => f.type === 'date')
+  .map(field => `
+  if (initialValues.${field.name}) {
+    initialValues.${field.name} = new Date(initialValues.${field.name})
+  }`).join('')}
+}`
+    : ''
+}
 
-  return `${aiHeader}<template>
+// The generated handleSubmit body (create/update/delete + optional date serialization)
+function buildHandleSubmitCode(hasDateFields: boolean, regularFields: Record<string, any>[], useTabs: boolean): string {
+  return `const handleSubmit = async () => {
+  try {${hasDateFields
+    ? `
+    // Serialize Date objects to ISO strings for API submission
+    const serializedData: Record<string, any> = { ...state.value }${regularFields
+      .filter(f => f.type === 'date')
+      .map(field => `
+    if (serializedData.${field.name} instanceof Date) {
+      serializedData.${field.name} = serializedData.${field.name}.toISOString()
+    }`).join('')}
+`
+    : ''}
+    if (props.action === 'create') {
+      await create(${hasDateFields ? 'serializedData' : 'state.value'})
+    } else if (props.action === 'update' && state.value.id) {
+      await update(state.value.id, ${hasDateFields ? 'serializedData' : 'state.value'})
+    } else if (props.action === 'delete') {
+      await deleteItems(props.items)
+    }
+${useTabs
+  ? `
+    // Clear validation errors on successful submission
+    validationErrors.value = []
+`
+  : ''}
+    close()
+
+  } catch (error) {
+    console.error('Form submission failed:', error)
+    // You can add toast notification here if available
+    // toast.add({ title: 'Error', description: 'Failed to submit form', color: 'red' })
+  }
+}`
+}
+
+// ── SFC assembly ───────────────────────────────────────────────────────────
+
+// Assemble the <template> half of the generated SFC
+function renderTemplateSection(opts: {
+  useTabs: boolean
+  mainAreaMarkup: string
+  translationField: string
+  hasSidebar: boolean
+  hasHierarchy: boolean
+  parentPickerSection: string
+  sidebarAreaMarkup: string
+}): string {
+  const { useTabs, mainAreaMarkup, translationField, hasSidebar, hasHierarchy, parentPickerSection, sidebarAreaMarkup } = opts
+
+  return `<template>
   <CroutonFormActionButton
     v-if="action === 'delete'"
     :action="action"
@@ -668,9 +759,40 @@ ${sidebarAreaMarkup}
       </template>
     </CroutonFormLayout>
   </UForm>
-</template>
+</template>`
+}
 
-<script setup lang="ts">
+// Assemble the <script setup> half of the generated SFC
+function renderScriptSection(opts: {
+  prefixedPascalCase: string
+  prefixedPascalCasePlural: string
+  typesPath: string
+  navigationItemsCode: string
+  inlineOptionsCode: string
+  fieldToGroupCode: string
+  errorTrackingCode: string
+  hierarchyDefaultsCode: string
+  hasHierarchy: boolean
+  dateInitCode: string
+  scriptAdditions: string
+  handleSubmitCode: string
+}): string {
+  const {
+    prefixedPascalCase,
+    prefixedPascalCasePlural,
+    typesPath,
+    navigationItemsCode,
+    inlineOptionsCode,
+    fieldToGroupCode,
+    errorTrackingCode,
+    hierarchyDefaultsCode,
+    hasHierarchy,
+    dateInitCode,
+    scriptAdditions,
+    handleSubmitCode
+  } = opts
+
+  return `<script setup lang="ts">
 import type { ${prefixedPascalCase}FormProps, ${prefixedPascalCase}FormData } from '${typesPath}'
 import use${prefixedPascalCasePlural} from '../composables/use${prefixedPascalCasePlural}'
 
@@ -691,68 +813,105 @@ const { create, update, deleteItems } = useCollectionMutation(collection)
 // useCrouton still manages modal state
 const { close, loading } = useCrouton()
 
-// Initialize form state with proper values (no watch needed!)${hasHierarchy
-  ? `
-// Hierarchy defaults for new items (parentId, path, depth, order)
-const hierarchyDefaults = {
-  ${parentField}: null,
-  ${hierarchy.pathField || 'path'}: '/',
-  ${hierarchy.depthField || 'depth'}: 0,
-  ${hierarchy.orderField || 'order'}: 0
-}`
-  : ''}
+// Initialize form state with proper values (no watch needed!)${hierarchyDefaultsCode}
 const initialValues = props.action === 'update' && props.activeItem?.id
   ? { ...defaultValue, ...props.activeItem }
-  : { ...defaultValue${hasHierarchy ? ', ...hierarchyDefaults' : ''} }${hasDateFields
-    ? `
-
-// Convert date strings to Date objects for date fields during editing
-if (props.action === 'update' && props.activeItem?.id) {${regularFields
-  .filter(f => f.type === 'date')
-  .map(field => `
-  if (initialValues.${field.name}) {
-    initialValues.${field.name} = new Date(initialValues.${field.name})
-  }`).join('')}
-}`
-    : ''}
+  : { ...defaultValue${hasHierarchy ? ', ...hierarchyDefaults' : ''} }${dateInitCode}
 
 // Draft state: seeded from defaults (required fields may start null/empty until
 // the user fills them; the zod schema validates on submit), so cast the initial
 // values to the validated shape.
 const state = ref<${prefixedPascalCase}FormData & { id?: string | null }>(initialValues as ${prefixedPascalCase}FormData & { id?: string | null })${scriptAdditions}
 
-const handleSubmit = async () => {
-  try {${hasDateFields
-    ? `
-    // Serialize Date objects to ISO strings for API submission
-    const serializedData: Record<string, any> = { ...state.value }${regularFields
-      .filter(f => f.type === 'date')
-      .map(field => `
-    if (serializedData.${field.name} instanceof Date) {
-      serializedData.${field.name} = serializedData.${field.name}.toISOString()
-    }`).join('')}
-`
-    : ''}
-    if (props.action === 'create') {
-      await create(${hasDateFields ? 'serializedData' : 'state.value'})
-    } else if (props.action === 'update' && state.value.id) {
-      await update(state.value.id, ${hasDateFields ? 'serializedData' : 'state.value'})
-    } else if (props.action === 'delete') {
-      await deleteItems(props.items)
-    }
-${useTabs
-  ? `
-    // Clear validation errors on successful submission
-    validationErrors.value = []
-`
-  : ''}
-    close()
-
-  } catch (error) {
-    console.error('Form submission failed:', error)
-    // You can add toast notification here if available
-    // toast.add({ title: 'Error', description: 'Failed to submit form', color: 'red' })
-  }
-}
+${handleSubmitCode}
 </script>`
+}
+
+export function generateFormComponent(data: Record<string, any>, config: Record<string, any> = {}): string {
+  const { pascalCase, pascalCasePlural, layerPascalCase, layerCamelCase, fields, plural, layer, hierarchy } = data
+  const prefixedPascalCase = `${layerPascalCase}${pascalCase}`
+  const prefixedPascalCasePlural = `${layerPascalCase}${pascalCasePlural}`
+
+  const {
+    hasHierarchy,
+    parentField,
+    translatableFieldNames,
+    hasTranslations,
+    translatableFields,
+    regularFields,
+    hasDateFields,
+    formEnhancements,
+    excludedFieldNames,
+    fieldsToDisplay,
+    fieldsWithInlineOptions
+  } = analyzeFields(data, config)
+
+  // Context handed to the module-scope field/group renderers
+  const ctx: FieldMarkupContext = {
+    layerCamelCase,
+    layerPascalCase,
+    pascalCasePlural,
+    formEnhancements,
+    labelAttr: createLabelAttr(`${layer}.${plural}.fields`)
+  }
+
+  const { mainGroups, sidebarGroups } = buildFieldGroups(fieldsToDisplay, fields, excludedFieldNames, formEnhancements)
+
+  // Determine if we should use tabs (multiple main groups)
+  const useTabs = mainGroups.size > 1
+  // Sidebar is shown if there are sidebar fields OR if hierarchy is enabled (for parent picker)
+  const hasSidebar = sidebarGroups.size > 0 || hasHierarchy
+
+  // Generate navigation items from main groups
+  const navigationItems = useTabs
+    ? Array.from(mainGroups.keys()).map(groupName => ({
+        label: humanizeGroupName(groupName),
+        value: groupName || 'general'
+      }))
+    : []
+
+  // Generate main area groups
+  const mainAreaMarkup = Array.from(mainGroups.entries())
+    .map(([groupName, groupFields]) => buildGroupSection(groupName, groupFields, useTabs, ctx))
+    .join('\n\n')
+
+  // Generate sidebar area groups
+  const sidebarAreaMarkup = hasSidebar
+    ? Array.from(sidebarGroups.entries())
+        .map(([groupName, groupFields]) => buildGroupSection(groupName, groupFields, false, ctx))
+        .join('\n\n')
+    : ''
+
+  // Generate AI context header
+  const apiPath = `${layer}-${plural}`
+  const aiHeader = generateAIHeader(data, apiPath)
+
+  const templateSection = renderTemplateSection({
+    useTabs,
+    mainAreaMarkup,
+    translationField: buildTranslationField(hasTranslations, translatableFieldNames, translatableFields, plural),
+    hasSidebar,
+    hasHierarchy,
+    parentPickerSection: buildParentPickerSection(hasHierarchy, parentField, layerCamelCase, pascalCasePlural),
+    sidebarAreaMarkup
+  })
+
+  const scriptSection = renderScriptSection({
+    prefixedPascalCase,
+    prefixedPascalCasePlural,
+    typesPath: '../../types',
+    navigationItemsCode: buildNavigationItemsCode(useTabs, navigationItems),
+    inlineOptionsCode: buildInlineOptionsCode(fieldsWithInlineOptions),
+    fieldToGroupCode: buildFieldToGroupCode(useTabs, mainGroups),
+    errorTrackingCode: useTabs ? ERROR_TRACKING_CODE : '',
+    hierarchyDefaultsCode: buildHierarchyDefaultsCode(hasHierarchy, hierarchy, parentField),
+    hasHierarchy,
+    dateInitCode: buildDateInitCode(hasDateFields, regularFields),
+    scriptAdditions: (formEnhancements.scriptAdditions || []).join('\n'),
+    handleSubmitCode: buildHandleSubmitCode(hasDateFields, regularFields, useTabs)
+  })
+
+  return `${aiHeader}${templateSection}
+
+${scriptSection}`
 }

--- a/packages/crouton-pages/server/api/teams/[id]/pages/[...slug].get.ts
+++ b/packages/crouton-pages/server/api/teams/[id]/pages/[...slug].get.ts
@@ -14,6 +14,444 @@
  */
 import { eq, and, or, asc } from 'drizzle-orm'
 
+interface RequiredScope {
+  resourceType?: string
+  resourceId?: string
+  nameRequired?: boolean
+}
+
+interface PageChrome {
+  hideNav?: boolean
+  hideAuthControls?: boolean
+}
+
+/** Shared lookup context threaded through the page-resolution helpers. */
+interface PageLookupCtx {
+  database: any
+  pagesSchema: any
+  sql: any
+  teamId: string
+  locale: string
+}
+
+/** Resolve the team by id or slug; 404 when it doesn't exist. */
+async function resolveTeam(database: any, authSchema: any, teamParam: string): Promise<{ id: string, slug: string }> {
+  const team = await database
+    .select({ id: authSchema.organization.id as any, slug: authSchema.organization.slug as any })
+    .from(authSchema.organization as any)
+    .where(
+      or(
+        eq(authSchema.organization.id as any, teamParam),
+        eq(authSchema.organization.slug as any, teamParam)
+      )
+    )
+    .limit(1)
+    .then((rows: Array<{ id: string; slug: string }>) => rows[0])
+
+  if (!team) {
+    throw createError({
+      status: 404,
+      statusText: 'Team not found'
+    })
+  }
+
+  return team
+}
+
+// Localized slug for a page row: translated slug for the locale, else base.
+function rowLocalizedSlug(row: any, locale: string): string {
+  if (!row?.translations) return row?.slug || ''
+  try {
+    const tr = typeof row.translations === 'string' ? JSON.parse(row.translations) : row.translations
+    return tr?.[locale]?.slug || row.slug || ''
+  } catch {
+    return row?.slug || ''
+  }
+}
+
+// Find a page by its slug for this team, matching base slug OR the
+// translated slug for the current locale.
+async function findPageBySlug(ctx: PageLookupCtx, slugValue: string): Promise<any> {
+  const { database, pagesSchema, sql, teamId, locale } = ctx
+  const byBase = await database
+    .select()
+    .from(pagesSchema.pagesPages as any)
+    .where(
+      and(
+        eq(pagesSchema.pagesPages.teamId as any, teamId),
+        eq(pagesSchema.pagesPages.slug as any, slugValue)
+      )
+    )
+    .limit(1)
+    .then((rows: any[]) => rows[0])
+  if (byBase) return byBase
+  return database
+    .select()
+    .from(pagesSchema.pagesPages as any)
+    .where(
+      and(
+        eq(pagesSchema.pagesPages.teamId as any, teamId),
+        sql`json_extract(${(pagesSchema.pagesPages as any).translations}, '$.' || ${locale} || '.slug') = ${slugValue}`
+      )
+    )
+    .limit(1)
+    .then((rows: any[]) => rows[0])
+}
+
+// Walk a page's parentId chain, returning ancestor localized slugs
+// ordered root → parent (excluding the page itself).
+async function resolveAncestorSlugs(ctx: PageLookupCtx, startPage: any): Promise<string[]> {
+  const { database, pagesSchema, teamId, locale } = ctx
+  const slugs: string[] = []
+  const seen = new Set<string>([startPage.id])
+  let parentId: string | null = startPage.parentId || null
+  while (parentId && !seen.has(parentId)) {
+    seen.add(parentId)
+    const parent = await database
+      .select()
+      .from(pagesSchema.pagesPages as any)
+      .where(
+        and(
+          eq(pagesSchema.pagesPages.teamId as any, teamId),
+          eq(pagesSchema.pagesPages.id as any, parentId)
+        )
+      )
+      .limit(1)
+      .then((rows: any[]) => rows[0])
+    if (!parent) break
+    const s = rowLocalizedSlug(parent, locale)
+    if (s) slugs.unshift(s)
+    parentId = parent.parentId || null
+  }
+  return slugs
+}
+
+/** Homepage: fetch first published root page by sort order; 404 when none. */
+async function fetchHomepage(ctx: PageLookupCtx): Promise<any> {
+  const { database, pagesSchema, teamId } = ctx
+  const page = await database
+    .select()
+    .from(pagesSchema.pagesPages as any)
+    .where(
+      and(
+        eq(pagesSchema.pagesPages.teamId as any, teamId),
+        eq(pagesSchema.pagesPages.status as any, 'published'),
+        eq(pagesSchema.pagesPages.depth as any, 0) // Root level only
+      )
+    )
+    .orderBy(asc(pagesSchema.pagesPages.order as any))
+    .limit(1)
+    .then((rows: any[]) => rows[0])
+
+  if (!page) {
+    throw createError({
+      status: 404,
+      statusText: 'No published homepage found'
+    })
+  }
+
+  return page
+}
+
+/**
+ * Resolve the URL slug segments to a page row.
+ *
+ * Returns the page plus:
+ * - `fullPath`: the canonical nested slug path of the resolved page
+ *   (localized), e.g. "events/summer-fair". Empty for the homepage.
+ *   Returned for SEO.
+ * - `binderItemId`: non-null only for collection-binder sub-routes.
+ */
+async function resolvePage(ctx: PageLookupCtx, slugParts: string[]): Promise<{ page: any, fullPath: string, binderItemId: string | null }> {
+  const slug = slugParts[0] || ''
+
+  if (!slug) {
+    return { page: await fetchHomepage(ctx), fullPath: '', binderItemId: null }
+  }
+
+  const lastSeg = slugParts[slugParts.length - 1]!
+
+  // 1) Treat the last segment as a page slug (unique per team).
+  let page = await findPageBySlug(ctx, lastSeg)
+
+  if (page) {
+    // Nested page: its ancestor slug chain must match the URL prefix,
+    // otherwise the URL is non-canonical → 404.
+    const ancestorSlugs = await resolveAncestorSlugs(ctx, page)
+    const prefix = slugParts.slice(0, -1)
+    if (ancestorSlugs.join('/') !== prefix.join('/')) {
+      throw createError({ status: 404, statusText: 'Page not found' })
+    }
+    const fullPath = [...ancestorSlugs, rowLocalizedSlug(page, ctx.locale)].filter(Boolean).join('/')
+    return { page, fullPath, binderItemId: null }
+  }
+
+  if (slugParts.length >= 2) {
+    // 2) Collection-binder sub-route: the segment before the last is the
+    // binder page, the last segment is the item id.
+    const binderSlug = slugParts[slugParts.length - 2]!
+    page = await findPageBySlug(ctx, binderSlug)
+
+    if (!page || page.pageType !== 'pages:collection-binder') {
+      throw createError({ status: 404, statusText: 'Page not found' })
+    }
+
+    // Binder's own ancestry must match the segments before it.
+    const ancestorSlugs = await resolveAncestorSlugs(ctx, page)
+    const prefix = slugParts.slice(0, -2)
+    if (ancestorSlugs.join('/') !== prefix.join('/')) {
+      throw createError({ status: 404, statusText: 'Page not found' })
+    }
+
+    const fullPath = [...ancestorSlugs, rowLocalizedSlug(page, ctx.locale)].filter(Boolean).join('/')
+    return { page, fullPath, binderItemId: lastSeg }
+  }
+
+  throw createError({ status: 404, statusText: 'Page not found' })
+}
+
+/**
+ * Parse the page's config for scoped-visibility inputs: the stored scope
+ * narrowing ({ requiredScope }) and the per-page chrome flags, echoed in the
+ * 401 payload so the access gate renders with the same (hidden) chrome as
+ * the unlocked page.
+ */
+function parseScopedPageConfig(page: any): { requiredScope: RequiredScope | null, chrome: PageChrome | undefined } {
+  let requiredScope: RequiredScope | null = null
+  let chrome: PageChrome | undefined
+  try {
+    const config = typeof page.config === 'string' ? JSON.parse(page.config) : page.config
+    requiredScope = config?.requiredScope || null
+    if (config?.hideNav || config?.hideAuthControls) {
+      chrome = { hideNav: !!config.hideNav, hideAuthControls: !!config.hideAuthControls }
+    }
+  } catch {
+    // Malformed config — treat as no scope restriction
+  }
+  return { requiredScope, chrome }
+}
+
+/**
+ * Extract the page's content blocks (for scope derivation): base `content`
+ * first, falling back to any locale's translations content — the embedded
+ * blocks are identical across locales.
+ */
+function extractContentBlocks(page: any): Array<{ type?: string, attrs?: Record<string, unknown> }> {
+  const docBlocks = (raw: unknown): Array<{ type?: string, attrs?: Record<string, unknown> }> => {
+    try {
+      const doc = typeof raw === 'string' ? JSON.parse(raw) : raw
+      return Array.isArray((doc as any)?.content) ? (doc as any).content : []
+    } catch {
+      return []
+    }
+  }
+  let blocks = docBlocks(page.content)
+  if (!blocks.length && page.translations) {
+    // Block content may live only in the translations (localized
+    // editor) — any locale will do, the embedded blocks are identical.
+    try {
+      const tr = typeof page.translations === 'string' ? JSON.parse(page.translations) : page.translations
+      for (const localeData of Object.values(tr || {})) {
+        blocks = docBlocks((localeData as any)?.content)
+        if (blocks.length) break
+      }
+    } catch {
+      // Malformed translations — no blocks to derive from
+    }
+  }
+  return blocks
+}
+
+/**
+ * Derive the scope from the page's content blocks at read time
+ * (crouton:pages:derive-scope — e.g. crouton-sales answers
+ * ('event', eventId) for an embedded eventWorkspaceBlock, so the gate
+ * redeems the event's helper PIN directly). The blocks are the source
+ * of truth — nothing is stored, so there's no state to drift. A
+ * derived scope outranks config.requiredScope; no answer (block
+ * removed, event deleted, slug unresolvable) falls back to the
+ * stored scope, then to the page's own ('page', pageId) gate.
+ */
+async function deriveScopeFromBlocks(
+  teamId: string,
+  blocks: Array<{ type?: string, attrs?: Record<string, unknown> }>,
+  requiredScope: RequiredScope | null
+): Promise<RequiredScope | null> {
+  if (!blocks.length) return requiredScope
+  try {
+    const derivePayload = { teamId, blocks, result: null as { resourceType: string, resourceId: string, nameRequired?: boolean } | null }
+    await useNitroApp().hooks.callHook('crouton:pages:derive-scope', derivePayload)
+    if (derivePayload.result) {
+      return derivePayload.result
+    }
+  } catch (err) {
+    console.error('[crouton-pages] derive-scope hook failed:', err)
+  }
+  return requiredScope
+}
+
+/**
+ * Check whether the request may see a scoped page: a valid scoped-access
+ * token for this team (matching the required scope, when one is set), or —
+ * as a fallback — a team-member session (admin preview). Any error during
+ * validation denies access.
+ */
+async function hasScopedAccess(event: any, database: any, authSchema: any, teamId: string, requiredScope: RequiredScope | null): Promise<boolean> {
+  let allowed = false
+  try {
+    const { validateScopedTokenFromEvent } = await import('@fyit/crouton-auth/server/utils/scoped-access')
+    const access = await validateScopedTokenFromEvent(event)
+
+    if (access && access.organizationId === teamId) {
+      allowed = !requiredScope
+        || ((!requiredScope.resourceType || access.resourceType === requiredScope.resourceType)
+          && (!requiredScope.resourceId || access.resourceId === requiredScope.resourceId))
+    }
+
+    if (!allowed) {
+      // Fall back to a team-member session (admin preview)
+      const { getServerSession } = await import('@fyit/crouton-auth/server/utils/useServerAuth')
+      const session = await getServerSession(event)
+      if (session?.user) {
+        const membership = await database
+          .select({ id: authSchema.member.id as any })
+          .from(authSchema.member as any)
+          .where(
+            and(
+              eq(authSchema.member.userId as any, session.user.id),
+              eq(authSchema.member.organizationId as any, teamId)
+            )
+          )
+          .limit(1)
+          .then((rows: any[]) => rows[0])
+        allowed = !!membership
+      }
+    }
+  } catch {
+    allowed = false
+  }
+  return allowed
+}
+
+/**
+ * Enforce `visibility: 'scoped'`: a valid scoped-access token for this team
+ * unlocks the page (volunteers/guests — see crouton-auth grants). Team
+ * members pass too, so admins can preview. The page's config may narrow the
+ * required token via { requiredScope: { resourceType, resourceId? } } —
+ * compared as plain strings, pages never learns what the resource is.
+ * Throws 401 when access is denied.
+ */
+async function enforceScopedVisibility(event: any, database: any, authSchema: any, teamId: string, page: any): Promise<void> {
+  const parsed = parseScopedPageConfig(page)
+  const chrome = parsed.chrome
+  let requiredScope = parsed.requiredScope
+
+  const blocks = extractContentBlocks(page)
+  requiredScope = await deriveScopeFromBlocks(teamId, blocks, requiredScope)
+
+  const allowed = await hasScopedAccess(event, database, authSchema, teamId, requiredScope)
+
+  if (!allowed) {
+    // The data payload lets the client render a PIN gate instead of the
+    // member login: it says which resource a credential must be redeemed
+    // against — the page's requiredScope, or the page itself (so a grant
+    // on ('page', pageId) makes the page self-service PIN-protectable).
+    throw createError({
+      status: 401,
+      statusText: 'Access token required',
+      data: {
+        reason: 'scoped',
+        teamId,
+        scope: requiredScope ?? { resourceType: 'page', resourceId: page.id },
+        ...(chrome ? { chrome } : {})
+      }
+    })
+  }
+
+  // Prevent ISR/SWR from caching token-gated page responses
+  setResponseHeader(event, 'Cache-Control', 'private, no-store')
+}
+
+/**
+ * Enforce `visibility: 'members' | 'admin'`: requires an authenticated team
+ * member; admin pages additionally require the admin or owner role.
+ */
+async function enforceMemberVisibility(event: any, database: any, authSchema: any, teamId: string, page: any): Promise<void> {
+  // Members/admin-only pages require authentication
+  try {
+    const { getServerSession } = await import('@fyit/crouton-auth/server/utils/useServerAuth')
+    const session = await getServerSession(event)
+
+    if (!session?.user) {
+      throw createError({
+        status: 401,
+        statusText: 'Authentication required'
+      })
+    }
+
+    // Check team membership
+    const membership = await database
+      .select({ id: authSchema.member.id as any, role: authSchema.member.role as any })
+      .from(authSchema.member as any)
+      .where(
+        and(
+          eq(authSchema.member.userId as any, session.user.id),
+          eq(authSchema.member.organizationId as any, teamId)
+        )
+      )
+      .limit(1)
+      .then((rows: any[]) => rows[0])
+
+    if (!membership) {
+      throw createError({
+        status: 403,
+        statusText: 'Access denied - not a team member'
+      })
+    }
+
+    // Admin-only pages require admin or owner role
+    if (page.visibility === 'admin' && membership.role !== 'admin' && membership.role !== 'owner') {
+      throw createError({
+        status: 403,
+        statusText: 'Access denied - admin access required'
+      })
+    }
+
+    // Prevent ISR/SWR from caching restricted page responses
+    setResponseHeader(event, 'Cache-Control', 'private, no-store')
+  } catch (authError: any) {
+    if (authError.statusCode) throw authError
+    throw createError({
+      status: 401,
+      statusText: 'Authentication required'
+    })
+  }
+}
+
+/** Resolve translations - merge translated fields over base values (mutates the row). */
+function applyPageTranslations(page: any, locale: string): void {
+  if (!page.translations) return
+  try {
+    const translations = typeof page.translations === 'string'
+      ? JSON.parse(page.translations)
+      : page.translations
+
+    const localeTranslations = translations[locale] || translations['en'] || Object.values(translations)[0]
+
+    if (localeTranslations && typeof localeTranslations === 'object') {
+      const originalSlug = page.slug
+      for (const [key, value] of Object.entries(localeTranslations)) {
+        if (value !== null && value !== undefined) {
+          page[key] = value
+        }
+      }
+      page.baseSlug = originalSlug
+    }
+  } catch (e) {
+    console.error('[pages] Translation parsing error:', e)
+  }
+}
+
 export default defineEventHandler(async (event) => {
   const teamParam = getRouterParam(event, 'id')
   const slugParam = getRouterParam(event, 'slug')
@@ -34,8 +472,6 @@ export default defineEventHandler(async (event) => {
   // per team, so the last segment alone identifies the page; the preceding
   // segments must match its ancestor chain for the URL to be canonical.
   const slugParts = rawSlug ? rawSlug.split('/').filter(Boolean) : []
-  // Resolved during lookup — non-null only for binder sub-routes.
-  let binderItemId: string | null = null
 
   // Get locale from query parameter (for translated slug lookup)
   const locale = getQuery(event).locale as string || 'en'
@@ -45,163 +481,17 @@ export default defineEventHandler(async (event) => {
 
     // Resolve team
     const authSchema = await import('@fyit/crouton-auth/server/database/schema/auth')
-
-    const team = await database
-      .select({ id: authSchema.organization.id as any, slug: authSchema.organization.slug as any })
-      .from(authSchema.organization as any)
-      .where(
-        or(
-          eq(authSchema.organization.id as any, teamParam),
-          eq(authSchema.organization.slug as any, teamParam)
-        )
-      )
-      .limit(1)
-      .then((rows: Array<{ id: string; slug: string }>) => rows[0])
-
-    if (!team) {
-      throw createError({
-        status: 404,
-        statusText: 'Team not found'
-      })
-    }
+    const team = await resolveTeam(database, authSchema, teamParam)
 
     // Try to get page from pagesPages table
     try {
       const pagesSchema = await import('~~/layers/pages/collections/pages/server/database/schema')
       const { sql } = await import('drizzle-orm')
 
-      // Localized slug for a page row: translated slug for the locale, else base.
-      const rowLocalizedSlug = (row: any): string => {
-        if (!row?.translations) return row?.slug || ''
-        try {
-          const tr = typeof row.translations === 'string' ? JSON.parse(row.translations) : row.translations
-          return tr?.[locale]?.slug || row.slug || ''
-        } catch {
-          return row?.slug || ''
-        }
-      }
+      const ctx: PageLookupCtx = { database, pagesSchema, sql, teamId: team.id, locale }
 
-      // Find a page by its slug for this team, matching base slug OR the
-      // translated slug for the current locale.
-      const findPageBySlug = async (slugValue: string): Promise<any> => {
-        const byBase = await database
-          .select()
-          .from(pagesSchema.pagesPages as any)
-          .where(
-            and(
-              eq(pagesSchema.pagesPages.teamId as any, team.id),
-              eq(pagesSchema.pagesPages.slug as any, slugValue)
-            )
-          )
-          .limit(1)
-          .then((rows: any[]) => rows[0])
-        if (byBase) return byBase
-        return database
-          .select()
-          .from(pagesSchema.pagesPages as any)
-          .where(
-            and(
-              eq(pagesSchema.pagesPages.teamId as any, team.id),
-              sql`json_extract(${(pagesSchema.pagesPages as any).translations}, '$.' || ${locale} || '.slug') = ${slugValue}`
-            )
-          )
-          .limit(1)
-          .then((rows: any[]) => rows[0])
-      }
-
-      // Walk a page's parentId chain, returning ancestor localized slugs
-      // ordered root → parent (excluding the page itself).
-      const resolveAncestorSlugs = async (startPage: any): Promise<string[]> => {
-        const slugs: string[] = []
-        const seen = new Set<string>([startPage.id])
-        let parentId: string | null = startPage.parentId || null
-        while (parentId && !seen.has(parentId)) {
-          seen.add(parentId)
-          const parent = await database
-            .select()
-            .from(pagesSchema.pagesPages as any)
-            .where(
-              and(
-                eq(pagesSchema.pagesPages.teamId as any, team.id),
-                eq(pagesSchema.pagesPages.id as any, parentId)
-              )
-            )
-            .limit(1)
-            .then((rows: any[]) => rows[0])
-          if (!parent) break
-          const s = rowLocalizedSlug(parent)
-          if (s) slugs.unshift(s)
-          parentId = parent.parentId || null
-        }
-        return slugs
-      }
-
-      let page: any
-      // The canonical nested slug path of the resolved page (localized),
-      // e.g. "events/summer-fair". Empty for the homepage. Returned for SEO.
-      let fullPath = ''
-      const slug = slugParts[0] || ''
-
-      if (!slug) {
-        // Homepage: fetch first published root page by sort order
-        page = await database
-          .select()
-          .from(pagesSchema.pagesPages as any)
-          .where(
-            and(
-              eq(pagesSchema.pagesPages.teamId as any, team.id),
-              eq(pagesSchema.pagesPages.status as any, 'published'),
-              eq(pagesSchema.pagesPages.depth as any, 0) // Root level only
-            )
-          )
-          .orderBy(asc(pagesSchema.pagesPages.order as any))
-          .limit(1)
-          .then((rows: any[]) => rows[0])
-
-        if (!page) {
-          throw createError({
-            status: 404,
-            statusText: 'No published homepage found'
-          })
-        }
-      } else {
-        const lastSeg = slugParts[slugParts.length - 1]!
-
-        // 1) Treat the last segment as a page slug (unique per team).
-        page = await findPageBySlug(lastSeg)
-
-        if (page) {
-          // Nested page: its ancestor slug chain must match the URL prefix,
-          // otherwise the URL is non-canonical → 404.
-          const ancestorSlugs = await resolveAncestorSlugs(page)
-          const prefix = slugParts.slice(0, -1)
-          if (ancestorSlugs.join('/') !== prefix.join('/')) {
-            throw createError({ status: 404, statusText: 'Page not found' })
-          }
-          fullPath = [...ancestorSlugs, rowLocalizedSlug(page)].filter(Boolean).join('/')
-        } else if (slugParts.length >= 2) {
-          // 2) Collection-binder sub-route: the segment before the last is the
-          // binder page, the last segment is the item id.
-          const binderSlug = slugParts[slugParts.length - 2]!
-          page = await findPageBySlug(binderSlug)
-
-          if (!page || page.pageType !== 'pages:collection-binder') {
-            throw createError({ status: 404, statusText: 'Page not found' })
-          }
-
-          // Binder's own ancestry must match the segments before it.
-          const ancestorSlugs = await resolveAncestorSlugs(page)
-          const prefix = slugParts.slice(0, -2)
-          if (ancestorSlugs.join('/') !== prefix.join('/')) {
-            throw createError({ status: 404, statusText: 'Page not found' })
-          }
-
-          binderItemId = lastSeg
-          fullPath = [...ancestorSlugs, rowLocalizedSlug(page)].filter(Boolean).join('/')
-        } else {
-          throw createError({ status: 404, statusText: 'Page not found' })
-        }
-      }
+      // binderItemId is non-null only for binder sub-routes.
+      const { page, fullPath, binderItemId } = await resolvePage(ctx, slugParts)
 
       // Check page status
       if (page.status !== 'published') {
@@ -215,196 +505,12 @@ export default defineEventHandler(async (event) => {
       if (page.visibility === 'hidden') {
         // Hidden pages require direct link - allow access
       } else if (page.visibility === 'scoped') {
-        // Scoped pages: a valid scoped-access token for this team unlocks the
-        // page (volunteers/guests — see crouton-auth grants). Team members
-        // pass too, so admins can preview. The page's config may narrow the
-        // required token via { requiredScope: { resourceType, resourceId? } } —
-        // compared as plain strings, pages never learns what the resource is.
-        let allowed = false
-
-        let requiredScope: { resourceType?: string, resourceId?: string, nameRequired?: boolean } | null = null
-        // Per-page chrome flags, echoed in the 401 payload so the access gate
-        // renders with the same (hidden) chrome as the unlocked page.
-        let chrome: { hideNav?: boolean, hideAuthControls?: boolean } | undefined
-        try {
-          const config = typeof page.config === 'string' ? JSON.parse(page.config) : page.config
-          requiredScope = config?.requiredScope || null
-          if (config?.hideNav || config?.hideAuthControls) {
-            chrome = { hideNav: !!config.hideNav, hideAuthControls: !!config.hideAuthControls }
-          }
-        } catch {
-          // Malformed config — treat as no scope restriction
-        }
-
-        // Derive the scope from the page's content blocks at read time
-        // (crouton:pages:derive-scope — e.g. crouton-sales answers
-        // ('event', eventId) for an embedded eventWorkspaceBlock, so the gate
-        // redeems the event's helper PIN directly). The blocks are the source
-        // of truth — nothing is stored, so there's no state to drift. A
-        // derived scope outranks config.requiredScope; no answer (block
-        // removed, event deleted, slug unresolvable) falls back to the
-        // stored scope, then to the page's own ('page', pageId) gate.
-        const docBlocks = (raw: unknown): Array<{ type?: string, attrs?: Record<string, unknown> }> => {
-          try {
-            const doc = typeof raw === 'string' ? JSON.parse(raw) : raw
-            return Array.isArray((doc as any)?.content) ? (doc as any).content : []
-          } catch {
-            return []
-          }
-        }
-        let blocks = docBlocks(page.content)
-        if (!blocks.length && page.translations) {
-          // Block content may live only in the translations (localized
-          // editor) — any locale will do, the embedded blocks are identical.
-          try {
-            const tr = typeof page.translations === 'string' ? JSON.parse(page.translations) : page.translations
-            for (const localeData of Object.values(tr || {})) {
-              blocks = docBlocks((localeData as any)?.content)
-              if (blocks.length) break
-            }
-          } catch {
-            // Malformed translations — no blocks to derive from
-          }
-        }
-
-        if (blocks.length) {
-          try {
-            const derivePayload = { teamId: team.id, blocks, result: null as { resourceType: string, resourceId: string, nameRequired?: boolean } | null }
-            await useNitroApp().hooks.callHook('crouton:pages:derive-scope', derivePayload)
-            if (derivePayload.result) {
-              requiredScope = derivePayload.result
-            }
-          } catch (err) {
-            console.error('[crouton-pages] derive-scope hook failed:', err)
-          }
-        }
-
-        try {
-          const { validateScopedTokenFromEvent } = await import('@fyit/crouton-auth/server/utils/scoped-access')
-          const access = await validateScopedTokenFromEvent(event)
-
-          if (access && access.organizationId === team.id) {
-            allowed = !requiredScope
-              || ((!requiredScope.resourceType || access.resourceType === requiredScope.resourceType)
-                && (!requiredScope.resourceId || access.resourceId === requiredScope.resourceId))
-          }
-
-          if (!allowed) {
-            // Fall back to a team-member session (admin preview)
-            const { getServerSession } = await import('@fyit/crouton-auth/server/utils/useServerAuth')
-            const session = await getServerSession(event)
-            if (session?.user) {
-              const membership = await database
-                .select({ id: authSchema.member.id as any })
-                .from(authSchema.member as any)
-                .where(
-                  and(
-                    eq(authSchema.member.userId as any, session.user.id),
-                    eq(authSchema.member.organizationId as any, team.id)
-                  )
-                )
-                .limit(1)
-                .then((rows: any[]) => rows[0])
-              allowed = !!membership
-            }
-          }
-        } catch {
-          allowed = false
-        }
-
-        if (!allowed) {
-          // The data payload lets the client render a PIN gate instead of the
-          // member login: it says which resource a credential must be redeemed
-          // against — the page's requiredScope, or the page itself (so a grant
-          // on ('page', pageId) makes the page self-service PIN-protectable).
-          throw createError({
-            status: 401,
-            statusText: 'Access token required',
-            data: {
-              reason: 'scoped',
-              teamId: team.id,
-              scope: requiredScope ?? { resourceType: 'page', resourceId: page.id },
-              ...(chrome ? { chrome } : {})
-            }
-          })
-        }
-
-        // Prevent ISR/SWR from caching token-gated page responses
-        setResponseHeader(event, 'Cache-Control', 'private, no-store')
+        await enforceScopedVisibility(event, database, authSchema, team.id, page)
       } else if (page.visibility === 'members' || page.visibility === 'admin') {
-        // Members/admin-only pages require authentication
-        try {
-          const { getServerSession } = await import('@fyit/crouton-auth/server/utils/useServerAuth')
-          const session = await getServerSession(event)
-
-          if (!session?.user) {
-            throw createError({
-              status: 401,
-              statusText: 'Authentication required'
-            })
-          }
-
-          // Check team membership
-          const membership = await database
-            .select({ id: authSchema.member.id as any, role: authSchema.member.role as any })
-            .from(authSchema.member as any)
-            .where(
-              and(
-                eq(authSchema.member.userId as any, session.user.id),
-                eq(authSchema.member.organizationId as any, team.id)
-              )
-            )
-            .limit(1)
-            .then((rows: any[]) => rows[0])
-
-          if (!membership) {
-            throw createError({
-              status: 403,
-              statusText: 'Access denied - not a team member'
-            })
-          }
-
-          // Admin-only pages require admin or owner role
-          if (page.visibility === 'admin' && membership.role !== 'admin' && membership.role !== 'owner') {
-            throw createError({
-              status: 403,
-              statusText: 'Access denied - admin access required'
-            })
-          }
-
-          // Prevent ISR/SWR from caching restricted page responses
-          setResponseHeader(event, 'Cache-Control', 'private, no-store')
-        } catch (authError: any) {
-          if (authError.statusCode) throw authError
-          throw createError({
-            status: 401,
-            statusText: 'Authentication required'
-          })
-        }
+        await enforceMemberVisibility(event, database, authSchema, team.id, page)
       }
 
-      // Resolve translations - merge translated fields over base values
-      if (page.translations) {
-        try {
-          const translations = typeof page.translations === 'string'
-            ? JSON.parse(page.translations)
-            : page.translations
-
-          const localeTranslations = translations[locale] || translations['en'] || Object.values(translations)[0]
-
-          if (localeTranslations && typeof localeTranslations === 'object') {
-            const originalSlug = page.slug
-            for (const [key, value] of Object.entries(localeTranslations)) {
-              if (value !== null && value !== undefined) {
-                page[key] = value
-              }
-            }
-            page.baseSlug = originalSlug
-          }
-        } catch (e) {
-          console.error('[pages] Translation parsing error:', e)
-        }
-      }
+      applyPageTranslations(page, locale)
 
       // For binder sub-routes: inject binderItemId into config
       if (binderItemId) {

--- a/packages/crouton-triage/server/api/crouton-triage/webhooks/notion-input.post.ts
+++ b/packages/crouton-triage/server/api/crouton-triage/webhooks/notion-input.post.ts
@@ -160,127 +160,584 @@ function checkRateLimit(workspaceId: string): boolean {
   return true
 }
 
+/**
+ * Read the raw request body (kept for signature verification) and parse it as
+ * a Notion webhook payload.
+ */
+async function readAndParseWebhookBody(event: any) {
+  const rawBody = await readRawBody(event) as string | undefined
+
+  if (!rawBody) {
+    logger.warn('[Notion Webhook] Empty request body')
+    // Return 200 to prevent retries
+    return { ok: false as const, response: { success: false, message: 'Empty request body' } }
+  }
+
+  // Parse JSON body
+  let body: NotionWebhookPayload & { verification_token?: string }
+  try {
+    body = JSON.parse(rawBody)
+  }
+  catch {
+    logger.warn('[Notion Webhook] Invalid JSON body')
+    return { ok: false as const, response: { success: false, message: 'Invalid JSON body' } }
+  }
+
+  logger.info('[Notion Webhook] Payload received', {
+    type: body?.type,
+    keys: Object.keys(body || {}),
+    entity: body?.entity,
+    data: body?.data,
+  })
+
+  return { ok: true as const, rawBody, body }
+}
+
+/**
+ * Handle the Notion URL verification challenge.
+ * Returns the echo response to send, or null when this is a regular event.
+ */
+function resolveVerificationChallenge(
+  body: NotionWebhookPayload & { verification_token?: string },
+): { verification_token: string } | null {
+  // Notion sends: { "verification_token": "secret_..." } without a type field
+  if (body && body.verification_token && !body.type) {
+    logger.info('[Notion Webhook] URL verification challenge received')
+    logger.info('[Notion Webhook] VERIFICATION TOKEN received', { token: body.verification_token })
+
+    // Echo back the verification token
+    return { verification_token: body.verification_token }
+  }
+
+  // Also handle if Notion adds a type field in the future
+  if (body && body.type === 'url_verification' && body.verification_token) {
+    logger.info('[Notion Webhook] URL verification challenge received (with type)', { token: body.verification_token })
+
+    return { verification_token: body.verification_token }
+  }
+
+  return null
+}
+
+/**
+ * Enforce webhook signature verification when a signing secret is configured.
+ * Returns an error response to send, or null when the request may proceed.
+ */
+function enforceSignatureGate(event: any, rawBody: string) {
+  const config = useRuntimeConfig(event) as any
+  const signingSecret = config.notionWebhookSecret as string | undefined
+
+  // Only verify signature if signing secret is configured
+  if (signingSecret) {
+    const signature = getHeader(event, 'x-notion-signature') as string | undefined
+      || getHeader(event, 'X-Notion-Signature') as string | undefined
+
+    if (!signature) {
+      logger.warn('[Notion Webhook] Missing X-Notion-Signature header')
+      // Return 200 to prevent retries, but log the issue
+      return { success: false, message: 'Missing signature header' }
+    }
+
+    if (!verifyNotionSignature(rawBody, signature, signingSecret)) {
+      logger.warn('[Notion Webhook] Invalid signature')
+      return { success: false, message: 'Invalid signature' }
+    }
+
+    logger.debug('[Notion Webhook] Signature verified successfully')
+  }
+  else {
+    logger.warn('[Notion Webhook] No signing secret configured - skipping signature verification')
+  }
+
+  return null
+}
+
+/**
+ * Validate the comment.created payload structure and extract the comment
+ * identifiers from it.
+ *
+ * Notion webhook structure (as of 2024):
+ * - body.entity.id = comment ID
+ * - body.entity.type = "comment"
+ * - body.data.parent.id = page/block ID
+ * - body.data.parent.type = "page" | "block"
+ */
+function extractCommentEvent(body: NotionWebhookPayload, workspaceId: string) {
+  const commentId = body.entity?.id
+  const parentId = body.data?.parent?.id || body.data?.page_id
+  const parentType = body.data?.parent?.type || 'page'
+
+  if (!commentId) {
+    logger.warn('[Notion Webhook] Invalid comment.created payload - missing comment ID in entity')
+    return { ok: false as const, response: { success: false, message: 'Invalid payload structure - missing entity.id' } }
+  }
+
+  if (!parentId) {
+    logger.warn('[Notion Webhook] Missing parent ID in payload')
+    return { ok: false as const, response: { success: false, message: 'Missing parent ID' } }
+  }
+
+  const integrationId = body.integration_id
+  logger.info('[Notion Webhook] Comment event details', {
+    commentId,
+    parentId,
+    parentType,
+    workspaceId,
+    integrationId,
+  })
+
+  return { ok: true as const, commentId, parentId, parentType, integrationId }
+}
+
+/**
+ * Load the DB handle, triage schemas, and drizzle operators used by the
+ * flow-input matching and auto-capture steps.
+ */
+async function loadTriageDb() {
+  const db = useDB()
+  const { triageInputs } = await import(
+    '~~/layers/triage/collections/inputs/server/database/schema'
+  )
+  const { triageFlows } = await import(
+    '~~/layers/triage/collections/flows/server/database/schema'
+  )
+  const { eq, and } = await import('drizzle-orm')
+  return { db, triageInputs, triageFlows, eq, and }
+}
+
+type TriageDbContext = Awaited<ReturnType<typeof loadTriageDb>>
+
+/**
+ * Fetch the input's flow and return it only when it exists and is active.
+ */
+async function loadActiveFlow(dbCtx: TriageDbContext, flowId: string) {
+  const { db, triageFlows, eq, and } = dbCtx
+  const [flow] = await db
+    .select()
+    .from(triageFlows)
+    .where(and(
+      eq(triageFlows.id, flowId),
+      eq(triageFlows.active, true),
+    ))
+    .limit(1)
+  return flow
+}
+
+/**
+ * First matching pass: match an input by the workspace ID stored in its
+ * sourceMetadata (verifying its flow is active).
+ */
+async function matchInputByWorkspace(dbCtx: TriageDbContext, inputs: any[], workspaceId: string) {
+  for (const input of inputs) {
+    const inputWorkspaceId = input.sourceMetadata?.notionWorkspaceId
+    if (inputWorkspaceId === workspaceId) {
+      // Verify the flow exists and is active
+      const flow = await loadActiveFlow(dbCtx, input.flowId)
+      if (flow) {
+        logger.info('[Notion Webhook] Matched input by workspace ID', {
+          inputId: input.id,
+          workspaceId,
+        })
+        return { matchedInput: input, matchedFlow: flow }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Fallback matching pass when no workspace ID matched: only use an input when
+ * it's unambiguous (a single token-carrying input), or disambiguate by
+ * integration ID, or (dev/testing) fall back to the first with a warning.
+ * This prevents accidentally matching the wrong workspace when multiple are configured.
+ */
+async function matchInputByFallback(
+  dbCtx: TriageDbContext,
+  inputs: any[],
+  workspaceId: string,
+  integrationId: string | undefined,
+) {
+  logger.info('[Notion Webhook] No workspace ID match, checking for unambiguous fallback...')
+
+  // Find all inputs with tokens and active flows
+  const inputsWithTokens: Array<{ input: any; flow: any }> = []
+
+  for (const input of inputs) {
+    const hasToken = input.sourceMetadata?.notionToken || input.apiToken
+    if (hasToken) {
+      const flow = await loadActiveFlow(dbCtx, input.flowId)
+      if (flow) {
+        inputsWithTokens.push({ input, flow })
+      }
+    }
+  }
+
+  if (inputsWithTokens.length === 1) {
+    // Unambiguous - only one option
+    const { input, flow } = inputsWithTokens[0]!
+    logger.info('[Notion Webhook] Matched input by unambiguous fallback (single input with token)', {
+      inputId: input.id,
+      inputSourceType: input.sourceType,
+    })
+    return { matchedInput: input, matchedFlow: flow }
+  }
+
+  if (inputsWithTokens.length > 1) {
+    // Multiple inputs found - try to match by integration_id if stored
+    for (const { input, flow } of inputsWithTokens) {
+      if (input.sourceMetadata?.notionIntegrationId === integrationId) {
+        logger.info('[Notion Webhook] Matched input by integration ID', {
+          inputId: input.id,
+          integrationId,
+        })
+        return { matchedInput: input, matchedFlow: flow }
+      }
+    }
+
+    // Still no match - use first one with warning (for development/testing)
+    logger.warn('[Notion Webhook] Multiple Notion inputs found, using first one (configure workspace/integration ID for precise matching)', {
+      workspaceId,
+      integrationId,
+      inputCount: inputsWithTokens.length,
+      inputIds: inputsWithTokens.map(i => i.input.id),
+      selectedInput: inputsWithTokens[0]!.input.id,
+    })
+    return { matchedInput: inputsWithTokens[0]!.input, matchedFlow: inputsWithTokens[0]!.flow }
+  }
+
+  return null
+}
+
+/**
+ * Find the active flow input matching this webhook: query active Notion
+ * inputs, match by workspace ID, then fall back to unambiguous/integration-ID
+ * matching. Returns the input count for the not-found log.
+ */
+async function findMatchingFlowInput(
+  dbCtx: TriageDbContext,
+  workspaceId: string,
+  integrationId: string | undefined,
+) {
+  const { db, triageInputs, eq, and } = dbCtx
+
+  // Query for Notion inputs
+  const inputs = await db
+    .select()
+    .from(triageInputs)
+    .where(and(
+      eq(triageInputs.sourceType, 'notion'),
+      eq(triageInputs.active, true),
+    ))
+    .all()
+
+  // Find matching input by workspace ID (stored in sourceMetadata)
+  // Fallback: if no workspace ID stored, match any active Notion input with a valid token
+  const match = await matchInputByWorkspace(dbCtx, inputs, workspaceId)
+    || await matchInputByFallback(dbCtx, inputs, workspaceId, integrationId)
+
+  return {
+    matchedInput: match?.matchedInput,
+    matchedFlow: match?.matchedFlow,
+    inputCount: inputs.length,
+  }
+}
+
+/**
+ * Auto-capture workspace/integration IDs onto the matched input's
+ * sourceMetadata if not already stored (updates the DB row and the local
+ * reference). This enables user mapping to work for Notion inputs.
+ */
+async function autoCaptureSourceIds(
+  dbCtx: TriageDbContext,
+  matchedInput: any,
+  workspaceId: string,
+  integrationId: string | undefined,
+) {
+  const needsWorkspaceUpdate = !matchedInput.sourceMetadata?.notionWorkspaceId && workspaceId !== 'unknown'
+  const needsIntegrationUpdate = !matchedInput.sourceMetadata?.notionIntegrationId && integrationId
+
+  if (!(needsWorkspaceUpdate || needsIntegrationUpdate)) {
+    return
+  }
+
+  logger.info('[Notion Webhook] Auto-capturing workspace/integration IDs', {
+    inputId: matchedInput.id,
+    workspaceId: needsWorkspaceUpdate ? workspaceId : 'already set',
+    integrationId: needsIntegrationUpdate ? integrationId : 'already set',
+  })
+
+  const updatedMetadata = {
+    ...matchedInput.sourceMetadata,
+    ...(needsWorkspaceUpdate && { notionWorkspaceId: workspaceId }),
+    ...(needsIntegrationUpdate && { notionIntegrationId: integrationId }),
+  }
+
+  const { db, triageInputs, eq } = dbCtx
+  await db
+    .update(triageInputs)
+    .set({
+      sourceMetadata: updatedMetadata,
+      updatedAt: new Date(),
+    })
+    .where(eq(triageInputs.id, matchedInput.id))
+
+  // Update local reference for this request
+  matchedInput.sourceMetadata = updatedMetadata
+
+  logger.info('[Notion Webhook] Workspace/integration IDs captured successfully')
+}
+
+/**
+ * Resolve the input's API token, fetch the comment content, and check it for
+ * the configured trigger keyword. Returns the token on trigger, or the
+ * response to send otherwise.
+ */
+async function fetchCommentAndCheckTrigger(matchedInput: any, commentId: string, parentId: string) {
+  // Get API token from flow input (can be in apiToken or sourceMetadata.notionToken)
+  const apiToken = matchedInput.apiToken || matchedInput.sourceMetadata?.notionToken
+  if (!apiToken) {
+    logger.warn('[Notion Webhook] No API token configured for input', {
+      inputId: matchedInput.id,
+      hasApiToken: !!matchedInput.apiToken,
+      hasSourceMetadataToken: !!matchedInput.sourceMetadata?.notionToken,
+    })
+    return { ok: false as const, response: { success: false, message: 'No API token configured' } }
+  }
+
+  logger.info('[Notion Webhook] Using API token from input', {
+    inputId: matchedInput.id,
+    tokenSource: matchedInput.apiToken ? 'apiToken' : 'sourceMetadata.notionToken',
+  })
+
+  // Fetch the comment to get its content
+  const comment = await fetchComment(commentId, apiToken)
+  if (!comment) {
+    logger.warn('[Notion Webhook] Failed to fetch comment', {
+      commentId,
+      parentId,
+    })
+    return { ok: false as const, response: { success: false, message: 'Failed to fetch comment content' } }
+  }
+
+  // Check for trigger keyword
+  const triggerKeyword = matchedInput.sourceMetadata?.triggerKeyword || DEFAULT_TRIGGER_KEYWORD
+  logger.info('[Notion Webhook] Checking for trigger keyword', {
+    triggerKeyword,
+    commentTextPreview: comment.rich_text?.map((r: any) => r.plain_text).join('').substring(0, 100),
+  })
+  const hasTrigger = checkForTrigger(comment.rich_text, triggerKeyword)
+
+  if (!hasTrigger) {
+    logger.info('[Notion Webhook] No trigger keyword found in comment', {
+      commentId,
+      triggerKeyword,
+    })
+    return {
+      ok: false as const,
+      response: { success: true, message: `Comment does not contain trigger keyword '${triggerKeyword}'` },
+    }
+  }
+
+  logger.info('[Notion Webhook] Trigger keyword found - processing comment', {
+    commentId,
+    triggerKeyword,
+  })
+
+  return { ok: true as const, apiToken }
+}
+
+/**
+ * Parse the webhook event with the Notion adapter into a ParsedDiscussion,
+ * overriding the teamId with the matched flow's team and recording the
+ * workspace ID for flow lookup in the processor.
+ */
+async function parseNotionEvent(
+  body: NotionWebhookPayload,
+  matchedInput: any,
+  matchedFlow: any,
+  apiToken: string,
+  workspaceId: string,
+) {
+  const adapter = getAdapter('notion')
+
+  // Build a minimal config for parsing
+  const sourceConfig = {
+    id: matchedInput.id,
+    teamId: matchedFlow.teamId,
+    sourceType: 'notion' as const,
+    apiToken,
+    sourceMetadata: matchedInput.sourceMetadata,
+  }
+
+  try {
+    const parsed = await (adapter as any).parseIncoming(body, sourceConfig)
+
+    // Override teamId with the actual team from the matched flow
+    // (the adapter returns workspace_id which is not the correct team ID)
+    parsed.teamId = matchedFlow.teamId
+
+    // Add workspace ID to metadata for flow lookup in processor
+    parsed.metadata = {
+      ...parsed.metadata,
+      notionWorkspaceId: workspaceId,
+    }
+
+    logger.info('[Notion Webhook] Successfully parsed event', {
+      sourceThreadId: parsed.sourceThreadId,
+      teamId: parsed.teamId,
+      title: parsed.title,
+      authorHandle: parsed.authorHandle,
+    })
+
+    return { ok: true as const, parsed }
+  }
+  catch (parseError: any) {
+    logger.error('[Notion Webhook] Failed to parse event', parseError)
+    return {
+      ok: false as const,
+      response: { success: false, message: 'Failed to parse event', error: parseError.message },
+    }
+  }
+}
+
+/**
+ * Emit the webhook:received telemetry hook (fire-and-forget).
+ */
+function emitWebhookReceivedTelemetry(correlationId: any, rawBody: string, parsed: any) {
+  const notionContentHash = rawBody.length.toString(16) + '-' + (rawBody.charCodeAt(0) || 0).toString(16)
+  useNitroApp().hooks.callHook('crouton:operation', {
+    type: 'webhook:received',
+    source: 'crouton-triage',
+    correlationId,
+    metadata: {
+      source: 'notion',
+      threadId: parsed.sourceThreadId,
+      contentHash: notionContentHash,
+    },
+  }).catch(() => {})
+}
+
+/**
+ * Production path: queue discussion processing in the background via
+ * Cloudflare's waitUntil and acknowledge immediately.
+ */
+function dispatchBackgroundProcessing(cfCtx: any, parsed: any, correlationId: any) {
+  // Production: Process in background using waitUntil
+  logger.debug('[Notion Webhook] Using background processing (waitUntil)')
+
+  cfCtx.waitUntil(
+    processDiscussion(parsed, { correlationId })
+      .then((result) => {
+        logger.debug('[Notion Webhook] Background processing completed', {
+          discussionId: result.discussionId,
+          taskCount: result.notionTasks.length,
+          processingTime: `${result.processingTime}ms`,
+          isMultiTask: result.isMultiTask,
+        })
+      })
+      .catch((error) => {
+        logger.error('[Notion Webhook] Background processing failed', error)
+      }),
+  )
+
+  // Return immediately
+  return {
+    success: true,
+    message: 'Discussion queued for background processing',
+    timestamp: new Date().toISOString(),
+  }
+}
+
+/**
+ * Development path: process the discussion synchronously to see errors
+ * properly, returning the full result (or a 200 error body to prevent
+ * Notion retries).
+ */
+async function processDiscussionSynchronously(event: any, parsed: any, cfCtx: any, isDevMode: boolean) {
+  // Development: Process synchronously to see errors properly
+  logger.info('[Notion Webhook] Using synchronous processing', {
+    isDevMode,
+    hasCloudflareCtx: !!cfCtx,
+  })
+
+  let result: ProcessingResult
+
+  try {
+    result = await processDiscussion(parsed, { correlationId: (event.context as any).correlationId })
+
+    logger.debug('[Notion Webhook] Discussion processed successfully', {
+      discussionId: result.discussionId,
+      taskCount: result.notionTasks.length,
+      processingTime: `${result.processingTime}ms`,
+      isMultiTask: result.isMultiTask,
+    })
+  }
+  catch (processingError: any) {
+    logger.error('[Notion Webhook] Processing failed', processingError)
+
+    // Return 200 even on errors to prevent Notion retries
+    // The error is logged for debugging
+    return {
+      success: false,
+      message: 'Processing failed',
+      error: processingError.message,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  // Return with full result in dev mode
+  return {
+    success: true,
+    discussionId: result.discussionId,
+    taskCount: result.notionTasks.length,
+    tasks: result.notionTasks.map(t => ({
+      id: t.id,
+      url: t.url,
+    })),
+    isMultiTask: result.isMultiTask,
+    processingTime: result.processingTime,
+    summary: result.aiAnalysis.summary.summary,
+    timestamp: new Date().toISOString(),
+  }
+}
+
 export default defineEventHandler(async (event: any) => {
   logger.debug('[Notion Webhook] REQUEST RECEIVED', { method: event.method, path: event.path })
 
   try {
-    // ============================================================================
-    // READ RAW BODY FOR SIGNATURE VERIFICATION
-    // ============================================================================
-    const rawBody = await readRawBody(event) as string | undefined
+    // Read raw body (for signature verification) + parse payload
+    const payload = await readAndParseWebhookBody(event)
+    if (!payload.ok) {
+      return payload.response
+    }
+    const { rawBody, body } = payload
 
-    if (!rawBody) {
-      logger.warn('[Notion Webhook] Empty request body')
-      // Return 200 to prevent retries
-      return {
-        success: false,
-        message: 'Empty request body',
-      }
+    // Handle URL verification challenge
+    const challenge = resolveVerificationChallenge(body)
+    if (challenge) {
+      return challenge
     }
 
-    // Parse JSON body
-    let body: NotionWebhookPayload & { verification_token?: string }
-    try {
-      body = JSON.parse(rawBody)
-    }
-    catch {
-      logger.warn('[Notion Webhook] Invalid JSON body')
-      return {
-        success: false,
-        message: 'Invalid JSON body',
-      }
+    // Verify webhook signature
+    const signatureFailure = enforceSignatureGate(event, rawBody)
+    if (signatureFailure) {
+      return signatureFailure
     }
 
-    logger.info('[Notion Webhook] Payload received', {
-      type: body?.type,
-      keys: Object.keys(body || {}),
-      entity: body?.entity,
-      data: body?.data,
-    })
-
-    // ============================================================================
-    // HANDLE URL VERIFICATION CHALLENGE
-    // Notion sends: { "verification_token": "secret_..." } without a type field
-    // ============================================================================
-    if (body && body.verification_token && !body.type) {
-      logger.info('[Notion Webhook] URL verification challenge received')
-      logger.info('[Notion Webhook] VERIFICATION TOKEN received', { token: body.verification_token })
-
-      // Echo back the verification token
-      return {
-        verification_token: body.verification_token,
-      }
-    }
-
-    // Also handle if Notion adds a type field in the future
-    if (body && body.type === 'url_verification' && body.verification_token) {
-      logger.info('[Notion Webhook] URL verification challenge received (with type)', { token: body.verification_token })
-
-      return {
-        verification_token: body.verification_token,
-      }
-    }
-
-    // ============================================================================
-    // VERIFY WEBHOOK SIGNATURE
-    // ============================================================================
-    const config = useRuntimeConfig(event) as any
-    const signingSecret = config.notionWebhookSecret as string | undefined
-
-    // Only verify signature if signing secret is configured
-    if (signingSecret) {
-      const signature = getHeader(event, 'x-notion-signature') as string | undefined
-        || getHeader(event, 'X-Notion-Signature') as string | undefined
-
-      if (!signature) {
-        logger.warn('[Notion Webhook] Missing X-Notion-Signature header')
-        // Return 200 to prevent retries, but log the issue
-        return {
-          success: false,
-          message: 'Missing signature header',
-        }
-      }
-
-      if (!verifyNotionSignature(rawBody, signature, signingSecret)) {
-        logger.warn('[Notion Webhook] Invalid signature')
-        return {
-          success: false,
-          message: 'Invalid signature',
-        }
-      }
-
-      logger.debug('[Notion Webhook] Signature verified successfully')
-    }
-    else {
-      logger.warn('[Notion Webhook] No signing secret configured - skipping signature verification')
-    }
-
-    // ============================================================================
-    // VALIDATE TIMESTAMP (Replay Attack Prevention)
-    // ============================================================================
+    // Validate timestamp (replay attack prevention)
     if (!validateTimestamp(body.timestamp)) {
-      return {
-        success: false,
-        message: 'Request timestamp outside tolerance window',
-      }
+      return { success: false, message: 'Request timestamp outside tolerance window' }
     }
 
-    // ============================================================================
-    // RATE LIMITING
-    // ============================================================================
+    // Rate limiting
     const workspaceId = body.workspace_id || 'unknown'
     if (!checkRateLimit(workspaceId)) {
       // Return 429 for rate limiting
       setResponseStatus(event, 429)
-      return {
-        success: false,
-        message: 'Rate limit exceeded',
-      }
+      return { success: false, message: 'Rate limit exceeded' }
     }
 
-    // ============================================================================
-    // VALIDATE EVENT TYPE
-    // ============================================================================
+    // Validate event type
     if (body.type !== 'comment.created') {
       logger.debug('[Notion Webhook] Ignoring non-comment event', { type: body.type })
       return {
@@ -289,167 +746,21 @@ export default defineEventHandler(async (event: any) => {
       }
     }
 
-    // ============================================================================
-    // VALIDATE PAYLOAD STRUCTURE
-    // Notion webhook structure (as of 2024):
-    // - body.entity.id = comment ID
-    // - body.entity.type = "comment"
-    // - body.data.parent.id = page/block ID
-    // - body.data.parent.type = "page" | "block"
-    // ============================================================================
-    const commentId = body.entity?.id
-    const parentId = body.data?.parent?.id || body.data?.page_id
-    const parentType = body.data?.parent?.type || 'page'
-
-    if (!commentId) {
-      logger.warn('[Notion Webhook] Invalid comment.created payload - missing comment ID in entity')
-      return {
-        success: false,
-        message: 'Invalid payload structure - missing entity.id',
-      }
+    // Validate payload structure
+    const commentEvent = extractCommentEvent(body, workspaceId)
+    if (!commentEvent.ok) {
+      return commentEvent.response
     }
+    const { commentId, parentId, integrationId } = commentEvent
 
-    if (!parentId) {
-      logger.warn('[Notion Webhook] Missing parent ID in payload')
-      return {
-        success: false,
-        message: 'Missing parent ID',
-      }
-    }
-
-    const integrationId = body.integration_id
-    logger.info('[Notion Webhook] Comment event details', {
-      commentId,
-      parentId,
-      parentType,
-      workspaceId,
-      integrationId,
-    })
-
-    // ============================================================================
-    // FETCH COMMENT CONTENT AND CHECK FOR TRIGGER
-    // ============================================================================
-    // We need to fetch the comment to check its content for the trigger keyword
-    // First, we need to find the appropriate config/flow to get the API token
-
-    // Try to find a flow input for this Notion workspace
-    const db = useDB()
-    const { triageInputs } = await import(
-      '~~/layers/triage/collections/inputs/server/database/schema'
-    )
-    const { triageFlows } = await import(
-      '~~/layers/triage/collections/flows/server/database/schema'
-    )
-    const { eq, and } = await import('drizzle-orm')
-
-    // Query for Notion inputs
-    const inputs = await db
-      .select()
-      .from(triageInputs)
-      .where(and(
-        eq(triageInputs.sourceType, 'notion'),
-        eq(triageInputs.active, true),
-      ))
-      .all()
-
-    // Find matching input by workspace ID (stored in sourceMetadata)
-    // Fallback: if no workspace ID stored, match any active Notion input with a valid token
-    let matchedInput: typeof inputs[0] | undefined
-    let matchedFlow: any
-
-    // First try: match by workspace ID
-    for (const input of inputs) {
-      const inputWorkspaceId = input.sourceMetadata?.notionWorkspaceId
-      if (inputWorkspaceId === workspaceId) {
-        // Verify the flow exists and is active
-        const [flow] = await db
-          .select()
-          .from(triageFlows)
-          .where(and(
-            eq(triageFlows.id, input.flowId),
-            eq(triageFlows.active, true),
-          ))
-          .limit(1)
-
-        if (flow) {
-          matchedInput = input
-          matchedFlow = flow
-          logger.info('[Notion Webhook] Matched input by workspace ID', {
-            inputId: input.id,
-            workspaceId,
-          })
-          break
-        }
-      }
-    }
-
-    // Fallback: if no workspace match, only use fallback if there's exactly ONE Notion input with a token
-    // This prevents accidentally matching the wrong workspace when multiple are configured
-    if (!matchedInput) {
-      logger.info('[Notion Webhook] No workspace ID match, checking for unambiguous fallback...')
-
-      // Find all inputs with tokens and active flows
-      const inputsWithTokens: Array<{ input: typeof inputs[0]; flow: any }> = []
-
-      for (const input of inputs) {
-        const hasToken = input.sourceMetadata?.notionToken || input.apiToken
-        if (hasToken) {
-          const [flow] = await db
-            .select()
-            .from(triageFlows)
-            .where(and(
-              eq(triageFlows.id, input.flowId),
-              eq(triageFlows.active, true),
-            ))
-            .limit(1)
-
-          if (flow) {
-            inputsWithTokens.push({ input, flow })
-          }
-        }
-      }
-
-      if (inputsWithTokens.length === 1) {
-        // Unambiguous - only one option
-        matchedInput = inputsWithTokens[0]!.input
-        matchedFlow = inputsWithTokens[0]!.flow
-        logger.info('[Notion Webhook] Matched input by unambiguous fallback (single input with token)', {
-          inputId: matchedInput.id,
-          inputSourceType: matchedInput.sourceType,
-        })
-      } else if (inputsWithTokens.length > 1) {
-        // Multiple inputs found - try to match by integration_id if stored
-        for (const { input, flow } of inputsWithTokens) {
-          if (input.sourceMetadata?.notionIntegrationId === integrationId) {
-            matchedInput = input
-            matchedFlow = flow
-            logger.info('[Notion Webhook] Matched input by integration ID', {
-              inputId: input.id,
-              integrationId,
-            })
-            break
-          }
-        }
-
-        // Still no match - use first one with warning (for development/testing)
-        if (!matchedInput) {
-          logger.warn('[Notion Webhook] Multiple Notion inputs found, using first one (configure workspace/integration ID for precise matching)', {
-            workspaceId,
-            integrationId,
-            inputCount: inputsWithTokens.length,
-            inputIds: inputsWithTokens.map(i => i.input.id),
-            selectedInput: inputsWithTokens[0]!.input.id,
-          })
-          matchedInput = inputsWithTokens[0]!.input
-          matchedFlow = inputsWithTokens[0]!.flow
-        }
-      }
-    }
+    // Find the flow input for this workspace (source of the API token)
+    const dbCtx = await loadTriageDb()
+    const { matchedInput, matchedFlow, inputCount } = await findMatchingFlowInput(dbCtx, workspaceId, integrationId)
 
     if (!matchedInput || !matchedFlow) {
       logger.warn('[Notion Webhook] No active flow found for workspace', {
         workspaceId,
-        availableInputs: inputs.length,
+        availableInputs: inputCount,
       })
       // Return 200 to prevent retries
       return {
@@ -464,236 +775,36 @@ export default defineEventHandler(async (event: any) => {
       inputId: matchedInput.id,
     })
 
-    // Auto-capture workspace/integration IDs if not already stored
-    // This enables user mapping to work for Notion inputs
-    const needsWorkspaceUpdate = !matchedInput.sourceMetadata?.notionWorkspaceId && workspaceId !== 'unknown'
-    const needsIntegrationUpdate = !matchedInput.sourceMetadata?.notionIntegrationId && integrationId
+    await autoCaptureSourceIds(dbCtx, matchedInput, workspaceId, integrationId)
 
-    if (needsWorkspaceUpdate || needsIntegrationUpdate) {
-      logger.info('[Notion Webhook] Auto-capturing workspace/integration IDs', {
-        inputId: matchedInput.id,
-        workspaceId: needsWorkspaceUpdate ? workspaceId : 'already set',
-        integrationId: needsIntegrationUpdate ? integrationId : 'already set',
-      })
-
-      const updatedMetadata = {
-        ...matchedInput.sourceMetadata,
-        ...(needsWorkspaceUpdate && { notionWorkspaceId: workspaceId }),
-        ...(needsIntegrationUpdate && { notionIntegrationId: integrationId }),
-      }
-
-      await db
-        .update(triageInputs)
-        .set({
-          sourceMetadata: updatedMetadata,
-          updatedAt: new Date(),
-        })
-        .where(eq(triageInputs.id, matchedInput.id))
-
-      // Update local reference for this request
-      matchedInput.sourceMetadata = updatedMetadata
-
-      logger.info('[Notion Webhook] Workspace/integration IDs captured successfully')
+    // Fetch comment content and check for the trigger keyword
+    const trigger = await fetchCommentAndCheckTrigger(matchedInput, commentId, parentId)
+    if (!trigger.ok) {
+      return trigger.response
     }
 
-    // Get API token from flow input (can be in apiToken or sourceMetadata.notionToken)
-    const apiToken = matchedInput.apiToken || matchedInput.sourceMetadata?.notionToken
-    if (!apiToken) {
-      logger.warn('[Notion Webhook] No API token configured for input', {
-        inputId: matchedInput.id,
-        hasApiToken: !!matchedInput.apiToken,
-        hasSourceMetadataToken: !!matchedInput.sourceMetadata?.notionToken,
-      })
-      return {
-        success: false,
-        message: 'No API token configured',
-      }
+    // Parse event with the Notion adapter
+    const parseResult = await parseNotionEvent(body, matchedInput, matchedFlow, trigger.apiToken, workspaceId)
+    if (!parseResult.ok) {
+      return parseResult.response
     }
+    const { parsed } = parseResult
 
-    logger.info('[Notion Webhook] Using API token from input', {
-      inputId: matchedInput.id,
-      tokenSource: matchedInput.apiToken ? 'apiToken' : 'sourceMetadata.notionToken',
-    })
-
-    // Fetch the comment to get its content
-    const comment = await fetchComment(commentId, apiToken)
-    if (!comment) {
-      logger.warn('[Notion Webhook] Failed to fetch comment', {
-        commentId,
-        parentId,
-      })
-      return {
-        success: false,
-        message: 'Failed to fetch comment content',
-      }
-    }
-
-    // Check for trigger keyword
-    const triggerKeyword = matchedInput.sourceMetadata?.triggerKeyword || DEFAULT_TRIGGER_KEYWORD
-    logger.info('[Notion Webhook] Checking for trigger keyword', {
-      triggerKeyword,
-      commentTextPreview: comment.rich_text?.map((r: any) => r.plain_text).join('').substring(0, 100),
-    })
-    const hasTrigger = checkForTrigger(comment.rich_text, triggerKeyword)
-
-    if (!hasTrigger) {
-      logger.info('[Notion Webhook] No trigger keyword found in comment', {
-        commentId,
-        triggerKeyword,
-      })
-      return {
-        success: true,
-        message: `Comment does not contain trigger keyword '${triggerKeyword}'`,
-      }
-    }
-
-    logger.info('[Notion Webhook] Trigger keyword found - processing comment', {
-      commentId,
-      triggerKeyword,
-    })
-
-    // ============================================================================
-    // PARSE EVENT WITH NOTION ADAPTER
-    // ============================================================================
-    const adapter = getAdapter('notion')
-
-    // Build a minimal config for parsing
-    const sourceConfig = {
-      id: matchedInput.id,
-      teamId: matchedFlow.teamId,
-      sourceType: 'notion' as const,
-      apiToken,
-      sourceMetadata: matchedInput.sourceMetadata,
-    }
-
-    let parsed
-    try {
-      parsed = await (adapter as any).parseIncoming(body, sourceConfig)
-
-      // Override teamId with the actual team from the matched flow
-      // (the adapter returns workspace_id which is not the correct team ID)
-      parsed.teamId = matchedFlow.teamId
-
-      // Add workspace ID to metadata for flow lookup in processor
-      parsed.metadata = {
-        ...parsed.metadata,
-        notionWorkspaceId: workspaceId,
-      }
-
-      logger.info('[Notion Webhook] Successfully parsed event', {
-        sourceThreadId: parsed.sourceThreadId,
-        teamId: parsed.teamId,
-        title: parsed.title,
-        authorHandle: parsed.authorHandle,
-      })
-    }
-    catch (parseError: any) {
-      logger.error('[Notion Webhook] Failed to parse event', parseError)
-      return {
-        success: false,
-        message: 'Failed to parse event',
-        error: parseError.message,
-      }
-    }
-
-    // ============================================================================
-    // EMIT WEBHOOK:RECEIVED TELEMETRY
-    // ============================================================================
+    // Emit webhook:received telemetry
     const notionCorrelationId = (event.context as any).correlationId
-    const notionContentHash = rawBody.length.toString(16) + '-' + (rawBody.charCodeAt(0) || 0).toString(16)
-    useNitroApp().hooks.callHook('crouton:operation', {
-      type: 'webhook:received',
-      source: 'crouton-triage',
-      correlationId: notionCorrelationId,
-      metadata: {
-        source: 'notion',
-        threadId: parsed.sourceThreadId,
-        contentHash: notionContentHash,
-      },
-    }).catch(() => {})
+    emitWebhookReceivedTelemetry(notionCorrelationId, rawBody, parsed)
 
-    // ============================================================================
-    // PROCESS DISCUSSION
-    // ============================================================================
+    // Process discussion — background (waitUntil) in production, synchronous in dev
     logger.debug('[Notion Webhook] Starting discussion processing...')
 
-    // Use Cloudflare Workers waitUntil to process in background
     const cfCtx = (event.context as any).cloudflare?.context
     const isDevMode = import.meta.dev
 
     if (cfCtx && !isDevMode) {
-      // Production: Process in background using waitUntil
-      logger.debug('[Notion Webhook] Using background processing (waitUntil)')
-
-      cfCtx.waitUntil(
-        processDiscussion(parsed, { correlationId: notionCorrelationId })
-          .then((result) => {
-            logger.debug('[Notion Webhook] Background processing completed', {
-              discussionId: result.discussionId,
-              taskCount: result.notionTasks.length,
-              processingTime: `${result.processingTime}ms`,
-              isMultiTask: result.isMultiTask,
-            })
-          })
-          .catch((error) => {
-            logger.error('[Notion Webhook] Background processing failed', error)
-          }),
-      )
-
-      // Return immediately
-      return {
-        success: true,
-        message: 'Discussion queued for background processing',
-        timestamp: new Date().toISOString(),
-      }
+      return dispatchBackgroundProcessing(cfCtx, parsed, notionCorrelationId)
     }
-    else {
-      // Development: Process synchronously to see errors properly
-      logger.info('[Notion Webhook] Using synchronous processing', {
-        isDevMode,
-        hasCloudflareCtx: !!cfCtx,
-      })
 
-      let result: ProcessingResult
-
-      try {
-        result = await processDiscussion(parsed, { correlationId: (event.context as any).correlationId })
-
-        logger.debug('[Notion Webhook] Discussion processed successfully', {
-          discussionId: result.discussionId,
-          taskCount: result.notionTasks.length,
-          processingTime: `${result.processingTime}ms`,
-          isMultiTask: result.isMultiTask,
-        })
-      }
-      catch (processingError: any) {
-        logger.error('[Notion Webhook] Processing failed', processingError)
-
-        // Return 200 even on errors to prevent Notion retries
-        // The error is logged for debugging
-        return {
-          success: false,
-          message: 'Processing failed',
-          error: processingError.message,
-          timestamp: new Date().toISOString(),
-        }
-      }
-
-      // Return with full result in dev mode
-      return {
-        success: true,
-        discussionId: result.discussionId,
-        taskCount: result.notionTasks.length,
-        tasks: result.notionTasks.map(t => ({
-          id: t.id,
-          url: t.url,
-        })),
-        isMultiTask: result.isMultiTask,
-        processingTime: result.processingTime,
-        summary: result.aiAnalysis.summary.summary,
-        timestamp: new Date().toISOString(),
-      }
-    }
+    return await processDiscussionSynchronously(event, parsed, cfCtx, isDevMode)
   }
   catch (error) {
     // Log the error but return 200 to prevent Notion retries

--- a/packages/crouton-triage/server/services/notion.ts
+++ b/packages/crouton-triage/server/services/notion.ts
@@ -283,6 +283,100 @@ async function getTitlePropertyName(apiKey: string, databaseId: string): Promise
 }
 
 /**
+ * Resolve the field-mapping entry for an AI field.
+ *
+ * Supports both the new format: { priority: { notionProperty, propertyType, valueMap } }
+ * and the old format: { priorityProperty: 'Priority' } (converted to the new shape).
+ */
+function resolveFieldMappingEntry(
+  fieldMapping: Record<string, any>,
+  aiField: string,
+): any {
+  let mapping = fieldMapping[aiField]
+
+  // If not found, try old format (aiField + 'Property')
+  if (!mapping) {
+    const oldKey = aiField + 'Property'
+    const oldValue = fieldMapping[oldKey]
+    if (typeof oldValue === 'string') {
+      // Convert old format to new format, default to 'select' type
+      mapping = {
+        notionProperty: oldValue,
+        propertyType: 'select', // Default assumption for legacy data
+        valueMap: {},
+      }
+      logger.warn('Using legacy field mapping format', { aiField, oldKey, oldValue })
+    }
+  }
+
+  return mapping
+}
+
+/**
+ * Resolve an assignee value to a Notion user and set it as a 'people' property.
+ *
+ * The AI value is either a Notion UUID (used directly) or a source user ID that
+ * must be mapped to a Notion user ID via userMappings. Logs and skips (no-op)
+ * when no mapping can be resolved.
+ */
+function applyPeopleProperty(
+  properties: Record<string, any>,
+  notionProperty: string,
+  value: any,
+  propertyType: string,
+  userMappings?: Map<string, string>,
+): void {
+  logger.debug('Assignee field - AI extracted value', { value })
+
+  // Check if the value is already a Notion UUID (format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+  const isNotionUuid = typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+
+  let notionUserId: string | undefined
+
+  if (isNotionUuid) {
+    // AI returned Notion UUID directly (new flow with @Name (uuid) format)
+    notionUserId = value
+    logger.debug('AI returned Notion UUID directly', { notionUserId })
+  } else {
+    // Old flow: AI returned source user ID, need to map to Notion ID
+    logger.debug('Value is not a UUID, attempting user mapping lookup', {
+      value,
+      userMappingsAvailable: userMappings ? userMappings.size : 0
+    })
+
+    if (!userMappings) {
+      logger.warn('No user mappings Map provided for assignee field', { value })
+      return
+    }
+
+    if (userMappings.size === 0) {
+      logger.warn('User mappings Map is empty - no mappings to lookup')
+    } else {
+      logger.debug('Available mapping keys', { keys: Array.from(userMappings.keys()) })
+    }
+
+    const lookupKey = String(value)
+    logger.debug('Looking up key', { lookupKey })
+    notionUserId = userMappings.get(lookupKey)
+
+    if (!notionUserId) {
+      logger.warn('No user mapping found for assignee', { value, tip: 'Ensure sourceUserId in your mapping exactly matches this value' })
+      return
+    }
+
+    logger.debug('Found mapping', { value, notionUserId })
+  }
+
+  const formattedProperty = formatNotionProperty(notionUserId, propertyType)
+  if (formattedProperty) {
+    properties[notionProperty] = formattedProperty
+    logger.debug('Successfully set assignee to property', { notionProperty, notionUserId })
+  } else {
+    logger.warn('formatNotionProperty returned null for assignee', { notionUserId })
+  }
+}
+
+/**
  * Build Notion properties from task data
  *
  * Strategy: Use the database's title property + apply field mappings for other properties.
@@ -333,25 +427,8 @@ async function buildTaskProperties(
       continue
     }
 
-    // Check if this field has a mapping
-    // Support both new format: { priority: { notionProperty, propertyType, valueMap } }
-    // And old format: { priorityProperty: 'Priority' }
-    let mapping = fieldMapping[aiField]
-
-    // If not found, try old format (aiField + 'Property')
-    if (!mapping) {
-      const oldKey = aiField + 'Property'
-      const oldValue = fieldMapping[oldKey]
-      if (typeof oldValue === 'string') {
-        // Convert old format to new format, default to 'select' type
-        mapping = {
-          notionProperty: oldValue,
-          propertyType: 'select', // Default assumption for legacy data
-          valueMap: {},
-        }
-        logger.warn('Using legacy field mapping format', { aiField, oldKey, oldValue })
-      }
-    }
+    // Check if this field has a mapping (supports new + legacy formats)
+    const mapping = resolveFieldMappingEntry(fieldMapping, aiField)
 
     if (!mapping || !mapping.notionProperty) {
       continue
@@ -373,54 +450,7 @@ async function buildTaskProperties(
 
     // Special handling for 'people' type (assignee field)
     if (propertyType === 'people') {
-      logger.debug('Assignee field - AI extracted value', { value })
-
-      // Check if the value is already a Notion UUID (format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
-      const isNotionUuid = typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
-
-      let notionUserId: string | undefined
-
-      if (isNotionUuid) {
-        // AI returned Notion UUID directly (new flow with @Name (uuid) format)
-        notionUserId = value
-        logger.debug('AI returned Notion UUID directly', { notionUserId })
-      } else {
-        // Old flow: AI returned source user ID, need to map to Notion ID
-        logger.debug('Value is not a UUID, attempting user mapping lookup', {
-          value,
-          userMappingsAvailable: userMappings ? userMappings.size : 0
-        })
-
-        if (!userMappings) {
-          logger.warn('No user mappings Map provided for assignee field', { value })
-          continue
-        }
-
-        if (userMappings.size === 0) {
-          logger.warn('User mappings Map is empty - no mappings to lookup')
-        } else {
-          logger.debug('Available mapping keys', { keys: Array.from(userMappings.keys()) })
-        }
-
-        const lookupKey = String(value)
-        logger.debug('Looking up key', { lookupKey })
-        notionUserId = userMappings.get(lookupKey)
-
-        if (!notionUserId) {
-          logger.warn('No user mapping found for assignee', { value, tip: 'Ensure sourceUserId in your mapping exactly matches this value' })
-          continue
-        }
-
-        logger.debug('Found mapping', { value, notionUserId })
-      }
-
-      const formattedProperty = formatNotionProperty(notionUserId, propertyType)
-      if (formattedProperty) {
-        properties[notionProperty] = formattedProperty
-        logger.debug('Successfully set assignee to property', { notionProperty, notionUserId })
-      } else {
-        logger.warn('formatNotionProperty returned null for assignee', { notionUserId })
-      }
+      applyPeopleProperty(properties, notionProperty, value, propertyType, userMappings)
       continue
     }
 
@@ -446,215 +476,264 @@ async function buildTaskProperties(
 }
 
 /**
- * Build rich content blocks for Notion page
- *
- * Generic structure that works for any source type:
- * - AI Summary callout
- * - Action items as checkboxes
- * - Participants list with @mentions (if userMentions provided)
- * - Thread content
- * - Generic metadata section
- * - Deep link back to source
- *
- * @param userMentions - Optional map of source user IDs to Notion user IDs for @mentions
- * @param sourceMetadata - Optional metadata for building source platform links
+ * Notion limits toggle blocks to 100 children.
  */
-function buildTaskContent(
-  task: DetectedTask,
-  thread: DiscussionThread,
-  aiSummary: AISummary,
-  config: NotionTaskConfig,
-  userMentions?: Map<string, string>,
-  sourceMetadata?: SourceMetadata,
-): any[] {
-  const NOTION_MAX_TOGGLE_CHILDREN = 100
-  const blocks: any[] = []
+const NOTION_MAX_TOGGLE_CHILDREN = 100
 
-  // AI Summary callout (concise, task-focused)
-  if (aiSummary.summary) {
+/**
+ * Create a divider block
+ */
+function dividerBlock(): any {
+  return {
+    object: 'block',
+    type: 'divider',
+    divider: {},
+  }
+}
+
+/**
+ * AI Summary callout (concise, task-focused)
+ */
+function buildSummaryBlocks(aiSummary: AISummary): any[] {
+  if (!aiSummary.summary) return []
+
+  return [{
+    object: 'block',
+    type: 'callout',
+    callout: {
+      icon: { emoji: '🤖' },
+      rich_text: [
+        {
+          type: 'text',
+          text: { content: `AI Summary: ${aiSummary.summary}` },
+        },
+      ],
+    },
+  }]
+}
+
+/**
+ * Task-specific action items as a heading + unchecked to-dos
+ */
+function buildActionItemBlocks(task: DetectedTask): any[] {
+  if (!task.actionItems || task.actionItems.length === 0) return []
+
+  const blocks: any[] = [{
+    object: 'block',
+    type: 'heading_3',
+    heading_3: {
+      rich_text: [
+        {
+          type: 'text',
+          text: { content: '📋 This Task Requires' },
+        },
+      ],
+    },
+  }]
+
+  for (const item of task.actionItems) {
     blocks.push({
       object: 'block',
-      type: 'callout',
-      callout: {
-        icon: { emoji: '🤖' },
+      type: 'to_do',
+      to_do: {
+        checked: false,
         rich_text: [
           {
             type: 'text',
-            text: { content: `AI Summary: ${aiSummary.summary}` },
+            text: { content: item },
           },
         ],
       },
     })
   }
 
-  // Task-specific action items (NEW)
-  if (task.actionItems && task.actionItems.length > 0) {
-    blocks.push({
-      object: 'block',
-      type: 'heading_3',
-      heading_3: {
-        rich_text: [
-          {
-            type: 'text',
-            text: { content: '📋 This Task Requires' },
-          },
-        ],
-      },
-    })
+  return blocks
+}
 
-    for (const item of task.actionItems) {
-      blocks.push({
+/**
+ * Discussion Context (collapsible) - Global insights from discussion
+ */
+function buildDiscussionContextBlocks(aiSummary: AISummary): any[] {
+  if (!aiSummary.keyPoints || aiSummary.keyPoints.length === 0) return []
+
+  return [{
+    object: 'block',
+    type: 'toggle',
+    toggle: {
+      rich_text: [
+        {
+          type: 'text',
+          text: { content: '🔍 Discussion Context' },
+          annotations: { bold: true },
+        },
+      ],
+      children: aiSummary.keyPoints.slice(0, NOTION_MAX_TOGGLE_CHILDREN).map(point => ({
         object: 'block',
-        type: 'to_do',
-        to_do: {
-          checked: false,
+        type: 'bulleted_list_item',
+        bulleted_list_item: {
           rich_text: [
             {
               type: 'text',
-              text: { content: item },
+              text: { content: point },
             },
           ],
         },
+      })),
+    },
+  }]
+}
+
+/**
+ * Participants paragraph with @mentions (if userMentions provided)
+ */
+function buildParticipantBlocks(
+  thread: DiscussionThread,
+  userMentions?: Map<string, string>,
+): any[] {
+  if (thread.participants.length === 0) return []
+
+  logger.debug('Building participants section', {
+    participantCount: thread.participants.length,
+    userMentionsAvailable: userMentions ? userMentions.size : 0
+  })
+
+  const participantRichText: any[] = [
+    {
+      type: 'text',
+      text: { content: '👥 Participants: ' },
+    },
+  ]
+
+  // Build rich text with @mentions for each participant
+  for (let i = 0; i < thread.participants.length; i++) {
+    const participantId = thread.participants[i]
+    if (!participantId) continue
+
+    // Try to get Notion user ID for mention
+    const notionUserId = userMentions?.get(participantId)
+
+    if (notionUserId) {
+      // Add proper @mention
+      logger.debug('Creating @mention for participant', { participantId, notionUserId })
+      const mentionObject = {
+        type: 'mention',
+        mention: {
+          type: 'user',
+          user: {
+            object: 'user', // Required by Notion API
+            id: notionUserId,
+          },
+        },
+      }
+      logger.debug('Mention object structure', { mentionObject })
+      participantRichText.push(mentionObject)
+    }
+    else {
+      // Fallback to plain text if no mapping
+      logger.debug('No mention mapping for participant, using plain text', { participantId })
+      participantRichText.push({
+        type: 'text',
+        text: { content: `@${participantId}` },
+      })
+    }
+
+    // Add separator between participants (except for last one)
+    if (i < thread.participants.length - 1) {
+      participantRichText.push({
+        type: 'text',
+        text: { content: ', ' },
       })
     }
   }
 
-  // Discussion Context (collapsible) - Global insights from discussion
-  if (aiSummary.keyPoints && aiSummary.keyPoints.length > 0) {
-    blocks.push({
+  logger.debug('Complete participantRichText array', { participantRichText })
+
+  return [{
+    object: 'block',
+    type: 'paragraph',
+    paragraph: {
+      rich_text: participantRichText,
+    },
+  }]
+}
+
+/**
+ * Thread content summary (task-specific description): heading + description paragraph
+ */
+function buildThreadContentBlocks(task: DetectedTask): any[] {
+  return [
+    {
       object: 'block',
-      type: 'toggle',
-      toggle: {
+      type: 'heading_2',
+      heading_2: {
         rich_text: [
           {
             type: 'text',
-            text: { content: '🔍 Discussion Context' },
-            annotations: { bold: true },
+            text: { content: 'Thread Content' },
           },
         ],
-        children: aiSummary.keyPoints.slice(0, NOTION_MAX_TOGGLE_CHILDREN).map(point => ({
-          object: 'block',
-          type: 'bulleted_list_item',
-          bulleted_list_item: {
-            rich_text: [
-              {
-                type: 'text',
-                text: { content: point },
-              },
-            ],
-          },
-        })),
       },
-    })
-  }
-
-  // Participants with @mentions (if userMentions provided)
-  if (thread.participants.length > 0) {
-    logger.debug('Building participants section', {
-      participantCount: thread.participants.length,
-      userMentionsAvailable: userMentions ? userMentions.size : 0
-    })
-
-    const participantRichText: any[] = [
-      {
-        type: 'text',
-        text: { content: '👥 Participants: ' },
-      },
-    ]
-
-    // Build rich text with @mentions for each participant
-    for (let i = 0; i < thread.participants.length; i++) {
-      const participantId = thread.participants[i]
-      if (!participantId) continue
-
-      // Try to get Notion user ID for mention
-      const notionUserId = userMentions?.get(participantId)
-
-      if (notionUserId) {
-        // Add proper @mention
-        logger.debug('Creating @mention for participant', { participantId, notionUserId })
-        const mentionObject = {
-          type: 'mention',
-          mention: {
-            type: 'user',
-            user: {
-              object: 'user', // Required by Notion API
-              id: notionUserId,
-            },
-          },
-        }
-        logger.debug('Mention object structure', { mentionObject })
-        participantRichText.push(mentionObject)
-      }
-      else {
-        // Fallback to plain text if no mapping
-        logger.debug('No mention mapping for participant, using plain text', { participantId })
-        participantRichText.push({
-          type: 'text',
-          text: { content: `@${participantId}` },
-        })
-      }
-
-      // Add separator between participants (except for last one)
-      if (i < thread.participants.length - 1) {
-        participantRichText.push({
-          type: 'text',
-          text: { content: ', ' },
-        })
-      }
-    }
-
-    logger.debug('Complete participantRichText array', { participantRichText })
-
-    blocks.push({
+    },
+    {
       object: 'block',
       type: 'paragraph',
       paragraph: {
-        rich_text: participantRichText,
+        rich_text: [
+          {
+            type: 'text',
+            text: { content: task.description.substring(0, 2000) },
+          },
+        ],
       },
-    })
-  }
-
-  // Divider
-  blocks.push({
-    object: 'block',
-    type: 'divider',
-    divider: {},
-  })
-
-  // Thread content summary (task-specific description)
-  blocks.push({
-    object: 'block',
-    type: 'heading_2',
-    heading_2: {
-      rich_text: [
-        {
-          type: 'text',
-          text: { content: 'Thread Content' },
-        },
-      ],
     },
-  })
+  ]
+}
 
-  blocks.push({
+/**
+ * Bold author line ("@Name:"), linked to the source message when a URL is available
+ */
+function buildAuthorLineBlock(authorLabel: string, messageUrl: string | null): any {
+  return {
     object: 'block',
     type: 'paragraph',
     paragraph: {
       rich_text: [
         {
           type: 'text',
-          text: { content: task.description.substring(0, 2000) },
+          text: {
+            content: `${authorLabel}:`,
+            link: messageUrl ? { url: messageUrl } : undefined,
+          },
+          annotations: { bold: true, color: messageUrl ? 'blue' : 'default' },
         },
       ],
     },
-  })
-
-
-  // Helper to get display name (resolved name or fallback to ID)
-  const getDisplayName = (authorHandle: string, authorName?: string) => {
-    return authorName ? `@${authorName}` : authorHandle
   }
-  // Full Discussion Thread (collapsible)
+}
+
+/**
+ * Message body paragraph with mentions/links parsed (capped at Notion's 2000-char limit)
+ */
+function buildMessageBodyBlock(content: string, messageUrl: string | null): any {
+  return {
+    object: 'block',
+    type: 'paragraph',
+    paragraph: {
+      rich_text: parseContentWithMentionsAndLinks(
+        content.substring(0, 2000),
+        messageUrl || undefined,
+      ),
+    },
+  }
+}
+
+/**
+ * Flatten the root message + replies into paragraph blocks ("—" separator before each reply)
+ */
+function buildThreadMessageBlocks(
+  thread: DiscussionThread,
+  sourceMetadata?: SourceMetadata,
+): any[] {
   const threadMessages: any[] = []
 
   // Add root message
@@ -663,32 +742,8 @@ function buildTaskContent(
     : thread.rootMessage.authorHandle
   const rootMessageUrl = buildMessageUrl(thread.rootMessage.id, sourceMetadata)
 
-  threadMessages.push({
-    object: 'block',
-    type: 'paragraph',
-    paragraph: {
-      rich_text: [
-        {
-          type: 'text',
-          text: {
-            content: `${rootAuthorName}:`,
-            link: rootMessageUrl ? { url: rootMessageUrl } : undefined,
-          },
-          annotations: { bold: true, color: rootMessageUrl ? 'blue' : 'default' },
-        },
-      ],
-    },
-  })
-  threadMessages.push({
-    object: 'block',
-    type: 'paragraph',
-    paragraph: {
-      rich_text: parseContentWithMentionsAndLinks(
-        thread.rootMessage.content.substring(0, 2000),
-        rootMessageUrl || undefined,
-      ),
-    },
-  })
+  threadMessages.push(buildAuthorLineBlock(rootAuthorName, rootMessageUrl))
+  threadMessages.push(buildMessageBodyBlock(thread.rootMessage.content, rootMessageUrl))
 
   // Add replies
   for (const reply of thread.replies) {
@@ -709,36 +764,18 @@ function buildTaskContent(
         ],
       },
     })
-    threadMessages.push({
-      object: 'block',
-      type: 'paragraph',
-      paragraph: {
-        rich_text: [
-          {
-            type: 'text',
-            text: {
-              content: `${replyAuthorName}:`,
-              link: replyMessageUrl ? { url: replyMessageUrl } : undefined,
-            },
-            annotations: { bold: true, color: replyMessageUrl ? 'blue' : 'default' },
-          },
-        ],
-      },
-    })
-    threadMessages.push({
-      object: 'block',
-      type: 'paragraph',
-      paragraph: {
-        rich_text: parseContentWithMentionsAndLinks(
-          reply.content.substring(0, 2000),
-          replyMessageUrl || undefined,
-        ),
-      },
-    })
+    threadMessages.push(buildAuthorLineBlock(replyAuthorName, replyMessageUrl))
+    threadMessages.push(buildMessageBodyBlock(reply.content, replyMessageUrl))
   }
 
-  // Notion limits toggle children to 100. Truncate and add a note if needed.
-  const truncatedMessages = threadMessages.length > NOTION_MAX_TOGGLE_CHILDREN
+  return threadMessages
+}
+
+/**
+ * Notion limits toggle children to 100. Truncate and add a note if needed.
+ */
+function truncateToggleChildren(threadMessages: any[]): any[] {
+  return threadMessages.length > NOTION_MAX_TOGGLE_CHILDREN
     ? [
         ...threadMessages.slice(0, NOTION_MAX_TOGGLE_CHILDREN - 1),
         {
@@ -754,8 +791,18 @@ function buildTaskContent(
         },
       ]
     : threadMessages
+}
 
-  blocks.push({
+/**
+ * Full Discussion Thread (collapsible)
+ */
+function buildFullThreadToggleBlock(
+  thread: DiscussionThread,
+  sourceMetadata?: SourceMetadata,
+): any {
+  const truncatedMessages = truncateToggleChildren(buildThreadMessageBlocks(thread, sourceMetadata))
+
+  return {
     object: 'block',
     type: 'toggle',
     toggle: {
@@ -768,17 +815,58 @@ function buildTaskContent(
       ],
       children: truncatedMessages,
     },
-  })
+  }
+}
 
-  // Divider
-  blocks.push({
+/**
+ * Create a metadata bulleted list item with optional Notion mention
+ */
+function createMetadataItem(label: string, value: string, notionUserId?: string): any {
+  const richText: any[] = [
+    {
+      type: 'text',
+      text: { content: `${label}: ` },
+    },
+  ]
+
+  if (notionUserId) {
+    // Add Notion user mention
+    richText.push({
+      type: 'mention',
+      mention: {
+        type: 'user',
+        user: {
+          object: 'user',
+          id: notionUserId,
+        },
+      },
+    })
+  } else {
+    // Just add plain text
+    richText.push({
+      type: 'text',
+      text: { content: value },
+    })
+  }
+
+  return {
     object: 'block',
-    type: 'divider',
-    divider: {},
-  })
+    type: 'bulleted_list_item',
+    bulleted_list_item: { rich_text: richText },
+  }
+}
 
-  // Metadata section (generic for any source)
-  blocks.push({
+/**
+ * Metadata section (generic for any source): heading + bulleted metadata items
+ */
+function buildMetadataBlocks(
+  task: DetectedTask,
+  thread: DiscussionThread,
+  aiSummary: AISummary,
+  config: NotionTaskConfig,
+  userMentions?: Map<string, string>,
+): any[] {
+  const blocks: any[] = [{
     object: 'block',
     type: 'heading_2',
     heading_2: {
@@ -789,43 +877,7 @@ function buildTaskContent(
         },
       ],
     },
-  })
-
-  // Helper to create metadata item with optional Notion mention
-  const createMetadataItem = (label: string, value: string, notionUserId?: string) => {
-    const richText: any[] = [
-      {
-        type: 'text',
-        text: { content: `${label}: ` },
-      },
-    ]
-
-    if (notionUserId) {
-      // Add Notion user mention
-      richText.push({
-        type: 'mention',
-        mention: {
-          type: 'user',
-          user: {
-            object: 'user',
-            id: notionUserId,
-          },
-        },
-      })
-    } else {
-      // Just add plain text
-      richText.push({
-        type: 'text',
-        text: { content: value },
-      })
-    }
-
-    return {
-      object: 'block',
-      type: 'bulleted_list_item',
-      bulleted_list_item: { rich_text: richText },
-    }
-  }
+  }]
 
   // Get Notion user ID for the message author
   const authorHandle = thread.rootMessage.authorHandle
@@ -862,15 +914,18 @@ function buildTaskContent(
     blocks.push(createMetadataItem('Tags', task.tags.join(', ')))
   }
 
-  // Deep link back to source
-  if (config.sourceUrl) {
-    blocks.push({
-      object: 'block',
-      type: 'divider',
-      divider: {},
-    })
+  return blocks
+}
 
-    blocks.push({
+/**
+ * Deep link back to source (divider + link paragraph), when config.sourceUrl is set
+ */
+function buildSourceLinkBlocks(config: NotionTaskConfig): any[] {
+  if (!config.sourceUrl) return []
+
+  return [
+    dividerBlock(),
+    {
       object: 'block',
       type: 'paragraph',
       paragraph: {
@@ -892,8 +947,44 @@ function buildTaskContent(
           },
         ],
       },
-    })
-  }
+    },
+  ]
+}
+
+/**
+ * Build rich content blocks for Notion page
+ *
+ * Generic structure that works for any source type:
+ * - AI Summary callout
+ * - Action items as checkboxes
+ * - Participants list with @mentions (if userMentions provided)
+ * - Thread content
+ * - Generic metadata section
+ * - Deep link back to source
+ *
+ * @param userMentions - Optional map of source user IDs to Notion user IDs for @mentions
+ * @param sourceMetadata - Optional metadata for building source platform links
+ */
+function buildTaskContent(
+  task: DetectedTask,
+  thread: DiscussionThread,
+  aiSummary: AISummary,
+  config: NotionTaskConfig,
+  userMentions?: Map<string, string>,
+  sourceMetadata?: SourceMetadata,
+): any[] {
+  const blocks: any[] = [
+    ...buildSummaryBlocks(aiSummary),
+    ...buildActionItemBlocks(task),
+    ...buildDiscussionContextBlocks(aiSummary),
+    ...buildParticipantBlocks(thread, userMentions),
+    dividerBlock(),
+    ...buildThreadContentBlocks(task),
+    buildFullThreadToggleBlock(thread, sourceMetadata),
+    dividerBlock(),
+    ...buildMetadataBlocks(task, thread, aiSummary, config, userMentions),
+    ...buildSourceLinkBlocks(config),
+  ]
 
   logger.debug('Complete blocks array (children)', { blocksCount: blocks.length })
 

--- a/packages/crouton-triage/server/services/processor.ts
+++ b/packages/crouton-triage/server/services/processor.ts
@@ -355,6 +355,33 @@ export function isBootstrapComment(
 }
 
 /**
+ * Match an active input row against the source identifier for its source type
+ */
+function inputMatchesIdentifier(
+  input: any,
+  sourceType: string,
+  identifier: string,
+  metadata?: Record<string, any>,
+): boolean {
+  if (sourceType === 'slack') {
+    return input.sourceMetadata?.slackTeamId === identifier
+  } else if (sourceType === 'figma') {
+    return input.emailSlug === metadata?.emailSlug
+  } else if (sourceType === 'notion') {
+    // Match by workspace ID stored in sourceMetadata
+    // Check metadata.notionWorkspaceId first (preferred), then fall back to identifier
+    const inputWorkspaceId = input.sourceMetadata?.notionWorkspaceId
+    const lookupWorkspaceId = metadata?.notionWorkspaceId || identifier
+    if (inputWorkspaceId) {
+      return inputWorkspaceId === lookupWorkspaceId
+    }
+    // Fallback: if no workspace ID stored, accept any active Notion input
+    return true
+  }
+  return false
+}
+
+/**
  * Load flow with inputs and outputs by input identifier
  *
  * Queries flowinputs by slackTeamId (from sourceMetadata) or emailSlug,
@@ -398,24 +425,7 @@ async function loadFlow(
   let flow: any
 
   // Filter inputs by source identifier
-  const candidateInputs = inputs.filter((input: any) => {
-    if (sourceType === 'slack') {
-      return input.sourceMetadata?.slackTeamId === identifier
-    } else if (sourceType === 'figma') {
-      return input.emailSlug === metadata?.emailSlug
-    } else if (sourceType === 'notion') {
-      // Match by workspace ID stored in sourceMetadata
-      // Check metadata.notionWorkspaceId first (preferred), then fall back to identifier
-      const inputWorkspaceId = input.sourceMetadata?.notionWorkspaceId
-      const lookupWorkspaceId = metadata?.notionWorkspaceId || identifier
-      if (inputWorkspaceId) {
-        return inputWorkspaceId === lookupWorkspaceId
-      }
-      // Fallback: if no workspace ID stored, accept any active Notion input
-      return true
-    }
-    return false
-  })
+  const candidateInputs = inputs.filter((input: any) => inputMatchesIdentifier(input, sourceType, identifier, metadata))
 
   // Try each candidate input and verify its flow exists
   for (const input of candidateInputs) {
@@ -830,60 +840,16 @@ async function buildThread(
 
   // Use user mappings passed from Stage 2.5 (already loaded once)
   const userIdToMentionMap = userMappings || new Map<string, { name: string; notionId: string }>()
-  const handleToMentionMap = new Map<string, { name: string; notionId: string }>() // For Figma @handle mentions
+  let handleToMentionMap = new Map<string, { name: string; notionId: string }>() // For Figma @handle mentions
 
   // For Notion sources, auto-fetch user info if no mappings exist
   if (parsed.sourceType === 'notion' && userIdToMentionMap.size === 0 && config.apiToken) {
-    try {
-      logger.debug('Fetching Notion users for author resolution')
-      const NOTION_API_VERSION = '2022-06-28'
-      const response = await $fetch<{ results: Array<{ id: string; name?: string; type: string }> }>(
-        'https://api.notion.com/v1/users',
-        {
-          method: 'GET',
-          headers: {
-            'Authorization': `Bearer ${config.apiToken}`,
-            'Notion-Version': NOTION_API_VERSION,
-          },
-        }
-      )
-
-      // Build map of Notion user ID -> name
-      for (const user of response.results) {
-        if (user.name) {
-          userIdToMentionMap.set(user.id, {
-            name: user.name,
-            notionId: user.id, // For Notion, the source ID is the Notion ID
-          })
-        }
-      }
-      logger.info('Fetched Notion users for author resolution', {
-        userCount: userIdToMentionMap.size,
-      })
-    } catch (error) {
-      logger.warn('Failed to fetch Notion users, will use IDs as author names', { error })
-    }
+    await fetchNotionUsersIntoMap(config.apiToken, userIdToMentionMap)
   }
 
   // Build handle map for Figma (only if we have user mappings)
   if (userMappings && parsed.sourceType === 'figma' && teamId) {
-    try {
-      const { getAllTriageUsers } = await import('~~/layers/triage/collections/users/server/database/queries')
-      const allUserMappings = await getAllTriageUsers(teamId)
-
-      for (const mapping of allUserMappings) {
-        if (mapping.sourceType === 'figma' && mapping.active && mapping.sourceUserName) {
-          const displayName = mapping.notionUserName || mapping.sourceUserName || mapping.sourceUserId
-          const mentionData = {
-            name: String(displayName),
-            notionId: String(mapping.notionUserId)
-          }
-          handleToMentionMap.set(String(mapping.sourceUserName), mentionData)
-        }
-      }
-    } catch (error) {
-      logger.warn('Failed to load Figma handle mappings', { error })
-    }
+    handleToMentionMap = await loadFigmaHandleMap(teamId)
   }
 
   logger.debug('User mappings available for mention conversion', {
@@ -892,121 +858,241 @@ async function buildThread(
   })
 
   // Convert user ID mentions to readable names with Notion IDs and filter out bot
+  applyMentionConversion(thread, parsed.sourceType, config, userIdToMentionMap, handleToMentionMap)
+
+  // Resolve author IDs to names for display in Notion
+  resolveThreadAuthorNames(thread, userIdToMentionMap)
+
+  return thread
+}
+
+/**
+ * Fetch Notion workspace users and add them to the mention map
+ *
+ * Used for Notion sources when no user mappings exist so that author IDs
+ * can still be resolved to display names. Failures are logged, not thrown.
+ */
+async function fetchNotionUsersIntoMap(
+  apiToken: string,
+  userIdToMentionMap: Map<string, { name: string; notionId: string }>,
+): Promise<void> {
+  try {
+    logger.debug('Fetching Notion users for author resolution')
+    const NOTION_API_VERSION = '2022-06-28'
+    const response = await $fetch<{ results: Array<{ id: string; name?: string; type: string }> }>(
+      'https://api.notion.com/v1/users',
+      {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${apiToken}`,
+          'Notion-Version': NOTION_API_VERSION,
+        },
+      }
+    )
+
+    // Build map of Notion user ID -> name
+    for (const user of response.results) {
+      if (user.name) {
+        userIdToMentionMap.set(user.id, {
+          name: user.name,
+          notionId: user.id, // For Notion, the source ID is the Notion ID
+        })
+      }
+    }
+    logger.info('Fetched Notion users for author resolution', {
+      userCount: userIdToMentionMap.size,
+    })
+  } catch (error) {
+    logger.warn('Failed to fetch Notion users, will use IDs as author names', { error })
+  }
+}
+
+/**
+ * Load the Figma @handle -> mention data map from stored user mappings
+ *
+ * Returns an empty map on failure (logged, not thrown).
+ */
+async function loadFigmaHandleMap(
+  teamId: string,
+): Promise<Map<string, { name: string; notionId: string }>> {
+  const handleToMentionMap = new Map<string, { name: string; notionId: string }>()
+
+  try {
+    const { getAllTriageUsers } = await import('~~/layers/triage/collections/users/server/database/queries')
+    const allUserMappings = await getAllTriageUsers(teamId)
+
+    for (const mapping of allUserMappings) {
+      if (mapping.sourceType === 'figma' && mapping.active && mapping.sourceUserName) {
+        const displayName = mapping.notionUserName || mapping.sourceUserName || mapping.sourceUserId
+        const mentionData = {
+          name: String(displayName),
+          notionId: String(mapping.notionUserId)
+        }
+        handleToMentionMap.set(String(mapping.sourceUserName), mentionData)
+      }
+    }
+  } catch (error) {
+    logger.warn('Failed to load Figma handle mappings', { error })
+  }
+
+  return handleToMentionMap
+}
+
+/**
+ * Convert Slack user ID mentions (<@U123ABC456>) to @Name (NotionID)
+ * and strip bot mentions entirely
+ */
+function convertSlackMentionContent(
+  content: string,
+  botUserId: string | undefined,
+  userIdToMentionMap: Map<string, { name: string; notionId: string }>,
+): string {
+  let converted = content
+
+  // First, remove bot mentions entirely
+  if (botUserId) {
+    converted = converted.replace(new RegExp(`<@${botUserId}>`, 'g'), '').trim()
+    // Clean up multiple spaces
+    converted = converted.replace(/\s+/g, ' ').trim()
+  }
+
+  // Then convert remaining user IDs to @Name (NotionID)
+  userIdToMentionMap.forEach((mention, userId) => {
+    converted = converted.replace(
+      new RegExp(`<@${userId}>`, 'g'),
+      `@${mention.name} (${mention.notionId})`
+    )
+  })
+
+  return converted
+}
+
+/**
+ * Convert the three Figma mention formats — parentheses @Name (uuid),
+ * bracket @[userId:displayName], and plain @handle — to readable names,
+ * stripping bot mentions entirely
+ */
+function convertFigmaMentionContent(
+  content: string,
+  config: AdapterConfig,
+  userIdToMentionMap: Map<string, { name: string; notionId: string }>,
+  handleToMentionMap: Map<string, { name: string; notionId: string }>,
+): string {
+  let converted = content
+  const botUserId = config.sourceMetadata?.botUserId
+  const botHandle = config.sourceMetadata?.botHandle
+
+  // STEP 1: Handle Figma parentheses format @Name (uuid)
+  // This is the actual format seen in Figma comments: @Maarten Lauwaert (a36f9347-1da7-400e-9ac5-06442413f18d)
+  const parenMentionRegex = /@([^(@]+?)\s*\(([a-f0-9-]+)\)/gi
+
+  converted = converted.replace(parenMentionRegex, (_match, displayName, userId) => {
+    const trimmedName = displayName.trim()
+
+    // Skip bot mentions entirely (check both userId and handle/name)
+    if ((botUserId && userId === botUserId) ||
+        (botHandle && trimmedName.toLowerCase() === botHandle.toLowerCase())) {
+      return '' // Remove bot mention
+    }
+
+    // Look up user in mappings by userId (Figma user ID)
+    const mappedUser = userIdToMentionMap.get(userId)
+    if (mappedUser) {
+      return `@${mappedUser.name}`
+    }
+
+    // Fallback: just use displayName without the UUID
+    return `@${trimmedName}`
+  })
+
+  // Clean up multiple spaces from removed bot mentions
+  converted = converted.replace(/\s+/g, ' ').trim()
+
+  // STEP 2: Handle Figma bracket format @[userId:displayName]
+  // Alternative format that may be returned by Figma API
+  const bracketMentionRegex = /@\[([^\]:]+):([^\]]+)\]/g
+
+  converted = converted.replace(bracketMentionRegex, (_match, userId, displayName) => {
+    // Skip bot mentions entirely (check both userId and handle)
+    if ((botUserId && userId === botUserId) ||
+        (botHandle && displayName.toLowerCase() === botHandle.toLowerCase())) {
+      return '' // Remove bot mention
+    }
+
+    // Look up user in mappings by userId (Figma user ID)
+    const mappedUser = userIdToMentionMap.get(userId)
+    if (mappedUser) {
+      return `@${mappedUser.name} (${mappedUser.notionId})`
+    }
+
+    // Fallback: just use displayName (cleaned)
+    return `@${displayName.trim()}`
+  })
+
+  // Clean up multiple spaces from removed bot mentions
+  converted = converted.replace(/\s+/g, ' ').trim()
+
+  // STEP 3: Handle plain @handle format (for email webhook content)
+  // First, remove bot mentions entirely (before converting user mentions)
+  if (botHandle) {
+    // Escape special regex characters in handle
+    const escapedBotHandle = botHandle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    // Match @bothandle with word boundary (case-insensitive)
+    const botPattern = new RegExp(`@${escapedBotHandle}(?!\\S)`, 'gi')
+    converted = converted.replace(botPattern, '').trim()
+    // Clean up multiple spaces
+    converted = converted.replace(/\s+/g, ' ').trim()
+  }
+
+  // Convert @handle mentions to @Name (just use display name, no ID in output)
+  handleToMentionMap.forEach((mention, handle) => {
+    // Escape special regex characters in handle
+    const escapedHandle = handle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const pattern = `@${escapedHandle}(?!\\S)` // Case-insensitive, not followed by non-whitespace
+
+    const regex = new RegExp(pattern, 'gi')
+    converted = converted.replace(
+      regex,
+      `@${mention.name}`
+    )
+  })
+
+  return converted
+}
+
+/**
+ * Convert user mentions in a thread's root message and replies to readable
+ * names (stripping bot mentions), when conversion applies to the source type
+ */
+function applyMentionConversion(
+  thread: DiscussionThread,
+  sourceType: string,
+  config: AdapterConfig,
+  userIdToMentionMap: Map<string, { name: string; notionId: string }>,
+  handleToMentionMap: Map<string, { name: string; notionId: string }>,
+): void {
   const botUserId = config.sourceMetadata?.botUserId
 
   const convertMentions = (content: string): string => {
-    let converted = content
-
-    if (parsed.sourceType === 'slack') {
+    if (sourceType === 'slack') {
       // Slack format: <@U123ABC456>
-
-      // First, remove bot mentions entirely
-      if (botUserId) {
-        converted = converted.replace(new RegExp(`<@${botUserId}>`, 'g'), '').trim()
-        // Clean up multiple spaces
-        converted = converted.replace(/\s+/g, ' ').trim()
-      }
-
-      // Then convert remaining user IDs to @Name (NotionID)
-      userIdToMentionMap.forEach((mention, userId) => {
-        converted = converted.replace(
-          new RegExp(`<@${userId}>`, 'g'),
-          `@${mention.name} (${mention.notionId})`
-        )
-      })
-    } else if (parsed.sourceType === 'figma') {
-      const botUserId = config.sourceMetadata?.botUserId
-      const botHandle = config.sourceMetadata?.botHandle
-
-      // STEP 1: Handle Figma parentheses format @Name (uuid)
-      // This is the actual format seen in Figma comments: @Maarten Lauwaert (a36f9347-1da7-400e-9ac5-06442413f18d)
-      const parenMentionRegex = /@([^(@]+?)\s*\(([a-f0-9-]+)\)/gi
-
-      converted = converted.replace(parenMentionRegex, (_match, displayName, userId) => {
-        const trimmedName = displayName.trim()
-
-        // Skip bot mentions entirely (check both userId and handle/name)
-        if ((botUserId && userId === botUserId) ||
-            (botHandle && trimmedName.toLowerCase() === botHandle.toLowerCase())) {
-          return '' // Remove bot mention
-        }
-
-        // Look up user in mappings by userId (Figma user ID)
-        const mappedUser = userIdToMentionMap.get(userId)
-        if (mappedUser) {
-          return `@${mappedUser.name}`
-        }
-
-        // Fallback: just use displayName without the UUID
-        return `@${trimmedName}`
-      })
-
-      // Clean up multiple spaces from removed bot mentions
-      converted = converted.replace(/\s+/g, ' ').trim()
-
-      // STEP 2: Handle Figma bracket format @[userId:displayName]
-      // Alternative format that may be returned by Figma API
-      const bracketMentionRegex = /@\[([^\]:]+):([^\]]+)\]/g
-
-      converted = converted.replace(bracketMentionRegex, (_match, userId, displayName) => {
-        // Skip bot mentions entirely (check both userId and handle)
-        if ((botUserId && userId === botUserId) ||
-            (botHandle && displayName.toLowerCase() === botHandle.toLowerCase())) {
-          return '' // Remove bot mention
-        }
-
-        // Look up user in mappings by userId (Figma user ID)
-        const mappedUser = userIdToMentionMap.get(userId)
-        if (mappedUser) {
-          return `@${mappedUser.name} (${mappedUser.notionId})`
-        }
-
-        // Fallback: just use displayName (cleaned)
-        return `@${displayName.trim()}`
-      })
-
-      // Clean up multiple spaces from removed bot mentions
-      converted = converted.replace(/\s+/g, ' ').trim()
-
-      // STEP 3: Handle plain @handle format (for email webhook content)
-      // First, remove bot mentions entirely (before converting user mentions)
-      if (botHandle) {
-        // Escape special regex characters in handle
-        const escapedBotHandle = botHandle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        // Match @bothandle with word boundary (case-insensitive)
-        const botPattern = new RegExp(`@${escapedBotHandle}(?!\\S)`, 'gi')
-        converted = converted.replace(botPattern, '').trim()
-        // Clean up multiple spaces
-        converted = converted.replace(/\s+/g, ' ').trim()
-      }
-
-      // Convert @handle mentions to @Name (just use display name, no ID in output)
-      handleToMentionMap.forEach((mention, handle) => {
-        // Escape special regex characters in handle
-        const escapedHandle = handle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        const pattern = `@${escapedHandle}(?!\\S)` // Case-insensitive, not followed by non-whitespace
-
-        const regex = new RegExp(pattern, 'gi')
-        converted = converted.replace(
-          regex,
-          `@${mention.name}`
-        )
-      })
+      return convertSlackMentionContent(content, botUserId, userIdToMentionMap)
+    } else if (sourceType === 'figma') {
+      return convertFigmaMentionContent(content, config, userIdToMentionMap, handleToMentionMap)
     }
-
-    return converted
+    return content
   }
 
   // Always run conversion for Figma (to strip UUIDs from mentions even without mappings)
   // For other sources, only run if bot or mappings are configured
-  const shouldConvert = parsed.sourceType === 'figma' ||
+  const shouldConvert = sourceType === 'figma' ||
     botUserId ||
     userIdToMentionMap.size > 0 ||
     handleToMentionMap.size > 0
 
   if (shouldConvert) {
     logger.debug('Converting user mentions for AI', {
-      sourceType: parsed.sourceType,
+      sourceType,
       hasBot: !!botUserId,
       mappingCount: userIdToMentionMap.size + handleToMentionMap.size
     })
@@ -1020,37 +1106,1382 @@ async function buildThread(
       content: convertMentions(reply.content)
     }))
   }
+}
 
-  // Resolve author IDs to names for display in Notion
-  if (userIdToMentionMap.size > 0) {
-    // Resolve root message author
-    const rootAuthorData = userIdToMentionMap.get(thread.rootMessage.authorHandle)
-    if (rootAuthorData) {
-      thread.rootMessage.authorName = rootAuthorData.name
-      logger.debug('Resolved root author', {
-        from: thread.rootMessage.authorHandle,
-        to: rootAuthorData.name,
-      })
-    }
+/**
+ * Resolve author IDs to display names on a thread (root message + replies)
+ */
+function resolveThreadAuthorNames(
+  thread: DiscussionThread,
+  userIdToMentionMap: Map<string, { name: string; notionId: string }>,
+): void {
+  if (userIdToMentionMap.size === 0) {
+    return
+  }
 
-    // Resolve reply authors
-    thread.replies = thread.replies.map((reply: any) => {
-      const replyAuthorData = userIdToMentionMap.get(reply.authorHandle)
-      return {
-        ...reply,
-        authorName: replyAuthorData?.name,
-      }
-    })
-
-    logger.debug('Resolved author IDs to names', {
-      totalAuthors: new Set([
-        thread.rootMessage.authorHandle,
-        ...thread.replies.map((r: any) => r.authorHandle)
-      ]).size,
+  // Resolve root message author
+  const rootAuthorData = userIdToMentionMap.get(thread.rootMessage.authorHandle)
+  if (rootAuthorData) {
+    thread.rootMessage.authorName = rootAuthorData.name
+    logger.debug('Resolved root author', {
+      from: thread.rootMessage.authorHandle,
+      to: rootAuthorData.name,
     })
   }
 
+  // Resolve reply authors
+  thread.replies = thread.replies.map((reply: any) => {
+    const replyAuthorData = userIdToMentionMap.get(reply.authorHandle)
+    return {
+      ...reply,
+      authorName: replyAuthorData?.name,
+    }
+  })
+
+  logger.debug('Resolved author IDs to names', {
+    totalAuthors: new Set([
+      thread.rootMessage.authorHandle,
+      ...thread.replies.map((r: any) => r.authorHandle)
+    ]).size,
+  })
+}
+
+/**
+ * Emit a crouton:operation telemetry hook (fire-and-forget)
+ */
+function emitTriageHook(
+  type: string,
+  teamId: string | undefined,
+  correlationId: string | undefined,
+  metadata: Record<string, any>,
+): void {
+  useNitroApp().hooks.callHook('crouton:operation', {
+    type,
+    source: 'crouton-triage',
+    teamId: teamId ?? undefined,
+    correlationId,
+    metadata,
+  }).catch(() => {})
+}
+
+/**
+ * Stage 1.5: Deduplication check
+ *
+ * Checks if we're already processing this sourceThreadId to prevent duplicates
+ * from Slack retries. Returns an "already processed" result when a live
+ * duplicate exists; deletes the old record (and returns undefined) when a
+ * retry is allowed (failed discussions or bootstrap comments).
+ */
+async function checkDuplicateDiscussion(
+  parsed: ParsedDiscussion,
+  correlationId?: string,
+): Promise<ProcessingResult | undefined> {
+  const db = useDB()
+  const { triageDiscussions } = await import(
+    '~~/layers/triage/collections/discussions/server/database/schema'
+  )
+
+  // Check if this looks like a bootstrap comment (before we have the full thread)
+  const contentLower = parsed.content.toLowerCase()
+  const isLikelyBootstrap = contentLower.includes('user sync') || contentLower.includes('bootstrap')
+
+  const [existingDiscussion] = await db
+    .select({ id: triageDiscussions.id, status: triageDiscussions.status })
+    .from(triageDiscussions)
+    .where(eq(triageDiscussions.sourceThreadId, parsed.sourceThreadId))
+    .limit(1)
+
+  if (!existingDiscussion) {
+    return undefined
+  }
+
+  // Allow retry for failed discussions or bootstrap comments
+  const shouldAllowRetry = existingDiscussion.status === 'failed' || isLikelyBootstrap
+
+  if (!shouldAllowRetry) {
+    logger.info('Discussion already exists for this thread, skipping duplicate', {
+      sourceThreadId: parsed.sourceThreadId,
+      existingDiscussionId: existingDiscussion.id,
+      existingStatus: existingDiscussion.status,
+    })
+    // Return a mock result to indicate this was already processed
+    return {
+      discussionId: existingDiscussion.id,
+      aiAnalysis: {
+        summary: { summary: 'Already processed', keyPoints: [] },
+        taskDetection: { isMultiTask: false, tasks: [] },
+        processingTime: 0,
+        cached: true,
+      },
+      notionTasks: [],
+      processingTime: 0,
+      isMultiTask: false,
+      correlationId,
+    }
+  }
+
+  // Delete the existing failed/bootstrap discussion to allow fresh processing
+  logger.info('Allowing retry for discussion', {
+    sourceThreadId: parsed.sourceThreadId,
+    existingDiscussionId: existingDiscussion.id,
+    existingStatus: existingDiscussion.status,
+    reason: isLikelyBootstrap ? 'bootstrap_comment' : 'failed_status',
+  })
+
+  // Delete the old record to allow fresh processing
+  await db
+    .delete(triageDiscussions)
+    .where(eq(triageDiscussions.id, existingDiscussion.id))
+
+  return undefined
+}
+
+/**
+ * Stage 2: Flow/Config loading
+ *
+ * Uses the provided config when given (for testing); otherwise loads the
+ * flow (v2 architecture) and resolves the actual team ID from it.
+ */
+async function resolveFlowConfig(
+  parsed: ParsedDiscussion,
+  providedConfig?: AdapterConfig,
+): Promise<{ config: AdapterConfig | undefined; flowData: FlowWithRelations | undefined; actualTeamId: string }> {
+  let config: AdapterConfig | undefined
+  let flowData: FlowWithRelations | undefined
+  let actualTeamId: string = parsed.teamId
+
+  if (providedConfig) {
+    // Use provided config (for testing)
+    config = providedConfig
+    logger.debug('Using provided config')
+  }
+  else {
+    // Load flow (v2 architecture — sole config loading mechanism)
+    flowData = await loadFlow(parsed.teamId, parsed.sourceType, parsed.metadata)
+    actualTeamId = flowData.flow.teamId
+    logger.info('Loaded flow for processing', {
+      flowId: flowData.flow.id,
+      flowName: flowData.flow.name,
+      inputCount: flowData.inputs.length,
+      outputCount: flowData.outputs.length,
+    })
+  }
+
+  // Update actualTeamId
+  if (config && !flowData) {
+    actualTeamId = config.teamId
+    logger.debug('Resolved team IDs from config', {
+      sourceIdentifier: parsed.teamId,
+      actualTeamId: config.teamId,
+    })
+  }
+  else if (flowData) {
+    actualTeamId = flowData.flow.teamId
+    logger.debug('Resolved team IDs from flow', {
+      sourceIdentifier: parsed.teamId,
+      actualTeamId: flowData.flow.teamId,
+    })
+  }
+
+  return { config, flowData, actualTeamId }
+}
+
+/**
+ * Resolve the input token (once, used for all adapter calls)
+ *
+ * Prefers the connected-account token for flow inputs, falling back to the
+ * inline token; legacy configs use their apiToken directly.
+ */
+async function resolveProcessingToken(
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): Promise<string> {
+  let resolvedInputToken = ''
+  if (flowData) {
+    try {
+      const { resolveInputToken } = await import('../utils/tokenResolver')
+      resolvedInputToken = await resolveInputToken(flowData.matchedInput, flowData.flow.teamId)
+    } catch (error) {
+      logger.warn('Failed to resolve input token from account, falling back to inline', { error })
+      resolvedInputToken = flowData.matchedInput.apiToken || ''
+    }
+  } else if (config) {
+    resolvedInputToken = config.apiToken || ''
+  }
+  return resolvedInputToken
+}
+
+/**
+ * Build an AdapterConfig from a flow's matched input (used for reactions
+ * and replies)
+ */
+function buildFlowAdapterConfig(flowData: FlowWithRelations, apiToken: string): AdapterConfig {
+  return {
+    id: flowData.matchedInput.id,
+    teamId: flowData.flow.teamId,
+    sourceType: flowData.matchedInput.sourceType,
+    apiToken,
+    sourceMetadata: flowData.matchedInput.sourceMetadata,
+  } as AdapterConfig
+}
+
+/**
+ * Stage 2.25: Add the initial "eyes" status reaction to show the bot is
+ * processing (best-effort)
+ */
+async function addInitialStatusReaction(
+  parsed: ParsedDiscussion,
+  initialReactionConfig: AdapterConfig | undefined,
+): Promise<void> {
+  // Skip early reaction for sources where threadId isn't fully resolved yet
+  // (e.g. email-sourced Figma discussions only have fileKey, not fileKey:commentId)
+  // Stage 3 will add the reaction after thread building enriches the threadId
+  if (!initialReactionConfig || !parsed.sourceThreadId.includes(':')) {
+    return
+  }
+
+  try {
+    const { getAdapter } = await import('../adapters')
+    const adapter = getAdapter(parsed.sourceType)
+    await adapter.updateStatus(parsed.sourceThreadId, 'pending', initialReactionConfig)
+    logger.debug('Initial status reaction added')
+  } catch (error) {
+    // Don't fail if initial reaction fails
+    logger.warn('Failed to add initial status reaction', { error })
+  }
+}
+
+/**
+ * Determine the source workspace ID used for filtering user mappings
+ */
+function resolveSourceWorkspaceId(
+  parsed: ParsedDiscussion,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): string | undefined {
+  if (flowData) {
+    // Extract from flow input's sourceMetadata
+    return flowData.matchedInput.sourceMetadata?.slackTeamId ||
+      flowData.matchedInput.sourceMetadata?.figmaOrgId ||
+      flowData.matchedInput.sourceMetadata?.notionWorkspaceId ||
+      parsed.metadata?.notionWorkspaceId ||
+      parsed.teamId
+  }
+  if (config) {
+    // Extract from legacy config's sourceMetadata
+    return config.sourceMetadata?.slackTeamId ||
+      config.sourceMetadata?.figmaOrgId ||
+      config.sourceMetadata?.notionWorkspaceId ||
+      parsed.metadata?.notionWorkspaceId ||
+      parsed.teamId
+  }
+  return undefined
+}
+
+/**
+ * Stage 2.5: Load user mappings (once, used throughout the pipeline)
+ *
+ * Returns a sourceUserId -> mention data map filtered by source type,
+ * active status, and workspace; undefined when loading fails.
+ */
+async function loadUserMappings(
+  parsed: ParsedDiscussion,
+  actualTeamId: string,
+  sourceWorkspaceId: string | undefined,
+): Promise<Map<string, { name: string; notionId: string }> | undefined> {
+  try {
+    const { getAllTriageUsers } = await import(
+      '~~/layers/triage/collections/users/server/database/queries'
+    )
+    const allUserMappings = await getAllTriageUsers(actualTeamId)
+
+    const userIdToMentionMap = new Map<string, { name: string; notionId: string }>()
+
+    for (const mapping of allUserMappings) {
+      // Filter by sourceType, active status, and sourceWorkspaceId
+      // Allow mappings with empty sourceWorkspaceId to match any workspace (global mappings)
+      const matchesWorkspace = !sourceWorkspaceId || !mapping.sourceWorkspaceId || mapping.sourceWorkspaceId === sourceWorkspaceId
+      if (mapping.sourceType === parsed.sourceType && mapping.active && matchesWorkspace) {
+        const displayName = mapping.notionUserName || mapping.sourceUserName || mapping.sourceUserId
+        const mentionData = {
+          name: String(displayName),
+          notionId: String(mapping.notionUserId),
+        }
+        userIdToMentionMap.set(String(mapping.sourceUserId), mentionData)
+      }
+    }
+
+    logger.info(`Loaded ${userIdToMentionMap.size} user mappings for ${parsed.sourceType}`, {
+      sourceWorkspaceId,
+      filtered: !!sourceWorkspaceId,
+    })
+    return userIdToMentionMap
+  }
+  catch (error) {
+    logger.warn('Failed to load user mappings', { error })
+    // Continue without mappings - operations will fallback to IDs
+    return undefined
+  }
+}
+
+/**
+ * Create the job record tracking this processing run (best-effort)
+ *
+ * Returns the job ID, or undefined when creation fails.
+ */
+async function createJobRecord(
+  parsed: ParsedDiscussion,
+  actualTeamId: string,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): Promise<string | undefined> {
+  try {
+    const { createTriageJob } = await import(
+      '~~/layers/triage/collections/jobs/server/database/queries'
+    )
+
+    const job = await createTriageJob({
+      teamId: actualTeamId,
+      owner: SYSTEM_USER_ID,
+      createdBy: SYSTEM_USER_ID,
+      updatedBy: SYSTEM_USER_ID,
+      discussionId: '', // Will update after discussion is created
+      flowInputId: flowData ? flowData.matchedInput.id : (config?.id || ''),
+      status: 'processing',
+      stage: 'thread_building',
+      attempts: 0,
+      maxAttempts: 3,
+      error: undefined,
+      errorStack: undefined,
+      startedAt: new Date(),
+      completedAt: undefined,
+      processingTime: undefined,
+      taskIds: [],
+      metadata: {
+        sourceType: parsed.sourceType,
+        sourceThreadId: parsed.sourceThreadId,
+        emailSlug: parsed.teamId, // Store original email slug for reference
+        startTimestamp: Date.now(),
+        flowId: flowData?.flow.id, // Include flow ID if using flows
+        inputId: flowData?.matchedInput.id, // Include matched input ID
+      },
+    })
+
+    const jobId = job?.id
+    logger.debug('Job created', {
+      jobId,
+      teamId: config?.teamId,
+    })
+    return jobId
+  } catch (error) {
+    logger.error('Failed to create job record', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    })
+    // Don't fail processing if job creation fails
+    return undefined
+  }
+}
+
+/**
+ * Cross-link the job and discussion records after both exist (best-effort)
+ */
+async function linkDiscussionToJob(
+  discussionId: string,
+  jobId: string | undefined,
+  actualTeamId: string,
+): Promise<void> {
+  if (!jobId || !discussionId) {
+    return
+  }
+
+  try {
+    const { updateTriageJob } = await import(
+      '~~/layers/triage/collections/jobs/server/database/queries'
+    )
+
+    await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
+      discussionId,
+    })
+
+    // Link discussion to job
+    const { updateTriageDiscussion } = await import(
+      '~~/layers/triage/collections/discussions/server/database/queries'
+    )
+
+    await updateTriageDiscussion(
+      discussionId,
+      currentTeamId!,
+      SYSTEM_USER_ID,
+      {
+        syncJobId: jobId,
+      },
+    )
+
+    logger.debug('Linked discussion to job', {
+      discussionId,
+      jobId,
+    })
+  } catch (error) {
+    logger.error('Failed to link discussion to job', error)
+    // Don't fail processing if linking fails
+  }
+}
+
+/**
+ * Build the AdapterConfig used for thread building (flow input or legacy)
+ *
+ * For Figma inputs, uses the input's name as botHandle if not explicitly set.
+ * For Notion inputs, the token may be in sourceMetadata.notionToken instead
+ * of apiToken.
+ */
+function buildThreadConfig(
+  resolvedInputToken: string,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): AdapterConfig {
+  return flowData
+    ? {
+        id: flowData.matchedInput.id,
+        teamId: flowData.flow.teamId,
+        sourceType: flowData.matchedInput.sourceType,
+        apiToken: resolvedInputToken || flowData.matchedInput.sourceMetadata?.notionToken || '',
+        sourceMetadata: {
+          ...flowData.matchedInput.sourceMetadata,
+          // Use sourceMetadata botHandle for Figma (the bot account name)
+          botHandle: flowData.matchedInput.sourceMetadata?.botHandle || flowData.matchedInput.sourceType,
+        },
+      } as AdapterConfig
+    : config!
+}
+
+/**
+ * For Figma discussions, rewrite sourceUrl/sourceThreadId with the comment ID
+ * discovered during thread building, persist them, and add the "eyes" reaction
+ *
+ * Mutates `parsed` in place.
+ */
+async function enrichFigmaThreadReference(
+  parsed: ParsedDiscussion,
+  thread: DiscussionThread,
+  discussionId: string,
+  threadBuildConfig: AdapterConfig,
+): Promise<void> {
+  if (!(parsed.sourceType === 'figma' && thread.id && parsed.metadata?.fileKey)) {
+    return
+  }
+
+  const fileKey = parsed.metadata.fileKey
+  parsed.sourceUrl = `https://www.figma.com/file/${fileKey}#${thread.id}`
+  // Update sourceThreadId to include comment ID (format: fileKey:commentId)
+  parsed.sourceThreadId = `${fileKey}:${thread.id}`
+
+  logger.debug('Updated Figma URLs', {
+    sourceUrl: parsed.sourceUrl,
+    sourceThreadId: parsed.sourceThreadId,
+  })
+
+  // Update the discussion record with the correct URL and threadId using Crouton query
+  const { updateTriageDiscussion } = await import(
+    '~~/layers/triage/collections/discussions/server/database/queries'
+  )
+  await updateTriageDiscussion(
+    discussionId,
+    currentTeamId!,
+    SYSTEM_USER_ID,
+    {
+      sourceUrl: parsed.sourceUrl,
+      sourceThreadId: parsed.sourceThreadId,
+    },
+  )
+
+  // Now that we have the comment ID, add the "eyes" emoji reaction
+  try {
+    const { getAdapter } = await import('../adapters')
+    const adapter = getAdapter(parsed.sourceType)
+    await adapter.updateStatus(parsed.sourceThreadId, 'pending', threadBuildConfig)
+    logger.debug('Added eyes emoji to Figma comment', { commentId: thread.id })
+  } catch (error) {
+    logger.warn('Failed to add eyes emoji to Figma comment', { error })
+    // Don't fail the whole process for emoji failures
+  }
+}
+
+/**
+ * Stage 4: AI analysis (summary + task detection)
+ *
+ * Returns a mock analysis when skipAI is set (for testing).
+ */
+async function runAiAnalysis(
+  parsed: ParsedDiscussion,
+  thread: DiscussionThread,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+  skipAI?: boolean,
+): Promise<AIAnalysisResult> {
+  if (skipAI) {
+    // Mock AI analysis for testing
+    return {
+      summary: {
+        summary: 'Mock summary',
+        keyPoints: ['Mock point 1'],
+      },
+      taskDetection: {
+        isMultiTask: false,
+        tasks: [{
+          title: parsed.title,
+          description: parsed.content,
+        }],
+      },
+      processingTime: 0,
+      cached: false,
+    }
+  }
+
+  // Get AI settings from flow or config
+  const customSummaryPrompt = flowData?.flow.aiSummaryPrompt || (config as any)?.aiSummaryPrompt || undefined
+  const customTaskPrompt = flowData?.flow.aiTaskPrompt || (config as any)?.aiTaskPrompt || undefined
+  const availableDomains = flowData?.flow.availableDomains || undefined
+
+  logger.debug('Using AI settings', {
+    hasSummaryPrompt: !!customSummaryPrompt,
+    hasTaskPrompt: !!customTaskPrompt,
+    availableDomains,
+  })
+
+  const aiAnalysis = await analyzeDiscussion(thread, {
+    sourceType: parsed.sourceType,
+    customSummaryPrompt,
+    customTaskPrompt,
+    availableDomains, // Pass available domains for domain detection
+  })
+
+  logger.info('AI analysis complete', {
+    taskCount: aiAnalysis.taskDetection.tasks.length,
+    isMultiTask: aiAnalysis.taskDetection.isMultiTask,
+    cached: aiAnalysis.cached,
+  })
+
+  return aiAnalysis
+}
+
+/**
+ * Resolve the workspace identifier used to store bootstrap-discovered users
+ *
+ * Uses the same sourceWorkspaceId semantics as Stage 2.5:
+ * for Slack the slackTeamId from sourceMetadata, for Figma the emailSlug
+ * from the flow input or parsed metadata.
+ */
+function resolveBootstrapWorkspaceId(
+  parsed: ParsedDiscussion,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): string {
+  if (parsed.sourceType === 'slack') {
+    return flowData?.matchedInput?.sourceMetadata?.slackTeamId
+      || config?.sourceMetadata?.slackTeamId
+      || ''
+  }
+  if (parsed.sourceType === 'figma') {
+    // For Figma, use emailSlug from flow input or parsed metadata
+    return flowData?.matchedInput?.emailSlug
+      || parsed.metadata?.emailSlug
+      || ''
+  }
+  return ''
+}
+
+/**
+ * Persist users discovered in a bootstrap comment as pending user mappings
+ */
+async function storeBootstrapUsers(
+  parsed: ParsedDiscussion,
+  bootstrapResult: BootstrapCommentResult,
+  actualTeamId: string,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): Promise<void> {
+  const bootstrapSourceWorkspaceId = resolveBootstrapWorkspaceId(parsed, flowData, config)
+
+  if (bootstrapSourceWorkspaceId) {
+    const newMappingsCount = await storeDiscoveredUsers(
+      bootstrapResult.mentionedUsers,
+      actualTeamId,
+      parsed.sourceType,
+      bootstrapSourceWorkspaceId,
+    )
+    logger.info('Stored discovered users from bootstrap comment', {
+      newMappingsCount,
+      totalMentioned: bootstrapResult.mentionedUsers.length,
+      sourceWorkspaceId: bootstrapSourceWorkspaceId,
+    })
+  } else {
+    logger.warn('Cannot store discovered users - sourceWorkspaceId not found', {
+      sourceType: parsed.sourceType,
+      hasFlowData: !!flowData,
+      hasConfig: !!config,
+    })
+  }
+}
+
+/**
+ * Post the bootstrap reply back to the source thread (best-effort)
+ */
+async function sendBootstrapReply(
+  parsed: ParsedDiscussion,
+  bootstrapResult: BootstrapCommentResult,
+  replyConfig: AdapterConfig,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): Promise<void> {
+  try {
+    const { getAdapter } = await import('../adapters')
+    const adapter = getAdapter(parsed.sourceType)
+
+    // Remove the initial "eyes" reaction if present
+    if ('removeReaction' in adapter && typeof adapter.removeReaction === 'function') {
+      await adapter.removeReaction(parsed.sourceThreadId, 'eyes', replyConfig)
+    }
+
+    // Build bootstrap response message with personality
+    const userCount = bootstrapResult.mentionedUsers.length
+    const replyPersonality = flowData?.flow.replyPersonality || null
+    const encryptedBootstrapKey = flowData?.flow.anthropicApiKey
+    const anthropicApiKey = encryptedBootstrapKey
+      ? await decryptSecret(encryptedBootstrapKey)
+      : (config as any)?.anthropicApiKey
+    const personalityIcon = flowData?.flow.personalityIcon || undefined
+    const bootstrapMessage = await generateBootstrapMessage(userCount, replyPersonality, anthropicApiKey, personalityIcon)
+
+    await adapter.postReply(parsed.sourceThreadId, bootstrapMessage, replyConfig)
+    await adapter.updateStatus(parsed.sourceThreadId, 'completed', replyConfig)
+
+    logger.info('Bootstrap reply sent to source', {
+      userCount,
+      sourceType: parsed.sourceType,
+    })
+  } catch (error) {
+    logger.warn('Failed to send bootstrap reply to source', { error })
+    // Don't fail the process if reply fails
+  }
+}
+
+/**
+ * Mark the job completed for a bootstrap comment (best-effort)
+ */
+async function finalizeBootstrapJob(
+  jobId: string,
+  actualTeamId: string,
+  processingTime: number,
+  bootstrapResult: BootstrapCommentResult,
+): Promise<void> {
+  try {
+    const { updateTriageJob } = await import(
+      '~~/layers/triage/collections/jobs/server/database/queries'
+    )
+
+    await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
+      status: 'completed',
+      completedAt: new Date(),
+      processingTime,
+      metadata: {
+        isBootstrap: true,
+        bootstrapReason: bootstrapResult.reason,
+        mentionedUsers: bootstrapResult.mentionedUsers,
+      },
+    })
+  } catch (error) {
+    logger.warn('Failed to finalize bootstrap job', { error })
+  }
+}
+
+/**
+ * Handle a bootstrap/user-sync comment: store discovered users, reply to
+ * the source, finalize the job, and return the early processing result
+ * (bootstrap comments never create tasks)
+ */
+async function handleBootstrapComment(ctx: {
+  parsed: ParsedDiscussion
+  bootstrapResult: BootstrapCommentResult
+  discussionId: string
+  jobId: string | undefined
+  actualTeamId: string
+  flowData?: FlowWithRelations
+  config?: AdapterConfig
+  resolvedInputToken: string
+  aiAnalysis: AIAnalysisResult
+  startTime: number
+  correlationId?: string
+}): Promise<ProcessingResult> {
+  const { parsed, bootstrapResult, discussionId, jobId, actualTeamId, flowData, config, resolvedInputToken, aiAnalysis, startTime, correlationId } = ctx
+
+  logger.info('Bootstrap comment detected - skipping Notion task creation', {
+    reason: bootstrapResult.reason,
+    mentionedUserCount: bootstrapResult.mentionedUsers.length,
+    mentionedUsers: bootstrapResult.mentionedUsers.map((u) => u.displayName),
+    sourceType: parsed.sourceType,
+    discussionId,
+  })
+
+  // Store discovered users as pending mappings
+  if (bootstrapResult.mentionedUsers.length > 0) {
+    await storeBootstrapUsers(parsed, bootstrapResult, actualTeamId, flowData, config)
+  }
+
+  // Update discussion status to indicate bootstrap processing
+  await updateDiscussionStatus(discussionId, 'completed')
+
+  // Build config for posting reply (from flow or legacy config)
+  const replyConfig = flowData
+    ? buildFlowAdapterConfig(flowData, resolvedInputToken)
+    : config!
+
+  // Post reply to source with discovered users info
+  await sendBootstrapReply(parsed, bootstrapResult, replyConfig, flowData, config)
+
+  // Finalize job for bootstrap
+  if (jobId) {
+    await finalizeBootstrapJob(jobId, actualTeamId, Date.now() - startTime, bootstrapResult)
+  }
+
+  // Return early - no task creation for bootstrap comments
+  return {
+    discussionId,
+    aiAnalysis,
+    notionTasks: [], // No tasks created for bootstrap
+    processingTime: Date.now() - startTime,
+    isMultiTask: false,
+    correlationId,
+  }
+}
+
+/**
+ * Build source metadata for linking author names and @mentions to the
+ * source platform in created Notion tasks
+ */
+function buildSourceMetadata(
+  parsed: ParsedDiscussion,
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): SourceMetadata | undefined {
+  const sourceType = parsed.sourceType as 'figma' | 'slack' | 'notion'
+
+  if (sourceType === 'figma') {
+    const fileKey = parsed.metadata?.fileKey
+    if (fileKey) {
+      return { sourceType, fileKey }
+    }
+  } else if (sourceType === 'slack') {
+    const channelId = flowData?.matchedInput?.sourceMetadata?.channelId
+      || config?.sourceMetadata?.channelId
+      || parsed.metadata?.channelId
+    const slackTeamId = flowData?.matchedInput?.sourceMetadata?.slackTeamId
+      || config?.sourceMetadata?.slackTeamId
+      || parsed.teamId
+    if (channelId && slackTeamId) {
+      return { sourceType, channelId, slackTeamId }
+    }
+  } else if (sourceType === 'notion') {
+    // For Notion, extract parentId (page ID) from metadata
+    const pageId = parsed.metadata?.parentId
+    if (pageId) {
+      return { sourceType, pageId }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Create a single task in one Notion flow output (best-effort)
+ *
+ * Returns the created task, or undefined when creation fails so the caller
+ * can continue with other outputs.
+ */
+async function createTaskInNotionOutput(
+  task: AIAnalysisResult['taskDetection']['tasks'][number],
+  output: FlowOutput,
+  thread: DiscussionThread,
+  aiAnalysis: AIAnalysisResult,
+  parsed: ParsedDiscussion,
+  actualTeamId: string,
+  notionUserMappings: Map<string, string>,
+  sourceMetadata: SourceMetadata | undefined,
+): Promise<NotionTaskResult | undefined> {
+  try {
+    // Extract Notion config from output
+    const { config: notionConfig, fieldMapping } = await createNotionConfigFromOutput(
+      output,
+      parsed.sourceType,
+      parsed.sourceUrl,
+      actualTeamId,
+    )
+
+    logger.info('Creating task in output', {
+      outputId: output.id,
+      outputType: output.outputType,
+      taskTitle: task.title,
+    })
+
+    const result = await createNotionTask(
+      task,
+      thread,
+      aiAnalysis.summary,
+      notionConfig,
+      notionUserMappings,
+      fieldMapping,
+      notionUserMappings,
+      sourceMetadata,
+    )
+
+    logger.info('Task created successfully in output', {
+      outputId: output.id,
+      outputType: output.outputType,
+      notionTaskId: result.id,
+    })
+
+    return result
+  }
+  catch (error) {
+    logger.error('Failed to create task in output', error, {
+      outputId: output.id,
+      outputType: output.outputType,
+      taskTitle: task.title,
+    })
+    // Continue with other outputs even if one fails
+    return undefined
+  }
+}
+
+/**
+ * Flows architecture: route each detected task to matching outputs by
+ * domain and create it in every matched Notion output
+ */
+async function createTasksViaFlows(
+  tasks: AIAnalysisResult['taskDetection']['tasks'],
+  flowData: FlowWithRelations,
+  thread: DiscussionThread,
+  aiAnalysis: AIAnalysisResult,
+  parsed: ParsedDiscussion,
+  actualTeamId: string,
+  notionUserMappings: Map<string, string>,
+  sourceMetadata: SourceMetadata | undefined,
+): Promise<NotionTaskResult[]> {
+  logger.info('Processing with flows architecture', {
+    flowId: flowData.flow.id,
+    taskCount: tasks.length,
+    outputCount: flowData.outputs.length,
+  })
+
+  const notionTasks: NotionTaskResult[] = []
+
+  // Process each task
+  for (let taskIndex = 0; taskIndex < tasks.length; taskIndex++) {
+    const task = tasks[taskIndex]
+    if (!task) {
+      logger.warn('Task is undefined, skipping', { taskIndex })
+      continue
+    }
+
+    // Route task to matching outputs based on domain
+    const matchedOutputs = routeTaskToOutputs(task, flowData.outputs)
+
+    logger.info('Task routed to outputs', {
+      taskIndex,
+      taskDomain: task.domain,
+      matchedOutputCount: matchedOutputs.length,
+      outputTypes: matchedOutputs.map(o => o.outputType),
+    })
+
+    // Create task in all matched outputs
+    for (const output of matchedOutputs) {
+      if (output.outputType !== 'notion') {
+        logger.warn('Non-Notion output types not yet supported', {
+          outputType: output.outputType,
+          outputId: output.id,
+        })
+        continue
+      }
+
+      const result = await createTaskInNotionOutput(
+        task,
+        output,
+        thread,
+        aiAnalysis,
+        parsed,
+        actualTeamId,
+        notionUserMappings,
+        sourceMetadata,
+      )
+      if (result) {
+        notionTasks.push(result)
+      }
+    }
+  }
+
+  logger.info('All tasks processed with flows', {
+    totalTasksCreated: notionTasks.length,
+    taskIds: notionTasks.map(t => t.id),
+  })
+
+  return notionTasks
+}
+
+/**
+ * Legacy config: create task(s) in the single configured Notion database
+ * (backward compatibility)
+ */
+async function createTasksViaLegacyConfig(
+  tasks: AIAnalysisResult['taskDetection']['tasks'],
+  config: AdapterConfig,
+  thread: DiscussionThread,
+  aiAnalysis: AIAnalysisResult,
+  parsed: ParsedDiscussion,
+  notionUserMappings: Map<string, string>,
+  sourceMetadata: SourceMetadata | undefined,
+): Promise<NotionTaskResult[]> {
+  const notionConfig: NotionTaskConfig = {
+    databaseId: (config as any).notionDatabaseId,
+    apiKey: (config as any).notionToken,
+    sourceType: parsed.sourceType,
+    sourceUrl: parsed.sourceUrl,
+  }
+
+  const fieldMapping = (config as any).notionFieldMapping || {}
+
+  let notionTasks: NotionTaskResult[] = []
+
+  if (tasks.length === 1) {
+    // Single task
+    const task = tasks[0]
+    if (!task) {
+      logger.warn('Task is undefined, skipping')
+    }
+    else {
+      logger.info('Creating single Notion task (legacy config)')
+
+      const result = await createNotionTask(
+        task,
+        thread,
+        aiAnalysis.summary,
+        notionConfig,
+        notionUserMappings,
+        fieldMapping,
+        notionUserMappings,
+        sourceMetadata,
+      )
+
+      notionTasks.push(result)
+    }
+  }
+  else {
+    // Multiple tasks
+    logger.info('Creating multiple Notion tasks (legacy config)', { count: tasks.length })
+
+    notionTasks = await createNotionTasks(
+      tasks,
+      thread,
+      aiAnalysis.summary,
+      notionConfig,
+      notionUserMappings,
+      fieldMapping,
+      notionUserMappings,
+      sourceMetadata,
+    )
+  }
+
+  logger.info('Notion tasks created (legacy)', {
+    count: notionTasks.length,
+    ids: notionTasks.map(t => t.id),
+  })
+
+  return notionTasks
+}
+
+/**
+ * Stage 5: Task creation
+ *
+ * Converts user mappings for the Notion API, builds source metadata,
+ * creates tasks via the flows architecture or legacy config, and saves
+ * the resulting task records to the database.
+ */
+async function runTaskCreationStage(ctx: {
+  parsed: ParsedDiscussion
+  thread: DiscussionThread
+  aiAnalysis: AIAnalysisResult
+  actualTeamId: string
+  discussionId: string
+  jobId: string | undefined
+  flowData?: FlowWithRelations
+  config?: AdapterConfig
+  userMappings?: Map<string, { name: string; notionId: string }>
+}): Promise<NotionTaskResult[]> {
+  const { parsed, thread, aiAnalysis, actualTeamId, discussionId, jobId, flowData, config, userMappings } = ctx
+
+  // Use user mappings from Stage 2.5 (already loaded once)
+  // Convert to simple userId -> notionId map for Notion API
+  const notionUserMappings = new Map<string, string>()
+  if (userMappings) {
+    for (const [userId, data] of userMappings.entries()) {
+      notionUserMappings.set(userId, data.notionId)
+    }
+  }
+
+  logger.debug('User mappings available for Notion tasks', {
+    active: notionUserMappings.size,
+    sourceType: parsed.sourceType
+  })
+
+  const tasks = aiAnalysis.taskDetection.tasks
+
+  const sourceMetadata = buildSourceMetadata(parsed, flowData, config)
+
+  logger.debug('Source metadata for platform linking', {
+    sourceMetadata,
+    hasMetadata: !!sourceMetadata,
+  })
+
+  let notionTasks: NotionTaskResult[] = []
+
+  if (tasks.length === 0) {
+    logger.info('No tasks detected, skipping Notion creation')
+  }
+  else if (flowData) {
+    notionTasks = await createTasksViaFlows(tasks, flowData, thread, aiAnalysis, parsed, actualTeamId, notionUserMappings, sourceMetadata)
+  }
+  else if (config) {
+    notionTasks = await createTasksViaLegacyConfig(tasks, config, thread, aiAnalysis, parsed, notionUserMappings, sourceMetadata)
+  }
+
+  // Save task records to database
+  if (notionTasks.length > 0 && discussionId && jobId) {
+    await saveTaskRecords(
+      notionTasks,
+      aiAnalysis.taskDetection.tasks,
+      discussionId,
+      jobId,
+      parsed,
+    )
+  }
+
+  return notionTasks
+}
+
+/**
+ * Stage 6: Send the completion notification back to the source thread
+ * (best-effort)
+ *
+ * Uses threadBuildConfig which works with both flows and legacy configs.
+ */
+async function sendCompletionNotification(
+  parsed: ParsedDiscussion,
+  threadBuildConfig: AdapterConfig,
+  notionTasks: NotionTaskResult[],
+  flowData?: FlowWithRelations,
+  config?: AdapterConfig,
+): Promise<void> {
+  try {
+    const { getAdapter } = await import('../adapters')
+    const adapter = getAdapter(parsed.sourceType)
+
+    // Remove the initial "eyes" reaction
+    if ('removeReaction' in adapter && typeof adapter.removeReaction === 'function') {
+      await adapter.removeReaction(parsed.sourceThreadId, 'eyes', threadBuildConfig)
+    }
+
+    // Build confirmation message with personality
+    const replyPersonality = flowData?.flow.replyPersonality || null
+    const encryptedConfirmKey = flowData?.flow.anthropicApiKey
+    const anthropicApiKey = encryptedConfirmKey
+      ? await decryptSecret(encryptedConfirmKey)
+      : (config as any)?.anthropicApiKey
+    const personalityIcon = flowData?.flow.personalityIcon || undefined
+    const confirmationMessage = await generateReplyMessage(notionTasks, replyPersonality, anthropicApiKey, personalityIcon, parsed.sourceType)
+
+    // Post reply to the thread
+    await adapter.postReply(parsed.sourceThreadId, confirmationMessage, threadBuildConfig)
+
+    // Update status with completed emoji/reaction
+    await adapter.updateStatus(parsed.sourceThreadId, 'completed', threadBuildConfig)
+
+    logger.info('Notification sent to source', {
+      sourceType: parsed.sourceType,
+      taskCount: notionTasks.length,
+    })
+  } catch (error) {
+    // Don't fail the entire process if notification fails
+    logger.error('Failed to send notification to source', error)
+  }
+}
+
+/**
+ * Mark the job completed after successful processing (best-effort)
+ */
+async function finalizeJobSuccess(
+  jobId: string | undefined,
+  actualTeamId: string,
+  processingTime: number,
+  notionTasks: NotionTaskResult[],
+): Promise<void> {
+  if (!jobId) {
+    return
+  }
+
+  try {
+    const { updateTriageJob } = await import(
+      '~~/layers/triage/collections/jobs/server/database/queries'
+    )
+
+    await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
+      status: 'completed',
+      completedAt: new Date(),
+      processingTime,
+      taskIds: notionTasks.map(t => t.id),
+    })
+
+    logger.debug('Job finalized', {
+      jobId,
+      processingTime,
+    })
+  } catch (error) {
+    logger.error('Failed to finalize job', error)
+    // Don't fail processing if job finalization fails
+  }
+}
+
+/**
+ * Handle a processing failure: mark discussion + job as failed, emit
+ * failure telemetry, and rethrow as a ProcessingError
+ */
+async function handleProcessingFailure(
+  error: unknown,
+  ctx: {
+    parsed: ParsedDiscussion
+    discussionId: string | undefined
+    jobId: string | undefined
+    actualTeamId: string
+    startTime: number
+    correlationId?: string
+  },
+): Promise<never> {
+  const { parsed, discussionId, jobId, actualTeamId, startTime, correlationId } = ctx
+
+  logger.error('Processing failed', error)
+
+  // Update discussion status to failed
+  if (discussionId) {
+    await updateDiscussionStatus(
+      discussionId,
+      'failed',
+      error instanceof Error ? error.message : 'Unknown error',
+    )
+  }
+
+  // Finalize job (failure)
+  if (jobId) {
+    try {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      const errorStack = error instanceof Error ? error.stack : undefined
+      const processingTime = Date.now() - startTime
+
+      const { updateTriageJob } = await import(
+        '~~/layers/triage/collections/jobs/server/database/queries'
+      )
+
+      await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
+        status: 'failed',
+        completedAt: new Date(),
+        processingTime,
+        error: errorMessage,
+        errorStack: errorStack || undefined,
+      })
+
+      logger.warn('Job marked as failed', {
+        jobId,
+        error: errorMessage,
+      })
+    } catch (updateError) {
+      logger.error('Failed to update job with error', { updateError })
+      // Don't fail processing if job update fails
+    }
+  }
+
+  // Emit failure telemetry
+  emitTriageHook('triage:discussion:processed', actualTeamId, correlationId, {
+    totalDuration: Date.now() - startTime,
+    success: false,
+    sourceType: parsed.sourceType,
+    errorStage: error instanceof ProcessingError ? error.stage : 'unknown',
+  })
+
+  // Wrap error if not already a ProcessingError
+  if (error instanceof ProcessingError) {
+    throw error
+  }
+
+  throw new ProcessingError(
+    error instanceof Error ? error.message : 'Unknown error',
+    'unknown',
+    { originalError: error },
+    true, // Assume retryable by default
+  )
+}
+
+/**
+ * Stage 3: Thread building
+ *
+ * Updates discussion/job status, builds the thread via the adapter (or uses
+ * the provided test thread), emits stage telemetry, refreshes discussion
+ * metadata from the built thread, and enriches Figma thread references.
+ */
+async function runThreadBuildingStage(ctx: {
+  parsed: ParsedDiscussion
+  threadInput?: DiscussionThread
+  threadBuildConfig: AdapterConfig
+  discussionId: string
+  jobId: string | undefined
+  actualTeamId: string
+  userMappings?: Map<string, { name: string; notionId: string }>
+  correlationId?: string
+}): Promise<DiscussionThread> {
+  const { parsed, threadInput, threadBuildConfig, discussionId, jobId, actualTeamId, userMappings, correlationId } = ctx
+
+  await updateDiscussionStatus(discussionId, 'processing')
+  await updateJobStatus(jobId, actualTeamId, {
+    stage: 'thread_building',
+  })
+
+  const stageThreadStart = Date.now()
+  const thread = await buildThread(parsed, threadBuildConfig, threadInput, actualTeamId, userMappings)
+  logger.info('Thread built', {
+    id: thread.id,
+    messages: thread.replies.length + 1,
+    participants: thread.participants.length,
+  })
+  emitTriageHook('triage:stage:completed', actualTeamId, correlationId, {
+    stage: 'thread-building',
+    duration: Date.now() - stageThreadStart,
+    success: true,
+  })
+
+  // Update discussion metadata with correct values from thread
+  // This fixes the issue where initial save had placeholder email addresses
+  logger.info('Stage 3.5: Updating discussion metadata...')
+  await updateDiscussionMetadata(discussionId, thread)
+  logger.info('Discussion metadata updated successfully')
+
+  // Update sourceUrl and sourceThreadId with comment ID for Figma
+  await enrichFigmaThreadReference(parsed, thread, discussionId, threadBuildConfig)
+
   return thread
+}
+
+/**
+ * Stage 4: AI analysis, with the job stage update and stage telemetry
+ */
+async function runAiAnalysisStage(
+  parsed: ParsedDiscussion,
+  thread: DiscussionThread,
+  flowData: FlowWithRelations | undefined,
+  config: AdapterConfig | undefined,
+  skipAI: boolean | undefined,
+  jobId: string | undefined,
+  actualTeamId: string,
+  correlationId: string | undefined,
+): Promise<AIAnalysisResult> {
+  logger.info('Stage 4: Starting AI Analysis...')
+  await updateJobStatus(jobId, actualTeamId, {
+    stage: 'ai_analysis',
+  })
+
+  const stageAiStart = Date.now()
+  const aiAnalysis = await runAiAnalysis(parsed, thread, flowData, config, skipAI)
+
+  emitTriageHook('triage:stage:completed', actualTeamId, correlationId, {
+    stage: 'ai-analysis',
+    duration: Date.now() - stageAiStart,
+    success: true,
+    taskCount: aiAnalysis.taskDetection.tasks.length,
+    isMultiTask: aiAnalysis.taskDetection.isMultiTask,
+    cached: aiAnalysis.cached,
+  })
+
+  return aiAnalysis
+}
+
+/**
+ * Stages 5.5 + 6: emit task-creation telemetry, persist results, mark the
+ * discussion completed, notify the source, finalize the job, and build the
+ * successful processing result
+ */
+async function finalizeSuccessfulProcessing(ctx: {
+  parsed: ParsedDiscussion
+  thread: DiscussionThread
+  threadBuildConfig: AdapterConfig
+  aiAnalysis: AIAnalysisResult
+  notionTasks: NotionTaskResult[]
+  discussionId: string
+  jobId: string | undefined
+  actualTeamId: string
+  flowData?: FlowWithRelations
+  config?: AdapterConfig
+  startTime: number
+  correlationId?: string
+}): Promise<ProcessingResult> {
+  const { parsed, thread, threadBuildConfig, aiAnalysis, notionTasks, discussionId, jobId, actualTeamId, flowData, config, startTime, correlationId } = ctx
+
+  // Emit task creation telemetry
+  if (notionTasks.length > 0) {
+    emitTriageHook('triage:stage:completed', actualTeamId, correlationId, {
+      stage: 'notion-creation',
+      success: true,
+      taskCount: notionTasks.length,
+    })
+  }
+
+  await updateJobStatus(jobId, actualTeamId, {
+    stage: 'notification',
+  })
+
+  // Update discussion with results
+  await updateDiscussionResults(
+    discussionId,
+    thread,
+    aiAnalysis,
+    notionTasks,
+  )
+
+  // Mark as completed
+  await updateDiscussionStatus(discussionId, 'completed')
+
+  // Send notification back to source
+  await sendCompletionNotification(parsed, threadBuildConfig, notionTasks, flowData, config)
+
+  const processingTime = Date.now() - startTime
+
+  await finalizeJobSuccess(jobId, actualTeamId, processingTime, notionTasks)
+
+  logger.info('Processing complete', {
+    discussionId,
+    processingTime,
+    taskCount: notionTasks.length,
+  })
+
+  emitTriageHook('triage:discussion:processed', actualTeamId, correlationId, {
+    totalDuration: processingTime,
+    success: true,
+    taskCount: notionTasks.length,
+    isMultiTask: aiAnalysis.taskDetection.isMultiTask,
+    sourceType: parsed.sourceType,
+  })
+
+  return {
+    discussionId,
+    aiAnalysis,
+    notionTasks,
+    processingTime,
+    isMultiTask: aiAnalysis.taskDetection.isMultiTask,
+    correlationId,
+  }
 }
 
 /**
@@ -1104,1021 +2535,92 @@ export async function processDiscussion(
   // Note: Job creation moved to after config loading to get correct teamId
 
   try {
-    // ============================================================================
     // STAGE 1: Validation
-    // ============================================================================
-
     validateParsedDiscussion(parsed)
 
-    // ============================================================================
-    // STAGE 1.5: Deduplication Check
-    // ============================================================================
-    // Check if we're already processing this sourceThreadId to prevent duplicates
-    // from Slack retries
-    //
-    // EXCEPTIONS:
-    // - Bootstrap/User Sync comments: Always allow (they don't create tasks)
-    // - Failed discussions: Allow retry
-    const db = useDB()
-    const { triageDiscussions } = await import(
-      '~~/layers/triage/collections/discussions/server/database/schema'
-    )
-
-    // Check if this looks like a bootstrap comment (before we have the full thread)
-    const contentLower = parsed.content.toLowerCase()
-    const isLikelyBootstrap = contentLower.includes('user sync') || contentLower.includes('bootstrap')
-
-    const [existingDiscussion] = await db
-      .select({ id: triageDiscussions.id, status: triageDiscussions.status })
-      .from(triageDiscussions)
-      .where(eq(triageDiscussions.sourceThreadId, parsed.sourceThreadId))
-      .limit(1)
-
-    if (existingDiscussion) {
-      // Allow retry for failed discussions or bootstrap comments
-      const shouldAllowRetry = existingDiscussion.status === 'failed' || isLikelyBootstrap
-
-      if (!shouldAllowRetry) {
-        logger.info('Discussion already exists for this thread, skipping duplicate', {
-          sourceThreadId: parsed.sourceThreadId,
-          existingDiscussionId: existingDiscussion.id,
-          existingStatus: existingDiscussion.status,
-        })
-        // Return a mock result to indicate this was already processed
-        return {
-          discussionId: existingDiscussion.id,
-          aiAnalysis: {
-            summary: { summary: 'Already processed', keyPoints: [] },
-            taskDetection: { isMultiTask: false, tasks: [] },
-            processingTime: 0,
-            cached: true,
-          },
-          notionTasks: [],
-          processingTime: 0,
-          isMultiTask: false,
-          correlationId,
-        }
-      }
-
-      // Delete the existing failed/bootstrap discussion to allow fresh processing
-      logger.info('Allowing retry for discussion', {
-        sourceThreadId: parsed.sourceThreadId,
-        existingDiscussionId: existingDiscussion.id,
-        existingStatus: existingDiscussion.status,
-        reason: isLikelyBootstrap ? 'bootstrap_comment' : 'failed_status',
-      })
-
-      // Delete the old record to allow fresh processing
-      await db
-        .delete(triageDiscussions)
-        .where(eq(triageDiscussions.id, existingDiscussion.id))
+    // STAGE 1.5: Deduplication check (failed discussions and bootstrap
+    // comments are allowed to retry; anything else short-circuits)
+    const duplicateResult = await checkDuplicateDiscussion(parsed, correlationId)
+    if (duplicateResult) {
+      return duplicateResult
     }
 
-    // ============================================================================
-    // STAGE 2: Flow/Config Loading
-    // ============================================================================
-    let config: AdapterConfig | undefined
-    let flowData: FlowWithRelations | undefined
+    // STAGE 2: Flow/Config loading
+    const { config, flowData, actualTeamId: resolvedTeamId } = await resolveFlowConfig(parsed, options.config)
+    actualTeamId = resolvedTeamId
 
-    if (options.config) {
-      // Use provided config (for testing)
-      config = options.config
-      logger.debug('Using provided config')
-    }
-    else {
-      // Load flow (v2 architecture — sole config loading mechanism)
-      flowData = await loadFlow(parsed.teamId, parsed.sourceType, parsed.metadata)
-      actualTeamId = flowData.flow.teamId
-      logger.info('Loaded flow for processing', {
-        flowId: flowData.flow.id,
-        flowName: flowData.flow.name,
-        inputCount: flowData.inputs.length,
-        outputCount: flowData.outputs.length,
-      })
-    }
+    // Resolve input token (once, used for all adapter calls)
+    const resolvedInputToken = await resolveProcessingToken(flowData, config)
 
-    // Update actualTeamId
-    if (config && !flowData) {
-      actualTeamId = config.teamId
-      logger.debug('Resolved team IDs from config', {
-        sourceIdentifier: parsed.teamId,
-        actualTeamId: config.teamId,
-      })
-    }
-    else if (flowData) {
-      actualTeamId = flowData.flow.teamId
-      logger.debug('Resolved team IDs from flow', {
-        sourceIdentifier: parsed.teamId,
-        actualTeamId: flowData.flow.teamId,
-      })
-    }
-
-    // ============================================================================
-    // RESOLVE INPUT TOKEN (once, used for all adapter calls)
-    // ============================================================================
-    let resolvedInputToken = ''
-    if (flowData) {
-      try {
-        const { resolveInputToken } = await import('../utils/tokenResolver')
-        resolvedInputToken = await resolveInputToken(flowData.matchedInput, flowData.flow.teamId)
-      } catch (error) {
-        logger.warn('Failed to resolve input token from account, falling back to inline', { error })
-        resolvedInputToken = flowData.matchedInput.apiToken || ''
-      }
-    } else if (config) {
-      resolvedInputToken = config.apiToken || ''
-    }
-
-    // ============================================================================
-    // STAGE 2.25: Add Initial Status Reaction (after config is loaded)
-    // ============================================================================
-    // Now that we have the config/flow, add the "eyes" reaction to show bot is processing
+    // STAGE 2.25: Add the "eyes" reaction to show the bot is processing
     const initialReactionConfig = flowData
-      ? {
-          id: flowData.matchedInput.id,
-          teamId: flowData.flow.teamId,
-          sourceType: flowData.matchedInput.sourceType,
-          apiToken: resolvedInputToken,
-          sourceMetadata: flowData.matchedInput.sourceMetadata,
-        } as AdapterConfig
+      ? buildFlowAdapterConfig(flowData, resolvedInputToken)
       : config
+    await addInitialStatusReaction(parsed, initialReactionConfig)
 
-    // Skip early reaction for sources where threadId isn't fully resolved yet
-    // (e.g. email-sourced Figma discussions only have fileKey, not fileKey:commentId)
-    // Stage 3 will add the reaction after thread building enriches the threadId
-    if (initialReactionConfig && parsed.sourceThreadId.includes(':')) {
-      try {
-        const { getAdapter } = await import('../adapters')
-        const adapter = getAdapter(parsed.sourceType)
-        await adapter.updateStatus(parsed.sourceThreadId, 'pending', initialReactionConfig)
-        logger.debug('Initial status reaction added')
-      } catch (error) {
-        // Don't fail if initial reaction fails
-        logger.warn('Failed to add initial status reaction', { error })
-      }
-    }
-
-    // ============================================================================
-    // STAGE 2.5: Load User Mappings (Once, used throughout pipeline)
-    // ============================================================================
+    // STAGE 2.5: Load user mappings (once, used throughout the pipeline)
     logger.info('Stage 2.5: Loading User Mappings')
-    let userMappings: Map<string, { name: string; notionId: string }> | undefined
+    const sourceWorkspaceId = resolveSourceWorkspaceId(parsed, flowData, config)
+    const userMappings = await loadUserMappings(parsed, actualTeamId, sourceWorkspaceId)
 
-    // Determine source workspace ID for filtering user mappings
-    let sourceWorkspaceId: string | undefined
-    if (flowData) {
-      // Extract from flow input's sourceMetadata
-      sourceWorkspaceId = flowData.matchedInput.sourceMetadata?.slackTeamId ||
-                          flowData.matchedInput.sourceMetadata?.figmaOrgId ||
-                          flowData.matchedInput.sourceMetadata?.notionWorkspaceId ||
-                          parsed.metadata?.notionWorkspaceId ||
-                          parsed.teamId
-    } else if (config) {
-      // Extract from legacy config's sourceMetadata
-      sourceWorkspaceId = config.sourceMetadata?.slackTeamId ||
-                          config.sourceMetadata?.figmaOrgId ||
-                          config.sourceMetadata?.notionWorkspaceId ||
-                          parsed.metadata?.notionWorkspaceId ||
-                          parsed.teamId
-    }
-
-    try {
-      const { getAllTriageUsers } = await import(
-        '~~/layers/triage/collections/users/server/database/queries'
-      )
-      const allUserMappings = await getAllTriageUsers(actualTeamId)
-
-      const userIdToMentionMap = new Map<string, { name: string; notionId: string }>()
-
-      for (const mapping of allUserMappings) {
-        // Filter by sourceType, active status, and sourceWorkspaceId
-        // Allow mappings with empty sourceWorkspaceId to match any workspace (global mappings)
-        const matchesWorkspace = !sourceWorkspaceId || !mapping.sourceWorkspaceId || mapping.sourceWorkspaceId === sourceWorkspaceId
-        if (mapping.sourceType === parsed.sourceType && mapping.active && matchesWorkspace) {
-          const displayName = mapping.notionUserName || mapping.sourceUserName || mapping.sourceUserId
-          const mentionData = {
-            name: String(displayName),
-            notionId: String(mapping.notionUserId),
-          }
-          userIdToMentionMap.set(String(mapping.sourceUserId), mentionData)
-        }
-      }
-
-      userMappings = userIdToMentionMap
-      logger.info(`Loaded ${userMappings.size} user mappings for ${parsed.sourceType}`, {
-        sourceWorkspaceId,
-        filtered: !!sourceWorkspaceId,
-      })
-    }
-    catch (error) {
-      logger.warn('Failed to load user mappings', { error })
-      // Continue without mappings - operations will fallback to IDs
-    }
-
-    // ============================================================================
-    // CREATE JOB RECORD (After config loaded to get correct teamId)
-    // ============================================================================
-    try {
-      const { createTriageJob } = await import(
-        '~~/layers/triage/collections/jobs/server/database/queries'
-      )
-
-      const job = await createTriageJob({
-        teamId: actualTeamId,
-        owner: SYSTEM_USER_ID,
-        createdBy: SYSTEM_USER_ID,
-        updatedBy: SYSTEM_USER_ID,
-        discussionId: '', // Will update after discussion is created
-        flowInputId: flowData ? flowData.matchedInput.id : (config?.id || ''),
-        status: 'processing',
-        stage: 'thread_building',
-        attempts: 0,
-        maxAttempts: 3,
-        error: undefined,
-        errorStack: undefined,
-        startedAt: new Date(),
-        completedAt: undefined,
-        processingTime: undefined,
-        taskIds: [],
-        metadata: {
-          sourceType: parsed.sourceType,
-          sourceThreadId: parsed.sourceThreadId,
-          emailSlug: parsed.teamId, // Store original email slug for reference
-          startTimestamp: Date.now(),
-          flowId: flowData?.flow.id, // Include flow ID if using flows
-          inputId: flowData?.matchedInput.id, // Include matched input ID
-        },
-      })
-
-      jobId = job?.id
-      logger.debug('Job created', {
-        jobId,
-        teamId: config?.teamId,
-      })
-    } catch (error) {
-      logger.error('Failed to create job record', {
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      })
-      // Don't fail processing if job creation fails
-    }
-
-    // Save discussion record with actual team ID
+    // Create job record (after config loaded to get correct teamId),
+    // save the discussion record with the actual team ID, and link them
+    jobId = await createJobRecord(parsed, actualTeamId, flowData, config)
     const inputId = flowData ? flowData.matchedInput.id : (config?.id || '')
     discussionId = await saveDiscussion(parsed, inputId, actualTeamId, 'processing')
+    await linkDiscussionToJob(discussionId, jobId, actualTeamId)
 
-    // Update job with discussion ID
-    if (jobId && discussionId) {
-      try {
-        const { updateTriageJob } = await import(
-          '~~/layers/triage/collections/jobs/server/database/queries'
-        )
-
-        await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
-          discussionId,
-        })
-
-        // Link discussion to job
-        const { updateTriageDiscussion } = await import(
-          '~~/layers/triage/collections/discussions/server/database/queries'
-        )
-
-        await updateTriageDiscussion(
-          discussionId,
-          currentTeamId!,
-          SYSTEM_USER_ID,
-          {
-            syncJobId: jobId,
-          },
-        )
-
-        logger.debug('Linked discussion to job', {
-          discussionId,
-          jobId,
-        })
-      } catch (error) {
-        logger.error('Failed to link discussion to job', error)
-        // Don't fail processing if linking fails
-      }
-    }
-
-    // ============================================================================
-    // STAGE 3: Thread Building
-    // ============================================================================
-    await updateDiscussionStatus(discussionId, 'processing')
-    await updateJobStatus(jobId, actualTeamId, {
-      stage: 'thread_building',
+    // STAGE 3: Thread building (with either flow input config or legacy config)
+    const threadBuildConfig = buildThreadConfig(resolvedInputToken, flowData, config)
+    const thread = await runThreadBuildingStage({
+      parsed, threadInput: options.thread, threadBuildConfig,
+      discussionId, jobId, actualTeamId, userMappings, correlationId,
     })
 
-    // Build thread with either flow input config or legacy config
-    // For Figma inputs, use the input's name as botHandle if not explicitly set
-    // For Notion inputs, token may be in sourceMetadata.notionToken instead of apiToken
-    const threadBuildConfig = flowData
-      ? {
-          id: flowData.matchedInput.id,
-          teamId: flowData.flow.teamId,
-          sourceType: flowData.matchedInput.sourceType,
-          apiToken: resolvedInputToken || flowData.matchedInput.sourceMetadata?.notionToken || '',
-          sourceMetadata: {
-            ...flowData.matchedInput.sourceMetadata,
-            // Use sourceMetadata botHandle for Figma (the bot account name)
-            botHandle: flowData.matchedInput.sourceMetadata?.botHandle || flowData.matchedInput.sourceType,
-          },
-        } as AdapterConfig
-      : config!
+    // STAGE 4: AI analysis
+    const aiAnalysis = await runAiAnalysisStage(parsed, thread, flowData, config, options.skipAI, jobId, actualTeamId, correlationId)
 
-    const stageThreadStart = Date.now()
-    const thread = await buildThread(parsed, threadBuildConfig, options.thread, actualTeamId, userMappings)
-    logger.info('Thread built', {
-      id: thread.id,
-      messages: thread.replies.length + 1,
-      participants: thread.participants.length,
-    })
-    useNitroApp().hooks.callHook('crouton:operation', {
-      type: 'triage:stage:completed',
-      source: 'crouton-triage',
-      teamId: actualTeamId ?? undefined,
-      correlationId,
-      metadata: {
-        stage: 'thread-building',
-        duration: Date.now() - stageThreadStart,
-        success: true,
-      },
-    }).catch(() => {})
-
-    // Update discussion metadata with correct values from thread
-    // This fixes the issue where initial save had placeholder email addresses
-    logger.info('Stage 3.5: Updating discussion metadata...')
-    await updateDiscussionMetadata(discussionId, thread)
-    logger.info('Discussion metadata updated successfully')
-
-    // Update sourceUrl and sourceThreadId with comment ID for Figma
-    if (parsed.sourceType === 'figma' && thread.id && parsed.metadata?.fileKey) {
-      const fileKey = parsed.metadata.fileKey
-      parsed.sourceUrl = `https://www.figma.com/file/${fileKey}#${thread.id}`
-      // Update sourceThreadId to include comment ID (format: fileKey:commentId)
-      parsed.sourceThreadId = `${fileKey}:${thread.id}`
-
-      logger.debug('Updated Figma URLs', {
-        sourceUrl: parsed.sourceUrl,
-        sourceThreadId: parsed.sourceThreadId,
-      })
-
-      // Update the discussion record with the correct URL and threadId using Crouton query
-      const { updateTriageDiscussion } = await import(
-        '~~/layers/triage/collections/discussions/server/database/queries'
-      )
-      await updateTriageDiscussion(
-        discussionId,
-        currentTeamId!,
-        SYSTEM_USER_ID,
-        {
-          sourceUrl: parsed.sourceUrl,
-          sourceThreadId: parsed.sourceThreadId,
-        },
-      )
-
-      // Now that we have the comment ID, add the "eyes" emoji reaction
-      try {
-        const { getAdapter } = await import('../adapters')
-        const adapter = getAdapter(parsed.sourceType)
-        await adapter.updateStatus(parsed.sourceThreadId, 'pending', threadBuildConfig)
-        logger.debug('Added eyes emoji to Figma comment', { commentId: thread.id })
-      } catch (error) {
-        logger.warn('Failed to add eyes emoji to Figma comment', { error })
-        // Don't fail the whole process for emoji failures
-      }
-    }
-
-    // ============================================================================
-    // STAGE 4: AI Analysis
-    // ============================================================================
-    logger.info('Stage 4: Starting AI Analysis...')
-    await updateJobStatus(jobId, actualTeamId, {
-      stage: 'ai_analysis',
-    })
-
-    const stageAiStart = Date.now()
-    let aiAnalysis: AIAnalysisResult
-
-    if (options.skipAI) {
-      // Mock AI analysis for testing
-      aiAnalysis = {
-        summary: {
-          summary: 'Mock summary',
-          keyPoints: ['Mock point 1'],
-        },
-        taskDetection: {
-          isMultiTask: false,
-          tasks: [{
-            title: parsed.title,
-            description: parsed.content,
-          }],
-        },
-        processingTime: 0,
-        cached: false,
-      }
-    }
-    else {
-      // Get AI settings from flow or config
-      const customSummaryPrompt = flowData?.flow.aiSummaryPrompt || (config as any)?.aiSummaryPrompt || undefined
-      const customTaskPrompt = flowData?.flow.aiTaskPrompt || (config as any)?.aiTaskPrompt || undefined
-      const availableDomains = flowData?.flow.availableDomains || undefined
-
-      logger.debug('Using AI settings', {
-        hasSummaryPrompt: !!customSummaryPrompt,
-        hasTaskPrompt: !!customTaskPrompt,
-        availableDomains,
-      })
-
-      aiAnalysis = await analyzeDiscussion(thread, {
-        sourceType: parsed.sourceType,
-        customSummaryPrompt,
-        customTaskPrompt,
-        availableDomains, // Pass available domains for domain detection
-      })
-
-      logger.info('AI analysis complete', {
-        taskCount: aiAnalysis.taskDetection.tasks.length,
-        isMultiTask: aiAnalysis.taskDetection.isMultiTask,
-        cached: aiAnalysis.cached,
-      })
-    }
-
-    useNitroApp().hooks.callHook('crouton:operation', {
-      type: 'triage:stage:completed',
-      source: 'crouton-triage',
-      teamId: actualTeamId ?? undefined,
-      correlationId,
-      metadata: {
-        stage: 'ai-analysis',
-        duration: Date.now() - stageAiStart,
-        success: true,
-        taskCount: aiAnalysis.taskDetection.tasks.length,
-        isMultiTask: aiAnalysis.taskDetection.isMultiTask,
-        cached: aiAnalysis.cached,
-      },
-    }).catch(() => {})
-
-    // ============================================================================
-    // STAGE 5: Task Creation
-    // ============================================================================
+    // STAGE 5: Task creation — bootstrap/user-sync comments skip it and
+    // store discovered users instead
     await updateDiscussionStatus(discussionId, 'analyzed')
-    await updateJobStatus(jobId, actualTeamId, {
-      stage: 'task_creation',
-    })
+    await updateJobStatus(jobId, actualTeamId, { stage: 'task_creation' })
+
+    const bootstrapResult = isBootstrapComment(thread, parsed.sourceType, parsed.content)
+    if (bootstrapResult.isBootstrap) {
+      return await handleBootstrapComment({
+        parsed, bootstrapResult, discussionId, jobId, actualTeamId,
+        flowData, config, resolvedInputToken, aiAnalysis, startTime, correlationId,
+      })
+    }
 
     let notionTasks: NotionTaskResult[] = []
-
-    // ============================================================================
-    // BOOTSTRAP COMMENT CHECK
-    // ============================================================================
-    // Check if this is a bootstrap/user sync comment
-    // Bootstrap comments skip task creation and are used for user discovery
-    const bootstrapResult = isBootstrapComment(thread, parsed.sourceType, parsed.content)
-
-    if (bootstrapResult.isBootstrap) {
-      logger.info('Bootstrap comment detected - skipping Notion task creation', {
-        reason: bootstrapResult.reason,
-        mentionedUserCount: bootstrapResult.mentionedUsers.length,
-        mentionedUsers: bootstrapResult.mentionedUsers.map((u) => u.displayName),
-        sourceType: parsed.sourceType,
-        discussionId,
-      })
-
-      // Store discovered users as pending mappings
-      if (bootstrapResult.mentionedUsers.length > 0) {
-        // Determine sourceWorkspaceId based on source type
-        // Use the same sourceWorkspaceId that was resolved earlier in Stage 2.5
-        // For Slack: slackTeamId from sourceMetadata
-        // For Figma: emailSlug from flow input or parsed metadata
-        let bootstrapSourceWorkspaceId: string
-        if (parsed.sourceType === 'slack') {
-          bootstrapSourceWorkspaceId = flowData?.matchedInput?.sourceMetadata?.slackTeamId
-            || config?.sourceMetadata?.slackTeamId
-            || ''
-        } else if (parsed.sourceType === 'figma') {
-          // For Figma, use emailSlug from flow input or parsed metadata
-          bootstrapSourceWorkspaceId = flowData?.matchedInput?.emailSlug
-            || parsed.metadata?.emailSlug
-            || ''
-        } else {
-          bootstrapSourceWorkspaceId = ''
-        }
-
-        if (bootstrapSourceWorkspaceId) {
-          const newMappingsCount = await storeDiscoveredUsers(
-            bootstrapResult.mentionedUsers,
-            actualTeamId,
-            parsed.sourceType,
-            bootstrapSourceWorkspaceId,
-          )
-          logger.info('Stored discovered users from bootstrap comment', {
-            newMappingsCount,
-            totalMentioned: bootstrapResult.mentionedUsers.length,
-            sourceWorkspaceId: bootstrapSourceWorkspaceId,
-          })
-        } else {
-          logger.warn('Cannot store discovered users - sourceWorkspaceId not found', {
-            sourceType: parsed.sourceType,
-            hasFlowData: !!flowData,
-            hasConfig: !!config,
-          })
-        }
-      }
-
-      // Update discussion status to indicate bootstrap processing
-      await updateDiscussionStatus(discussionId, 'completed')
-
-      // Build config for posting reply (from flow or legacy config)
-      const replyConfig = flowData
-        ? {
-            id: flowData.matchedInput.id,
-            teamId: flowData.flow.teamId,
-            sourceType: flowData.matchedInput.sourceType,
-            apiToken: resolvedInputToken,
-            sourceMetadata: flowData.matchedInput.sourceMetadata,
-          } as AdapterConfig
-        : config!
-
-      // Post reply to source with discovered users info
-      try {
-        const { getAdapter } = await import('../adapters')
-        const adapter = getAdapter(parsed.sourceType)
-
-        // Remove the initial "eyes" reaction if present
-        if ('removeReaction' in adapter && typeof adapter.removeReaction === 'function') {
-          await adapter.removeReaction(parsed.sourceThreadId, 'eyes', replyConfig)
-        }
-
-        // Build bootstrap response message with personality
-        const userCount = bootstrapResult.mentionedUsers.length
-        const replyPersonality = flowData?.flow.replyPersonality || null
-        const encryptedBootstrapKey = flowData?.flow.anthropicApiKey
-        const anthropicApiKey = encryptedBootstrapKey
-          ? await decryptSecret(encryptedBootstrapKey)
-          : (config as any)?.anthropicApiKey
-        const personalityIcon = flowData?.flow.personalityIcon || undefined
-        const bootstrapMessage = await generateBootstrapMessage(userCount, replyPersonality, anthropicApiKey, personalityIcon)
-
-        await adapter.postReply(parsed.sourceThreadId, bootstrapMessage, replyConfig)
-        await adapter.updateStatus(parsed.sourceThreadId, 'completed', replyConfig)
-
-        logger.info('Bootstrap reply sent to source', {
-          userCount,
-          sourceType: parsed.sourceType,
-        })
-      } catch (error) {
-        logger.warn('Failed to send bootstrap reply to source', { error })
-        // Don't fail the process if reply fails
-      }
-
-      // Finalize job for bootstrap
-      if (jobId) {
-        const processingTime = Date.now() - startTime
-        try {
-          const { updateTriageJob } = await import(
-            '~~/layers/triage/collections/jobs/server/database/queries'
-          )
-
-          await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
-            status: 'completed',
-            completedAt: new Date(),
-            processingTime,
-            metadata: {
-              isBootstrap: true,
-              bootstrapReason: bootstrapResult.reason,
-              mentionedUsers: bootstrapResult.mentionedUsers,
-            },
-          })
-        } catch (error) {
-          logger.warn('Failed to finalize bootstrap job', { error })
-        }
-      }
-
-      // Return early - no task creation for bootstrap comments
-      return {
-        discussionId,
-        aiAnalysis,
-        notionTasks: [], // No tasks created for bootstrap
-        processingTime: Date.now() - startTime,
-        isMultiTask: false,
-        correlationId,
-      }
-    }
-
     const aiEnabled = flowData?.flow.aiEnabled ?? (config as any)?.aiEnabled ?? false
 
     if (!options.skipNotion && aiEnabled) {
-      // Use user mappings from Stage 2.5 (already loaded once)
-      // Convert to simple userId -> notionId map for Notion API
-      const notionUserMappings = new Map<string, string>()
-      if (userMappings) {
-        for (const [userId, data] of userMappings.entries()) {
-          notionUserMappings.set(userId, data.notionId)
-        }
-      }
-
-      logger.debug('User mappings available for Notion tasks', {
-        active: notionUserMappings.size,
-        sourceType: parsed.sourceType
+      notionTasks = await runTaskCreationStage({
+        parsed, thread, aiAnalysis, actualTeamId,
+        discussionId, jobId, flowData, config, userMappings,
       })
-
-      const tasks = aiAnalysis.taskDetection.tasks
-
-      // Build source metadata for linking author names and @mentions to source platform
-      const sourceMetadata: SourceMetadata | undefined = (() => {
-        const sourceType = parsed.sourceType as 'figma' | 'slack' | 'notion'
-
-        if (sourceType === 'figma') {
-          const fileKey = parsed.metadata?.fileKey
-          if (fileKey) {
-            return { sourceType, fileKey }
-          }
-        } else if (sourceType === 'slack') {
-          const channelId = flowData?.matchedInput?.sourceMetadata?.channelId
-            || config?.sourceMetadata?.channelId
-            || parsed.metadata?.channelId
-          const slackTeamId = flowData?.matchedInput?.sourceMetadata?.slackTeamId
-            || config?.sourceMetadata?.slackTeamId
-            || parsed.teamId
-          if (channelId && slackTeamId) {
-            return { sourceType, channelId, slackTeamId }
-          }
-        } else if (sourceType === 'notion') {
-          // For Notion, extract parentId (page ID) from metadata
-          const pageId = parsed.metadata?.parentId
-          if (pageId) {
-            return { sourceType, pageId }
-          }
-        }
-        return undefined
-      })()
-
-      logger.debug('Source metadata for platform linking', {
-        sourceMetadata,
-        hasMetadata: !!sourceMetadata,
-      })
-
-      if (tasks.length === 0) {
-        logger.info('No tasks detected, skipping Notion creation')
-      }
-      else if (flowData) {
-        // ============================================================================
-        // FLOWS ARCHITECTURE: Route tasks to multiple outputs based on domain
-        // ============================================================================
-        logger.info('Processing with flows architecture', {
-          flowId: flowData.flow.id,
-          taskCount: tasks.length,
-          outputCount: flowData.outputs.length,
-        })
-
-        // Process each task
-        for (let taskIndex = 0; taskIndex < tasks.length; taskIndex++) {
-          const task = tasks[taskIndex]
-          if (!task) {
-            logger.warn('Task is undefined, skipping', { taskIndex })
-            continue
-          }
-
-          // Route task to matching outputs based on domain
-          const matchedOutputs = routeTaskToOutputs(task, flowData.outputs)
-
-          logger.info('Task routed to outputs', {
-            taskIndex,
-            taskDomain: task.domain,
-            matchedOutputCount: matchedOutputs.length,
-            outputTypes: matchedOutputs.map(o => o.outputType),
-          })
-
-          // Create task in all matched outputs
-          for (const output of matchedOutputs) {
-            if (output.outputType !== 'notion') {
-              logger.warn('Non-Notion output types not yet supported', {
-                outputType: output.outputType,
-                outputId: output.id,
-              })
-              continue
-            }
-
-            try {
-              // Extract Notion config from output
-              const { config: notionConfig, fieldMapping } = await createNotionConfigFromOutput(
-                output,
-                parsed.sourceType,
-                parsed.sourceUrl,
-                actualTeamId,
-              )
-
-              logger.info('Creating task in output', {
-                outputId: output.id,
-                outputType: output.outputType,
-                taskTitle: task.title,
-              })
-
-              const result = await createNotionTask(
-                task,
-                thread,
-                aiAnalysis.summary,
-                notionConfig,
-                notionUserMappings,
-                fieldMapping,
-                notionUserMappings,
-                sourceMetadata,
-              )
-
-              notionTasks.push(result)
-
-              logger.info('Task created successfully in output', {
-                outputId: output.id,
-                outputType: output.outputType,
-                notionTaskId: result.id,
-              })
-            }
-            catch (error) {
-              logger.error('Failed to create task in output', error, {
-                outputId: output.id,
-                outputType: output.outputType,
-                taskTitle: task.title,
-              })
-              // Continue with other outputs even if one fails
-            }
-          }
-        }
-
-        logger.info('All tasks processed with flows', {
-          totalTasksCreated: notionTasks.length,
-          taskIds: notionTasks.map(t => t.id),
-        })
-      }
-      else if (config) {
-        // ============================================================================
-        // LEGACY CONFIG: Single output (backward compatibility)
-        // ============================================================================
-        const notionConfig: NotionTaskConfig = {
-          databaseId: (config as any).notionDatabaseId,
-          apiKey: (config as any).notionToken,
-          sourceType: parsed.sourceType,
-          sourceUrl: parsed.sourceUrl,
-        }
-
-        const fieldMapping = (config as any).notionFieldMapping || {}
-
-        if (tasks.length === 1) {
-          // Single task
-          const task = tasks[0]
-          if (!task) {
-            logger.warn('Task is undefined, skipping')
-          }
-          else {
-            logger.info('Creating single Notion task (legacy config)')
-
-            const result = await createNotionTask(
-              task,
-              thread,
-              aiAnalysis.summary,
-              notionConfig,
-              notionUserMappings,
-              fieldMapping,
-              notionUserMappings,
-              sourceMetadata,
-            )
-
-            notionTasks.push(result)
-          }
-        }
-        else {
-          // Multiple tasks
-          logger.info('Creating multiple Notion tasks (legacy config)', { count: tasks.length })
-
-          notionTasks = await createNotionTasks(
-            tasks,
-            thread,
-            aiAnalysis.summary,
-            notionConfig,
-            notionUserMappings,
-            fieldMapping,
-            notionUserMappings,
-            sourceMetadata,
-          )
-        }
-
-        logger.info('Notion tasks created (legacy)', {
-          count: notionTasks.length,
-          ids: notionTasks.map(t => t.id),
-        })
-      }
-
-      // Save task records to database
-      if (notionTasks.length > 0 && discussionId && jobId) {
-        await saveTaskRecords(
-          notionTasks,
-          aiAnalysis.taskDetection.tasks,
-          discussionId,
-          jobId,
-          parsed,
-        )
-      }
     }
     else {
       logger.info('Skipping Notion task creation')
     }
 
-    // ============================================================================
-    // STAGE 5.5: Emit task creation telemetry
-    // ============================================================================
-    if (notionTasks.length > 0) {
-      useNitroApp().hooks.callHook('crouton:operation', {
-        type: 'triage:stage:completed',
-        source: 'crouton-triage',
-        teamId: actualTeamId ?? undefined,
-        correlationId,
-        metadata: {
-          stage: 'notion-creation',
-          success: true,
-          taskCount: notionTasks.length,
-        },
-      }).catch(() => {})
-    }
-
-    // ============================================================================
-    // STAGE 6: Finalization
-    // ============================================================================
-    await updateJobStatus(jobId, actualTeamId, {
-      stage: 'notification',
+    // STAGES 5.5 + 6: telemetry, results, notification, job finalization
+    return await finalizeSuccessfulProcessing({
+      parsed, thread, threadBuildConfig, aiAnalysis, notionTasks,
+      discussionId, jobId, actualTeamId, flowData, config, startTime, correlationId,
     })
-
-    // Update discussion with results
-    await updateDiscussionResults(
-      discussionId,
-      thread,
-      aiAnalysis,
-      notionTasks,
-    )
-
-    // Mark as completed
-    await updateDiscussionStatus(discussionId, 'completed')
-
-    // Send notification back to source
-    // Use threadBuildConfig which works with both flows and legacy configs
-    try {
-      const { getAdapter } = await import('../adapters')
-      const adapter = getAdapter(parsed.sourceType)
-
-      // Remove the initial "eyes" reaction
-      if ('removeReaction' in adapter && typeof adapter.removeReaction === 'function') {
-        await adapter.removeReaction(parsed.sourceThreadId, 'eyes', threadBuildConfig)
-      }
-
-      // Build confirmation message with personality
-      const replyPersonality = flowData?.flow.replyPersonality || null
-      const encryptedConfirmKey = flowData?.flow.anthropicApiKey
-      const anthropicApiKey = encryptedConfirmKey
-        ? await decryptSecret(encryptedConfirmKey)
-        : (config as any)?.anthropicApiKey
-      const personalityIcon = flowData?.flow.personalityIcon || undefined
-      const confirmationMessage = await generateReplyMessage(notionTasks, replyPersonality, anthropicApiKey, personalityIcon, parsed.sourceType)
-
-      // Post reply to the thread
-      await adapter.postReply(parsed.sourceThreadId, confirmationMessage, threadBuildConfig)
-
-      // Update status with completed emoji/reaction
-      await adapter.updateStatus(parsed.sourceThreadId, 'completed', threadBuildConfig)
-
-      logger.info('Notification sent to source', {
-        sourceType: parsed.sourceType,
-        taskCount: notionTasks.length,
-      })
-    } catch (error) {
-      // Don't fail the entire process if notification fails
-      logger.error('Failed to send notification to source', error)
-    }
-
-    const processingTime = Date.now() - startTime
-
-    // ============================================================================
-    // FINALIZE JOB (Success)
-    // ============================================================================
-    if (jobId) {
-      try {
-        const { updateTriageJob } = await import(
-          '~~/layers/triage/collections/jobs/server/database/queries'
-        )
-
-        await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
-          status: 'completed',
-          completedAt: new Date(),
-          processingTime,
-          taskIds: notionTasks.map(t => t.id),
-        })
-
-        logger.debug('Job finalized', {
-          jobId,
-          processingTime,
-        })
-      } catch (error) {
-        logger.error('Failed to finalize job', error)
-        // Don't fail processing if job finalization fails
-      }
-    }
-
-    logger.info('Processing complete', {
-      discussionId,
-      processingTime,
-      taskCount: notionTasks.length,
-    })
-
-    useNitroApp().hooks.callHook('crouton:operation', {
-      type: 'triage:discussion:processed',
-      source: 'crouton-triage',
-      teamId: actualTeamId ?? undefined,
-      correlationId,
-      metadata: {
-        totalDuration: processingTime,
-        success: true,
-        taskCount: notionTasks.length,
-        isMultiTask: aiAnalysis.taskDetection.isMultiTask,
-        sourceType: parsed.sourceType,
-      },
-    }).catch(() => {})
-
-    return {
-      discussionId,
-      aiAnalysis,
-      notionTasks,
-      processingTime,
-      isMultiTask: aiAnalysis.taskDetection.isMultiTask,
-      correlationId,
-    }
   }
   catch (error) {
-    logger.error('Processing failed', error)
-
-    // Update discussion status to failed
-    if (discussionId) {
-      await updateDiscussionStatus(
-        discussionId,
-        'failed',
-        error instanceof Error ? error.message : 'Unknown error',
-      )
-    }
-
-    // ============================================================================
-    // FINALIZE JOB (Failure)
-    // ============================================================================
-    if (jobId) {
-      try {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-        const errorStack = error instanceof Error ? error.stack : undefined
-        const processingTime = Date.now() - startTime
-
-        const { updateTriageJob } = await import(
-          '~~/layers/triage/collections/jobs/server/database/queries'
-        )
-
-        await updateTriageJob(jobId, actualTeamId, SYSTEM_USER_ID, {
-          status: 'failed',
-          completedAt: new Date(),
-          processingTime,
-          error: errorMessage,
-          errorStack: errorStack || undefined,
-        })
-
-        logger.warn('Job marked as failed', {
-          jobId,
-          error: errorMessage,
-        })
-      } catch (updateError) {
-        logger.error('Failed to update job with error', { updateError })
-        // Don't fail processing if job update fails
-      }
-    }
-
-    // Emit failure telemetry
-    useNitroApp().hooks.callHook('crouton:operation', {
-      type: 'triage:discussion:processed',
-      source: 'crouton-triage',
-      teamId: actualTeamId ?? undefined,
+    return await handleProcessingFailure(error, {
+      parsed,
+      discussionId,
+      jobId,
+      actualTeamId,
+      startTime,
       correlationId,
-      metadata: {
-        totalDuration: Date.now() - startTime,
-        success: false,
-        sourceType: parsed.sourceType,
-        errorStage: error instanceof ProcessingError ? error.stage : 'unknown',
-      },
-    }).catch(() => {})
-
-    // Wrap error if not already a ProcessingError
-    if (error instanceof ProcessingError) {
-      throw error
-    }
-
-    throw new ProcessingError(
-      error instanceof Error ? error.message : 'Unknown error',
-      'unknown',
-      { originalError: error },
-      true, // Assume retryable by default
-    )
+    })
   }
 }
 


### PR DESCRIPTION
Closes #1237 · part of epic #1235 (WS2)

## 👤 For humans

First worst-first batch of the large-function burn-down, scoped to `packages/` only (the WS3/WS4/WS5 lanes — apps, pocs, scripts — are untouched). The 12 biggest `.ts` functions over 120 LOC, across 8 files in 4 packages, are decomposed into named single-purpose helpers — including `processDiscussion`, the single worst function in the monorepo (1048 LOC, cognitive 175 → a 118-LOC stage orchestrator, cognitive 10). Behavior is provably unchanged (see evidence). Five more mid-size functions in the same files were cleared as a side effect because the per-file gate covers the whole file.

**Count delta (fallow):**
- `packages/` `.ts` functions >120 LOC: **70 → 53** (all 17 cleared by this PR; every target file now has zero)
- LOC locked inside >60-LOC functions in the 8 touched files: **6,899 → 2,123 (−69%)**
- Repo-wide >60-LOC unit count: 637 → 636 — near-flat by design: monsters became a handful of cohesive 60–119 helpers instead of artificial <60 slices. The long tail (53 in packages, plus apps/pocs) is for follow-up batches.

## 🤖 For agents

| File | Before → after (LOC, worst fn) | Evidence |
|---|---|---|
| crouton-triage `server/services/processor.ts` | `processDiscussion` 1048→118 (cog 175→10), `buildThread` 242→45, `loadFlow` 123→106 | diff audit (code moved verbatim), tsc error profile identical to HEAD |
| crouton-triage `server/services/notion.ts` | `buildTaskContent` 440→~25, `buildTaskProperties` 151→87 | 12-case before/after harness: byte-identical output (120,631 bytes) |
| crouton-triage `webhooks/notion-input.post.ts` | handler 547→117 | lines 1–161 byte-identical; tsc profile identical |
| crouton-cli `lib/generate-collection.ts` | `writeScaffold` 521→~90, `runConfig` 268→~43, +`buildGeneratorData`/`runPostGeneration`/`runGenerate` | end-to-end `crouton config` old vs new: identical trees + stdout; vitest same pass/fail set (280 passed) |
| crouton-cli `lib/generators/form-component.ts` | `generateFormComponent` 677→88, `generateFieldMarkup` 223→35 | 10-case byte-diff clean; form-component tests 21/21 incl. snapshots |
| crouton-cli `lib/generators/database-queries.ts` | `generateQueries` 409→88, `generateTreeQueries` 182→27 | 13-scenario byte-diff: 0 differences across 94,764 bytes |
| crouton-pages `teams/[id]/pages/[...slug].get.ts` | handler 429→97 (cog 124→22) | access-check order preserved step-for-step; tsc profile identical |
| crouton-auth `app/composables/useSession.ts` | `useSession` 401→~85 | helpers share the same useState refs (SessionContext); unit suite identical before/after (123 passed) |

- Export surfaces verified unchanged on all 8 files (diffed `^export` symbol lists vs HEAD).
- Guardrails honored: no `--save-baseline`, `.fallow-health-baseline.json` and `.fallowrc.json` untouched; verified with `npx fallow@2.104.0 health --base origin/main`.
- Local `pnpm typecheck` is not runnable in this worktree for pre-existing env reasons (packages' `dist/` never built here + the `#` in the checkout path breaks vite URL handling — also broke vitest in-place; suites were run from `#`-free copies). CI's typecheck on this PR is the authoritative gate.
- Deliberate non-fixes, preserved bit-for-bit: dead `tableJoinCounts` in database-queries (was dead before); pre-existing `promptedConfigs` ReferenceError in non-dry-run `crouton generate` (fails identically on old and new code — follow-up issue coming, needs bug-archaeology).

## 🧪 How to test

1. `npx fallow health` on this branch → the 8 files above no longer appear under large-function findings; `npx fallow@2.104.0 health --base origin/main` shows all 8 hotspots cooling/stable.
2. `cd packages/crouton-cli && npx vitest run` (from a path without `#`) → same results as `main` (280 passed / 4 pre-existing integration failures).
3. Generator equivalence: run `crouton config` against any schema on `main` and on this branch → generated trees are byte-identical.
4. `cd packages/crouton-auth && npx vitest run --dir tests/unit` → identical to `main` (123 passed | 1 skipped | 28 todo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)