### PR TITLE
fix(root): point triage stagingUrl at its live custom domain (#1250)

### DIFF
--- a/apps/triage/deploy.config.json
+++ b/apps/triage/deploy.config.json
@@ -1,5 +1,5 @@
 {
-  "stagingUrl": "https://triage-preview.cloudflare-e53.workers.dev",
+  "stagingUrl": "https://triage-preview.pmcp.dev",
   "productionUrl": "https://triage.friendlyinter.net",
   "layerPackages": "@fyit/crouton-core @fyit/crouton-auth @fyit/crouton-ai @fyit/crouton-triage @fyit/crouton-flow @fyit/crouton",
   "watchPaths": [


### PR DESCRIPTION
Closes #1250. Surfaced by the #1238 merge (first triage staging deploy in a while).

## 👤 For humans
One line: triage's deployed-smoke gate probed `triage-preview.cloudflare-e53.workers.dev`, which 404s (workers.dev serving is off; the worker is `triage-staging` anyway). The staging app lives on the custom domain `triage-preview.pmcp.dev` — probed live: root 200, sign-in endpoint 401 (healthy). With this the rung-2 smoke checks the URL users actually hit.

## 🤖 For agents
- `apps/triage/deploy.config.json` `stagingUrl` only — nothing else. The failed run (deploy chain green, smoke red): https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/28961007258

## 🧪 How to test
1. Before-value is dead: `curl -o /dev/null -w '%{http_code}' https://triage-preview.cloudflare-e53.workers.dev/` → 404.
2. New value is live: `curl -o /dev/null -w '%{http_code}' https://triage-preview.pmcp.dev/` → 200.
3. After merge, the next triage-touching push to main should pass the deployed-smoke step of `Deploy Apps (Cloudflare Workers)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)