### PR TITLE
fix: per-job pnpm setup dest for the non-deploy self-hosted workflows

### DIFF
--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -72,6 +72,10 @@ jobs:
 
       # The deep a11y pass runs eslint-a11y (needs deps) and may boot a fixture for axe.
       - uses: pnpm/action-setup@v4
+        with:
+          # per-job dest — the default ~/setup-pnpm collides between the two
+          # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -38,6 +38,10 @@ jobs:
 
       # The deep pass runs eslint-a11y (needs deps) and may boot a fixture for axe.
       - uses: pnpm/action-setup@v4
+        with:
+          # per-job dest — the default ~/setup-pnpm collides between the two
+          # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -50,6 +50,10 @@ jobs:
       # eslint.config.mjs, warn-first) — so unlike red-team's pure static read, the subagent
       # needs node_modules to actually run `npx eslint`. Install before invoking it.
       - uses: pnpm/action-setup@v4
+        with:
+          # per-job dest — the default ~/setup-pnpm collides between the two
+          # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -129,6 +129,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}   # writes the App token into the git remote → pushes cascade
 
       - uses: pnpm/action-setup@v4
+        with:
+          # per-job dest — the default ~/setup-pnpm collides between the two
+          # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -41,6 +41,10 @@ jobs:
 
       # The deep pass may boot a fixture for dynamic confirmation — give it node + pnpm + deps.
       - uses: pnpm/action-setup@v4
+        with:
+          # per-job dest — the default ~/setup-pnpm collides between the two
+          # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/sync-changelogs.yml
+++ b/.github/workflows/sync-changelogs.yml
@@ -23,6 +23,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          # per-job dest — the default ~/setup-pnpm collides between the two
+          # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Closes #1249

## 👤 For humans

Companion to the `deploy-app.yml` fix that landed on main (#1258): the same `ENOTEMPTY: rmdir ~/setup-pnpm` runner collision can hit **every other workflow that runs on the mac mini** (a11y, the dailies, sync-changelogs, decompose) — they still use `pnpm/action-setup`'s shared default dir. Each of those jobs now installs pnpm into its own `${{ runner.temp }}` dir. No shell access to the box needed; closes the last open failure-report ticket (#1249).

## 🤖 For agents

- `dest: ${{ runner.temp }}/setup-pnpm` added to `pnpm/action-setup@v4` in: `a11y.yml`, `a11y-daily.yml`, `a11y-daily-pidev.yml`, `red-team-daily.yml`, `sync-changelogs.yml`, `decompose-on-issue-pidev.yml` (all can land on `vars.AGENT_RUNNER`)
- `deploy-app.yml` deliberately untouched — #1258's `~/setup-pnpm-<app>-<env>` is the incumbent there (unique writer per dest via the deploy concurrency group). These six have **no** such uniqueness guarantee (two a11y jobs can run concurrently across the box's two runners), hence per-job `runner.temp` instead
- `ubuntu-latest`-only workflows untouched (ephemeral runners can't collide)

## 🧪 How to test

1. After merge, any of these jobs landing on the mini logs its "Setup pnpm" step installing under `$RUNNER_TEMP/setup-pnpm`
2. The `ENOTEMPTY ~/setup-pnpm` error string (5 occurrences across runs 28960755546 / 28967414053 / 29014787261) should not recur in these workflows
3. YAML validity of all 6 files checked with js-yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)