### PR TITLE
fix: per-app pnpm setup dest — stop parallel deploy races on the self-hosted runner (#1258)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -141,8 +141,14 @@ jobs:
         if: runner.os == 'macOS'
         run: command -v jq >/dev/null 2>&1 || brew install jq
 
+      # dest is keyed per app+env: on the self-hosted mini several app deploys run
+      # in parallel and the default shared ~/setup-pnpm races (ENOTEMPTY rmdir,
+      # #1254/#1255). The deploy-<app>-<env> concurrency group above guarantees one
+      # writer per dest; the dest set is bounded (apps × envs), so no disk creep. (#1258)
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          dest: ~/setup-pnpm-${{ inputs.app }}-${{ inputs.environment }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Closes #1258

## 👤 For humans

Both of today's post-merge deploy failures (#1254/#1255) were the same thing: parallel app deploys on the Mac mini runner all install pnpm into the default shared `~/setup-pnpm` and race on it (`ENOTEMPTY: rmdir`). This keys the install dir per app+env, so each deploy job has its own — no box access needed, no serialization of deploys, no disk creep (the dest set is bounded at apps × envs, and the existing `deploy-<app>-<env>` concurrency group guarantees exactly one writer per dest).

Verified `dest` is a supported input of `pnpm/action-setup@v4` (default `~/setup-pnpm` — exactly the raced path).

## 🤖 For agents

- One file: `.github/workflows/deploy-app.yml` — `pnpm/action-setup@v4` gains `dest: ~/setup-pnpm-${{ inputs.app }}-${{ inputs.environment }}`.
- Considered & rejected (in #1258): runner-wide serialization (slows every merge), pre-step `rm -rf` (worsens the race), fixing on the box (no access, loses parallelism).
- Other AGENT_RUNNER workflows keep the shared default for now — single scheduled jobs, low collision odds; extend the pattern if one flakes.

## 🧪 How to test

1. Merge this, then land any change touching ≥2 apps' `watchPaths` (or re-run a multi-app Deploy Apps run).
2. Before: parallel jobs could die in "Setup pnpm" with `ENOTEMPTY: rmdir '/Users/maarten/setup-pnpm'` (see #1254/#1255). After: each job logs its own `~/setup-pnpm-<app>-<env>` dest and the run is green on attempt 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)