### PR TITLE
fix(root): visible resume success + superseded-close guard + Closes-blocked warning (#1253)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -198,6 +198,11 @@ only — not visual taste (`/ui-proposal`), accessibility (`/a11y`), or security
   so parallel leaves never collide on branches/files. One issue → one branch → one PR
   with `Closes #NN`. Workers obey the `packages/` HARD GATE and the `/commit` + no-squash
   merge policy.
+- **`Closes` only YOUR issue; `Refs` any other blocked issue (#1253).** A PR body's `Closes`
+  on someone else's `status:blocked` issue (e.g. a retest your fix unblocks) auto-closes it
+  out from under the owner's pending reply — the #1233/#1234 race. Use `Refs #NN` for those;
+  `warn-closes-blocked.yml` warns on violations (gate PRs on `epic/*` are exempt — closing
+  their own blocked issue via merge-on-approval is the designed flow).
 
 ### Integration-branch flow & safety (#348)
 

--- a/.claude/agents/task-worker.md
+++ b/.claude/agents/task-worker.md
@@ -142,6 +142,11 @@ a feature branch.
      linked issue when the PR merges into the **default branch** (`main`); an epic-branch
      PR won't — the epic→`main` PR closes them later. So the breadcrumb comment (above) is
      how the issue reflects "done-for-now," not the merge.
+   - **`Closes` ONLY your own issue — `Refs`, never `Closes`, any OTHER blocked issue (#1253).**
+     A root-cause-fix PR that `Closes` a `status:blocked` retest/sibling issue auto-closes it
+     out from under the owner's pending reply (PR #1234 closed the #1233 retest 2s before the
+     owner's answer). Reference related blocked issues with `Refs #NN`; only the issue this PR
+     implements gets `Closes`. `warn-closes-blocked.yml` flags violations on non-epic PRs.
    - **Do not squash by default** (merge policy) — your commits are curated and atomic.
    - **If a sign-off gate already opened a draft PR** (step 5 — UI or schema), don't open a
      second one — reuse it: push the implementation/generated files, then mark it ready for

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -31,11 +31,45 @@ jobs:
         with:
           fetch-depth: 1
 
+      # ── Superseded-close re-check (#1253) ────────────────────────────────────────
+      # The job guard reads labels from the EVENT PAYLOAD snapshot — a close seconds
+      # before the reply still passes it (the #1233 race: PR #1234's stray `Closes`
+      # auto-closed the retest issue 2s before the owner's answer). And the artifact-gate
+      # below counts `closed` as PASS, so a resume against a superseded issue would exit
+      # green having done nothing. Re-fetch live state: if the issue is now CLOSED, tell
+      # the owner plainly and skip the agent run. Fail-OPEN on an API error (proceed as
+      # before) — a transient fetch failure must not eat a legitimate resume. The
+      # merge-on-approval step below stays `if: always()` on purpose: the #572
+      # deterministic-merge fallback must survive this early exit.
+      - name: Re-check the issue is still open
+        id: state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number
+            let issue
+            try {
+              issue = (await github.rest.issues.get({ ...context.repo, issue_number })).data
+            } catch (e) {
+              core.warning(`state re-check failed (${e.message}) — proceeding as open`)
+              core.setOutput('open', 'true'); return
+            }
+            const open = issue.state === 'open'
+            core.setOutput('open', String(open))
+            if (open) return
+            const closer = issue.closed_by ? issue.closed_by.login : 'unknown'
+            await github.rest.issues.createComment({ ...context.repo, issue_number,
+              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _resume skipped — issue already closed (#1253)_\n\n'
+                + `⚠️ This issue was **closed** (by ${closer}) just before your reply was picked up, so the resume did **not** run — `
+                + 'it looks superseded. Reply on the successor issue/PR instead, or **reopen this one and comment again** to retry.' })
+            core.info(`Issue #${issue_number} is closed — skipping the resume agent run.`)
+
       # Acknowledge the trigger comment immediately: 👀 = "picked up, working on it". The
       # final step swaps this for 🚀 (done) / 😕 (failed). The job guard already ensures we
       # only get here for comments we actually act on, so the reaction is never spurious.
       # (GitHub comment reactions have no ✅/❌ — 🚀/😕 are the closest.)
       - name: React 👀 — resume picked up
+        if: steps.state.outputs.open == 'true'
         id: eyes
         uses: actions/github-script@v7
         with:
@@ -49,6 +83,7 @@ jobs:
 
       # Timestamp run start so the artifact-gate (below) can tell "produced during THIS run".
       - id: t0
+        if: steps.state.outputs.open == 'true'
         run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       # ── Collect the answer payload across media (WS5, #1191) ─────────────────────
@@ -59,6 +94,7 @@ jobs:
       # them into `.resume-answer.md` for the prompt below. Dependency-free (system node +
       # fetch); the `||` fallback guarantees the file exists so the resume never fails on it.
       - name: Collect the answer payload
+        if: steps.state.outputs.open == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE: ${{ github.event.issue.number }}
@@ -72,6 +108,7 @@ jobs:
       # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
       # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
       - id: agent
+        if: steps.state.outputs.open == 'true'
         uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -169,8 +206,12 @@ jobs:
       # run hid it and it took a manual re-/delegate to notice. `decompose-on-issue` already
       # has this gate; the resume path didn't. Now a no-op resume goes RED (visible →
       # re-dispatch). Uses GITHUB_TOKEN (read-only check), never trips the bot-actor guard.
+      # Skipped on the superseded-close path (#1253): with no agent run there's no artifact
+      # to demand, and the state re-check already commented. Exports its facts as outputs
+      # so the success comment below can say WHAT the resume produced.
       - name: Artifact-gate — fail if the resume produced nothing
-        if: always()
+        id: gate
+        if: always() && steps.state.outputs.open == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -207,6 +248,12 @@ jobs:
               }
             } catch (e) { core.warning(`merged-PR check skipped: ${e.message}`) }
 
+            core.setOutput('subIssues', String(createdSubIssues))
+            core.setOutput('mergedPR', String(mergedPR))
+            core.setOutput('closed', String(closed))
+            core.setOutput('stillBlocked', String(stillBlocked))
+            core.setOutput('newComment', String(newComment))
+
             // PASS if the resume did anything observable, OR it's still holding (legit "still
             // iterating" — not a no-op). FAIL only when the block was cleared yet nothing came
             // of it — the silent no-op.
@@ -225,7 +272,7 @@ jobs:
       # 😕 failed (GitHub reactions have no ✅/❌). Comment ONLY on a hard agent error; a no-op
       # is already explained by the artifact-gate above, so we don't duplicate it (#1216).
       - name: React outcome — 🚀 done / 😕 failed
-        if: always()
+        if: always() && steps.state.outputs.open == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -248,6 +295,34 @@ jobs:
                   + '😕 The resume from your comment **errored before finishing** (billing / max-turns / tooling). '
                   + `🔗 [Run log](${runUrl}) — fix the cause, then comment again to retry.` })
             }
+
+      # ── Visible success (#1253, Fix A) ───────────────────────────────────────────
+      # A successful resume used to signal ONLY via the 🚀 reaction — easy to miss,
+      # especially on mobile (the #1233 "felt ignored" incident), and our own conventions
+      # call a reaction the weak signal. Post a top-level comment saying what the run
+      # produced, from the artifact-gate's own facts. ORDERING IS LOAD-BEARING: this step
+      # MUST come after the artifact-gate — a comment posted before it would make the
+      # gate's `newComment` check always-true and permanently disable the #603 no-op
+      # detection. Skipped when the agent already replied in-thread this run (no double
+      # ping — the gate's `newComment` flag knows). Posted with GITHUB_TOKEN on purpose:
+      # a Bot actor whose events never re-trigger this workflow (double loop safety on
+      # top of the job's `user.type != 'Bot'` guard).
+      - name: Comment ✅ — visible success
+        if: success() && steps.state.outputs.open == 'true' && steps.gate.outputs.newComment != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const facts = []
+            if ('${{ steps.gate.outputs.subIssues }}' === 'true') facts.push('created sub-issues')
+            if ('${{ steps.gate.outputs.mergedPR }}' === 'true') facts.push('merged the gate PR')
+            if ('${{ steps.gate.outputs.closed }}' === 'true') facts.push('closed this issue')
+            if ('${{ steps.gate.outputs.stillBlocked }}' === 'true') facts.push('still iterating — the block stays on for your next reply')
+            const did = facts.length ? facts.join(' · ') : 'continued the pipeline'
+            await github.rest.issues.createComment({ ...context.repo, issue_number,
+              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _resumed from your reply (#1253)_\n\n'
+                + `✅ **Resumed from your reply** — ${did}. 🔗 [Run log](${runUrl})` })
 
       # A cancelled resume (the 30-min timeout) must announce itself, not vanish silently (#1220).
       - name: Flag a timeout / cancellation

--- a/.github/workflows/warn-closes-blocked.yml
+++ b/.github/workflows/warn-closes-blocked.yml
@@ -1,0 +1,71 @@
+name: Warn on Closes of a blocked issue
+
+# (#1253, Fix B) A root-cause-fix PR that writes `Closes #<retest issue>` auto-closes a
+# `status:blocked` issue out from under the owner's pending reply — the #1233/#1234 race,
+# where the resume then ran against a closed, superseded issue.
+#
+# WARNING ONLY — deliberately NOT a required check. Closing a blocked issue via `Closes`
+# is the NORMAL flow for sign-off gate PRs: resume-on-comment's merge-on-approval step
+# merges exactly the PR whose body says `Closes #<blocked issue>` while the label is still
+# on. Gate PRs target `epic/*` branches (the merge step keys on that), so the job guard
+# exempts them; a hard block here would red-flag every gate PR and could deadlock the
+# auto-merge chain. Convention: a root-cause fix uses `Refs #NN` on a retest issue.
+#
+# Known limits (accepted): body-only parsing — a `Closes` in a commit message is invisible
+# here; and the target's label can change after this ran. This narrows the cause; the
+# raced-reply symptom is handled by resume-on-comment's superseded-close re-check.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+jobs:
+  warn:
+    # Gate PRs (base = epic/*) legitimately close their blocked issue — exempt.
+    if: ${{ !startsWith(github.event.pull_request.base.ref, 'epic/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const body = pr.body || ''
+            // GitHub's closing keywords (close/closes/closed, fix/fixes/fixed,
+            // resolve/resolves/resolved, optional colon).
+            const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)/gi
+            const nums = [...new Set([...body.matchAll(re)].map(m => Number(m[1])))]
+            if (!nums.length) { core.info('No closing references in the PR body.'); return }
+
+            const blocked = []
+            for (const issue_number of nums) {
+              try {
+                const issue = (await github.rest.issues.get({ ...context.repo, issue_number })).data
+                if (issue.pull_request) continue // a PR reference, not an issue
+                const isBlocked = (issue.labels || [])
+                  .some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
+                if (issue.state === 'open' && isBlocked) blocked.push(issue_number)
+              } catch (e) { core.warning(`could not check #${issue_number}: ${e.message}`) }
+            }
+            if (!blocked.length) { core.info('No open status:blocked issues referenced.'); return }
+
+            // Warn once per PR — dedupe on the marker so `edited` events don't re-post.
+            const marker = '<!-- warn-closes-blocked -->'
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { ...context.repo, issue_number: pr.number })
+            if (comments.some(c => (c.body || '').includes(marker))) {
+              core.info('Already warned on this PR.'); return
+            }
+
+            const list = blocked.map(n => `#${n}`).join(', ')
+            const plural = blocked.length > 1
+            await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number,
+              body: `${marker}\n> 🤖 **Claude Code** · agent pipeline (CI) · _Closes-a-blocked-issue check (#1253)_\n\n`
+                + `⚠️ This PR's body \`Closes\` **${list}**, which ${plural ? 'are' : 'is'} \`status:blocked\` — `
+                + `merging will auto-close ${plural ? 'them' : 'it'} out from under a pending owner reply `
+                + '(the #1233 race). If this PR is a **root-cause fix** rather than the blocked work itself, '
+                + `use \`Refs ${list}\` instead of \`Closes\`. Warning only — not a required check.` })
+            core.warning(`PR #${pr.number} Closes blocked issue(s): ${list}`)


### PR DESCRIPTION
## 👤 For humans

Two things went wrong in the #1233 retest: your correct reply produced only an easy-to-miss 🚀 reaction (so it *felt* ignored), and a stray `Closes` in PR #1234 had auto-closed the blocked issue 2 seconds before your comment, so the resume ran against a dead issue and exited green. This PR makes the loop honest:

- **A successful resume now posts a visible "✅ Resumed…" comment** saying what it did (sub-issues created / gate PR merged / issue closed), not just a reaction.
- **A reply that races a close gets a plain answer**: the resume re-checks live issue state, and if the issue closed out from under you it says "closed just before your reply — superseded; reopen or reply on the successor" instead of ghost-running.
- **Stray `Closes` gets caught at authoring time**: a new warning workflow flags non-epic PRs whose body `Closes` a `status:blocked` issue, suggesting `Refs` — plus the convention is now written into the agent docs.

Deliberately **warning-only, never a required check**: gate PRs on `epic/*` close their blocked issue by design (merge-on-approval), so a hard block would deadlock the pipeline.

## 🤖 For agents

- `.github/workflows/resume-on-comment.yml`:
  - New `state` step after checkout — re-fetches live issue state (job guard reads the stale event-payload label snapshot); if closed → superseded-close comment + skip eyes/t0/collect/agent/artifact-gate/outcome steps. Fail-open on API error. `merge-on-approval` stays `if: always()` (the #572 fallback survives the early exit).
  - Artifact-gate: now `id: gate`, exports `subIssues/mergedPR/closed/stillBlocked/newComment`.
  - New final `Comment ✅` step — **ordering is load-bearing**: it must stay *after* the artifact-gate (an earlier comment makes `newComment` always-true and disables the #603 no-op detection). Skipped when the agent already commented this run; posted with `GITHUB_TOKEN` (bot-loop safety).
- New `.github/workflows/warn-closes-blocked.yml` — `pull_request` opened/edited/reopened, non-`epic/*` bases only; parses closing keywords from the PR body; warns once per PR (marker-deduped). Known limits accepted in-file: body-only parsing, post-check label changes.
- `.claude/agents/task-worker.md` (step 9) + `.claude/agents/CLAUDE.md` (agent contract): `Closes` only your own issue; `Refs #NN` for any other blocked issue.
- Scope was reshaped + approved on the issue (lgtm'd comment): added the closed-issue re-check, rejected the strip-status-on-close variant, softened the issue's success criterion to what GitHub's event model can deliver.
- No app/package code touched (YAML + agent docs only) — `pnpm typecheck` not applicable; both workflows YAML-validated.

## 🧪 How to test

1. **Success visibility**: label a scratch issue `status:blocked`, reply on it. Before: only 👀→🚀 reactions. After: also a top-level "✅ Resumed from your reply — …" comment with the run link (unless the agent itself already commented — then no duplicate).
2. **Raced close**: close a `status:blocked` issue, then immediately comment on it (the event guard still sees the label). Before: agent runs against the closed issue, exits green. After: a "⚠️ closed just before your reply — superseded" comment, no agent run.
3. **Stray Closes warning**: open a PR against `main` whose body says `Closes #<open status:blocked issue>` → one warning comment suggesting `Refs`. Same PR against an `epic/*` base → no warning. Edit the body → no duplicate warning.

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
