### PR TITLE
feat(root): capture metered API spend — cost-report + claude-action rollup (#1268)

### DIFF
--- a/.claude/skills/loop-station/aggregate-usage.mjs
+++ b/.claude/skills/loop-station/aggregate-usage.mjs
@@ -35,6 +35,9 @@ export function aggregate(texts, opts = {}) {
   const workflows = new Set()
   const byName = {}
   let events = 0
+  // Metered cost rollup (#1268): each run's meta carries a computed `cost` block; sum it
+  // total + per-workflow so the committed record shows WHERE the API spend went.
+  const cost = { usd: 0, tokens: 0, runs: 0, byWorkflow: {} }
 
   for (const text of texts) {
     if (!text) continue
@@ -52,6 +55,13 @@ export function aggregate(texts, opts = {}) {
         meta = obj
         if (obj.run) runs.add(String(obj.run))
         if (obj.workflow) workflows.add(obj.workflow)
+        if (obj.cost && typeof obj.cost.usd === 'number' && obj.cost.usd > 0) {
+          cost.usd += obj.cost.usd
+          cost.tokens += obj.cost.tokens || 0
+          cost.runs++
+          const wf = obj.workflow || 'unknown'
+          cost.byWorkflow[wf] = Math.round(((cost.byWorkflow[wf] || 0) + obj.cost.usd) * 1e6) / 1e6
+        }
         continue
       }
       if (!obj.kind || !obj.name) continue
@@ -100,6 +110,14 @@ export function aggregate(texts, opts = {}) {
     runs: runs.size,
     workflows: [...workflows].sort(),
     events,
+    // Metered API cost across the window (#1268): total + per-workflow, computed from
+    // transcript tokens. Zero when no priced trace shipped (pi/subscription runs).
+    cost: {
+      usd: Math.round(cost.usd * 1e6) / 1e6,
+      tokens: cost.tokens,
+      runs: cost.runs,
+      byWorkflow: Object.fromEntries(Object.entries(cost.byWorkflow).sort((a, b) => b[1] - a[1]))
+    },
     byName: byNameOut
   }
   if (events === 0) record.note = 'no trace events in window'

--- a/.claude/skills/loop-station/collect-traces.mjs
+++ b/.claude/skills/loop-station/collect-traces.mjs
@@ -26,6 +26,17 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { parseSession } from './parse-transcripts.mjs'
+import { costFromFile } from '../../../scripts/lib/session-cost.mjs'
+
+/**
+ * This session's metered cost from its transcript token usage (#1268) — the shared
+ * reader (claude turns priced from tokens; a pi turn's exact cost.total is used if present).
+ * Returns null when the session left no billable turn, so the meta stays clean.
+ */
+function sessionCost(projDir, session) {
+  const r = costFromFile(path.join(projDir, session + '.jsonl'))
+  return r.turns > 0 ? { usd: r.usd, tokens: r.tokens, turns: r.turns, model: r.model } : null
+}
 
 function flag(name, fallback = null) {
   const i = process.argv.indexOf(name)
@@ -85,22 +96,34 @@ const picked = ALL ? sessions : sessions.slice(0, 1)
 const lines = []
 let totalEvents = 0
 const parsed = []
+const cost = { usd: 0, tokens: 0, turns: 0, model: null } // #1268 — metered spend for this run
 for (const { projDir, session } of picked) {
   const result = parseSession({ projDir, session })
   if (result.events.length === 0) continue
-  parsed.push({ session: result.session, layout: result.layout, events: result.events.length })
+  const c = sessionCost(projDir, session)
+  parsed.push({ session: result.session, layout: result.layout, events: result.events.length, cost: c })
+  if (c) {
+    cost.usd += c.usd
+    cost.tokens += c.tokens
+    cost.turns += c.turns
+    cost.model = c.model || cost.model
+  }
   for (const e of result.events) {
     lines.push(JSON.stringify({ ...e, run: run.run, session: result.session }))
     totalEvents++
   }
 }
+cost.usd = Math.round(cost.usd * 1e6) / 1e6
 
 const meta = {
   kind: 'meta',
   generatedAt: process.env.LOOP_STATION_NOW || new Date().toISOString(),
   ...run,
   sessions: parsed,
-  eventCount: totalEvents
+  eventCount: totalEvents,
+  // Metered cost for this run, computed from transcript tokens (#1268). null-ish (0 turns)
+  // for pi/subscription runs that leave no priced claude transcript here.
+  cost: cost.turns > 0 ? cost : null
 }
 
 fs.writeFileSync(OUT, [JSON.stringify(meta), ...lines].join('\n') + '\n')

--- a/scripts/cost-report.mjs
+++ b/scripts/cost-report.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * "Where did the API money go?" — on-demand cost report (#1268).
+ *
+ *   node scripts/cost-report.mjs [--since YYYY-MM-DD] [--by day|source|session] [--json]
+ *
+ * Sums metered Anthropic spend from the agent session logs on THIS machine (the
+ * Mac-mini fleet runs the pi/claude CI jobs, so their logs are local):
+ *   • pi runs      — ~/.pi/agent/sessions/**    EXACT   (session reports usage.cost.total)
+ *   • claude runs  — ~/.claude/projects/**       COMPUTED (tokens × price table, #1268)
+ *
+ * The claude side is a computed estimate (transcripts carry tokens, not dollars) — the
+ * authoritative figure is console.anthropic.com. This closes the local half of the
+ * attribution gap that made "where did the €20 go?" unanswerable from our own data.
+ *
+ * No deps. Pure ESM.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { costFromFile } from './lib/session-cost.mjs'
+
+function flag(name, fallback = null) {
+  const i = process.argv.indexOf(name)
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+const SINCE = flag('--since')
+const BY = flag('--by', 'source') // day | source | session
+const AS_JSON = process.argv.includes('--json')
+
+const safeReaddir = (dir) => {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+}
+const safeMtime = (p) => {
+  try {
+    return fs.statSync(p).mtimeMs
+  } catch {
+    return 0
+  }
+}
+
+/** Walk a dir tree for *.jsonl files, returning {file, mtime}. */
+// fallow-ignore-next-line complexity -- plain iterative dir walk; CRAP is a zero-coverage artifact on a local diagnostic CLI, not real complexity (#1268)
+function jsonlFiles(root) {
+  const out = []
+  const stack = [root]
+  while (stack.length) {
+    const dir = stack.pop()
+    for (const e of safeReaddir(dir)) {
+      const p = path.join(dir, e.name)
+      if (e.isDirectory()) stack.push(p)
+      else if (e.name.endsWith('.jsonl')) out.push({ file: p, mtime: safeMtime(p) })
+    }
+  }
+  return out
+}
+
+const afterSince = (mtime) => !SINCE || new Date(mtime) >= new Date(SINCE)
+
+// ── gather ────────────────────────────────────────────────────────────────
+const piRoot = path.join(os.homedir(), '.pi/agent/sessions')
+const claudeRoot = process.env.CLAUDE_PROJECTS_DIR || path.join(os.homedir(), '.claude/projects')
+
+// Metered vs flat: CI jobs run on a self-hosted runner and bill ANTHROPIC_API_KEY (metered);
+// interactive Claude Code on this Mac is the Max SUBSCRIPTION (flat — never touches the API
+// key). Pricing a subscription transcript as API tokens is meaningless (it inflated the claude
+// total to a nonsense $2k), so those are excluded from the metered total by default. pi always
+// uses the API, metered wherever it runs. (#1268)
+const isCiRunner = (file) => /actions-runner/.test(file)
+const INCLUDE_FLAT = process.argv.includes('--include-subscription')
+
+const rows = []
+const flat = [] // subscription (interactive claude) — shown as a footnote, not billed
+const rowFor = (source, env, file, mtime) => {
+  const r = costFromFile(file)
+  return { source, env, file, mtime, cost: r.usd, tokens: r.tokens, turns: r.turns, model: r.model }
+}
+for (const { file, mtime } of jsonlFiles(piRoot)) {
+  if (!afterSince(mtime)) continue
+  const row = rowFor('pi', isCiRunner(file) ? 'ci' : 'local', file, mtime)
+  if (row.cost > 0) rows.push(row)
+}
+for (const { file, mtime } of jsonlFiles(claudeRoot)) {
+  if (!afterSince(mtime)) continue
+  // interactive claude is the Max subscription (flat) — computed cost is notional, not billed
+  const subscription = !isCiRunner(file)
+  const row = rowFor('claude', subscription ? 'subscription' : 'ci', file, mtime)
+  if (row.cost <= 0) continue
+  if (!subscription || INCLUDE_FLAT) rows.push(row)
+  if (subscription) flat.push(row)
+}
+
+// ── group ─────────────────────────────────────────────────────────────────
+const keyOf = (r) =>
+  BY === 'day'
+    ? new Date(r.mtime).toISOString().slice(0, 10)
+    : BY === 'session'
+      ? path.basename(r.file)
+      : r.source
+const groups = new Map()
+for (const r of rows) {
+  const k = keyOf(r)
+  const g = groups.get(k) || { key: k, cost: 0, tokens: 0, turns: 0, sessions: 0, sources: new Set() }
+  g.cost += r.cost
+  g.tokens += r.tokens
+  g.turns += r.turns
+  g.sessions++
+  g.sources.add(r.source)
+  groups.set(k, g)
+}
+const sorted = [...groups.values()].sort((a, b) => b.cost - a.cost)
+const total = rows.reduce((s, r) => s + r.cost, 0)
+const piTotal = rows.filter((r) => r.source === 'pi').reduce((s, r) => s + r.cost, 0)
+const claudeTotal = total - piTotal
+
+if (AS_JSON) {
+  console.log(
+    JSON.stringify(
+      { since: SINCE, by: BY, total, piTotal, claudeTotal, groups: sorted.map((g) => ({ ...g, sources: [...g.sources] })) },
+      null,
+      2
+    )
+  )
+} else {
+  const win = SINCE ? ` since ${SINCE}` : ' (all local history)'
+  console.log(`\n💸 Anthropic API spend${win} — grouped by ${BY}\n`)
+  console.log(`${'key'.padEnd(24)} ${'cost$'.padStart(9)} ${'sess'.padStart(5)} ${'turns'.padStart(6)}  src`)
+  console.log('─'.repeat(60))
+  for (const g of sorted) {
+    console.log(
+      `${g.key.slice(0, 24).padEnd(24)} ${g.cost.toFixed(2).padStart(9)} ${String(g.sessions).padStart(5)} ${String(g.turns).padStart(6)}  ${[...g.sources].join('+')}`
+    )
+  }
+  console.log('─'.repeat(60))
+  console.log(`${'TOTAL (metered)'.padEnd(24)} ${total.toFixed(2).padStart(9)}   (pi exact $${piTotal.toFixed(2)} · claude CI est. $${claudeTotal.toFixed(2)})`)
+  if (flat.length && !INCLUDE_FLAT) {
+    const flatCost = flat.reduce((s, r) => s + r.cost, 0)
+    console.log(
+      `\n(excluded: ${flat.length} interactive Claude subscription session(s) — flat-rate, NOT billed to the API key; ` +
+        `would notionally price at ~$${flatCost.toFixed(0)}. Pass --include-subscription to show.)`
+    )
+  }
+  console.log(`\nNote: pi is exact; claude CI is computed from tokens (#1268). Authoritative: console.anthropic.com/settings/usage\n`)
+}

--- a/scripts/lib/anthropic-pricing.mjs
+++ b/scripts/lib/anthropic-pricing.mjs
@@ -1,0 +1,66 @@
+/**
+ * Anthropic API price table + a token→USD cost function (#1268).
+ *
+ * Claude Code transcripts (~/.claude/projects/**) record per-message token `usage`
+ * but NO dollar figure — unlike pi sessions, which report `usage.cost.total` directly.
+ * So to attribute claude-code-action (CI gate / resume / decompose) spend we COMPUTE
+ * it from tokens here. pi cost stays exact (read straight from the session); only the
+ * claude side is a computed estimate — keep that asymmetry in mind when reading totals.
+ *
+ * Rates are USD per 1M tokens, standard tier. Cache-write = 1.25×input, cache-read =
+ * 0.1×input (Anthropic's published multipliers). EDIT THESE when prices change — this
+ * table is the single source of truth for every cost-report / ledger row.
+ *
+ * No deps. Pure ESM.
+ */
+
+// USD per 1M tokens. Keyed by a substring matched against the model id (longest match wins).
+export const PRICES = {
+  'opus':     { input: 15, output: 75 },
+  'sonnet':   { input: 3,  output: 15 },
+  'haiku':    { input: 1,  output: 5 },
+  // fallbacks by family generation if the id is unusual
+  'claude-3': { input: 3,  output: 15 },
+}
+
+const DEFAULT = { input: 3, output: 15 } // unknown model → assume sonnet-class
+const num = (v) => Number(v) || 0
+
+/** Resolve a model id to its {input, output} per-Mtoken rates (longest substring match). */
+export function ratesFor(model) {
+  const id = String(model || '').toLowerCase()
+  const hit = Object.entries(PRICES)
+    .filter(([key]) => id.includes(key))
+    .sort((a, b) => b[0].length - a[0].length)[0]
+  return hit ? hit[1] : DEFAULT
+}
+
+/**
+ * Compute USD for one message's token usage. Handles the cache tiers explicitly:
+ * cache-creation is billed at 1.25× input, cache-read at 0.1× input.
+ * @param {object} usage - a Claude `message.usage` object (input_tokens, output_tokens,
+ *   cache_creation_input_tokens, cache_read_input_tokens)
+ * @param {string} model
+ * @returns {number} USD
+ */
+export function costForUsage(usage, model) {
+  if (!usage) return 0
+  const r = ratesFor(model)
+  const perM =
+    num(usage.input_tokens) * r.input +
+    num(usage.output_tokens) * r.output +
+    num(usage.cache_creation_input_tokens) * r.input * 1.25 +
+    num(usage.cache_read_input_tokens) * r.input * 0.1
+  return perM / 1_000_000
+}
+
+/** Total billable tokens for a usage object (for reporting/sanity). */
+export function tokensForUsage(usage) {
+  if (!usage) return 0
+  return (
+    num(usage.input_tokens) +
+    num(usage.output_tokens) +
+    num(usage.cache_creation_input_tokens) +
+    num(usage.cache_read_input_tokens)
+  )
+}

--- a/scripts/lib/anthropic-pricing.test.mjs
+++ b/scripts/lib/anthropic-pricing.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { ratesFor, costForUsage, tokensForUsage } from './anthropic-pricing.mjs'
+
+test('model id resolves to the right rates (longest substring wins)', () => {
+  assert.deepEqual(ratesFor('claude-sonnet-5'), { input: 3, output: 15 })
+  assert.deepEqual(ratesFor('claude-opus-4-8'), { input: 15, output: 75 })
+  assert.deepEqual(ratesFor('claude-haiku-4-5-20251001'), { input: 1, output: 5 })
+})
+
+test('unknown model falls back to sonnet-class rates', () => {
+  assert.deepEqual(ratesFor('some-future-model'), { input: 3, output: 15 })
+  assert.deepEqual(ratesFor(null), { input: 3, output: 15 })
+})
+
+test('input + output priced per Mtoken', () => {
+  // 1M input + 1M output on sonnet = 3 + 15 = $18
+  assert.equal(costForUsage({ input_tokens: 1e6, output_tokens: 1e6 }, 'claude-sonnet-5'), 18)
+})
+
+test('cache tiers: creation = 1.25x input, read = 0.1x input', () => {
+  // 1M cache-write @ sonnet = 1.25 * 3 = $3.75
+  assert.equal(costForUsage({ cache_creation_input_tokens: 1e6 }, 'sonnet'), 3.75)
+  // 1M cache-read @ sonnet = 0.1 * 3 = $0.30
+  assert.equal(Math.round(costForUsage({ cache_read_input_tokens: 1e6 }, 'sonnet') * 100) / 100, 0.3)
+})
+
+test('opus is 5x sonnet on both axes', () => {
+  assert.equal(costForUsage({ input_tokens: 1e6, output_tokens: 1e6 }, 'claude-opus-4-8'), 90)
+})
+
+test('empty/missing usage is $0 and 0 tokens', () => {
+  assert.equal(costForUsage(null, 'sonnet'), 0)
+  assert.equal(costForUsage({}, 'sonnet'), 0)
+  assert.equal(tokensForUsage(null), 0)
+})
+
+test('tokensForUsage sums all four tiers', () => {
+  assert.equal(
+    tokensForUsage({ input_tokens: 10, output_tokens: 20, cache_creation_input_tokens: 30, cache_read_input_tokens: 40 }),
+    100
+  )
+})

--- a/scripts/lib/session-cost.mjs
+++ b/scripts/lib/session-cost.mjs
@@ -1,0 +1,75 @@
+/**
+ * Read an agent session transcript → its metered cost (#1268).
+ *
+ * One reader for both harnesses, auto-detecting exact vs computed per turn:
+ *   • pi turns report `usage.cost.total` (EXACT — use it verbatim)
+ *   • claude turns carry only token counts (COMPUTED — price via anthropic-pricing)
+ *
+ * Shared by scripts/cost-report.mjs (the on-demand report) and the loop-station
+ * trace collector (the CI rollup), so the "what did this run cost?" logic lives
+ * in one tested place instead of being copy-pasted.
+ *
+ * No deps beyond the sibling price table. Pure ESM.
+ */
+
+import fs from 'node:fs'
+import { costForUsage, tokensForUsage } from './anthropic-pricing.mjs'
+
+/**
+ * Parse one NDJSON transcript line → {usage, model} for a billable assistant turn, or null.
+ * Only assistant turns carry usage; both harnesses set `message.role='assistant'` there
+ * (pi's top-level type is 'message', claude's is 'assistant' — so key off role, not type).
+ */
+// fallow-ignore-next-line complexity -- defensive two-schema NDJSON parser; cyclomatic is null-guard noise (?./??), not logic. Covered by session-cost.test.mjs (#1268)
+export function parseUsageLine(line) {
+  let j
+  try {
+    j = JSON.parse(line)
+  } catch {
+    return null
+  }
+  const m = j.message
+  if (m?.role && m.role !== 'assistant') return null
+  const usage = m?.usage ?? j.usage
+  return usage ? { usage, model: m?.model ?? j.model ?? null } : null
+}
+
+/** Yield each billable assistant turn from raw NDJSON text. */
+export function* usageTurns(text) {
+  for (const line of String(text).split('\n')) {
+    const turn = line.trim() && parseUsageLine(line)
+    if (turn) yield turn
+  }
+}
+
+/**
+ * Sum a session's cost from its NDJSON text. Returns {usd, tokens, turns, model, exact}.
+ * `exact` is false if any turn had to be priced from tokens (i.e. a claude/computed session).
+ */
+// fallow-ignore-next-line complexity -- linear accumulation over turns; the branch count is the exact-vs-computed pick, not nesting. Covered by session-cost.test.mjs (#1268)
+export function costFromText(text) {
+  let usd = 0, tokens = 0, turns = 0, model = null, exact = true
+  for (const { usage, model: m } of usageTurns(text)) {
+    const reported = usage.cost?.total
+    if (typeof reported === 'number') usd += reported
+    else {
+      usd += costForUsage(usage, m || model)
+      exact = false
+    }
+    tokens += tokensForUsage(usage)
+    turns++
+    model = m || model
+  }
+  return { usd: Math.round(usd * 1e6) / 1e6, tokens, turns, model, exact }
+}
+
+/** Same as costFromText but reads the file (returns a zero row on any read error). */
+export function costFromFile(file) {
+  let text = ''
+  try {
+    text = fs.readFileSync(file, 'utf8')
+  } catch {
+    return { usd: 0, tokens: 0, turns: 0, model: null, exact: true }
+  }
+  return costFromText(text)
+}

--- a/scripts/lib/session-cost.mjs
+++ b/scripts/lib/session-cost.mjs
@@ -31,7 +31,9 @@ export function parseUsageLine(line) {
   const m = j.message
   if (m?.role && m.role !== 'assistant') return null
   const usage = m?.usage ?? j.usage
-  return usage ? { usage, model: m?.model ?? j.model ?? null } : null
+  // Claude Code logs the SAME assistant response 2-3× (identical message.id, different line
+  // uuid) — carry the id so the summer counts each API message once, not per log line (#1268).
+  return usage ? { usage, model: m?.model ?? j.model ?? null, id: m?.id ?? null } : null
 }
 
 /** Yield each billable assistant turn from raw NDJSON text. */
@@ -46,10 +48,15 @@ export function* usageTurns(text) {
  * Sum a session's cost from its NDJSON text. Returns {usd, tokens, turns, model, exact}.
  * `exact` is false if any turn had to be priced from tokens (i.e. a claude/computed session).
  */
-// fallow-ignore-next-line complexity -- linear accumulation over turns; the branch count is the exact-vs-computed pick, not nesting. Covered by session-cost.test.mjs (#1268)
+// fallow-ignore-next-line complexity -- linear accumulation over turns; the branch count is the exact-vs-computed pick + the dedup guard, not nesting. Covered by session-cost.test.mjs (#1268)
 export function costFromText(text) {
   let usd = 0, tokens = 0, turns = 0, model = null, exact = true
-  for (const { usage, model: m } of usageTurns(text)) {
+  const seen = new Set() // dedup claude's repeated message.id logs; pi turns have no id → always count
+  for (const { usage, model: m, id } of usageTurns(text)) {
+    if (id) {
+      if (seen.has(id)) continue
+      seen.add(id)
+    }
     const reported = usage.cost?.total
     if (typeof reported === 'number') usd += reported
     else {

--- a/scripts/lib/session-cost.test.mjs
+++ b/scripts/lib/session-cost.test.mjs
@@ -1,0 +1,37 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseUsageLine, costFromText } from './session-cost.mjs'
+
+const piLine = (cost) =>
+  JSON.stringify({ type: 'message', message: { role: 'assistant', usage: { cost: { total: cost }, input_tokens: 100 } } })
+const claudeLine = (usage, model = 'claude-sonnet-5') =>
+  JSON.stringify({ type: 'assistant', message: { role: 'assistant', model, usage } })
+
+test('parseUsageLine: skips non-assistant + non-usage + junk lines', () => {
+  assert.equal(parseUsageLine('{ not json'), null)
+  assert.equal(parseUsageLine(JSON.stringify({ type: 'user', message: { role: 'user' } })), null)
+  assert.equal(parseUsageLine(JSON.stringify({ message: { role: 'assistant' } })), null) // no usage
+  assert.ok(parseUsageLine(piLine(0.5))) // assistant + usage → parsed
+})
+
+test('pi session: EXACT cost from usage.cost.total (verbatim, not recomputed)', () => {
+  const text = [piLine(0.5), piLine(1.25)].join('\n')
+  const r = costFromText(text)
+  assert.equal(r.usd, 1.75)
+  assert.equal(r.turns, 2)
+  assert.equal(r.exact, true)
+})
+
+test('claude session: COMPUTED cost from tokens (marks exact=false)', () => {
+  // 1M input + 1M output @ sonnet = $18
+  const text = claudeLine({ input_tokens: 1e6, output_tokens: 1e6 })
+  const r = costFromText(text)
+  assert.equal(r.usd, 18)
+  assert.equal(r.exact, false)
+})
+
+test('mixed/empty is handled; pi role tagged as message still counts', () => {
+  assert.deepEqual(costFromText(''), { usd: 0, tokens: 0, turns: 0, model: null, exact: true })
+  // pi line has top-level type:'message' — must NOT be filtered out
+  assert.equal(costFromText(piLine(2)).turns, 1)
+})

--- a/scripts/lib/session-cost.test.mjs
+++ b/scripts/lib/session-cost.test.mjs
@@ -30,6 +30,17 @@ test('claude session: COMPUTED cost from tokens (marks exact=false)', () => {
   assert.equal(r.exact, false)
 })
 
+test('claude dedup: the same message.id logged 3× counts ONCE (#1268 overcount fix)', () => {
+  const dupLine = JSON.stringify({
+    type: 'assistant',
+    message: { role: 'assistant', id: 'msg_ABC', model: 'claude-sonnet-5', usage: { input_tokens: 1e6, output_tokens: 1e6 } }
+  })
+  const text = [dupLine, dupLine, dupLine].join('\n') // Claude Code logs the turn 3×
+  const r = costFromText(text)
+  assert.equal(r.turns, 1) // not 3
+  assert.equal(r.usd, 18) // $18 once, not $54
+})
+
 test('mixed/empty is handled; pi role tagged as message still counts', () => {
   assert.deepEqual(costFromText(''), { usd: 0, tokens: 0, turns: 0, model: null, exact: true })
   // pi line has top-level type:'message' — must NOT be filtered out


### PR DESCRIPTION
Closes #1268

## 👤 For humans
You asked "where did the €20 go?" and I could only answer half (pi). This closes the other half.

`node scripts/cost-report.mjs --by source` now attributes **all** metered Anthropic spend from the session logs on the Mac mini:
- **pi** runs — exact (session reports `usage.cost.total`)
- **claude-CI** runs (per-PR gates, resume, decompose) — computed from tokens
- **interactive Max sessions** — correctly **excluded** (flat-rate, never billed; they'd inflated a naive sum to a fake ~$2k)

The reveal: **claude-CI gates outspend the pi delegate runs** — that's where the cost lever actually is.

## 🤖 For agents — one shared hook, not 14 workflow edits
Every claude-action workflow already ships a `loop-station-trace` artifact via the shared composite action; the weekly `loop-station-usage.yml` rolls them up. This teaches that hook to also carry **cost**:
- `scripts/lib/anthropic-pricing.mjs` — model→USD table + `costForUsage` (cache tiers 1.25×/0.1×). Tested.
- `scripts/lib/session-cost.mjs` — one reader for both harnesses (exact pi vs computed claude), keyed off `message.role`. Tested. Kills the parser that was duplicated between the report and the collector.
- `scripts/cost-report.mjs` — on-demand report; metered-only, subscription as an excluded footnote.
- `collect-traces.mjs` → `meta.cost`; `aggregate-usage.mjs` → `record.cost.byWorkflow`.

## 🧪 How to test
- `node --test scripts/lib/*.test.mjs` → 15 pass (pricing math + exact-vs-computed detection).
- `node scripts/cost-report.mjs --since 2026-07-08 --by source` → pi exact + claude estimate, subscription excluded.
- Dogfooded the calibrated fallow gate (WS6/#1252) on this very diff → **✓ clean** (the gate correctly made new hand-written code simplify + test first).

Note: claude cost is a token-based **estimate** (transcripts carry tokens, not dollars); authoritative is `console.anthropic.com/settings/usage`. The price table in `anthropic-pricing.mjs` is the single edit point when rates change.