### PR TITLE
chore(root): demote a11y + frontend-review gates Sonnet→Haiku (#1272)

### DIFF
--- a/.claude/agents/a11y.md
+++ b/.claude/agents/a11y.md
@@ -3,7 +3,7 @@ name: a11y
 layer: method
 description: An accessibility prober for this monorepo's Vue surfaces. Given a scope and a depth, it reads templates the way a screen-reader / keyboard-only user would — running the eslint-a11y rules, sniffing for ARIA-without-keyboard smells, and (deep) booting a fixture to run @axe-core/playwright — and returns structured, severity-rated findings. Reports only; it patches the working tree ONLY when called with fix=true.
 tools: Read, Grep, Glob, Bash, Edit
-model: sonnet
+model: haiku
 ---
 
 # A11y — read our own UI as a screen-reader / keyboard user would, then report what's broken

--- a/.claude/agents/frontend-review.md
+++ b/.claude/agents/frontend-review.md
@@ -3,7 +3,7 @@ name: frontend-review
 layer: stack
 description: A front-end conventions prober for this monorepo's Vue surfaces. Given a scope and a depth, it reads `.vue` templates the way a Nuxt UI 4 reviewer would — checking we build on Nuxt UI 4 / crouton components (not raw HTML re-implementations), use the v4 component names and patterns, and don't drift to Options API or hardcoded colors — and returns structured, severity-rated findings. Reports only; it patches the working tree ONLY when called with fix=true.
 tools: Read, Grep, Glob, Bash, Edit
-model: sonnet
+model: haiku
 ---
 
 # Frontend-review — read our own UI as a Nuxt UI 4 reviewer would, then report what's off-convention

--- a/.claude/routing.json
+++ b/.claude/routing.json
@@ -16,8 +16,8 @@
     "task-orchestrator": { "tier": "medium", "why": "reads epic → workstreams; no code written. Moved opus→Sonnet 5 on an N=4 decompose A/B (Sonnet 5 matched/beat Opus 4.8 on 3 of 4 real epics, ~5× cheaper, fewer NEEDS-SPLIT recursion rounds). Refines #824: the strong-but-cheaper model is a peer planner, not the blunt one that decision guarded against." },
     "task-decomposer":   { "tier": "medium", "why": "LEAF test + split issues; no code written. Moved opus→Sonnet 5 with the orchestrator on the same N=4 A/B evidence. Refines #824." },
     "red-team":          { "tier": "medium", "why": "security analysis, reports only — opus was overkill; moved to Sonnet 5 (no code written, daily deep sweep is the cost). Free win per #823/#824." },
-    "a11y":              { "tier": "medium", "proposed": "small", "why": "template review, reports only" },
-    "frontend-review":   { "tier": "medium", "proposed": "small", "why": "convention review, reports only" }
+    "a11y":              { "tier": "small", "why": "template review, reports only — Sonnet→Haiku (#1272/#823); reversible if the #865 scoreboard shows missed axe findings" },
+    "frontend-review":   { "tier": "small", "why": "convention review, reports only — Sonnet→Haiku (#1272/#823); reversible if it stops catching v3 names" }
   },
 
   "_overrides": "Per-flow exceptions that pin an exact model regardless of tier. This is where a one-off flow declares itself VISIBLY instead of burying the decision in a branch.",

--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -58,7 +58,9 @@ jobs:
           # deep sweep couldn't write its report, update the standing issue, or file a11y issues.
           # Broader than the per-PR gate's allowlist because this run also files GitHub issues
           # (MCP) + writes reports; the gate-package-edits hook still protects packages/.
-          claude_args: "--model claude-sonnet-5 --max-turns 60 --permission-mode bypassPermissions"
+          # Haiku, matching the a11y agent's small tier (#1272/#823) — the deep sweep's value is
+          # the deterministic @axe-core/playwright run, not LLM depth; Haiku drives it at ~3× less.
+          claude_args: "--model claude-haiku-4-5-20251001 --max-turns 60 --permission-mode bypassPermissions"
           prompt: |
             Run the **`/a11y`** skill (`.claude/skills/a11y/SKILL.md`) at
             **depth=deep, scope=repo**. Sweep the `vuejs-accessibility/*` eslint rules across

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -76,7 +76,9 @@ jobs:
           # --allowedTools REQUIRED (#834): the prompt has the top-level agent *act as* the
           # subagent and call Bash/Write directly; headless CI denies un-allowlisted tools, so
           # without this the agent can't write a11y-verdict.json / post the comment → fails OPEN.
-          claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          # Haiku, not Sonnet (#1272/#823): reports-only a11y review — ARIA/label/alt/tabindex
+          # pattern-matching that Haiku handles at ~3× lower cost. Reversible if axe findings slip.
+          claude_args: "--model claude-haiku-4-5-20251001 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **a11y subagent** defined in `.claude/agents/a11y.md`.
             Input: { scope: "diff", depth: "quick", fix: false }.

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -71,7 +71,9 @@ jobs:
           # bytes written. Bash covers `gh` (comment) + writing the verdict; Write/Edit for the
           # file; Read/Grep/Glob for the scan. Bump max-turns now that turns aren't wasted on
           # denied retries. NB: a11y.yml / red-team.yml share this exact latent bug.
-          claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          # Haiku, not Sonnet (#1272/#823): reports-only convention review — pattern-matching v3
+          # component names / raw-HTML re-impls that Haiku handles at ~3× lower cost. Reversible.
+          claude_args: "--model claude-haiku-4-5-20251001 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |
             Act as the **frontend-review subagent** defined in `.claude/agents/frontend-review.md`.
             Input: { scope: "diff", depth: "quick", fix: false }.

--- a/writeups/architecture/routing-registry.md
+++ b/writeups/architecture/routing-registry.md
@@ -19,8 +19,8 @@ Default tier: **medium**
 | `task-orchestrator` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | — | reads epic → workstreams; no code written. Moved opus→Sonnet 5 on an N=4 decompose A/B (Sonnet 5 matched/beat Opus 4.8 on 3 of 4 real epics, ~5× cheaper, fewer NEEDS-SPLIT recursion rounds). Refines #824: the strong-but-cheaper model is a peer planner, not the blunt one that decision guarded against. |
 | `task-decomposer` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | — | LEAF test + split issues; no code written. Moved opus→Sonnet 5 with the orchestrator on the same N=4 A/B evidence. Refines #824. |
 | `red-team` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | — | security analysis, reports only — opus was overkill; moved to Sonnet 5 (no code written, daily deep sweep is the cost). Free win per #823/#824. |
-| `a11y` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | small (claude-haiku-4-5) | template review, reports only |
-| `frontend-review` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | small (claude-haiku-4-5) | convention review, reports only |
+| `a11y` | small | claude-haiku-4-5 | deepseek-v3.2 | $5 | — | template review, reports only — Sonnet→Haiku (#1272/#823); reversible if the #865 scoreboard shows missed axe findings |
+| `frontend-review` | small | claude-haiku-4-5 | deepseek-v3.2 | $5 | — | convention review, reports only — Sonnet→Haiku (#1272/#823); reversible if it stops catching v3 names |
 
 ## Overrides (per-flow exact-model pins)
 - **prototype-example** → `claude-opus-4-8` — exploratory prototype flow — quality over cost (replace with your real flow)


### PR DESCRIPTION
Closes #1272 · part of #823 (cut the Claude bill via model tiering)

## 👤 For humans
The #1268 cost-report showed the **per-PR claude gates are the dominant metered spend** (not pi). They were running on **Sonnet** ($15/Mtok) to do reports-only pattern-matching — v3 component names, missing `alt`/labels. **Haiku** ($5/Mtok) handles that, cutting **~3×** on the two highest-volume gates.

Your own `routing.json` already recorded `proposed: "small"` for both — this just realizes it. **`red-team` stays Sonnet** (security is higher-stakes; not proposed for demotion). Fully reversible one-liner if quality dips.

## 🤖 For agents
| File | Change |
|---|---|
| `.github/workflows/{frontend-review,a11y,a11y-daily}.yml` | `--model claude-sonnet-5` → `claude-haiku-4-5-20251001` |
| `.claude/routing.json` | `a11y` + `frontend-review` tier `medium`→`small` |
| `.claude/agents/{frontend-review,a11y}.md` | frontmatter `model: sonnet`→`haiku` |
| `writeups/architecture/routing-registry.md` | regenerated (`gen-routing --check` ✓) |

## 🧪 How to test
On a PR that plants a v3 name (`UDropdown`) or a missing-`alt` `<img>`, the Haiku gate still flags it (pass/fail is the acceptance). Then `node scripts/cost-report.mjs --by day` after a few PRs should show the frontend/a11y line drop ~3×. The #865 scoreboard is the continuous quality check.

Note: leaves the deterministic-short-circuit idea (skip the LLM entirely when the static grep finds nothing) as the bigger follow-up lever — tracked separately.