### PR TITLE
fix(crouton-cli): verify a migration was produced before reporting success (#1286)

### DIFF
--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -1415,20 +1415,47 @@ async function runBatchDatabaseSetup(allCollections: Array<{ name: string; layer
   console.log(`\nRunning database migration...`)
   console.log(`Command: npx nuxt db generate (30s timeout)`)
 
+  // Snapshot existing migrations so we can VERIFY one is actually produced. A cold run
+  // (no @fyit/* dist → nuxt prepare can't emit .nuxt/hub/db/schema.mjs → drizzle finds no
+  // schema) makes `nuxt db generate` a silent no-op that still exits 0 — which used to print
+  // a false "✓ generated successfully" and send workers chasing a phantom migration. (#1286)
+  const migDir = 'server/db/migrations/sqlite'
+  const countSql = async (): Promise<number> => {
+    try {
+      return (await fsp.readdir(migDir)).filter((f) => f.endsWith('.sql')).length
+    } catch {
+      return 0
+    }
+  }
+  const migrationsBefore = await countSql()
+
   try {
     const timeoutPromise = new Promise((_, reject) => {
       setTimeout(() => reject(new Error('Command timed out after 30 seconds')), 30000)
     })
 
-    const { stdout, stderr } = await Promise.race([
+    const { stdout, stderr } = (await Promise.race([
       execAsync('npx nuxt db generate'),
       timeoutPromise
-    ])
+    ])) as { stdout: string; stderr: string }
 
-    if (stderr && !stderr.includes('Warning')) {
-      console.error(`⚠ Warnings:`, stderr)
+    // The cold-state failure `nuxt db generate` swallows behind a 0 exit code (#1286).
+    const combined = `${stdout || ''}\n${stderr || ''}`
+    const coldState = /Could not load @fyit|No schema files found|schema\.mjs/i.test(combined)
+    const migrationsAfter = await countSql()
+
+    if (migrationsAfter > migrationsBefore) {
+      console.log(`\n✓ Database migration generated successfully`)
+    } else {
+      // No migration written despite collections generated — DO NOT report success (#1286).
+      console.error(`\n✗ Database migration was NOT generated — 0 new files in ${migDir}/`)
+      if (coldState) {
+        console.error(`  Cause: the schema bundle isn't built — 'nuxt db generate' silently no-ops when the @fyit/* packages have no dist/.`)
+        console.error(`  Fix:   run 'pnpm build:packages', then re-run: npx nuxt db generate`)
+      } else {
+        console.error(`  'npx nuxt db generate' exited without writing a migration. Check server/db/schema.ts, then re-run: npx nuxt db generate`)
+      }
     }
-    console.log(`\n✓ Database migration generated successfully`)
   } catch (execError: any) {
     if (execError.message.includes('timed out')) {
       console.error(`\n✗ Database migration timed out after 30 seconds`)


### PR DESCRIPTION
Closes #1286 · part of #1281

## 👤 For humans
The single biggest time-sink in the hands-off pipeline: `crouton config`/generate printed **"✓ Database migration generated successfully"** while writing **zero** migration files — a silent no-op that lied, and sent CI workers chasing a phantom migration for ~22 minutes. Now it **verifies a migration was actually written**, and if not, **fails loudly** with the real cause and the fix.

## 🔬 Archaeology (recorded on #1286)
Not a regression — **latent since `87153dad` (2026-02-18)**. `runBatchDatabaseSetup` declared success whenever `npx nuxt db generate` didn't *throw*, never checking a `.sql` was produced; the `!stderr.includes('Warning')` guard downgraded the real `Could not load @fyit/crouton` crash to a warning. Cold CI runs (no `@fyit` dist → no schema bundle → drizzle no-ops but exits 0) exposed it.

## 🤖 What changed
`packages/crouton-cli/lib/generate-collection.ts`:
- Snapshot the `.sql` count in `server/db/migrations/sqlite/` **before** `nuxt db generate`; print `✓` **only if the count increased**.
- Otherwise a loud `✗ Database migration was NOT generated` + the cold-state cause + `pnpm build:packages` fix.
- Detects the swallowed class (`Could not load @fyit` / `No schema files found` / `schema.mjs`).

## 🧪 How to test
Run `crouton config` on a new collection with the `@fyit/*` packages **unbuilt** (`rm -rf packages/*/dist`): it now prints the loud `✗` + "run `pnpm build:packages`", **not** a false `✓`. With packages built, it prints `✓` as before. All **288 crouton-cli tests pass**.

## Follow-ups (not blocking)
- A mocked regression test (stub `execAsync` + fs to assert the false-success path is caught) — the migration step shells out, so it needs mocking; worth adding.
- Pairs with **#1222**: a warm `dist` means the crash never happens, but the CLI is now honest either way.