### PR TITLE
fix(root): warm @fyit dist via content-addressed cache + build-all fallback (#1222)

### DIFF
--- a/.github/actions/warm-packages/action.yml
+++ b/.github/actions/warm-packages/action.yml
@@ -1,0 +1,37 @@
+# Warm the @fyit/* package builds (#1222).
+#
+# Restore EVERY package's `dist/` from a content-addressed cache; on a cache MISS,
+# build them all with `pnpm build:packages`. One line in any job that runs a Nuxt
+# build/deploy, after `pnpm install`:
+#
+#   - uses: ./.github/actions/warm-packages
+#
+# Why "build ALL", not a per-caller subset (the old deploy-app.yml logic):
+#   - A subset can miss a package the app transitively extends — e.g. `@fyit/crouton`
+#     itself wasn't in a POC's `layer-packages`, so the build skipped it and `nuxt build`
+#     died with "Could not load @fyit/crouton" (the quotes-POC deploy). Building all
+#     removes the guess. `pnpm build:packages` is ~31s (topological), so it's cheap.
+#
+# Why content-addressed, not `clean:false` warmth:
+#   - Keyed on all package source + the lockfile, so a source change → new key → rebuild
+#     (never stale dist), and concurrent agents can't contaminate a shared mutable dir —
+#     the exact constraint recorded on #1222 for a multi-agent fleet.
+name: warm-packages
+description: Restore all @fyit/* package dist from a content-addressed cache; build every package on a cache miss.
+
+runs:
+  using: composite
+  steps:
+    - name: Restore package dist cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: packages/*/dist
+        # Source + lockfile only. dist/ is gitignored so it's absent at hash time → the
+        # key reflects inputs, not outputs. Bump the v-tag to bust the cache deliberately.
+        key: pkg-dist-v1-${{ hashFiles('packages/**/*.ts', 'packages/**/*.vue', 'pnpm-lock.yaml') }}
+
+    - name: Build all packages (cache miss)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm build:packages

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -140,6 +140,12 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      # Warm @fyit/* dist so the agent's `crouton init`/generate/migrate doesn't cold-build
+      # ~30 packages one-at-a-time mid-run (the #1213/#1247 tax — ~15-20 min). Content-addressed
+      # cache + build-all on miss; a warm cache makes this ~seconds. (#1222)
+      - name: Warm @fyit package builds
+        uses: ./.github/actions/warm-packages
+
       # Timestamp the run start so the artifact-gate distinguishes "produced this run"
       # from pre-existing comments/PRs.
       - id: t0

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -217,65 +217,15 @@ jobs:
       - name: Rebuild native build deps skipped by --ignore-scripts
         run: pnpm rebuild better-sqlite3 2>/dev/null || true
 
-      # The dist-consumed framework packages (inputs.layer-packages) must be built
-      # before the app build. Pure source layers (crouton-editor/pages/charts) have
-      # no build script and are skipped.
-
-      # The layer cache is shared across ALL callers (one runner cache), but the set
-      # of dists a deploy needs varies per app (different layer-packages, + devtools
-      # below). Keying on source alone (`hashFiles('packages/**/*.ts')`) meant the
-      # first app to populate the cache decided which dists every later app got — a
-      # cache HIT could restore a set MISSING a package the current app needs, and
-      # the build step (gated on cache-miss) would skip it → `nuxt prepare` failing
-      # to load it. That's the #745 devtools crash, but it's a general cross-app
-      # collision class (e.g. an i18n-needing app hitting an i18n-less cache). So we
-      # fold the resolved build set into the cache key: different sets → different
-      # entries → no collision.
-      - name: Compute layer build-set key
-        id: layer-set
-        env:
-          LAYER_PACKAGES: ${{ inputs['layer-packages'] }}
-        run: |
-          # The EXACT set built below: caller's layer-packages + devtools (always),
-          # sorted + de-duped so key is order-independent. crouton-devtools is in the
-          # set unconditionally — scaffolded apps declare it in nuxt.config `modules`
-          # (scaffold-app.ts), so `nuxt prepare` needs its dist on every deploy (there
-          # is no review flag to gate on; building it for apps that don't list it is
-          # cheap and inert). (#745)
-          set_str=$(printf '%s\n' $LAYER_PACKAGES @fyit/crouton-devtools | sort -u | tr '\n' ' ')
-          echo "Layer build set: $set_str"
-          echo "hash=$(printf '%s' "$set_str" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache layer builds
-        id: layer-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/*/dist
-          key: layer-builds-${{ steps.layer-set.outputs.hash }}-${{ hashFiles('packages/**/*.ts') }}
-
-      - name: Build layer packages
-        if: steps.layer-cache.outputs.cache-hit != 'true'
-        env:
-          LAYER_PACKAGES: ${{ inputs['layer-packages'] }}
-        run: |
-          # Same set the cache key was computed from (layer-set step). de-dupe is by
-          # "dist already built this run" so an explicit devtools in layer-packages
-          # isn't built twice.
-          for pkg in $LAYER_PACKAGES @fyit/crouton-devtools; do
-            dir="packages/${pkg#@fyit/}"
-            # de-dupe: skip if this dist was already built earlier in the loop
-            if [ -d "$dir/dist" ] && [ -n "$(ls -A "$dir/dist" 2>/dev/null)" ]; then
-              echo "Skipping $pkg (already built this run)"
-              continue
-            fi
-            if node -e "process.exit(require('./$dir/package.json').scripts?.build ? 0 : 1)" 2>/dev/null; then
-              echo "Building $pkg"
-              pnpm --filter "$pkg" build
-            else
-              echo "Skipping $pkg (no build script / pure source layer)"
-            fi
-          done
+      # Ensure EVERY @fyit/* dist is present before the app build. Content-addressed
+      # cache + build-ALL-on-miss (warm-packages action, #1222) — replaces the old
+      # per-caller subset build, which could miss a package the app transitively
+      # extends (e.g. @fyit/crouton itself wasn't in a POC's layer-packages → the
+      # 0.06s "Could not load @fyit/crouton" that killed the quotes-POC deploy). It
+      # also subsumes the #745 cross-app cache-collision class: every entry contains
+      # ALL dist, so no caller can restore a set missing a package it needs.
+      - name: Warm @fyit package builds
+        uses: ./.github/actions/warm-packages
 
       - name: Cache Nuxt build artifacts
         uses: actions/cache@v4


### PR DESCRIPTION
Closes #1222 · part of #1281 · with #1286, the last of the two must-haves

## 👤 For humans
The cold-build tax, killed. A fresh CI checkout has no built `@fyit/*` packages, which caused **two** failures we hit this week:
1. **Scaffold+generate cold-builds ~30 packages one-at-a-time (~15-20 min)** — the bulk of the 22-min quotes/notes runs.
2. **A deploy on a cache miss with no fallback dies** at `Could not load @fyit/crouton` — that's why `quotes.pmcp.dev` never came up.

A reusable **warm-packages** action fixes both: restore *all* package `dist/` from a content-addressed cache, and `pnpm build:packages` on a miss (~31s).

## 🤖 What changed
- **`.github/actions/warm-packages`** (new): `actions/cache` on `packages/*/dist` keyed by `hashFiles(<all package source>, pnpm-lock.yaml)` + `pnpm build:packages` on miss.
- **`deploy-app.yml`**: replaces the per-caller **subset** build (which could miss `@fyit/crouton` itself → the quotes deploy failure; also the #745 cross-app cache-collision class) — every entry now holds **all** dist.
- **`decompose-on-issue-pidev.yml`**: warms *before* the agent runs, so `crouton init`/generate/migrate doesn't cold-build mid-run.

## Why content-addressed, not `clean:false`
Keyed on source + lockfile → a source change rebuilds (never stale), and no shared mutable dir for concurrent agents to contaminate — the exact multi-agent constraint recorded on #1222.

## 🧪 How to test
- **The acceptance test:** after merge, re-trigger the **quotes deploy** (`epic/1264-quotes-poc` → PR #1294) — it should now build all packages and bring `quotes.pmcp.dev` live (the failure that motivated this).
- A `/delegate-pi` POC run should scaffold+generate in ~minutes (warm dist), not cold-build for ~15.

## Follow-ups (optional, noted in code)
- Adopt `warm-packages` in `ci.yml` (replaces its 3-package cache) and the claude decompose variant.

**Verification caveat:** this is a CI-only change — YAML validated locally, but the cache/build behavior is exercised on the first real deploy/decompose after merge (that's the acceptance test above).