### PR TITLE
fix(root): name the billing cause when a pi run fails (#1299)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -184,9 +184,19 @@ jobs:
           PI_PROMPT
           printf '/task-decompose #%s\n' "$ISSUE" >> "$PROMPT_FILE"
           # Confirmed on the mac-mini (#888): pin provider + load skills via --skill.
+          # GHA runs `run:` steps with bash -e; `set -uo pipefail` above does not clear it.
+          # So the instant `pi | tee` fails (pipefail), -e aborts the script BEFORE
+          # RC/conclusion/exec_log are written — the artifact-gate then has no exec_log to
+          # read and posts the generic "no deliverable" instead of naming the cause (the
+          # #1299 billing case). Disable errexit around JUST this pipeline; PIPESTATUS[0]
+          # still carries pi's real exit code. (NB: a trailing `|| true` does NOT work — it
+          # runs `true` as its own pipeline, clobbering PIPESTATUS[0] to 0 and masking the
+          # failure as success. Verified empirically, #1299.)
+          set +e
           pi --print --provider anthropic --model "$PI_MODEL" --skill .claude/skills \
             "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
           RC=${PIPESTATUS[0]}
+          set -e
           END=$(date +%s)
           echo "wall=$((END-START))" >> "$GITHUB_OUTPUT"
           echo "conclusion=$([ "$RC" -eq 0 ] && echo success || echo failure)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #1299

## 👤 For humans
When the mac-mini pi.dev agent step fails on an out-of-credit key, the artifact-gate posted the **generic** "produced no deliverable" message with no cause — so you had to open the raw run log to find *"Your credit balance is too low."* This makes the mini flow name the real cause (billing / error / underspecified), matching the hosted flow.

**Live repro this session:** the snippets retest WS2 (#1316, run `29090244379`) died on exactly this — an exhausted `PI_PROVIDER_KEY` — and fell to the generic message.

## 🤖 For agents
- `.github/workflows/decompose-on-issue-pidev.yml`, the `pi` step. GHA runs `run:` steps with `bash -e`; the step's `set -uo pipefail` does not clear `-e`, so the instant `pi … | tee "$LOG"` fails (pipefail), `-e` aborts the script **before** `RC` / `conclusion` / `exec_log` are written. The artifact-gate then has no `exec_log` to classify → generic fallback.
- **Fix:** wrap just that pipeline in `set +e` … `set -e`; `RC=${PIPESTATUS[0]}` still captures pi's real exit code.
- ⚠️ The issue's *suggested* `| tee "$LOG" || true` is **subtly wrong** — `|| true` runs `true` as its own pipeline, clobbering `PIPESTATUS[0]` to `0`, which masks a failure as `conclusion=success`. Verified empirically before choosing `set +e`.

## 🧪 How to test
1. `bash -eo pipefail -c 'set -uo pipefail; set +e; false | tee /tmp/x >/dev/null; echo rc=${PIPESTATUS[0]}; set -e; echo reached'` → prints `rc=1` **and** `reached` (no early abort, real code preserved). The `|| true` variant prints `rc=0` (the bug).
2. Re-dispatch `decompose-on-issue-pidev.yml` against an out-of-credit `PI_PROVIDER_KEY` → the artifact-gate comment now names the billing cause instead of the generic message.