### PR TITLE
fix(root): stop per-PR deploy fan-out on shared-package changes (#1297)

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -131,7 +131,17 @@ jobs:
             for cfg in apps/*/deploy.config.json; do
               [ -f "$cfg" ] || continue
               app=$(basename "$(dirname "$cfg")")
-              mapfile -t pats < <(jq -r '.watchPaths[]? // empty' "$cfg")
+              # Rung split (#1297): a pull_request deploys ONLY the app whose OWN paths
+              # (apps/<app>/**) changed. A shared-package change that breaks a consuming
+              # app is caught by the fixture smoke (fast, no deploy) + the rung-2 push
+              # deploy — NOT a per-PR fan-out redeploy of every consuming app, which
+              # saturated the runners and starved the changed app's own deploy (#1297).
+              # push (merge to main) keeps the full watchPaths incl. shared packages.
+              if [ "$EVENT" = "pull_request" ]; then
+                pats=("apps/$app/**")
+              else
+                mapfile -t pats < <(jq -r '.watchPaths[]? // empty' "$cfg")
+              fi
               hit=false
               while IFS= read -r f; do
                 [ -z "$f" ] && continue


### PR DESCRIPTION
Closes #1297

## 👤 For humans
A quotes-POC PR (#1294) redeployed fanfare, triage, **and** velo to staging — none of which changed — because each app's `watchPaths` lists the shared packages it consumes, so any shared-package touch (or a broad diff) fanned out a redeploy to every app. That saturated the runners and starved the changed app's own deploy. This session I watched the same saturation block a signed-off pipeline for 15+ min.

**This is a throughput fix, not a cost lever** — deploys are deterministic CI (build → wrangler → migrate), zero LLM.

Now: a **PR** deploys only the app whose *own* paths changed. Shared-package coverage still runs — at **merge-to-main** (rung 2), off the PR critical path — plus the e2e fixture smoke already covers "did a shared change break a consuming app" per-PR (fast, no deploy).

## 🤖 For agents
- `.github/workflows/deploy-apps.yml`, `detect` job. Single change: on `pull_request` the pattern set becomes `apps/<app>/**` (own paths only); on `push` it keeps the full `deploy.config.json` `watchPaths` (incl. shared packages). No `deploy.config.json` edits — `watchPaths` stays the single source for the rung-2 fan-out.
- Implements the #632 check-ladder: rung 1 (PR) = fixtures + own-app deploy; rung 2 (merge) = real-app coverage for shared changes.

## 🧪 How to test
Verified the `[[ ]]` glob matching in bash (the workflow's shell):
- PR touches `packages/*` only → **0 apps deploy** (was: all 3).
- PR touches `apps/velo/*` → only velo deploys.
- push to main touching `packages/*` → full `watchPaths` (rung 2), unchanged.