### PR TITLE
Subtractive replacers for every theme + correct runtime switching + the resurrected KO showcase

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -421,15 +421,27 @@ still merges). It works in `app.config.ui`, the per-instance `:ui` prop, and
 can transform rather than blank it (keep layout, drop only decorative utilities):
 
 ```ts
-// minimal/app.config.ts — strip rounded/shadow/ring, keep layout, no !important
-const stripDecorative = (defaults: string) =>
-  defaults.split(/\s+/).filter(c => !/^-?(rounded|shadow|ring)(-|$)/.test(c.split(':').pop()!))
-    .concat('minimal-flat').join(' ')
+// any theme's app.config.ts — the SHARED marker-gated replacer (#1304)
+import { subtractThemeDefaults } from '../lib/subtractive'
 
 export default defineAppConfig({
-  ui: { button: { slots: { base: stripDecorative } } }
+  ui: { button: { slots: { base: subtractThemeDefaults } } }
 })
 ```
+
+**All four themes use one shared replacer: `lib/subtractive.ts` (#1304).** It is
+**marker-gated**: the resolved string it receives contains the theme's own marker
+classes (`ko-bezel`, `kr-pad`, `bw-solid`, `minimal-btn`, …) injected by that
+theme's variants, so one function detects *which* theme is in play and applies
+that theme's subtraction set — and passes unmarked (default-theme) renders
+through untouched. This is what makes a global replacer safe in a MULTI-theme
+app (the playground): each theme only subtracts under its own markers. Per-theme
+sets: `minimal` drops decorative only (rounded/shadow/ring, the #364 behaviour);
+`ko`/`kr11` also own color, motion and typography; `bw` keeps Nuxt UI's rounding
+and text sizes. **`focus-visible:` classes are never stripped** (no theme ships
+its own button focus styles — a11y guard; minimal predates the guard).
+Result: the theme CSS needs **no `!important`** (three deliberate `padding`
+exceptions remain — spacing utilities are never stripped — each commented).
 
 **Hard constraints (verified against `@nuxt/ui` `dist/runtime/utils/tv.ts`):**
 
@@ -443,14 +455,47 @@ export default defineAppConfig({
 - **Replacers are NOT variant-scoped.** `extractDirectives` only reads top-level
   `base`/`slots` — a function inside `variants.variant.minimal.base` is ignored. So
   subtractive theming is a *global/subtree/per-instance* tool, orthogonal to the
-  variant system; the two modes coexist (the `minimal` button uses both).
+  variant system; the two modes coexist (every theme's button uses both).
 - **Keep replacers pure & deterministic** so SSR and client compute the same string
   (no hydration mismatch) — the original reason this package avoided base overrides.
-- **Multi-theme caveat:** a global `app.config` base replacer applies to *all*
-  buttons, so an app that `extends` several themes + flips them at runtime should
-  prefer `<UTheme>` (subtree) over a global replacer. Single-theme apps are clean.
+- **The defu double-role gotcha (#1304):** Nuxt merges layered app.configs with
+  defu's *fn* variant, which treats a FUNCTION value as a merger and CALLS it with
+  the lower layer's value. Several layers assign the shared replacer to the same
+  slot key, so `subtractThemeDefaults` guards: called with a non-string (merge
+  time) it returns itself, so the merged value stays the replacer. Any new
+  replacer-style function in an app.config needs the same guard.
+- **Multi-theme apps are safe** with the shared replacer because of marker gating
+  (above). A *custom, un-gated* replacer is still global — gate it on a marker
+  class or scope it with `<UTheme>`.
 
-Spike: #364.
+Spike: #364; rollout to all themes: #1304.
+
+### Runtime switching swaps SCALARS only (deepAssign hazard) — #1304
+
+`updateAppConfig()` merges with Nuxt's `deepAssign`, which merges **arrays by
+index** — a runtime write to `compoundVariants` overwrites whatever entries sit
+at those indices in the built config (this silently broke the named variants on
+every switch). Hence the split:
+
+- **Layer app.config (build-time, merge-safe):** ALL classes — named variants
+  (`ko`, `kr11`, `minimal*`, `bw-*`) + their `compoundVariants` + replacers.
+- **`themes/configs/themeConfigs.ts` (runtime):** scalar leaves only —
+  `colors.*` and `<component>.defaultVariants.variant`, pointing plain
+  variant-less usage at the theme's named variant. Every config sets EVERY key
+  the swap owns, so switching A → B never leaves A's value behind.
+
+Consequences: a plain `<UButton>` follows the active theme; an **explicit**
+`variant="outline"` is the author's literal choice and stays default-styled —
+use `useThemeSwitcher().getVariant('outline')` to follow the theme (`ko-outline`,
+`bw-outline`, …). `blackandwhite` registers **named `bw-*` variants** (it no
+longer overrides the standard variant slots, which used to bleed into every
+other theme in a multi-theme app) and sets its own layer
+`defaultVariants.variant: 'bw-solid'` so single-theme bw apps still need no
+runtime. The theme restore from localStorage runs **onMounted** (never during
+setup — the server can't know localStorage, so a setup-time restore is a
+guaranteed hydration mismatch). And in `ThemeSwitcher.vue`, per-item slot names
+are prefixed `theme-<name>` — a slot literally named `default` overrides the
+dropdown's trigger slot (the chip froze on "Default" forever).
 
 ## Dev workflow — the playground (#1306)
 

--- a/packages/crouton-themes/blackandwhite/app.config.ts
+++ b/packages/crouton-themes/blackandwhite/app.config.ts
@@ -1,3 +1,5 @@
+import { subtractThemeDefaults } from '../lib/subtractive'
+
 export default defineAppConfig({
   ui: {
     theme: {
@@ -21,16 +23,29 @@ export default defineAppConfig({
       }
     },
     button: {
-      // Register bw-* as valid variants and override solid/outline/soft/ghost/link
-      // to inject our CSS class names. The CSS file handles actual styling with
-      // !important to override Nuxt UI's CSS-variable-based defaults.
+      // NAMED bw-* variants + a defaultVariants pointer (#1304, was an override
+      // of the standard solid/outline/... slots). Same single-theme contract —
+      // a plain <UButton> in an app extending this layer resolves to bw-solid —
+      // but the standard variants stay untouched, so in a multi-theme app (the
+      // playground) this layer no longer restyles the other themes' buttons,
+      // and an explicit variant="outline" is the author's literal choice.
+      // The shared marker-gated replacer (#1304) strips the conflicting
+      // defaults (color/elevation/motion/underline) when a bw-* marker is
+      // present, so the CSS needs no !important; Nuxt UI's rounding, sizing
+      // and focus ring are kept.
+      slots: {
+        base: subtractThemeDefaults
+      },
+      defaultVariants: {
+        variant: 'bw-solid'
+      },
       variants: {
         variant: {
-          solid: 'bw-solid',
-          outline: 'bw-outline',
-          soft: 'bw-soft',
-          ghost: 'bw-ghost',
-          link: 'bw-link'
+          'bw-solid': 'bw-solid',
+          'bw-outline': 'bw-outline',
+          'bw-soft': 'bw-soft',
+          'bw-ghost': 'bw-ghost',
+          'bw-link': 'bw-link'
         }
       }
     },

--- a/packages/crouton-themes/blackandwhite/assets/css/main.css
+++ b/packages/crouton-themes/blackandwhite/assets/css/main.css
@@ -8,8 +8,11 @@
      --ui-text-highlighted → near-black in light mode,  #fff  in dark mode
      --ui-border-inverted  → near-black in light mode,  #fff  in dark mode
 
-   We still use !important to override Nuxt UI's compound-variant Tailwind
-   utilities (e.g. bg-primary, text-primary) which are not !important.
+   No !important needed (#1304): the shared subtractive replacer
+   (../lib/subtractive.ts) strips the conflicting Nuxt UI defaults
+   (background, text color, shadow, ring, border, transition, underline)
+   whenever a bw- marker class is present, so these rules win by normal
+   cascade.
 */
 
 /* ============================================
@@ -18,19 +21,19 @@
    ============================================ */
 
 .bw-solid {
-  background-color: var(--ui-bg-inverted) !important;
-  color: var(--ui-text-inverted) !important;
-  box-shadow: none !important;
-  border: none !important;
-  transition: opacity 150ms ease !important;
+  background-color: var(--ui-bg-inverted);
+  color: var(--ui-text-inverted);
+  box-shadow: none;
+  border: none;
+  transition: opacity 150ms ease;
 }
 
 .bw-solid:hover {
-  opacity: 0.85 !important;
+  opacity: 0.85;
 }
 
 .bw-solid:active {
-  opacity: 0.7 !important;
+  opacity: 0.7;
 }
 
 /* ============================================
@@ -38,16 +41,16 @@
    ============================================ */
 
 .bw-outline {
-  background-color: transparent !important;
-  color: var(--ui-text-highlighted) !important;
-  box-shadow: inset 0 0 0 1px var(--ui-border-accented) !important;
-  border: none !important;
-  transition: background-color 150ms ease, box-shadow 150ms ease !important;
+  background-color: transparent;
+  color: var(--ui-text-highlighted);
+  box-shadow: inset 0 0 0 1px var(--ui-border-accented);
+  border: none;
+  transition: background-color 150ms ease, box-shadow 150ms ease;
 }
 
 .bw-outline:hover {
-  background-color: var(--ui-bg-elevated) !important;
-  box-shadow: inset 0 0 0 1px var(--ui-border-inverted) !important;
+  background-color: var(--ui-bg-elevated);
+  box-shadow: inset 0 0 0 1px var(--ui-border-inverted);
 }
 
 /* ============================================
@@ -55,15 +58,15 @@
    ============================================ */
 
 .bw-soft {
-  background-color: var(--ui-bg-elevated) !important;
-  color: var(--ui-text-highlighted) !important;
-  box-shadow: none !important;
-  border: none !important;
-  transition: background-color 150ms ease !important;
+  background-color: var(--ui-bg-elevated);
+  color: var(--ui-text-highlighted);
+  box-shadow: none;
+  border: none;
+  transition: background-color 150ms ease;
 }
 
 .bw-soft:hover {
-  background-color: var(--ui-bg-accented) !important;
+  background-color: var(--ui-bg-accented);
 }
 
 /* ============================================
@@ -72,19 +75,19 @@
    ============================================ */
 
 .bw-ghost {
-  background-color: transparent !important;
-  color: var(--ui-text-highlighted) !important;
-  box-shadow: none !important;
-  border: none !important;
-  transition: background-color 150ms ease !important;
+  background-color: transparent;
+  color: var(--ui-text-highlighted);
+  box-shadow: none;
+  border: none;
+  transition: background-color 150ms ease;
 }
 
 .bw-ghost:hover {
-  background-color: var(--ui-bg-elevated) !important;
+  background-color: var(--ui-bg-elevated);
 }
 
 .bw-ghost:active {
-  background-color: var(--ui-bg-accented) !important;
+  background-color: var(--ui-bg-accented);
 }
 
 /* ============================================
@@ -92,15 +95,15 @@
    ============================================ */
 
 .bw-link {
-  background-color: transparent !important;
-  color: var(--ui-text-highlighted) !important;
-  box-shadow: none !important;
-  border: none !important;
-  text-decoration: underline !important;
-  text-underline-offset: 2px !important;
-  transition: opacity 150ms ease !important;
+  background-color: transparent;
+  color: var(--ui-text-highlighted);
+  box-shadow: none;
+  border: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: opacity 150ms ease;
 }
 
 .bw-link:hover {
-  opacity: 0.75 !important;
+  opacity: 0.75;
 }

--- a/packages/crouton-themes/ko/app.config.ts
+++ b/packages/crouton-themes/ko/app.config.ts
@@ -1,6 +1,8 @@
 // KO-UI Theme Configuration
 // Hardware-inspired styling based on Teenage Engineering KO II
 
+import { subtractThemeDefaults } from '../lib/subtractive'
+
 export default defineAppConfig({
   ui: {
     colors: {
@@ -9,8 +11,13 @@ export default defineAppConfig({
     },
 
     button: {
-      // Add KO variants - base and compound (ko-ghost, ko-outline, etc)
-      // Note: No slots.base override - let Nuxt UI handle base classes to avoid hydration mismatches
+      // Subtractive base via the shared marker-gated replacer (#1304): when the
+      // resolved classes carry a ko-* marker, the defaults KO's CSS re-supplies
+      // (color/decoration/motion/typography) are stripped, so the CSS below
+      // needs no !important. Unmarked (non-ko) renders pass through untouched.
+      slots: {
+        base: subtractThemeDefaults
+      },
       variants: {
         variant: {
           ko: '',
@@ -104,6 +111,10 @@ export default defineAppConfig({
 
     // INPUT OVERRIDES
     input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
       // Add 'ko' to the variant options
       variants: {
         variant: {
@@ -117,6 +128,12 @@ export default defineAppConfig({
 
     // CARD OVERRIDES
     card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
       // Add 'ko' to the variant options
       variants: {
         variant: {

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -66,6 +66,16 @@
 
 [data-theme="ko"] {
   background-color: var(--ko-surface-light);
+}
+
+/* The display font is CHROME, not body copy (#1304 readability feedback):
+   putting ko-tech on the root made every form label and paragraph read like
+   a spec sheet. Scope it to headings + explicit .ko-font opt-ins; tactile
+   components (.ko-bezel, .ko-input-base, ...) already set their own font. */
+[data-theme="ko"] h1,
+[data-theme="ko"] h2,
+[data-theme="ko"] h3,
+[data-theme="ko"] .ko-font {
   font-family: 'ko-tech', sans-serif;
 }
 
@@ -529,8 +539,11 @@
 }
 
 .ko-input-base::placeholder {
-  color: var(--ko-surface-dark);
-  opacity: 0.7;
+  /* Was --ko-surface-dark at 0.7 — dark-on-dark, unreadable on the LCD
+     panel (#1304 readability feedback). Mid gray keeps the dimmed-segment
+     look while staying legible. */
+  color: var(--ko-surface-mid);
+  opacity: 1;
 }
 
 .ko-input-base:focus {

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -82,20 +82,20 @@
 
 /* Base tactile button - default gray */
 .ko-tactile {
-  position: relative !important;
-  overflow: visible !important;
-  isolation: isolate !important;
-  font-family: 'ko-tech', sans-serif !important;
-  letter-spacing: 0.075em !important;
-  text-transform: uppercase !important;
-  background-color: var(--ko-surface-light) !important;
-  color: var(--ko-text-dark) !important;
-  border: none !important;
+  position: relative;
+  overflow: visible;
+  isolation: isolate;
+  font-family: 'ko-tech', sans-serif;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  background-color: var(--ko-surface-light);
+  color: var(--ko-text-dark);
+  border: none;
   box-shadow:
     rgba(0, 0, 0, 0.377) 10px 10px 8px,
     #ffffff 1.5px 1.5px 2px 0px inset,
-    #c7c3c0 -3.2px -3.2px 8px 0px inset !important;
-  transition: all 0.1s ease-in-out !important;
+    #c7c3c0 -3.2px -3.2px 8px 0px inset;
+  transition: all 0.1s ease-in-out;
 }
 
 /* Dark bezel/wrapper effect */
@@ -109,125 +109,127 @@
 }
 
 .ko-tactile:hover {
-  background-color: #bfbbb8 !important;
+  background-color: #bfbbb8;
 }
 
 .ko-tactile:active {
   box-shadow:
     rgba(0, 0, 0, 0.377) 0px 0px 0px,
     inset 0.5px 0.5px 4px #000000,
-    #c7c3c0 -3.2px -3.2px 8px 0px inset !important;
+    #c7c3c0 -3.2px -3.2px 8px 0px inset;
   transform: translateY(0.5px);
 }
 
 /* Orange variant */
 .ko-tactile.ko-tactile--orange {
-  background-color: var(--ko-accent-orange) !important;
-  color: var(--ko-text-light) !important;
+  background-color: var(--ko-accent-orange);
+  color: var(--ko-text-light);
   box-shadow:
     rgba(0, 0, 0, 0.377) 10px 10px 8px,
     var(--ko-highlight-orange) 1.5px 1.5px 1px 0px inset,
-    var(--ko-accent-orange) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-orange) -3.2px -3.2px 8px 0px inset;
 }
 
 .ko-tactile.ko-tactile--orange:hover {
-  background-color: #e85520 !important;
+  background-color: #e85520;
 }
 
 .ko-tactile.ko-tactile--orange:active {
   box-shadow:
     rgba(0, 0, 0, 0.377) 0px 0px 0px,
     inset 0.5px 0.5px 4px #000000,
-    var(--ko-accent-orange-dark) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-orange-dark) -3.2px -3.2px 8px 0px inset;
 }
 
 /* Dark variant */
 .ko-tactile.ko-tactile--dark {
-  background-color: var(--ko-surface-dark) !important;
-  color: var(--ko-text-light) !important;
+  background-color: var(--ko-surface-dark);
+  color: var(--ko-text-light);
   box-shadow:
     rgba(0, 0, 0, 0.377) 10px 10px 8px,
     var(--ko-highlight-dark) 1.5px 1.5px 1px 0px inset,
-    var(--ko-surface-dark) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-surface-dark) -3.2px -3.2px 8px 0px inset;
 }
 
 .ko-tactile.ko-tactile--dark:hover {
-  background-color: #4a4948 !important;
+  background-color: #4a4948;
 }
 
 .ko-tactile.ko-tactile--dark:active {
   box-shadow:
     rgba(0, 0, 0, 0.377) 0px 0px 0px,
     inset 0.5px 0.5px 4px #000000,
-    var(--ko-surface-dark) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-surface-dark) -3.2px -3.2px 8px 0px inset;
 }
 
 /* Red variant */
 .ko-tactile.ko-tactile--red {
-  background-color: var(--ko-accent-red) !important;
-  color: var(--ko-text-light) !important;
+  background-color: var(--ko-accent-red);
+  color: var(--ko-text-light);
   box-shadow:
     rgba(0, 0, 0, 0.377) 10px 10px 8px,
     var(--ko-highlight-red) 1.5px 1.5px 1px 0px inset,
-    var(--ko-accent-red) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-red) -3.2px -3.2px 8px 0px inset;
 }
 
 .ko-tactile.ko-tactile--red:hover {
-  background-color: #d92015 !important;
+  background-color: #d92015;
 }
 
 .ko-tactile.ko-tactile--red:active {
   box-shadow:
     rgba(0, 0, 0, 0.377) 0px 0px 0px,
     inset 0.5px 0.5px 4px #000000,
-    var(--ko-accent-red) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-red) -3.2px -3.2px 8px 0px inset;
 }
 
 /* Pink variant */
 .ko-tactile.ko-tactile--pink {
-  background-color: var(--ko-accent-pink) !important;
-  color: var(--ko-text-light) !important;
+  background-color: var(--ko-accent-pink);
+  color: var(--ko-text-light);
   box-shadow:
     rgba(0, 0, 0, 0.377) 10px 10px 8px,
     var(--ko-highlight-pink) 1.5px 1.5px 1px 0px inset,
-    var(--ko-accent-pink) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-pink) -3.2px -3.2px 8px 0px inset;
 }
 
 .ko-tactile.ko-tactile--pink:hover {
-  background-color: #cc2550 !important;
+  background-color: #cc2550;
 }
 
 .ko-tactile.ko-tactile--pink:active {
   box-shadow:
     rgba(0, 0, 0, 0.377) 0px 0px 0px,
     inset 0.5px 0.5px 4px #000000,
-    var(--ko-accent-pink) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-pink) -3.2px -3.2px 8px 0px inset;
 }
 
 /* Blue variant */
 .ko-tactile.ko-tactile--blue {
-  background-color: var(--ko-accent-blue) !important;
-  color: var(--ko-text-light) !important;
+  background-color: var(--ko-accent-blue);
+  color: var(--ko-text-light);
   box-shadow:
     rgba(0, 0, 0, 0.377) 10px 10px 8px,
     var(--ko-highlight-blue) 1.5px 1.5px 1px 0px inset,
-    var(--ko-accent-blue) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-blue) -3.2px -3.2px 8px 0px inset;
 }
 
 .ko-tactile.ko-tactile--blue:hover {
-  background-color: #3a8ab8 !important;
+  background-color: #3a8ab8;
 }
 
 .ko-tactile.ko-tactile--blue:active {
   box-shadow:
     rgba(0, 0, 0, 0.377) 0px 0px 0px,
     inset 0.5px 0.5px 4px #000000,
-    var(--ko-accent-blue) -3.2px -3.2px 8px 0px inset !important;
+    var(--ko-accent-blue) -3.2px -3.2px 8px 0px inset;
 }
 
 /* Square shape modifier */
 .ko-tactile--square {
-  aspect-ratio: 1 !important;
+  aspect-ratio: 1;
+  /* !important stays: spacing utilities (px, py) are deliberately NOT
+     stripped by the subtractive replacer (#1304), so this must outrank them. */
   padding: 1rem !important;
 }
 
@@ -320,23 +322,23 @@
    Uses ::before for dark bezel (sharp corners) and ::after for button face (round corners)
    This creates the signature KO look with different corner radii */
 .ko-bezel {
-  position: relative !important;
-  overflow: visible !important;  /* Required for ::before bezel to extend outside */
-  font-family: 'ko-tech', sans-serif !important;
-  letter-spacing: 0.075em !important;
-  text-transform: uppercase !important;
-  font-size: 0.7em !important;
-  border: none !important;
-  border-radius: var(--ko-button-radius) !important;
-  transition: all 0.1s ease-in-out !important;
+  position: relative;
+  overflow: visible;  /* Required for ::before bezel to extend outside */
+  font-family: 'ko-tech', sans-serif;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  font-size: 0.7em;
+  border: none;
+  border-radius: var(--ko-button-radius);
+  transition: all 0.1s ease-in-out;
   /* Transparent bg - actual color comes from ::after */
-  background-color: transparent !important;
-  color: var(--ko-text-dark) !important;
-  z-index: 0 !important;
+  background-color: transparent;
+  color: var(--ko-text-dark);
+  z-index: 0;
   /* Center content */
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Dark bezel - sharp corners */
@@ -383,7 +385,7 @@
 
 /* Orange variant */
 .ko-bezel.ko-bezel--orange {
-  color: var(--ko-text-light) !important;
+  color: var(--ko-text-light);
 }
 
 .ko-bezel.ko-bezel--orange::after {
@@ -405,7 +407,7 @@
 
 /* Dark variant */
 .ko-bezel.ko-bezel--dark {
-  color: var(--ko-text-light) !important;
+  color: var(--ko-text-light);
 }
 
 .ko-bezel.ko-bezel--dark::after {
@@ -427,7 +429,7 @@
 
 /* Red variant */
 .ko-bezel.ko-bezel--red {
-  color: var(--ko-text-light) !important;
+  color: var(--ko-text-light);
 }
 
 .ko-bezel.ko-bezel--red::after {
@@ -449,7 +451,7 @@
 
 /* Pink variant */
 .ko-bezel.ko-bezel--pink {
-  color: var(--ko-text-light) !important;
+  color: var(--ko-text-light);
 }
 
 .ko-bezel.ko-bezel--pink::after {
@@ -471,7 +473,7 @@
 
 /* Blue variant */
 .ko-bezel.ko-bezel--blue {
-  color: var(--ko-text-light) !important;
+  color: var(--ko-text-light);
 }
 
 .ko-bezel.ko-bezel--blue::after {
@@ -497,8 +499,8 @@
    ============================================ */
 
 .ko-input {
-  position: relative !important;
-  z-index: 0 !important;
+  position: relative;
+  z-index: 0;
 }
 
 /* Dark bezel wrapper - sharp corners */
@@ -514,29 +516,29 @@
 
 /* The actual input styling - applied via slot class */
 .ko-input-base {
-  font-family: 'ko-tech', monospace !important;
-  font-size: 0.85rem !important;
-  letter-spacing: 0.1em !important;
-  text-transform: uppercase !important;
-  background-color: var(--ko-surface-panel) !important;
-  color: var(--ko-accent-orange) !important;
-  border: 1px solid var(--ko-surface-recess) !important;
-  border-radius: var(--ko-button-radius) !important;
-  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.3) !important;
-  caret-color: var(--ko-accent-orange) !important;
+  font-family: 'ko-tech', monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background-color: var(--ko-surface-panel);
+  color: var(--ko-accent-orange);
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: var(--ko-button-radius);
+  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.3);
+  caret-color: var(--ko-accent-orange);
 }
 
 .ko-input-base::placeholder {
-  color: var(--ko-surface-dark) !important;
-  opacity: 0.7 !important;
+  color: var(--ko-surface-dark);
+  opacity: 0.7;
 }
 
 .ko-input-base:focus {
-  outline: none !important;
-  border-color: var(--ko-accent-orange) !important;
+  outline: none;
+  border-color: var(--ko-accent-orange);
   box-shadow:
     inset 1px 1px 4px rgba(0, 0, 0, 0.3),
-    0 0 0 1px var(--ko-accent-orange) !important;
+    0 0 0 1px var(--ko-accent-orange);
 }
 
 /* ============================================
@@ -545,17 +547,17 @@
    ============================================ */
 
 .ko-card {
-  position: relative !important;
-  overflow: visible !important;  /* Required for ::before bezel to extend outside */
-  font-family: 'ko-tech', sans-serif !important;
-  background-color: var(--ko-surface-light) !important;
-  border: none !important;
-  border-radius: var(--ko-button-radius) !important;
+  position: relative;
+  overflow: visible;  /* Required for ::before bezel to extend outside */
+  font-family: 'ko-tech', sans-serif;
+  background-color: var(--ko-surface-light);
+  border: none;
+  border-radius: var(--ko-button-radius);
   box-shadow:
     var(--ko-shadow-drop),
     var(--ko-highlight-light) 1.5px 1.5px 2px 0px inset,
-    var(--ko-surface-mid) -2px -2px 4px 0px inset !important;
-  z-index: 0 !important;
+    var(--ko-surface-mid) -2px -2px 4px 0px inset;
+  z-index: 0;
 }
 
 /* Dark bezel wrapper - sharp corners */
@@ -571,20 +573,20 @@
 
 /* Slot-based styling */
 .ko-card-header {
-  font-family: 'ko-tech', sans-serif !important;
-  letter-spacing: 0.1em !important;
-  text-transform: uppercase !important;
-  font-size: 0.75rem !important;
-  color: var(--ko-text-label) !important;
-  border-bottom: 1px solid var(--ko-surface-mid) !important;
+  font-family: 'ko-tech', sans-serif;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--ko-text-label);
+  border-bottom: 1px solid var(--ko-surface-mid);
 }
 
 .ko-card-body {
-  color: var(--ko-text-dark) !important;
+  color: var(--ko-text-dark);
 }
 
 .ko-card-footer {
-  border-top: 1px solid var(--ko-surface-mid) !important;
+  border-top: 1px solid var(--ko-surface-mid);
 }
 
 /* ============================================
@@ -593,20 +595,20 @@
    ============================================ */
 
 .ko-outline {
-  position: relative !important;
-  font-family: 'ko-tech', sans-serif !important;
-  letter-spacing: 0.075em !important;
-  text-transform: uppercase !important;
-  font-size: 0.7em !important;
-  background-color: transparent !important;
-  border: 2px solid var(--ko-surface-dark) !important;
-  border-radius: var(--ko-button-radius) !important;
-  color: var(--ko-text-dark) !important;
-  transition: all 0.1s ease-in-out !important;
+  position: relative;
+  font-family: 'ko-tech', sans-serif;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  font-size: 0.7em;
+  background-color: transparent;
+  border: 2px solid var(--ko-surface-dark);
+  border-radius: var(--ko-button-radius);
+  color: var(--ko-text-dark);
+  transition: all 0.1s ease-in-out;
 }
 
 .ko-outline:hover {
-  background-color: var(--ko-surface-light) !important;
+  background-color: var(--ko-surface-light);
 }
 
 .ko-outline:active {
@@ -614,48 +616,48 @@
 }
 
 .ko-outline.ko-outline--orange {
-  border-color: var(--ko-accent-orange) !important;
-  color: var(--ko-accent-orange) !important;
+  border-color: var(--ko-accent-orange);
+  color: var(--ko-accent-orange);
 }
 
 .ko-outline.ko-outline--orange:hover {
-  background-color: rgba(250, 95, 40, 0.1) !important;
+  background-color: rgba(250, 95, 40, 0.1);
 }
 
 .ko-outline.ko-outline--dark {
-  border-color: var(--ko-surface-dark) !important;
-  color: var(--ko-text-dark) !important;
+  border-color: var(--ko-surface-dark);
+  color: var(--ko-text-dark);
 }
 
 .ko-outline.ko-outline--dark:hover {
-  background-color: rgba(84, 82, 81, 0.1) !important;
+  background-color: rgba(84, 82, 81, 0.1);
 }
 
 .ko-outline.ko-outline--red {
-  border-color: var(--ko-accent-red) !important;
-  color: var(--ko-accent-red) !important;
+  border-color: var(--ko-accent-red);
+  color: var(--ko-accent-red);
 }
 
 .ko-outline.ko-outline--red:hover {
-  background-color: rgba(241, 38, 24, 0.1) !important;
+  background-color: rgba(241, 38, 24, 0.1);
 }
 
 .ko-outline.ko-outline--pink {
-  border-color: var(--ko-accent-pink) !important;
-  color: var(--ko-accent-pink) !important;
+  border-color: var(--ko-accent-pink);
+  color: var(--ko-accent-pink);
 }
 
 .ko-outline.ko-outline--pink:hover {
-  background-color: rgba(230, 44, 94, 0.1) !important;
+  background-color: rgba(230, 44, 94, 0.1);
 }
 
 .ko-outline.ko-outline--blue {
-  border-color: var(--ko-accent-blue) !important;
-  color: var(--ko-accent-blue) !important;
+  border-color: var(--ko-accent-blue);
+  color: var(--ko-accent-blue);
 }
 
 .ko-outline.ko-outline--blue:hover {
-  background-color: rgba(66, 156, 206, 0.1) !important;
+  background-color: rgba(66, 156, 206, 0.1);
 }
 
 /* ============================================
@@ -664,20 +666,20 @@
    ============================================ */
 
 .ko-soft {
-  position: relative !important;
-  font-family: 'ko-tech', sans-serif !important;
-  letter-spacing: 0.075em !important;
-  text-transform: uppercase !important;
-  font-size: 0.7em !important;
-  background-color: var(--ko-surface-light) !important;
-  border: none !important;
-  border-radius: var(--ko-button-radius) !important;
-  color: var(--ko-text-dark) !important;
-  transition: all 0.1s ease-in-out !important;
+  position: relative;
+  font-family: 'ko-tech', sans-serif;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  font-size: 0.7em;
+  background-color: var(--ko-surface-light);
+  border: none;
+  border-radius: var(--ko-button-radius);
+  color: var(--ko-text-dark);
+  transition: all 0.1s ease-in-out;
 }
 
 .ko-soft:hover {
-  background-color: #bfbbb8 !important;
+  background-color: #bfbbb8;
 }
 
 .ko-soft:active {
@@ -685,48 +687,48 @@
 }
 
 .ko-soft.ko-soft--orange {
-  background-color: rgba(250, 95, 40, 0.15) !important;
-  color: var(--ko-accent-orange) !important;
+  background-color: rgba(250, 95, 40, 0.15);
+  color: var(--ko-accent-orange);
 }
 
 .ko-soft.ko-soft--orange:hover {
-  background-color: rgba(250, 95, 40, 0.25) !important;
+  background-color: rgba(250, 95, 40, 0.25);
 }
 
 .ko-soft.ko-soft--dark {
-  background-color: rgba(84, 82, 81, 0.15) !important;
-  color: var(--ko-text-dark) !important;
+  background-color: rgba(84, 82, 81, 0.15);
+  color: var(--ko-text-dark);
 }
 
 .ko-soft.ko-soft--dark:hover {
-  background-color: rgba(84, 82, 81, 0.25) !important;
+  background-color: rgba(84, 82, 81, 0.25);
 }
 
 .ko-soft.ko-soft--red {
-  background-color: rgba(241, 38, 24, 0.15) !important;
-  color: var(--ko-accent-red) !important;
+  background-color: rgba(241, 38, 24, 0.15);
+  color: var(--ko-accent-red);
 }
 
 .ko-soft.ko-soft--red:hover {
-  background-color: rgba(241, 38, 24, 0.25) !important;
+  background-color: rgba(241, 38, 24, 0.25);
 }
 
 .ko-soft.ko-soft--pink {
-  background-color: rgba(230, 44, 94, 0.15) !important;
-  color: var(--ko-accent-pink) !important;
+  background-color: rgba(230, 44, 94, 0.15);
+  color: var(--ko-accent-pink);
 }
 
 .ko-soft.ko-soft--pink:hover {
-  background-color: rgba(230, 44, 94, 0.25) !important;
+  background-color: rgba(230, 44, 94, 0.25);
 }
 
 .ko-soft.ko-soft--blue {
-  background-color: rgba(66, 156, 206, 0.15) !important;
-  color: var(--ko-accent-blue) !important;
+  background-color: rgba(66, 156, 206, 0.15);
+  color: var(--ko-accent-blue);
 }
 
 .ko-soft.ko-soft--blue:hover {
-  background-color: rgba(66, 156, 206, 0.25) !important;
+  background-color: rgba(66, 156, 206, 0.25);
 }
 
 /* ============================================
@@ -735,20 +737,20 @@
    ============================================ */
 
 .ko-ghost {
-  position: relative !important;
-  font-family: 'ko-tech', sans-serif !important;
-  letter-spacing: 0.075em !important;
-  text-transform: uppercase !important;
-  font-size: 0.7em !important;
-  background-color: transparent !important;
-  border: none !important;
-  border-radius: var(--ko-button-radius) !important;
-  color: var(--ko-text-dark) !important;
-  transition: all 0.1s ease-in-out !important;
+  position: relative;
+  font-family: 'ko-tech', sans-serif;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  font-size: 0.7em;
+  background-color: transparent;
+  border: none;
+  border-radius: var(--ko-button-radius);
+  color: var(--ko-text-dark);
+  transition: all 0.1s ease-in-out;
 }
 
 .ko-ghost:hover {
-  background-color: rgba(199, 195, 192, 0.3) !important;
+  background-color: rgba(199, 195, 192, 0.3);
 }
 
 .ko-ghost:active {
@@ -756,43 +758,43 @@
 }
 
 .ko-ghost.ko-ghost--orange {
-  color: var(--ko-accent-orange) !important;
+  color: var(--ko-accent-orange);
 }
 
 .ko-ghost.ko-ghost--orange:hover {
-  background-color: rgba(250, 95, 40, 0.1) !important;
+  background-color: rgba(250, 95, 40, 0.1);
 }
 
 .ko-ghost.ko-ghost--dark {
-  color: var(--ko-text-dark) !important;
+  color: var(--ko-text-dark);
 }
 
 .ko-ghost.ko-ghost--dark:hover {
-  background-color: rgba(84, 82, 81, 0.1) !important;
+  background-color: rgba(84, 82, 81, 0.1);
 }
 
 .ko-ghost.ko-ghost--red {
-  color: var(--ko-accent-red) !important;
+  color: var(--ko-accent-red);
 }
 
 .ko-ghost.ko-ghost--red:hover {
-  background-color: rgba(241, 38, 24, 0.1) !important;
+  background-color: rgba(241, 38, 24, 0.1);
 }
 
 .ko-ghost.ko-ghost--pink {
-  color: var(--ko-accent-pink) !important;
+  color: var(--ko-accent-pink);
 }
 
 .ko-ghost.ko-ghost--pink:hover {
-  background-color: rgba(230, 44, 94, 0.1) !important;
+  background-color: rgba(230, 44, 94, 0.1);
 }
 
 .ko-ghost.ko-ghost--blue {
-  color: var(--ko-accent-blue) !important;
+  color: var(--ko-accent-blue);
 }
 
 .ko-ghost.ko-ghost--blue:hover {
-  background-color: rgba(66, 156, 206, 0.1) !important;
+  background-color: rgba(66, 156, 206, 0.1);
 }
 
 /* ============================================
@@ -801,40 +803,40 @@
    ============================================ */
 
 .ko-link {
-  position: relative !important;
-  font-family: 'ko-tech', sans-serif !important;
-  letter-spacing: 0.075em !important;
-  text-transform: uppercase !important;
-  font-size: 0.7em !important;
-  background-color: transparent !important;
-  border: none !important;
-  border-radius: 0 !important;
-  color: var(--ko-text-dark) !important;
-  text-decoration: underline !important;
-  text-underline-offset: 2px !important;
-  transition: all 0.1s ease-in-out !important;
+  position: relative;
+  font-family: 'ko-tech', sans-serif;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  font-size: 0.7em;
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
+  color: var(--ko-text-dark);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: all 0.1s ease-in-out;
 }
 
 .ko-link:hover {
-  text-decoration-thickness: 2px !important;
+  text-decoration-thickness: 2px;
 }
 
 .ko-link.ko-link--orange {
-  color: var(--ko-accent-orange) !important;
+  color: var(--ko-accent-orange);
 }
 
 .ko-link.ko-link--dark {
-  color: var(--ko-text-dark) !important;
+  color: var(--ko-text-dark);
 }
 
 .ko-link.ko-link--red {
-  color: var(--ko-accent-red) !important;
+  color: var(--ko-accent-red);
 }
 
 .ko-link.ko-link--pink {
-  color: var(--ko-accent-pink) !important;
+  color: var(--ko-accent-pink);
 }
 
 .ko-link.ko-link--blue {
-  color: var(--ko-accent-blue) !important;
+  color: var(--ko-accent-blue);
 }

--- a/packages/crouton-themes/kr11/app.config.ts
+++ b/packages/crouton-themes/kr11/app.config.ts
@@ -1,6 +1,8 @@
 // KR-11 Theme Configuration
 // Korg KR-11 Compact Rhythm Box inspired styling
 
+import { subtractThemeDefaults } from '../lib/subtractive'
+
 export default defineAppConfig({
   ui: {
     colors: {
@@ -9,7 +11,12 @@ export default defineAppConfig({
     },
 
     button: {
-      // Note: No slots.base override - let Nuxt UI handle base classes to avoid hydration mismatches
+      // Subtractive base via the shared marker-gated replacer (#1304): fires only
+      // when a kr-* marker is in the resolved classes; strips the defaults the
+      // KR-11 CSS re-supplies so it needs no !important.
+      slots: {
+        base: subtractThemeDefaults
+      },
       variants: {
         variant: {
           kr11: '',
@@ -68,6 +75,10 @@ export default defineAppConfig({
     },
 
     input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
       variants: {
         variant: {
           kr11: {
@@ -79,6 +90,12 @@ export default defineAppConfig({
     },
 
     card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
       variants: {
         variant: {
           kr11: {
@@ -92,6 +109,9 @@ export default defineAppConfig({
     },
 
     badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
       variants: {
         variant: {
           kr11: 'kr-badge'

--- a/packages/crouton-themes/kr11/assets/css/main.css
+++ b/packages/crouton-themes/kr11/assets/css/main.css
@@ -88,63 +88,63 @@
    ============================================ */
 
 .kr-pad {
-  font-family: var(--kr-font) !important;
-  font-weight: 500 !important;
-  font-size: 0.875rem !important;
-  background-color: var(--kr-pad-cream) !important;
-  color: var(--kr-text-dark) !important;
-  border: none !important;
-  border-radius: var(--kr-pad-radius) !important;
+  font-family: var(--kr-font);
+  font-weight: 500;
+  font-size: 0.875rem;
+  background-color: var(--kr-pad-cream);
+  color: var(--kr-text-dark);
+  border: none;
+  border-radius: var(--kr-pad-radius);
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.1),
     0 4px 8px rgba(0, 0, 0, 0.05),
-    inset 0 1px 0 rgba(255, 255, 255, 0.5) !important;
-  transition: all var(--kr-transition-fast) !important;
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  transition: all var(--kr-transition-fast);
 }
 
 .kr-pad:hover {
-  background-color: var(--kr-pad-cream-pressed) !important;
+  background-color: var(--kr-pad-cream-pressed);
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.1),
     0 2px 4px rgba(0, 0, 0, 0.05),
-    inset 0 1px 0 rgba(255, 255, 255, 0.3) !important;
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 .kr-pad:active {
-  transform: translateY(1px) !important;
+  transform: translateY(1px);
   box-shadow:
     0 0 1px rgba(0, 0, 0, 0.1),
-    inset 0 2px 4px rgba(0, 0, 0, 0.1) !important;
+    inset 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 /* Coral Pink Pad (Pad 1 style) */
 .kr-pad.kr-pad--coral {
-  background-color: var(--kr-pad-coral) !important;
-  color: var(--kr-text-dark) !important;
+  background-color: var(--kr-pad-coral);
+  color: var(--kr-text-dark);
 }
 
 .kr-pad.kr-pad--coral:hover {
-  background-color: var(--kr-pad-coral-pressed) !important;
+  background-color: var(--kr-pad-coral-pressed);
 }
 
 /* Golden Yellow Pad (Fill buttons) */
 .kr-pad.kr-pad--gold {
-  background-color: var(--kr-pad-gold) !important;
-  color: var(--kr-text-dark) !important;
+  background-color: var(--kr-pad-gold);
+  color: var(--kr-text-dark);
 }
 
 .kr-pad.kr-pad--gold:hover {
-  background-color: var(--kr-pad-gold-pressed) !important;
+  background-color: var(--kr-pad-gold-pressed);
 }
 
 /* Mint Green Pad (Play button) */
 .kr-pad.kr-pad--mint {
-  background-color: var(--kr-pad-mint) !important;
-  color: var(--kr-text-dark) !important;
+  background-color: var(--kr-pad-mint);
+  color: var(--kr-text-dark);
 }
 
 .kr-pad.kr-pad--mint:hover {
-  background-color: var(--kr-pad-mint-pressed) !important;
+  background-color: var(--kr-pad-mint-pressed);
 }
 
 /* ============================================
@@ -153,31 +153,33 @@
    ============================================ */
 
 .kr-mode-btn {
-  font-family: var(--kr-font) !important;
-  font-weight: 500 !important;
-  font-size: 0.75rem !important;
-  text-transform: uppercase !important;
-  letter-spacing: 0.02em !important;
-  background-color: var(--kr-pad-cream) !important;
-  color: var(--kr-text-dark) !important;
-  border: none !important;
-  border-radius: var(--kr-button-radius) !important;
+  font-family: var(--kr-font);
+  font-weight: 500;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  background-color: var(--kr-pad-cream);
+  color: var(--kr-text-dark);
+  border: none;
+  border-radius: var(--kr-button-radius);
+  /* !important stays: spacing utilities (px, py) are deliberately NOT stripped
+     by the subtractive replacer (#1304), so this must outrank them. */
   padding: 0.5rem 1rem !important;
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.1),
-    inset 0 1px 0 rgba(255, 255, 255, 0.5) !important;
-  transition: all var(--kr-transition-fast) !important;
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  transition: all var(--kr-transition-fast);
 }
 
 .kr-mode-btn:hover {
-  background-color: var(--kr-pad-cream-pressed) !important;
+  background-color: var(--kr-pad-cream-pressed);
 }
 
 .kr-mode-btn:active {
-  transform: translateY(1px) !important;
+  transform: translateY(1px);
   box-shadow:
     0 0 1px rgba(0, 0, 0, 0.1),
-    inset 0 1px 2px rgba(0, 0, 0, 0.1) !important;
+    inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 /* ============================================
@@ -189,26 +191,26 @@
 }
 
 .kr-input-base {
-  font-family: var(--kr-font) !important;
-  font-size: 0.875rem !important;
-  background-color: var(--kr-pad-cream) !important;
-  color: var(--kr-text-dark) !important;
-  border: 1px solid var(--kr-chassis-dark) !important;
-  border-radius: var(--kr-button-radius) !important;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05) !important;
-  transition: all var(--kr-transition) !important;
+  font-family: var(--kr-font);
+  font-size: 0.875rem;
+  background-color: var(--kr-pad-cream);
+  color: var(--kr-text-dark);
+  border: 1px solid var(--kr-chassis-dark);
+  border-radius: var(--kr-button-radius);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: all var(--kr-transition);
 }
 
 .kr-input-base::placeholder {
-  color: var(--kr-text-light) !important;
+  color: var(--kr-text-light);
 }
 
 .kr-input-base:focus {
-  outline: none !important;
-  border-color: var(--kr-pad-mint) !important;
+  outline: none;
+  border-color: var(--kr-pad-mint);
   box-shadow:
     inset 0 1px 2px rgba(0, 0, 0, 0.05),
-    0 0 0 2px rgba(126, 232, 199, 0.3) !important;
+    0 0 0 2px rgba(126, 232, 199, 0.3);
 }
 
 /* ============================================
@@ -217,31 +219,31 @@
    ============================================ */
 
 .kr-card {
-  font-family: var(--kr-font) !important;
-  background-color: var(--kr-chassis-light) !important;
-  border: none !important;
-  border-radius: var(--kr-card-radius) !important;
+  font-family: var(--kr-font);
+  background-color: var(--kr-chassis-light);
+  border: none;
+  border-radius: var(--kr-card-radius);
   box-shadow:
     0 2px 8px rgba(0, 0, 0, 0.08),
     0 4px 16px rgba(0, 0, 0, 0.04),
-    inset 0 1px 0 rgba(255, 255, 255, 0.5) !important;
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 .kr-card-header {
-  font-weight: 600 !important;
-  font-size: 0.75rem !important;
-  letter-spacing: 0.05em !important;
-  text-transform: uppercase !important;
-  color: var(--kr-text-medium) !important;
-  border-bottom: 1px solid var(--kr-chassis-dark) !important;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--kr-text-medium);
+  border-bottom: 1px solid var(--kr-chassis-dark);
 }
 
 .kr-card-body {
-  color: var(--kr-text-dark) !important;
+  color: var(--kr-text-dark);
 }
 
 .kr-card-footer {
-  border-top: 1px solid var(--kr-chassis-dark) !important;
+  border-top: 1px solid var(--kr-chassis-dark);
 }
 
 /* ============================================
@@ -249,14 +251,16 @@
    ============================================ */
 
 .kr-badge {
-  font-family: var(--kr-font) !important;
-  font-size: 0.625rem !important;
-  font-weight: 600 !important;
-  text-transform: uppercase !important;
-  letter-spacing: 0.05em !important;
-  background-color: var(--kr-display-bg) !important;
-  color: var(--kr-display-red) !important;
-  border-radius: 2px !important;
+  font-family: var(--kr-font);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: var(--kr-display-bg);
+  color: var(--kr-display-red);
+  border-radius: 2px;
+  /* !important stays: spacing utilities (px, py) are deliberately NOT stripped
+     by the subtractive replacer (#1304), so this must outrank them. */
   padding: 0.25rem 0.5rem !important;
 }
 
@@ -441,49 +445,49 @@
    ============================================ */
 
 .kr-outline {
-  font-family: var(--kr-font) !important;
-  font-weight: 500 !important;
-  font-size: 0.875rem !important;
-  background-color: transparent !important;
-  color: var(--kr-text-dark) !important;
-  border: 2px solid var(--kr-chassis-dark) !important;
-  border-radius: var(--kr-pad-radius) !important;
-  transition: all var(--kr-transition-fast) !important;
+  font-family: var(--kr-font);
+  font-weight: 500;
+  font-size: 0.875rem;
+  background-color: transparent;
+  color: var(--kr-text-dark);
+  border: 2px solid var(--kr-chassis-dark);
+  border-radius: var(--kr-pad-radius);
+  transition: all var(--kr-transition-fast);
 }
 
 .kr-outline:hover {
-  background-color: var(--kr-chassis-light) !important;
+  background-color: var(--kr-chassis-light);
 }
 
 .kr-outline:active {
-  transform: translateY(1px) !important;
+  transform: translateY(1px);
 }
 
 .kr-outline.kr-outline--mint {
-  border-color: var(--kr-pad-mint) !important;
-  color: #2a9d6d !important;
+  border-color: var(--kr-pad-mint);
+  color: #2a9d6d;
 }
 
 .kr-outline.kr-outline--mint:hover {
-  background-color: rgba(126, 232, 199, 0.15) !important;
+  background-color: rgba(126, 232, 199, 0.15);
 }
 
 .kr-outline.kr-outline--gold {
-  border-color: var(--kr-pad-gold) !important;
-  color: #9a7832 !important;
+  border-color: var(--kr-pad-gold);
+  color: #9a7832;
 }
 
 .kr-outline.kr-outline--gold:hover {
-  background-color: rgba(212, 168, 83, 0.15) !important;
+  background-color: rgba(212, 168, 83, 0.15);
 }
 
 .kr-outline.kr-outline--coral {
-  border-color: var(--kr-pad-coral) !important;
-  color: #d4614f !important;
+  border-color: var(--kr-pad-coral);
+  color: #d4614f;
 }
 
 .kr-outline.kr-outline--coral:hover {
-  background-color: rgba(255, 154, 139, 0.15) !important;
+  background-color: rgba(255, 154, 139, 0.15);
 }
 
 /* ============================================
@@ -492,49 +496,49 @@
    ============================================ */
 
 .kr-soft {
-  font-family: var(--kr-font) !important;
-  font-weight: 500 !important;
-  font-size: 0.875rem !important;
-  background-color: var(--kr-chassis-light) !important;
-  color: var(--kr-text-dark) !important;
-  border: none !important;
-  border-radius: var(--kr-pad-radius) !important;
-  transition: all var(--kr-transition-fast) !important;
+  font-family: var(--kr-font);
+  font-weight: 500;
+  font-size: 0.875rem;
+  background-color: var(--kr-chassis-light);
+  color: var(--kr-text-dark);
+  border: none;
+  border-radius: var(--kr-pad-radius);
+  transition: all var(--kr-transition-fast);
 }
 
 .kr-soft:hover {
-  background-color: var(--kr-chassis-dark) !important;
+  background-color: var(--kr-chassis-dark);
 }
 
 .kr-soft:active {
-  transform: translateY(1px) !important;
+  transform: translateY(1px);
 }
 
 .kr-soft.kr-soft--mint {
-  background-color: rgba(126, 232, 199, 0.2) !important;
-  color: #2a9d6d !important;
+  background-color: rgba(126, 232, 199, 0.2);
+  color: #2a9d6d;
 }
 
 .kr-soft.kr-soft--mint:hover {
-  background-color: rgba(126, 232, 199, 0.35) !important;
+  background-color: rgba(126, 232, 199, 0.35);
 }
 
 .kr-soft.kr-soft--gold {
-  background-color: rgba(212, 168, 83, 0.2) !important;
-  color: #9a7832 !important;
+  background-color: rgba(212, 168, 83, 0.2);
+  color: #9a7832;
 }
 
 .kr-soft.kr-soft--gold:hover {
-  background-color: rgba(212, 168, 83, 0.35) !important;
+  background-color: rgba(212, 168, 83, 0.35);
 }
 
 .kr-soft.kr-soft--coral {
-  background-color: rgba(255, 154, 139, 0.2) !important;
-  color: #d4614f !important;
+  background-color: rgba(255, 154, 139, 0.2);
+  color: #d4614f;
 }
 
 .kr-soft.kr-soft--coral:hover {
-  background-color: rgba(255, 154, 139, 0.35) !important;
+  background-color: rgba(255, 154, 139, 0.35);
 }
 
 /* ============================================
@@ -543,46 +547,46 @@
    ============================================ */
 
 .kr-ghost {
-  font-family: var(--kr-font) !important;
-  font-weight: 500 !important;
-  font-size: 0.875rem !important;
-  background-color: transparent !important;
-  color: var(--kr-text-dark) !important;
-  border: none !important;
-  border-radius: var(--kr-pad-radius) !important;
-  transition: all var(--kr-transition-fast) !important;
+  font-family: var(--kr-font);
+  font-weight: 500;
+  font-size: 0.875rem;
+  background-color: transparent;
+  color: var(--kr-text-dark);
+  border: none;
+  border-radius: var(--kr-pad-radius);
+  transition: all var(--kr-transition-fast);
 }
 
 .kr-ghost:hover {
-  background-color: var(--kr-chassis-light) !important;
+  background-color: var(--kr-chassis-light);
 }
 
 .kr-ghost:active {
-  transform: translateY(1px) !important;
+  transform: translateY(1px);
 }
 
 .kr-ghost.kr-ghost--mint {
-  color: #2a9d6d !important;
+  color: #2a9d6d;
 }
 
 .kr-ghost.kr-ghost--mint:hover {
-  background-color: rgba(126, 232, 199, 0.15) !important;
+  background-color: rgba(126, 232, 199, 0.15);
 }
 
 .kr-ghost.kr-ghost--gold {
-  color: #9a7832 !important;
+  color: #9a7832;
 }
 
 .kr-ghost.kr-ghost--gold:hover {
-  background-color: rgba(212, 168, 83, 0.15) !important;
+  background-color: rgba(212, 168, 83, 0.15);
 }
 
 .kr-ghost.kr-ghost--coral {
-  color: #d4614f !important;
+  color: #d4614f;
 }
 
 .kr-ghost.kr-ghost--coral:hover {
-  background-color: rgba(255, 154, 139, 0.15) !important;
+  background-color: rgba(255, 154, 139, 0.15);
 }
 
 /* ============================================
@@ -591,29 +595,29 @@
    ============================================ */
 
 .kr-link {
-  font-family: var(--kr-font) !important;
-  font-weight: 500 !important;
-  font-size: 0.875rem !important;
-  background-color: transparent !important;
-  color: var(--kr-text-dark) !important;
-  border: none !important;
-  text-decoration: underline !important;
-  text-underline-offset: 3px !important;
-  transition: all var(--kr-transition-fast) !important;
+  font-family: var(--kr-font);
+  font-weight: 500;
+  font-size: 0.875rem;
+  background-color: transparent;
+  color: var(--kr-text-dark);
+  border: none;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: all var(--kr-transition-fast);
 }
 
 .kr-link:hover {
-  text-decoration-thickness: 2px !important;
+  text-decoration-thickness: 2px;
 }
 
 .kr-link.kr-link--mint {
-  color: #2a9d6d !important;
+  color: #2a9d6d;
 }
 
 .kr-link.kr-link--gold {
-  color: #9a7832 !important;
+  color: #9a7832;
 }
 
 .kr-link.kr-link--coral {
-  color: #d4614f !important;
+  color: #d4614f;
 }

--- a/packages/crouton-themes/lib/subtractive.ts
+++ b/packages/crouton-themes/lib/subtractive.ts
@@ -1,0 +1,93 @@
+// Shared subtractive-theming helper (Nuxt UI >= 4.9 slot-class replacers, #364/#1304).
+//
+// A slot value that is a `(defaults) => classes` function REPLACES the resolved
+// default classes instead of merging onto them. The function receives the FULLY
+// RESOLVED class string for the actual props in play — base + matched variants +
+// compoundVariants — which includes the theme marker classes our compoundVariants
+// inject (`ko-bezel`, `kr-pad`, `bw-solid`, `minimal-btn`, ...).
+//
+// That makes ONE marker-gated replacer safe to share across every theme in this
+// package, including in multi-theme apps (the playground): each theme's
+// subtraction set fires only when that theme's marker is present in the resolved
+// string, and an unmarked (default-theme) render passes through untouched. All
+// themes assign this same function to the same slot keys, so app.config layer
+// merging is order-independent.
+//
+// Pure + deterministic — SSR and client must compute the identical class string
+// (hydration-mismatch rule from #364). No Date/random/env reads here, ever.
+
+type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw'
+
+// First matching prefix wins; a resolved string only ever carries one theme's
+// markers because `variant` is single-valued and the bw markers live on the
+// standard variants no other theme touches.
+const MARKERS: Array<[prefix: string, theme: ThemeKey]> = [
+  ['minimal-', 'minimal'],
+  ['ko-', 'ko'],
+  ['kr-', 'kr11'],
+  ['bw-', 'bw']
+]
+
+// text-* utilities that are NOT color (sizes, alignment, wrapping) — kept when a
+// theme only owns text color, stripped when it owns typography wholesale.
+const TEXT_NON_COLOR = /^text-(xs|sm|base|lg|[2-9]?xl|left|center|right|justify|start|end|wrap|nowrap|balance|pretty|ellipsis|clip)$/
+
+const isColor = (u: string): boolean =>
+  /^(bg|from|via|to|placeholder|caret|accent|fill|stroke)-/.test(u)
+  || (/^text-/.test(u) && !TEXT_NON_COLOR.test(u))
+
+const isDecor = (u: string): boolean =>
+  /^-?(rounded|shadow|ring|ring-offset|inset-ring|outline|border|divide)(-|$)/.test(u)
+
+const isMotion = (u: string): boolean =>
+  /^(transition|duration|ease|animate)(-|$)/.test(u)
+
+const isType = (u: string): boolean =>
+  /^(font|tracking|leading)(-|$)/.test(u)
+  || /^(uppercase|lowercase|capitalize|normal-case|italic|not-italic)$/.test(u)
+
+// What each theme's CSS re-supplies, so the conflicting defaults can go.
+// NOT stripped anywhere: layout/flex/sizing/spacing (themes keep Nuxt UI's
+// geometry — the few `padding` fights keep their `!important` in the CSS).
+const STRIP: Record<ThemeKey, (u: string) => boolean> = {
+  // Exactly the #364 behaviour: decorative-only (rounded/shadow/ring).
+  minimal: u => /^-?(rounded|shadow|ring)(-|$)/.test(u),
+  // Skeuomorphic themes own color, decoration, motion AND typography
+  // (font-family/size/weight/case all come from the theme CSS).
+  ko: u => isColor(u) || /^text-/.test(u) || isDecor(u) || isMotion(u) || isType(u),
+  kr11: u => isColor(u) || /^text-/.test(u) || isDecor(u) || isMotion(u) || isType(u),
+  // B&W keeps Nuxt UI's rounding + text sizes; owns color, elevation, motion,
+  // and link underlines.
+  bw: u => isColor(u) || isMotion(u)
+    || /^-?(shadow|ring|ring-offset|inset-ring|outline|border)(-|$)/.test(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u)
+}
+
+// a11y guard: none of the themes ship their own button focus styles, so the
+// default focus-visible ring must survive subtraction (minimal is exempt only
+// because its shipped #364 behaviour already dropped it — see CLAUDE.md).
+const keepsFocusVisible = (theme: ThemeKey): boolean => theme !== 'minimal'
+
+const utilOf = (cls: string): string => cls.split(':').pop() ?? cls
+
+export const subtractThemeDefaults = (defaults: string): string => {
+  // Double-role guard: Nuxt merges layered app.configs with defu's *fn*
+  // variant, which treats a function value as a MERGER and calls it with the
+  // lower layer's value (another theme's replacer function, or undefined).
+  // Several themes assign this same function to the same slot key, so at
+  // merge time we return ourselves — the merged value stays the replacer —
+  // and only do real work at render time, when tv passes a string.
+  if (typeof (defaults as unknown) !== 'string') {
+    return subtractThemeDefaults as unknown as string
+  }
+  const tokens = defaults.split(/\s+/).filter(Boolean)
+  const marker = MARKERS.find(([prefix]) => tokens.some(t => t.startsWith(prefix)))
+  if (!marker) return defaults
+  const theme = marker[1]
+  const kept = tokens.filter((t) => {
+    if (keepsFocusVisible(theme) && t.includes('focus-visible:')) return true
+    return !STRIP[theme](utilOf(t))
+  })
+  if (theme === 'minimal') kept.push('minimal-flat')
+  return kept.join(' ')
+}

--- a/packages/crouton-themes/minimal/app.config.ts
+++ b/packages/crouton-themes/minimal/app.config.ts
@@ -1,24 +1,7 @@
 // Minimal Theme Configuration
 // Super clean, black lines, white background, minimal aesthetic
 
-// Subtractive-theming helper (Nuxt UI >= 4.9, PR #6562).
-// A slot value that is a `(defaults) => classes` function REPLACES the resolved
-// default classes instead of merging onto them. We keep Nuxt UI's layout/sizing
-// and remove only the decorative utilities (rounded-* / shadow-* / ring-*, incl.
-// variant-prefixed ones like `focus-visible:ring-2`), then tag the element with
-// `minimal-flat`. Pure + deterministic, so SSR and client compute the identical
-// class string -> no hydration mismatch.
-const isDecorative = (cls: string): boolean => {
-  const util = cls.split(':').pop() ?? cls // drop variant prefixes (hover:, focus-visible:, dark:)
-  return /^-?(rounded|shadow|ring)(-|$)/.test(util)
-}
-
-const stripDecorative = (defaults: string): string =>
-  defaults
-    .split(/\s+/)
-    .filter(c => c && !isDecorative(c))
-    .concat('minimal-flat')
-    .join(' ')
+import { subtractThemeDefaults } from '../lib/subtractive'
 
 export default defineAppConfig({
   ui: {
@@ -28,14 +11,14 @@ export default defineAppConfig({
     },
 
     button: {
-      // Subtractive base via a slot-class replacer (see stripDecorative above).
-      // NOTE: this is GLOBAL to every <UButton> in an app that extends this
-      // theme -- it is NOT scoped to `variant="minimal"`. Replacers are only read
-      // at the top-level base/slots or the per-instance :ui prop, never inside
-      // variants/compoundVariants, so a theme that wants to *subtract* defaults
-      // does it here, while the named `minimal*` variants below stay additive.
+      // Subtractive base via the SHARED marker-gated replacer (#1304, was an
+      // inline stripDecorative from #364). Same subtraction set as before
+      // (rounded/shadow/ring + the minimal-flat tag), with one refinement: it
+      // now fires only when a minimal-* marker is in the resolved classes
+      // (i.e. the minimal variants below are in play), so in multi-theme apps
+      // like the playground it no longer flattens the other themes' buttons.
       slots: {
-        base: stripDecorative
+        base: subtractThemeDefaults
       },
       variants: {
         variant: {

--- a/packages/crouton-themes/package.json
+++ b/packages/crouton-themes/package.json
@@ -20,7 +20,8 @@
     "ko",
     "minimal",
     "kr11",
-    "blackandwhite"
+    "blackandwhite",
+    "lib"
   ],
   "keywords": [
     "nuxt",

--- a/packages/crouton-themes/playground/app/app.config.ts
+++ b/packages/crouton-themes/playground/app/app.config.ts
@@ -1,0 +1,25 @@
+// The playground extends EVERY theme layer, and blackandwhite's layer sets
+// defaultVariants (variant bw-solid, size sm) for its single-theme apps. In a
+// multi-theme app the pre-swap baseline must be Nuxt UI's true defaults — this
+// app-level config outranks all layers and pins them; the runtime switcher
+// then swaps defaultVariants per theme (see themes/configs/themeConfigs.ts).
+export default defineAppConfig({
+  ui: {
+    theme: {
+      defaultVariants: {
+        size: 'md'
+      }
+    },
+    colors: {
+      primary: 'emerald',
+      neutral: 'slate'
+    },
+    button: { defaultVariants: { variant: 'solid' } },
+    input: { defaultVariants: { variant: 'outline' } },
+    card: { defaultVariants: { variant: 'outline' } },
+    badge: { defaultVariants: { variant: 'solid' } },
+    alert: { defaultVariants: { variant: 'solid' } },
+    textarea: { defaultVariants: { variant: 'outline' } },
+    select: { defaultVariants: { variant: 'outline' } }
+  }
+})

--- a/packages/crouton-themes/playground/app/app.vue
+++ b/packages/crouton-themes/playground/app/app.vue
@@ -1,20 +1,8 @@
 <script setup lang="ts">
 // crouton-themes playground (#1306) — the daily dev surface AND the theme
-// gallery this epic (#1303) uses for ui-proposal sign-off. Every themed
-// component below is rendered once; flipping <ThemeSwitcher> restyles the
-// whole page live via useThemeSwitcher()'s updateAppConfig() swap.
-const { variant, getVariant } = useThemeSwitcher()
-
-const colors = ['primary', 'neutral', 'error'] as const
-
-const dropdownItems = [
-  [{ label: 'Profile', icon: 'i-lucide-user' }, { label: 'Settings', icon: 'i-lucide-settings' }],
-  [{ label: 'Log out', icon: 'i-lucide-log-out' }]
-]
-
-const isModalOpen = ref(false)
-
-const switchValue = ref(true)
+// gallery this epic (#1303) uses for ui-proposal sign-off. Pages:
+//   /    the gallery — every themed component once, restyled by the switcher
+//   /ko  the original ko-ui hardware showcase, resurrected (#1304)
 </script>
 
 <template>
@@ -28,109 +16,14 @@ const switchValue = ref(true)
           Every current theme, one component set. Switch themes to compare —
           nothing here is hand-drawn per theme, it's the same markup restyled.
         </p>
+        <nav class="flex gap-4 text-sm">
+          <NuxtLink to="/" class="underline underline-offset-2">Gallery</NuxtLink>
+          <NuxtLink to="/ko" class="underline underline-offset-2">KO hardware showcase</NuxtLink>
+        </nav>
       </div>
       <ThemeSwitcher />
     </header>
 
-    <section class="space-y-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
-        Buttons
-      </h2>
-      <div class="flex flex-wrap items-center gap-3">
-        <UButton
-          v-for="color in colors"
-          :key="`solid-${color}`"
-          :color="color"
-          :variant="variant"
-        >
-          {{ color }}
-        </UButton>
-      </div>
-      <div class="flex flex-wrap items-center gap-3">
-        <!-- getVariant follows the active theme's named variants (ko-outline,
-             minimal-outline, ...) — an explicit variant string would stay
-             default-styled by design (the runtime swap only remaps defaults). -->
-        <UButton color="primary" :variant="getVariant('outline')">Outline</UButton>
-        <UButton color="primary" :variant="getVariant('soft')">Soft</UButton>
-        <UButton color="primary" :variant="getVariant('ghost')">Ghost</UButton>
-        <UButton color="primary" :variant="getVariant('link')">Link</UButton>
-      </div>
-    </section>
-
-    <section class="space-y-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
-        Inputs
-      </h2>
-      <div class="flex flex-wrap items-center gap-3 max-w-sm">
-        <UInput placeholder="Text input" />
-        <UInput placeholder="Disabled" disabled />
-      </div>
-    </section>
-
-    <section class="space-y-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
-        Card
-      </h2>
-      <UCard class="max-w-sm">
-        <template #header>
-          <p class="font-medium">Card header</p>
-        </template>
-        <p class="text-sm">
-          A themed card body, restyled by the active theme's card variants.
-        </p>
-        <template #footer>
-          <UButton color="primary" size="sm">Action</UButton>
-        </template>
-      </UCard>
-    </section>
-
-    <section class="space-y-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
-        Separator
-      </h2>
-      <USeparator label="Section" />
-    </section>
-
-    <section class="space-y-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
-        Badge &amp; Switch
-      </h2>
-      <div class="flex flex-wrap items-center gap-4">
-        <UBadge color="primary">Primary</UBadge>
-        <UBadge color="neutral" variant="outline">Neutral</UBadge>
-        <USwitch v-model="switchValue" label="Enabled" />
-      </div>
-    </section>
-
-    <section class="space-y-3">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
-        Dropdown &amp; Modal
-      </h2>
-      <div class="flex flex-wrap items-center gap-3">
-        <UDropdownMenu :items="dropdownItems">
-          <UButton color="neutral" variant="outline" trailing-icon="i-lucide-chevron-down">
-            Menu
-          </UButton>
-        </UDropdownMenu>
-        <UButton color="neutral" variant="outline" @click="isModalOpen = true">
-          Open modal
-        </UButton>
-        <UModal v-model:open="isModalOpen" title="Themed modal">
-          <template #body>
-            <p class="text-sm">
-              Modal body content, restyled per-theme like every other surface.
-            </p>
-          </template>
-          <template #footer>
-            <UButton color="neutral" variant="outline" @click="isModalOpen = false">
-              Close
-            </UButton>
-            <UButton color="primary" @click="isModalOpen = false">
-              Confirm
-            </UButton>
-          </template>
-        </UModal>
-      </div>
-    </section>
+    <NuxtPage />
   </div>
 </template>

--- a/packages/crouton-themes/playground/app/app.vue
+++ b/packages/crouton-themes/playground/app/app.vue
@@ -3,7 +3,7 @@
 // gallery this epic (#1303) uses for ui-proposal sign-off. Every themed
 // component below is rendered once; flipping <ThemeSwitcher> restyles the
 // whole page live via useThemeSwitcher()'s updateAppConfig() swap.
-const { variant } = useThemeSwitcher()
+const { variant, getVariant } = useThemeSwitcher()
 
 const colors = ['primary', 'neutral', 'error'] as const
 
@@ -47,10 +47,13 @@ const switchValue = ref(true)
         </UButton>
       </div>
       <div class="flex flex-wrap items-center gap-3">
-        <UButton color="primary" variant="outline">Outline</UButton>
-        <UButton color="primary" variant="soft">Soft</UButton>
-        <UButton color="primary" variant="ghost">Ghost</UButton>
-        <UButton color="primary" variant="link">Link</UButton>
+        <!-- getVariant follows the active theme's named variants (ko-outline,
+             minimal-outline, ...) — an explicit variant string would stay
+             default-styled by design (the runtime swap only remaps defaults). -->
+        <UButton color="primary" :variant="getVariant('outline')">Outline</UButton>
+        <UButton color="primary" :variant="getVariant('soft')">Soft</UButton>
+        <UButton color="primary" :variant="getVariant('ghost')">Ghost</UButton>
+        <UButton color="primary" :variant="getVariant('link')">Link</UButton>
       </div>
     </section>
 

--- a/packages/crouton-themes/playground/app/pages/index.vue
+++ b/packages/crouton-themes/playground/app/pages/index.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+// crouton-themes gallery (#1306) — every themed component rendered once;
+// flipping <ThemeSwitcher> (in app.vue) restyles the whole page live.
+const { getVariant } = useThemeSwitcher()
+const { variant } = useThemeSwitcher()
+
+const colors = ['primary', 'neutral', 'error'] as const
+
+const dropdownItems = [
+  [{ label: 'Profile', icon: 'i-lucide-user' }, { label: 'Settings', icon: 'i-lucide-settings' }],
+  [{ label: 'Log out', icon: 'i-lucide-log-out' }]
+]
+
+const isModalOpen = ref(false)
+
+const switchValue = ref(true)
+</script>
+
+<template>
+  <div class="space-y-10">
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Buttons
+      </h2>
+      <div class="flex flex-wrap items-center gap-3">
+        <UButton
+          v-for="color in colors"
+          :key="`solid-${color}`"
+          :color="color"
+          :variant="variant"
+        >
+          {{ color }}
+        </UButton>
+      </div>
+      <div class="flex flex-wrap items-center gap-3">
+        <!-- getVariant follows the active theme's named variants (ko-outline,
+             minimal-outline, ...) — an explicit variant string would stay
+             default-styled by design (the runtime swap only remaps defaults). -->
+        <UButton color="primary" :variant="getVariant('outline')">Outline</UButton>
+        <UButton color="primary" :variant="getVariant('soft')">Soft</UButton>
+        <UButton color="primary" :variant="getVariant('ghost')">Ghost</UButton>
+        <UButton color="primary" :variant="getVariant('link')">Link</UButton>
+      </div>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Inputs
+      </h2>
+      <div class="flex flex-wrap items-center gap-3 max-w-sm">
+        <UInput placeholder="Text input" />
+        <UInput placeholder="Disabled" disabled />
+      </div>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Card
+      </h2>
+      <UCard class="max-w-sm">
+        <template #header>
+          <p class="font-medium">Card header</p>
+        </template>
+        <p class="text-sm">
+          A themed card body, restyled by the active theme's card variants.
+        </p>
+        <template #footer>
+          <UButton color="primary" size="sm">Action</UButton>
+        </template>
+      </UCard>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Separator
+      </h2>
+      <USeparator label="Section" />
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Badge &amp; Switch
+      </h2>
+      <div class="flex flex-wrap items-center gap-4">
+        <UBadge color="primary">Primary</UBadge>
+        <UBadge color="neutral" variant="outline">Neutral</UBadge>
+        <USwitch v-model="switchValue" label="Enabled" />
+      </div>
+    </section>
+
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Dropdown &amp; Modal
+      </h2>
+      <div class="flex flex-wrap items-center gap-3">
+        <UDropdownMenu :items="dropdownItems">
+          <UButton color="neutral" variant="outline" trailing-icon="i-lucide-chevron-down">
+            Menu
+          </UButton>
+        </UDropdownMenu>
+        <UButton color="neutral" variant="outline" @click="isModalOpen = true">
+          Open modal
+        </UButton>
+        <UModal v-model:open="isModalOpen" title="Themed modal">
+          <template #body>
+            <p class="text-sm">
+              Modal body content, restyled per-theme like every other surface.
+            </p>
+          </template>
+          <template #footer>
+            <UButton color="neutral" variant="outline" @click="isModalOpen = false">
+              Close
+            </UButton>
+            <UButton color="primary" @click="isModalOpen = false">
+              Confirm
+            </UButton>
+          </template>
+        </UModal>
+      </div>
+    </section>
+  </div>
+</template>

--- a/packages/crouton-themes/playground/app/pages/ko.vue
+++ b/packages/crouton-themes/playground/app/pages/ko.vue
@@ -1,0 +1,620 @@
+<script setup lang="ts">
+// The ORIGINAL ko-ui showcase (#1304) — resurrected verbatim from the retired
+// apps/ko-ui app (git 1129c8a8, removed by "chore(root): remove ko-ui app").
+// It mocks a full KO II device: custom Ko* components (buttons with LED slots,
+// knobs, 7-segment displays, punch holes, speaker grills) side-by-side with
+// the same aesthetic done through Nuxt UI `variant="ko"`. Only this comment
+// and the back-link differ from the original.
+
+// Demo state
+const knobValue = ref(50)
+const bpmKnob = ref(120)
+const isRecording = ref(false)
+const isPlaying = ref(false)
+
+// Toggle handlers
+const toggleRecord = () => {
+  isRecording.value = !isRecording.value
+}
+
+const togglePlay = () => {
+  isPlaying.value = !isPlaying.value
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-[var(--ko-surface-light)] p-8">
+    <!-- Header -->
+    <header class="mb-12">
+      <h1 class="ko-font text-3xl text-[var(--ko-text-dark)] mb-2">
+        KO-UI
+      </h1>
+      <p class="text-[var(--ko-text-label)] text-sm">
+        Hardware-inspired design system based on Teenage Engineering KO II —
+        the original ko-ui showcase, resurrected.
+      </p>
+      <NuxtLink to="/" class="text-xs text-[var(--ko-accent-orange)] font-mono underline underline-offset-2">
+        ← back to the theme gallery
+      </NuxtLink>
+    </header>
+
+    <!-- Main Grid -->
+    <div class="grid gap-12">
+      <!-- ============================================
+           SECTION: Buttons
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Buttons
+        </h2>
+
+        <!-- Square Buttons Comparison -->
+        <div class="mb-8">
+          <h3 class="text-sm text-[var(--ko-text-label)] mb-4">Square Buttons</h3>
+
+          <!-- Custom KoButton -->
+          <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;KoButton&gt; (custom)</p>
+          <div class="flex flex-wrap gap-4 mb-4">
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Keys</KoLabel>
+              <KoButton variant="default" shape="square">
+                Keys
+              </KoButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel variant="orange">Sample</KoLabel>
+              <KoButton variant="orange" shape="square">
+                X
+                <template #led>
+                  <KoLed state="on" />
+                </template>
+              </KoButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Dark</KoLabel>
+              <KoButton variant="dark" shape="square">
+                7
+              </KoButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Pink</KoLabel>
+              <KoButton variant="pink" shape="square">
+                FX
+              </KoButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Blue</KoLabel>
+              <KoButton variant="blue" shape="square">
+                Y
+              </KoButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Red</KoLabel>
+              <KoButton
+                variant="red"
+                shape="square"
+                @click="toggleRecord"
+              >
+                Rec
+                <template #led>
+                  <KoLed :state="isRecording ? 'blink' : 'off'" color="red" />
+                </template>
+              </KoButton>
+            </div>
+          </div>
+
+          <!-- Nuxt UI via variant="ko" (config-based) -->
+          <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;UButton variant="ko"&gt; (config variant)</p>
+          <div class="flex flex-wrap gap-4">
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Keys</KoLabel>
+              <UButton variant="ko" class="aspect-square p-4">
+                Keys
+              </UButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel variant="orange">Sample</KoLabel>
+              <UButton variant="ko" color="primary" class="aspect-square p-4">
+                X
+              </UButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Dark</KoLabel>
+              <UButton variant="ko" color="neutral" class="aspect-square p-4">
+                7
+              </UButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Pink</KoLabel>
+              <UButton variant="ko" color="secondary" class="aspect-square p-4">
+                FX
+              </UButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Blue</KoLabel>
+              <UButton variant="ko" color="info" class="aspect-square p-4">
+                Y
+              </UButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Red</KoLabel>
+              <UButton variant="ko" color="error" class="aspect-square p-4">
+                Rec
+              </UButton>
+            </div>
+          </div>
+        </div>
+
+        <!-- Rectangular Buttons Comparison -->
+        <div class="mb-8">
+          <h3 class="text-sm text-[var(--ko-text-label)] mb-4">Rectangular Buttons</h3>
+
+          <!-- Custom KoButton -->
+          <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;KoButton&gt; (custom)</p>
+          <div class="flex flex-wrap gap-4 mb-4">
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Sound</KoLabel>
+              <KoButton variant="default" shape="rect">
+                Edit
+              </KoButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel variant="orange">Main</KoLabel>
+              <KoButton variant="orange" shape="rect">
+                Commit
+              </KoButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Tempo</KoLabel>
+              <KoButton variant="dark" shape="rect">
+                Loop
+              </KoButton>
+            </div>
+          </div>
+
+          <!-- Nuxt UI via variant="ko" -->
+          <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;UButton variant="ko"&gt;</p>
+          <div class="flex flex-wrap gap-4">
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Sound</KoLabel>
+              <UButton variant="ko" class="px-4 py-2">
+                Edit
+              </UButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel variant="orange">Main</KoLabel>
+              <UButton variant="ko" color="primary" class="px-4 py-2">
+                Commit
+              </UButton>
+            </div>
+
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Tempo</KoLabel>
+              <UButton variant="ko" color="neutral" class="px-4 py-2">
+                Loop
+              </UButton>
+            </div>
+          </div>
+        </div>
+
+        <!-- Number Pad Comparison -->
+        <div>
+          <h3 class="text-sm text-[var(--ko-text-label)] mb-4">Number Pad</h3>
+          <div class="flex gap-8">
+            <!-- Custom -->
+            <div>
+              <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;KoButton&gt;</p>
+              <div class="grid grid-cols-3 gap-1 w-fit">
+                <KoButton variant="dark" shape="square">7</KoButton>
+                <KoButton variant="dark" shape="square">8</KoButton>
+                <KoButton variant="dark" shape="square">9</KoButton>
+                <KoButton variant="dark" shape="square">4</KoButton>
+                <KoButton variant="dark" shape="square">5</KoButton>
+                <KoButton variant="dark" shape="square">6</KoButton>
+                <KoButton variant="dark" shape="square">1</KoButton>
+                <KoButton variant="dark" shape="square">2</KoButton>
+                <KoButton variant="dark" shape="square">3</KoButton>
+              </div>
+            </div>
+
+            <!-- Nuxt UI -->
+            <div>
+              <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;UButton variant="ko" color="neutral"&gt;</p>
+              <div class="grid grid-cols-3 gap-2 w-fit">
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">7</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">8</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">9</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">4</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">5</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">6</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">1</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">2</UButton>
+                <UButton variant="ko" color="neutral" class="aspect-square p-4">3</UButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: LEDs
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          LEDs
+        </h2>
+
+        <div class="flex flex-wrap gap-8">
+          <!-- States -->
+          <div>
+            <h3 class="text-sm text-[var(--ko-text-label)] mb-4">States</h3>
+            <div class="flex gap-4 items-center bg-[var(--ko-surface-panel)] p-4 rounded">
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="off" />
+                <span class="text-xs text-[var(--ko-text-label)]">Off</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" />
+                <span class="text-xs text-[var(--ko-text-label)]">On</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="blink" />
+                <span class="text-xs text-[var(--ko-text-label)]">Blink</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="fast" />
+                <span class="text-xs text-[var(--ko-text-label)]">Fast</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="alive" />
+                <span class="text-xs text-[var(--ko-text-label)]">Alive</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Colors -->
+          <div>
+            <h3 class="text-sm text-[var(--ko-text-label)] mb-4">Colors</h3>
+            <div class="flex gap-4 items-center bg-[var(--ko-surface-panel)] p-4 rounded">
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" color="orange" />
+                <span class="text-xs text-[var(--ko-text-label)]">Orange</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" color="red" />
+                <span class="text-xs text-[var(--ko-text-label)]">Red</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" color="blue" />
+                <span class="text-xs text-[var(--ko-text-label)]">Blue</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" color="green" />
+                <span class="text-xs text-[var(--ko-text-label)]">Green</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Sizes -->
+          <div>
+            <h3 class="text-sm text-[var(--ko-text-label)] mb-4">Sizes</h3>
+            <div class="flex gap-4 items-center bg-[var(--ko-surface-panel)] p-4 rounded">
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" size="sm" />
+                <span class="text-xs text-[var(--ko-text-label)]">sm</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" size="md" />
+                <span class="text-xs text-[var(--ko-text-label)]">md</span>
+              </div>
+              <div class="flex flex-col items-center gap-2">
+                <KoLed state="on" size="lg" />
+                <span class="text-xs text-[var(--ko-text-label)]">lg</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: Knobs
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Knobs
+        </h2>
+
+        <div class="flex flex-wrap gap-8">
+          <!-- Volume Knob -->
+          <div class="flex flex-col items-center gap-2">
+            <KoLabel>Volume</KoLabel>
+            <KoKnob v-model="knobValue" size="lg" />
+            <KoLabel variant="dark" position="below">{{ knobValue }}</KoLabel>
+          </div>
+
+          <!-- BPM Knob -->
+          <div class="flex flex-col items-center gap-2">
+            <KoLabel variant="orange">BPM</KoLabel>
+            <KoKnob v-model="bpmKnob" :min="60" :max="200" size="md" color="orange" />
+            <KoLabel variant="dark" position="below">{{ bpmKnob }}</KoLabel>
+          </div>
+
+          <!-- Small Knobs -->
+          <div class="flex flex-col items-center gap-2">
+            <KoLabel>Gain</KoLabel>
+            <KoKnob :model-value="75" size="sm" />
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: Displays
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Displays
+        </h2>
+
+        <div class="flex flex-wrap gap-8">
+          <KoDisplay label="BAR" :value="'19.3'" />
+          <KoDisplay label="BPM" :value="bpmKnob" />
+          <KoDisplay :value="'FX'" :segments="false" />
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: Inputs (Nuxt UI Variant)
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Inputs
+        </h2>
+
+        <div class="space-y-6 max-w-md">
+          <!-- Default Nuxt UI Input -->
+          <div>
+            <p class="text-xs text-[var(--ko-text-label)] mb-2 font-mono">&lt;UInput&gt; (default)</p>
+            <UInput placeholder="Default input..." />
+          </div>
+
+          <!-- KO Variant Input -->
+          <div>
+            <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;UInput variant="ko"&gt;</p>
+            <UInput variant="ko" placeholder="LCD style input..." />
+          </div>
+
+          <!-- KO Input with icon -->
+          <div>
+            <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;UInput variant="ko"&gt; with icon</p>
+            <UInput variant="ko" placeholder="Search samples..." icon="i-lucide-search" />
+          </div>
+
+          <!-- Multiple inputs in a row -->
+          <div>
+            <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">BPM / Bar inputs</p>
+            <div class="flex gap-4">
+              <UInput variant="ko" placeholder="120" class="w-24" />
+              <UInput variant="ko" placeholder="4/4" class="w-24" />
+              <UInput variant="ko" placeholder="C" class="w-16" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: Cards (Nuxt UI Variant)
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Cards
+        </h2>
+
+        <div class="grid gap-6 max-w-2xl">
+          <!-- Default Nuxt UI Card -->
+          <div>
+            <p class="text-xs text-[var(--ko-text-label)] mb-2 font-mono">&lt;UCard&gt; (default)</p>
+            <UCard>
+              <template #header>
+                Default Card Header
+              </template>
+              <p>This is the default Nuxt UI card styling.</p>
+              <template #footer>
+                <UButton size="sm">Action</UButton>
+              </template>
+            </UCard>
+          </div>
+
+          <!-- KO Variant Card (Light) -->
+          <div>
+            <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">&lt;UCard variant="ko"&gt;</p>
+            <UCard variant="ko">
+              <template #header>
+                Sample Bank
+              </template>
+              <div class="space-y-2">
+                <p>Hardware-styled card with beveled edges and drop shadow.</p>
+                <div class="flex gap-2">
+                  <UButton variant="ko" size="sm">Load</UButton>
+                  <UButton variant="ko" color="primary" size="sm">Save</UButton>
+                </div>
+              </div>
+            </UCard>
+          </div>
+
+          <!-- KO Card with inputs inside -->
+          <div>
+            <p class="text-xs text-[var(--ko-accent-orange)] mb-2 font-mono">KO Card with form</p>
+            <UCard variant="ko">
+              <template #header>
+                Project Settings
+              </template>
+              <div class="space-y-4">
+                <div>
+                  <label class="ko-font text-xs text-[var(--ko-text-label)] block mb-1">Project Name</label>
+                  <UInput variant="ko" placeholder="My project..." />
+                </div>
+                <div class="flex gap-4">
+                  <div class="flex-1">
+                    <label class="ko-font text-xs text-[var(--ko-text-label)] block mb-1">BPM</label>
+                    <UInput variant="ko" placeholder="120" />
+                  </div>
+                  <div class="flex-1">
+                    <label class="ko-font text-xs text-[var(--ko-text-label)] block mb-1">Time Sig</label>
+                    <UInput variant="ko" placeholder="4/4" />
+                  </div>
+                </div>
+              </div>
+              <template #footer>
+                <div class="flex justify-end gap-2">
+                  <UButton variant="ko" size="sm">Cancel</UButton>
+                  <UButton variant="ko" color="primary" size="sm">Save</UButton>
+                </div>
+              </template>
+            </UCard>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: Panels
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Panels
+        </h2>
+
+        <div class="grid gap-4 max-w-xl">
+          <KoPanel :dark="true" :glass="true">
+            <div class="flex items-center gap-4">
+              <KoLed state="alive" />
+              <span>Dark panel with glass effect</span>
+            </div>
+          </KoPanel>
+
+          <KoPanel :dark="false" :glass="false">
+            <span>Light panel without glass</span>
+          </KoPanel>
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: Hardware Elements
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Hardware Elements
+        </h2>
+
+        <div class="flex flex-wrap gap-8">
+          <!-- Punch Holes -->
+          <div>
+            <h3 class="text-sm text-[var(--ko-text-label)] mb-4">Punch Holes</h3>
+            <div class="flex gap-4">
+              <KoPunchHole size="sm" />
+              <KoPunchHole size="md" />
+              <KoPunchHole size="lg" />
+            </div>
+          </div>
+
+          <!-- Speaker Grill -->
+          <div>
+            <h3 class="text-sm text-[var(--ko-text-label)] mb-4">Speaker Grill</h3>
+            <KoSpeakerGrill :rows="8" :cols="6" />
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================
+           SECTION: Complete Demo
+           ============================================ -->
+      <section>
+        <h2 class="ko-font text-lg text-[var(--ko-text-dark)] mb-6 border-b border-[var(--ko-surface-mid)] pb-2">
+          Complete Demo
+        </h2>
+
+        <div class="bg-[var(--ko-surface-light)] p-6 rounded-lg shadow-xl max-w-2xl">
+          <!-- Display Area -->
+          <KoPanel :dark="true" :glass="true" class="mb-6">
+            <div class="flex items-center justify-between w-full">
+              <div class="flex items-center gap-4">
+                <KoDisplay label="BAR" value="19.3" />
+              </div>
+              <div class="flex items-center gap-2">
+                <KoLed :state="isPlaying ? 'alive' : 'off'" />
+                <KoLed :state="isRecording ? 'blink' : 'off'" color="red" />
+              </div>
+              <KoSpeakerGrill :rows="6" :cols="4" />
+            </div>
+          </KoPanel>
+
+          <!-- Controls -->
+          <div class="flex items-start gap-6">
+            <!-- Left: Volume -->
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel>Volume</KoLabel>
+              <KoKnob v-model="knobValue" size="lg" />
+            </div>
+
+            <!-- Center: Transport -->
+            <div class="flex gap-2">
+              <div class="flex flex-col items-center gap-2">
+                <KoLabel>Play</KoLabel>
+                <KoButton
+                  variant="default"
+                  shape="square"
+                  @click="togglePlay"
+                >
+                  ▶
+                  <template #led>
+                    <KoLed :state="isPlaying ? 'on' : 'off'" color="green" />
+                  </template>
+                </KoButton>
+              </div>
+
+              <div class="flex flex-col items-center gap-2">
+                <KoLabel variant="orange">Record</KoLabel>
+                <KoButton
+                  variant="red"
+                  shape="square"
+                  @click="toggleRecord"
+                >
+                  ●
+                  <template #led>
+                    <KoLed :state="isRecording ? 'blink' : 'off'" color="red" />
+                  </template>
+                </KoButton>
+              </div>
+            </div>
+
+            <!-- Right: BPM -->
+            <div class="flex flex-col items-center gap-2">
+              <KoLabel variant="orange">BPM</KoLabel>
+              <KoKnob v-model="bpmKnob" :min="60" :max="200" size="md" color="orange" />
+              <KoLabel variant="dark" position="below">{{ bpmKnob }}</KoLabel>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Footer -->
+    <footer class="mt-16 pt-8 border-t border-[var(--ko-surface-mid)]">
+      <p class="text-xs text-[var(--ko-text-label)]">
+        KO-UI • Inspired by Teenage Engineering KO II
+      </p>
+    </footer>
+  </div>
+</template>

--- a/packages/crouton-themes/themes/components/ThemeSwitcher.vue
+++ b/packages/crouton-themes/themes/components/ThemeSwitcher.vue
@@ -23,11 +23,15 @@ const toggleColorMode = () => {
   colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
 }
 
-// Dropdown menu items with custom slot for color swatches
+// Dropdown menu items with custom slot for color swatches.
+// Slot names are prefixed: a bare theme name would collide with Vue's
+// reserved slots — the 'default' theme literally became `#default` and
+// silently REPLACED the dropdown's trigger slot with a static item row
+// (the chip stuck on "Default" forever).
 const menuItems = computed(() =>
   themes.map(theme => ({
     label: theme.label,
-    slot: theme.name,
+    slot: `theme-${theme.name}`,
     onSelect: () => setTheme(theme.name),
     active: currentTheme.value === theme.name
   }))
@@ -61,8 +65,8 @@ const menuItems = computed(() =>
         </span>
       </UButton>
 
-      <!-- Custom slots for each theme item -->
-      <template v-for="theme in themes" :key="theme.name" #[theme.name]>
+      <!-- Custom slots for each theme item (prefixed — see menuItems) -->
+      <template v-for="theme in themes" :key="theme.name" #[`theme-${theme.name}`]>
         <span class="flex items-center gap-2 w-full">
           <span class="flex -space-x-0.5">
             <span

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -67,10 +67,21 @@ export function useThemeSwitcher() {
   // SSR-safe localStorage persistence via VueUse
   const storedTheme = useLocalStorage<ThemeName>(STORAGE_KEY, 'default')
 
-  // Initialize from stored preference on client
-  if (import.meta.client && AVAILABLE_THEMES.some(t => t.name === storedTheme.value)) {
-    currentTheme.value = storedTheme.value
-  }
+  // Restore the stored preference AFTER hydration (onMounted), never during
+  // setup: the server can't know localStorage, so a setup-time restore makes
+  // the client's first render differ from the SSR HTML → hydration class
+  // mismatch on every themed component (#1304). Post-mount it's a normal
+  // reactive update. Idempotent across the many components calling this.
+  // Guarded: plugins (themeProvider.client) call this composable outside any
+  // component instance, where onMounted can't register.
+  if (getCurrentInstance()) onMounted(() => {
+    if (
+      storedTheme.value !== currentTheme.value
+      && AVAILABLE_THEMES.some(t => t.name === storedTheme.value)
+    ) {
+      setTheme(storedTheme.value)
+    }
+  })
 
   // Computed for current theme config
   const currentThemeConfig = computed(() =>
@@ -78,15 +89,14 @@ export function useThemeSwitcher() {
   )
 
   // Get the variant name for Nuxt UI components.
-  // 'default' returns undefined to use Nuxt UI's default variant. 'blackandwhite'
-  // also returns undefined: unlike ko/minimal/kr11 (which register a *named*
-  // `variant="<theme>"` value), blackandwhite overrides the standard variant
-  // slots directly (solid/outline/soft/ghost/link -> bw-*), so plain UButton
-  // usage with no explicit variant already renders themed.
+  // 'default' returns undefined to use Nuxt UI's default variant. Every theme
+  // registers NAMED variants under its class prefix (ko, minimal, kr11, bw-*),
+  // and the runtime swap points defaultVariants.variant at the same name — so
+  // binding :variant="variant" and plain variant-less usage render identically.
   const variant = computed(() =>
-    currentTheme.value === 'default' || currentTheme.value === 'blackandwhite'
+    currentTheme.value === 'default'
       ? undefined
-      : currentTheme.value
+      : currentTheme.value === 'blackandwhite' ? 'bw-solid' : currentTheme.value
   )
 
   // Set theme and persist
@@ -122,23 +132,21 @@ export function useThemeSwitcher() {
     }
   })
 
-  // Initialize theme UI config on client
-  if (import.meta.client) {
-    const themeUIConfig = THEME_UI_CONFIGS[currentTheme.value]
-    if (themeUIConfig) {
-      updateAppConfig({
-        ui: themeUIConfig as any
-      })
-    }
-  }
+  // (No setup-time updateAppConfig: the onMounted restore above applies the
+  // stored theme's config post-hydration via setTheme.)
 
   // Get variant with theme prefix for compound variants
-  // e.g., getVariant('ghost') returns 'ko-ghost' when KO theme is active.
-  // blackandwhite has no prefixed variants (see `variant` above) — it remaps
-  // the base variant name itself, so the base variant passes through unchanged.
-  function getVariant(baseVariant: string = 'solid'): string {
-    if (currentTheme.value === 'default' || currentTheme.value === 'blackandwhite') return baseVariant
-    return `${currentTheme.value}-${baseVariant}`
+  // e.g., getVariant('ghost') returns 'ko-ghost' when KO theme is active and
+  // 'bw-ghost' under blackandwhite (whose named-variant prefix is 'bw', not
+  // the theme name). 'default' passes the base variant through unchanged.
+  // Returns `any`: the concrete union of registered variant names is generated
+  // per consuming app by Nuxt UI, so this composable can't name it — and a
+  // plain `string` fails assignment against that union in templates.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function getVariant(baseVariant: string = 'solid'): any {
+    if (currentTheme.value === 'default') return baseVariant
+    const prefix = currentTheme.value === 'blackandwhite' ? 'bw' : currentTheme.value
+    return `${prefix}-${baseVariant}`
   }
 
   return {

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -1,148 +1,94 @@
-// Theme UI Configurations
-// Each theme defines how standard Nuxt UI variants should look
-// These are swapped at runtime via updateAppConfig()
+// Theme UI Configurations — the RUNTIME side of theme switching.
+//
+// ⚠️ Scalars only. `updateAppConfig()` merges with Nuxt's deepAssign, which
+// merges ARRAYS BY INDEX — a runtime write to `compoundVariants` overwrites
+// whatever entries happen to sit at those indices in the built config (the
+// #1306/#1304 playground bug: the layer-registered named variants lost their
+// compounds on every switch). So a theme's classes/variants/compoundVariants
+// live ONLY in its layer app.config (build-time, merge-safe); the runtime swap
+// is limited to scalar leaves:
+//   - `colors.*`                → the semantic palette
+//   - `<component>.defaultVariants.variant` → which (named) variant plain,
+//     variant-less usage resolves to, e.g. <UButton> → variant "ko"
+// Explicitly-set variants are the author's choice and are not remapped; use
+// useThemeSwitcher().getVariant('outline') to follow the active theme.
 
 import type { ThemeName } from '../composables/useThemeSwitcher'
 
-// Type for the UI config structure
 export interface ThemeUIConfig {
   colors?: {
     primary?: string
     neutral?: string
   }
-  button?: {
-    variants?: {
-      variant?: Record<string, string>
-    }
-    compoundVariants?: Array<{
-      variant?: string
-      color?: string
-      class: string
-    }>
-  }
-  input?: {
-    variants?: {
-      variant?: Record<string, string>
-    }
-    compoundVariants?: Array<{
-      variant?: string
-      class: string
-    }>
-  }
-  card?: {
-    variants?: {
-      variant?: Record<string, string>
-    }
-    compoundVariants?: Array<{
-      variant?: string
-      class: string
-    }>
-  }
+  button?: { defaultVariants?: { variant?: string } }
+  input?: { defaultVariants?: { variant?: string } }
+  card?: { defaultVariants?: { variant?: string } }
+  badge?: { defaultVariants?: { variant?: string } }
 }
 
-// Default theme - no overrides, use Nuxt UI defaults
+// Every config sets EVERY key the swap owns, so switching A → B never leaves
+// A's value behind (deepAssign only overwrites what the new object names).
+
+// Default theme — Nuxt UI's own defaults, restated as the reset values.
 const defaultConfig: ThemeUIConfig = {
   colors: {
     primary: 'emerald',
     neutral: 'slate'
   },
-  button: {
-    compoundVariants: []
-  }
+  button: { defaultVariants: { variant: 'solid' } },
+  input: { defaultVariants: { variant: 'outline' } },
+  card: { defaultVariants: { variant: 'outline' } },
+  badge: { defaultVariants: { variant: 'solid' } }
 }
 
-// KO Theme - Hardware-inspired (Teenage Engineering)
-// Override variant classes directly to replace Nuxt UI defaults
+// KO — named variants registered by ko/app.config.ts (variant="ko" etc.)
 const koConfig: ThemeUIConfig = {
   colors: {
     primary: 'orange',
     neutral: 'stone'
   },
-  button: {
-    // Override variant definitions - these REPLACE Nuxt UI defaults
-    variants: {
-      variant: {
-        solid: 'ko-bezel',
-        outline: 'ko-outline',
-        soft: 'ko-soft',
-        ghost: 'ko-ghost',
-        link: 'ko-link'
-      }
-    },
-    // Color-specific adjustments via compoundVariants
-    compoundVariants: [
-      { variant: 'solid', color: 'primary', class: 'ko-bezel--orange' },
-      { variant: 'solid', color: 'neutral', class: 'ko-bezel--dark' },
-      { variant: 'solid', color: 'error', class: 'ko-bezel--red' },
-      { variant: 'solid', color: 'secondary', class: 'ko-bezel--pink' },
-      { variant: 'solid', color: 'info', class: 'ko-bezel--blue' },
-      { variant: 'outline', color: 'primary', class: 'ko-outline--orange' },
-      { variant: 'outline', color: 'neutral', class: 'ko-outline--dark' },
-      { variant: 'outline', color: 'error', class: 'ko-outline--red' },
-      { variant: 'ghost', color: 'primary', class: 'ko-ghost--orange' },
-      { variant: 'ghost', color: 'neutral', class: 'ko-ghost--dark' }
-    ]
-  }
+  button: { defaultVariants: { variant: 'ko' } },
+  input: { defaultVariants: { variant: 'ko' } },
+  card: { defaultVariants: { variant: 'ko' } },
+  badge: { defaultVariants: { variant: 'solid' } }
 }
 
-// Minimal Theme - Clean Bauhaus-inspired
+// Minimal — named variants registered by minimal/app.config.ts
 const minimalConfig: ThemeUIConfig = {
   colors: {
     primary: 'zinc',
     neutral: 'zinc'
   },
-  button: {
-    compoundVariants: [
-      // Solid variant overrides
-      { variant: 'solid', color: 'primary', class: 'minimal-solid' },
-      { variant: 'solid', color: 'neutral', class: 'minimal-solid minimal-solid--neutral' },
-      { variant: 'solid', color: 'error', class: 'minimal-solid minimal-solid--error' },
-      // Outline variant overrides
-      { variant: 'outline', color: 'primary', class: 'minimal-outline' },
-      { variant: 'outline', color: 'neutral', class: 'minimal-outline minimal-outline--neutral' },
-      { variant: 'outline', color: 'error', class: 'minimal-outline minimal-outline--error' },
-      // Ghost variant overrides
-      { variant: 'ghost', color: 'primary', class: 'minimal-ghost' },
-      { variant: 'ghost', color: 'neutral', class: 'minimal-ghost minimal-ghost--neutral' },
-      { variant: 'ghost', color: 'error', class: 'minimal-ghost minimal-ghost--error' }
-    ]
-  }
+  button: { defaultVariants: { variant: 'minimal' } },
+  input: { defaultVariants: { variant: 'minimal' } },
+  card: { defaultVariants: { variant: 'minimal' } },
+  badge: { defaultVariants: { variant: 'solid' } }
 }
 
-// KR-11 Theme - Friendly drum machine aesthetic
+// KR-11 — named variants registered by kr11/app.config.ts
 const kr11Config: ThemeUIConfig = {
   colors: {
     primary: 'emerald',
     neutral: 'stone'
   },
-  button: {
-    compoundVariants: [
-      // Solid variant overrides
-      { variant: 'solid', color: 'primary', class: 'kr-solid kr-solid--mint' },
-      { variant: 'solid', color: 'neutral', class: 'kr-solid kr-solid--cream' },
-      { variant: 'solid', color: 'warning', class: 'kr-solid kr-solid--gold' },
-      { variant: 'solid', color: 'error', class: 'kr-solid kr-solid--coral' },
-      // Soft variant overrides
-      { variant: 'soft', color: 'primary', class: 'kr-soft kr-soft--mint' },
-      { variant: 'soft', color: 'neutral', class: 'kr-soft kr-soft--cream' },
-      { variant: 'soft', color: 'warning', class: 'kr-soft kr-soft--gold' },
-      { variant: 'soft', color: 'error', class: 'kr-soft kr-soft--coral' },
-      // Ghost variant overrides
-      { variant: 'ghost', color: 'primary', class: 'kr-ghost kr-ghost--mint' },
-      { variant: 'ghost', color: 'neutral', class: 'kr-ghost kr-ghost--cream' }
-    ]
-  }
+  button: { defaultVariants: { variant: 'kr11' } },
+  input: { defaultVariants: { variant: 'kr11' } },
+  card: { defaultVariants: { variant: 'kr11' } },
+  badge: { defaultVariants: { variant: 'kr11' } }
 }
 
-// Black & White Theme - compact monochrome dashboard
-// Variant CLASSES are already registered by the theme's own app.config.ts
-// (bw-solid/bw-outline/bw-soft/bw-ghost/bw-link); the switcher only needs the
-// color palette here since the theme has no per-color compoundVariants.
+// Black & White — named bw-* variants registered by blackandwhite/app.config.ts
+// (the layer also sets defaultVariants itself, so single-theme bw apps need no
+// runtime swap; these values are for switching TO bw in a multi-theme app).
 const blackandwhiteConfig: ThemeUIConfig = {
   colors: {
     primary: 'neutral',
     neutral: 'neutral'
-  }
+  },
+  button: { defaultVariants: { variant: 'bw-solid' } },
+  input: { defaultVariants: { variant: 'subtle' } },
+  card: { defaultVariants: { variant: 'outline' } },
+  badge: { defaultVariants: { variant: 'solid' } }
 }
 
 // Export all theme configs


### PR DESCRIPTION
Closes #1304

> Stacked on #1314 (the playground) — GitHub will retarget this PR to `epic/1303-crouton-themes-2` when that merges; until then the diff shows both.

## 👤 For humans

The three remaining themes now subtract Nuxt UI's unwanted defaults the clean 4.9 way instead of fighting them: **356 of 359 `!important` declarations are deleted** and the themes look the same or better. Along the way this fixes four real bugs in runtime theme switching that made the playground demo lie (bare buttons after a switch, black&white leaking into every theme, hydration warnings on reload, the switcher chip frozen on "Default") — and resurrects the original 609-line KO-UI hardware showcase from the retired ko-ui app as the playground's `/ko` page.

## 🤖 For agents

**Commit 1 — subtractive rollout (`lib/subtractive.ts`):** one shared, marker-gated replacer for all four themes. The resolved slot string carries the theme's own marker classes (`ko-bezel`/`kr-pad`/`bw-*`/`minimal-*`), so a single function picks the right per-theme subtraction set and passes unmarked renders through — safe in multi-theme apps. Guards: `focus-visible:` classes never stripped (a11y — no theme ships button focus styles); non-string input returns the function itself (Nuxt merges layered app.configs with defu's **fn** variant, which CALLS function values as mergers — four layers share the slot key). `blackandwhite` migrates from overriding the standard variant slots to **named `bw-*` variants** + layer `defaultVariants.variant: 'bw-solid'` (single-theme contract intact; multi-theme bleed gone). No consumers outside the package (only `pocs/loop-station` extends `ko`, whose API is unchanged).

**Commit 2 — runtime switching correctness:** `updateAppConfig` merges with Nuxt's `deepAssign`, which merges **arrays by index** — the old `THEME_UI_CONFIGS` wrote `compoundVariants` at runtime and clobbered arbitrary entries of the built config (orphaning the layers' named variants). Runtime swap now writes **scalars only** (colors + per-component `defaultVariants.variant` → the named layer variants). localStorage restore moved to `onMounted` (setup-time restore ≠ SSR HTML → hydration mismatch). `ThemeSwitcher` item slots prefixed `theme-<name>` — the theme literally named `default` was producing a `#default` template that **replaced the dropdown's trigger slot** (the frozen chip). Playground pins true defaults in its own app.config (bw's layer defaults would otherwise win the extends merge).

**Commit 3 — the resurrected KO showcase:** playground becomes two pages, `/` (gallery) + `/ko` (`apps/ko-ui/app/pages/index.vue` verbatim from git `1129c8a8`; the KO CSS/tokens themselves were never lost — the package version is a strict superset).

Docs: `packages/crouton-themes/CLAUDE.md` — modes section rewritten (three modes incl. the shared replacer + defu gotcha) + new "Runtime switching swaps SCALARS only" section.

## 🧪 How to test

**What changed:** ko/kr11/blackandwhite render without CSS specificity hacks; theme switching in the playground is reliable end-to-end; a `/ko` page shows the full hardware demo.

**Where you'll see it:** the playground — `pnpm --filter crouton-themes-playground dev` (http://localhost:3031) or the deployed preview URL (posted on #1304).

**Steps:**
1. Open the gallery. **Before:** the "Default" theme showed dark bw-styled buttons with stripped corners; **after:** true Nuxt UI defaults (emerald primary, rounded, focus ring).
2. Switch to **KO**: the top button row becomes orange/dark/red tactile bezels with the tech font (**before:** bare unstyled text). Inputs go LCD-dark, the card becomes a hardware panel. The chip now reads "KO" (**before:** frozen on "Default").
3. Walk Minimal → KR-11 → Black & White: flat black/white geometry → cream/mint/coral pads + red LED badge → monochrome dashboard. Switch back to Default — nothing lingers from the previous theme.
4. Hard-refresh twice with a theme active — console shows **no hydration warnings** (before: one per themed component).
5. Open the modal and dropdown under KO — the modal centers with backdrop, the dropdown floats.
6. Visit **/ko** — the resurrected KO II device demo (pads, LEDs, knobs, displays, speaker grill, complete-device mock).
7. Tab through KO/KR-11/B&W buttons — the focus ring is visible (it used to be stripped by the CSS wars).

**Test data:** none — static playground.

_Dedup-checked: sub-issue #1304 of epic #1303; switcher fixes fold into it as the verification surface made them visible._

---
> 🤖 **Claude Code** · interactive agent session · work executed inline on the owner's request (see epic #1303 Decisions log) · PR opened from @pmcp's account
