### PR TITLE
feat(root): provider-key canary — alert when an agent key runs dry (#1327)

### DIFF
--- a/.github/workflows/pi-key-canary.yml
+++ b/.github/workflows/pi-key-canary.yml
@@ -1,0 +1,119 @@
+name: Provider key canary
+
+# #1327 — a provider-agnostic "is our agent key funded?" canary.
+#
+# The pi.dev harness runs on a metered provider key (PI_PROVIDER_KEY). It drained silently
+# once (funded 2026-07-07, dry by 2026-07-10) and every delegate run just failed until a
+# human noticed. We deliberately DON'T use Anthropic Console auto-reload (top-ups stay
+# manual), and there is NO balance endpoint to poll (the #1327 ecosystem-check) — so the
+# only proactive signal that a key is dead is to actually CALL it. This does exactly that,
+# daily, and alerts (standing issue + email) when a key reads dry/auth-broken.
+#
+# MULTI-PROVIDER (#669): scripts/provider-key-canary.mjs iterates a PROVIDERS list — add a
+# provider there + map its secret to the env below, and this covers it too. OpenAI is wired
+# and inert until secrets.OPENAI_KEY exists (an unset key → 'unconfigured' → skipped).
+#
+# Green even when a key is dry: detection working IS success — the dry key is surfaced via
+# the issue + email, not a red run (mirrors the digests' degrade-to-green philosophy).
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # daily 07:00 UTC — a cheap heads-up before the working day
+  workflow_dispatch: {} # run on demand to verify a fresh top-up landed
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Probe each configured provider key
+        id: canary
+        env:
+          # Map each provider's secret to the keyEnv the script expects. A secret that
+          # doesn't exist yet resolves to '' → that provider is reported 'unconfigured'.
+          ANTHROPIC_KEY: ${{ secrets.PI_PROVIDER_KEY }}
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+        run: node scripts/provider-key-canary.mjs | tee canary.json
+
+      # Alert rail 1 — a single STANDING issue (found by a hidden marker, not a new label so
+      # this needs no labels.yml change). Opened/updated when a key is dry; closed when all
+      # keys are healthy again, so the issue's open/closed state mirrors reality.
+      - name: Update the standing alert issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANY_ALERT: ${{ steps.canary.outputs.any_alert }}
+          SUMMARY: ${{ steps.canary.outputs.summary }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- provider-key-canary -->"
+          # Find the standing issue by its marker (search is body-aware).
+          NUM=$(gh issue list --state open --search "$MARKER in:body" --json number -q '.[0].number // empty')
+          if [ "$ANY_ALERT" = "true" ]; then
+            DETAIL=$(jq -c '.results' canary.json)
+            BODY="$MARKER
+          > 🤖 **Claude Code** · agent pipeline (CI) · _provider-key canary (#1327)_
+
+          **$SUMMARY**
+
+          A metered provider key read **dry** or **auth-broken** — the pi.dev harness will fail every run on it until it's topped up (or the harness fails over to a funded provider). Top up the named key, then re-run this workflow to confirm.
+
+          <details><summary>probe results</summary>
+
+          \`\`\`json
+          $DETAIL
+          \`\`\`
+          </details>
+
+          🔗 $RUN_URL"
+            if [ -n "$NUM" ]; then
+              gh issue edit "$NUM" --body "$BODY"
+              gh issue comment "$NUM" --body "> 🤖 canary re-checked $(date -u +%FT%TZ) — still needs attention: $SUMMARY"
+            else
+              gh issue create --title "🔑 Provider key canary: a key needs a top-up" --body "$BODY"
+            fi
+          else
+            # All healthy — close the standing issue if one is open.
+            if [ -n "$NUM" ]; then
+              gh issue comment "$NUM" --body "> 🤖 canary $(date -u +%FT%TZ) — all provider keys healthy again. Closing."
+              gh issue close "$NUM"
+            fi
+            echo "All provider keys OK."
+          fi
+
+      # Alert rail 2 — email (Resend, mirrors housekeeping.yml). Only on an alert; degrades
+      # to a green no-op when RESEND_API_KEY / recipients are unset.
+      - name: Email the alert (Resend)
+        if: steps.canary.outputs.any_alert == 'true'
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          EMAIL_FROM: ${{ vars.DIGEST_EMAIL_FROM }}
+          EMAIL_TO: ${{ vars.DIGEST_REPORT_EMAIL }}
+          SUMMARY: ${{ steps.canary.outputs.summary }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$RESEND_API_KEY" ] || [ -z "$EMAIL_FROM" ] || [ -z "$EMAIL_TO" ]; then
+            echo "::warning::RESEND_API_KEY / DIGEST_EMAIL_FROM / DIGEST_DEFAULT_TO not set — skipping email (run stays green)."
+            exit 0
+          fi
+          BODY="$SUMMARY
+
+          A metered provider key is dry or auth-broken. The pi.dev harness will fail on it until topped up.
+          Run: $RUN_URL"
+          jq -n --arg from "$EMAIL_FROM" --arg to "$EMAIL_TO" \
+            --arg subject "🔑 Provider key needs a top-up — $(date -u +%F)" --arg body "$BODY" \
+            '{from:$from, to:($to|split(",")), subject:$subject, text:$body}' \
+          | curl -sS -X POST https://api.resend.com/emails \
+              -H "Authorization: Bearer $RESEND_API_KEY" -H "Content-Type: application/json" \
+              -d @- -w '\nHTTP %{http_code}\n'

--- a/scripts/provider-key-canary.mjs
+++ b/scripts/provider-key-canary.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// provider-key-canary.mjs (#1327) — a provider-agnostic "is our agent key funded?" canary.
+//
+// WHY THIS EXISTS: the pi.dev harness runs on a metered provider key (PI_PROVIDER_KEY).
+// It drained silently once (funded 2026-07-07, dry by 2026-07-10) and EVERY delegate run
+// just failed at the agent step until a human noticed. Two facts from the #1327
+// ecosystem-check shaped this:
+//   1. Anthropic exposes NO balance / credits-remaining endpoint — you can read spend
+//      (Admin cost_report), never remaining. So "poll the balance" is impossible.
+//   2. We deliberately do NOT use Console auto-reload (top-ups stay manual — cost control).
+// So the only proactive signal that a key is dead is to ACTUALLY CALL IT. This canary fires
+// one tiny (max_tokens:1) request per configured provider and classifies the result.
+//
+// MULTI-PROVIDER BY DESIGN (#669): the harness is going multi-provider (OpenAI in the mix,
+// etc.). Adding a provider is ONE entry in PROVIDERS below — the canary then reports which
+// specific key is dry, so you top up the right one (and the harness can fail over to a
+// funded provider instead of going dark).
+//
+// CONTRACT: prints a JSON summary to stdout, and — when run in CI — appends
+// `any_alert` / `summary` to $GITHUB_OUTPUT for the workflow to branch on. Exits 0 even
+// when a key is dry (detection succeeded → the run is green; the DRY key is surfaced via
+// the standing issue + email, mirroring the digests' degrade-to-green philosophy). A
+// non-zero exit means the canary itself broke.
+
+import { appendFileSync } from 'node:fs'
+
+// Add a provider here to cover it. `keyEnv` is the env var the workflow maps its secret to.
+export const PROVIDERS = [
+  {
+    id: 'anthropic',
+    keyEnv: 'ANTHROPIC_KEY', // ← secrets.PI_PROVIDER_KEY in CI
+    probe: (key) =>
+      fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': key,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: 'claude-haiku-4-5-20251001',
+          max_tokens: 1,
+          messages: [{ role: 'user', content: 'ping' }],
+        }),
+      }),
+  },
+  {
+    id: 'openai',
+    keyEnv: 'OPENAI_KEY', // ← secrets.OPENAI_KEY (add when OpenAI joins the mix)
+    probe: (key) =>
+      fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${key}` },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          max_completion_tokens: 1,
+          messages: [{ role: 'user', content: 'ping' }],
+        }),
+      }),
+  },
+]
+
+// Pull a human-readable message out of a provider error body (best-effort).
+function firstMsg(body) {
+  try {
+    const j = JSON.parse(body)
+    return (j.error && (j.error.message || j.error.type)) || j.message || ''
+  } catch {
+    return (body || '').slice(0, 160)
+  }
+}
+
+// Map an HTTP status + body to a state. ORDER MATTERS: the billing check runs before the
+// 429 check because OpenAI's out-of-credit error is ALSO a 429 (insufficient_quota) — we
+// must not misread a dry key as a transient rate-limit.
+export function classify(status, body) {
+  if (status === 200) return { state: 'ok' }
+  const b = (body || '').toLowerCase()
+  if (/credit balance is too low|insufficient_quota|billing|not enough|payment|purchase credits/.test(b))
+    return { state: 'dry', status, detail: firstMsg(body) }
+  if (status === 401 || status === 403 || /invalid.*api.?key|unauthorized|authentication_error/.test(b))
+    return { state: 'auth', status, detail: firstMsg(body) }
+  if (status === 429) return { state: 'ratelimited', status, detail: firstMsg(body) } // transient — NOT an alert
+  return { state: 'error', status, detail: firstMsg(body) }
+}
+
+// States that warrant waking a human: the key is dead (dry) or misconfigured (auth).
+export const ALERT_STATES = new Set(['dry', 'auth'])
+
+async function checkProvider(p) {
+  const key = process.env[p.keyEnv]
+  if (!key) return { id: p.id, state: 'unconfigured' }
+  try {
+    const res = await p.probe(key)
+    return { id: p.id, ...classify(res.status, await res.text()) }
+  } catch (e) {
+    // A network/DNS error is canary-infra noise, not a key problem — surface as 'error'.
+    return { id: p.id, state: 'error', detail: e.message }
+  }
+}
+
+export async function runCanary(providers = PROVIDERS) {
+  const results = []
+  for (const p of providers) results.push(await checkProvider(p))
+  const alerting = results.filter((r) => ALERT_STATES.has(r.state))
+  return { ok: alerting.length === 0, alerting: alerting.map((r) => r.id), results }
+}
+
+// Run only when invoked directly (not when imported by the test).
+const isMain = import.meta.url === `file://${process.argv[1]}`
+if (isMain) {
+  const summary = await runCanary()
+  console.log(JSON.stringify(summary, null, 2))
+  const out = process.env.GITHUB_OUTPUT
+  if (out) {
+    const line = summary.ok
+      ? 'all provider keys OK'
+      : `⚠️ provider key(s) need attention: ${summary.results
+          .filter((r) => ALERT_STATES.has(r.state))
+          .map((r) => `${r.id} (${r.state})`)
+          .join(', ')}`
+    appendFileSync(out, `any_alert=${summary.ok ? 'false' : 'true'}\n`)
+    appendFileSync(out, `summary=${line}\n`)
+  }
+  // Exit 0 even on a dry key: detection worked. Only a thrown canary-infra fault is a red run.
+  process.exit(0)
+}

--- a/scripts/provider-key-canary.test.mjs
+++ b/scripts/provider-key-canary.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { classify, runCanary, ALERT_STATES } from './provider-key-canary.mjs'
+
+const anthropicDry = JSON.stringify({
+  type: 'error',
+  error: { type: 'invalid_request_error', message: 'Your credit balance is too low to access the Anthropic API.' },
+})
+const openaiQuota = JSON.stringify({
+  error: { message: 'You exceeded your current quota', type: 'insufficient_quota', code: 'insufficient_quota' },
+})
+const openaiRateLimit = JSON.stringify({ error: { message: 'Rate limit reached', type: 'rate_limit_error' } })
+const badKey = JSON.stringify({ error: { type: 'authentication_error', message: 'invalid x-api-key' } })
+
+test('classify: 200 → ok', () => {
+  assert.equal(classify(200, '{}').state, 'ok')
+})
+
+test('classify: Anthropic out-of-credit (400) → dry', () => {
+  assert.equal(classify(400, anthropicDry).state, 'dry')
+})
+
+test('classify: OpenAI insufficient_quota is a 429 but must read as DRY, not ratelimited', () => {
+  // The load-bearing edge: OpenAI signals "out of credit" with HTTP 429. The billing
+  // check must win over the 429 check or a dead key looks like a transient blip.
+  assert.equal(classify(429, openaiQuota).state, 'dry')
+})
+
+test('classify: a genuine 429 rate-limit → ratelimited (transient, NOT an alert)', () => {
+  const r = classify(429, openaiRateLimit)
+  assert.equal(r.state, 'ratelimited')
+  assert.equal(ALERT_STATES.has(r.state), false)
+})
+
+test('classify: bad key → auth', () => {
+  assert.equal(classify(401, badKey).state, 'auth')
+  assert.equal(classify(200, '{}').state !== 'auth', true)
+})
+
+test('classify: unknown 500 → error', () => {
+  assert.equal(classify(500, 'upstream boom').state, 'error')
+})
+
+test('dry + auth are the only alerting states', () => {
+  assert.deepEqual([...ALERT_STATES].sort(), ['auth', 'dry'])
+})
+
+test('runCanary: unconfigured provider is skipped, not alerted', async () => {
+  const summary = await runCanary([{ id: 'ghost', keyEnv: 'DEFINITELY_UNSET_KEY_XYZ', probe: async () => ({ status: 200, text: async () => '{}' }) }])
+  assert.equal(summary.results[0].state, 'unconfigured')
+  assert.equal(summary.ok, true)
+})
+
+test('runCanary: a dry provider drives ok=false and names the key', async () => {
+  process.env.__FAKE_KEY = 'x'
+  const summary = await runCanary([
+    { id: 'fakeprov', keyEnv: '__FAKE_KEY', probe: async () => ({ status: 400, text: async () => anthropicDry }) },
+  ])
+  assert.equal(summary.ok, false)
+  assert.deepEqual(summary.alerting, ['fakeprov'])
+  delete process.env.__FAKE_KEY
+})
+
+test('runCanary: a network throw surfaces as error (canary noise), not a false all-clear alert', async () => {
+  process.env.__FAKE_KEY2 = 'x'
+  const summary = await runCanary([
+    { id: 'neterr', keyEnv: '__FAKE_KEY2', probe: async () => { throw new Error('ENOTFOUND api.example') } },
+  ])
+  assert.equal(summary.results[0].state, 'error')
+  assert.equal(summary.ok, true) // error is not an alert state; it doesn't cry "key dry"
+  delete process.env.__FAKE_KEY2
+})


### PR DESCRIPTION
Closes #1327

## 👤 For humans
The pi.dev harness runs on a metered provider key that **drained silently once** (funded 2026-07-07, dry by 2026-07-10) — every delegate run just failed at the agent step until a human noticed. Two constraints (from the [#1327 ecosystem-check](https://github.com/FriendlyInternet/nuxt-crouton/issues/1327#issuecomment-4935195449)):
- You **won't use Console auto-reload** — top-ups stay deliberate/manual (cost control).
- Anthropic has **no balance endpoint** to poll — you can read spend, never remaining.

So the only proactive signal that a key is dead is to **actually call it**. This canary does exactly that, daily, and alerts (standing issue + email) when a key reads **dry** or **auth-broken** — a "top me up" heads-up instead of a silently-failing pipeline.

**Multi-provider by design** (you're bringing OpenAI into the mix, #669): adding a provider is one entry in `PROVIDERS` + its secret in the workflow env. OpenAI is already wired and inert until `secrets.OPENAI_KEY` exists.

## 🤖 For agents
- `scripts/provider-key-canary.mjs` — iterates `PROVIDERS`, fires a `max_tokens:1` probe per configured key, `classify()` maps `status`+`body` → `ok|dry|auth|ratelimited|error`. **Load-bearing edge:** OpenAI's out-of-credit is a **429** (`insufficient_quota`) — the billing check runs *before* the 429 check so a dead key isn't misread as a transient rate-limit. Exits `0` even on a dry key (detection = success; the dry key surfaces via issue+email, not a red run).
- `scripts/provider-key-canary.test.mjs` — 10 `node:test` cases incl. the 429-quota edge, the network-throw-is-not-an-alert case, and unconfigured-is-skipped.
- `.github/workflows/pi-key-canary.yml` — daily cron + `workflow_dispatch`; **standing issue** found by a hidden marker (no `labels.yml` change), auto-closed when keys are healthy again; **Resend email** (degrades to green when `RESEND_API_KEY`/recipient unset).
- Auto-reload consciously skipped (#1327); pairs with #1299 ([PR #1325](https://github.com/FriendlyInternet/nuxt-crouton/pull/1325), after-the-fact legibility).

## 🧪 How to test
- `node --test scripts/provider-key-canary.test.mjs` → 10/10 pass.
- **Dispatch the workflow now:** with the key currently dry, it should immediately open the standing issue naming `anthropic (dry)` + email — a live self-verification. Top up + re-dispatch → it comments "healthy again" and **closes** the issue.