### PR TITLE
feat(root): CI message style + readable artifact-gate (WS1, #1338)

### DIFF
--- a/.github/CI-MESSAGE-STYLE.md
+++ b/.github/CI-MESSAGE-STYLE.md
@@ -1,0 +1,58 @@
+# CI message style — readable on the go
+
+The contract for **every human-facing comment a workflow posts** (issue/PR comments, standing
+alerts). The reader is the owner glancing at a GitHub notification **on their phone** — they must
+know *what happened* and *what to do* from the **first line**, without opening the run. Epic #1336.
+Sibling of #479 (same philosophy for ticket/epic bodies).
+
+## The five rules
+
+1. **First line = a status emoji + the problem/outcome in plain words.** No leading gate name, no
+   leading `(#NN)`, no internal mechanism. The reader learns *what happened* immediately.
+   - 🔴 broke / needs you · 🟢 done · ⏳ waiting / queued · ✅ ready / passed · 🚫 blocked
+2. **Second line = the ONE action**, imperative and concrete: `**Fix:** top up + re-dispatch`.
+   If there's nothing to do, say so (`No action needed`).
+3. **Mechanism goes in a footer**, small (`<sub>…</sub>`): which gate, the issue/PR #, the run link,
+   and the `🤖` provenance header (CLAUDE.md still requires it — the footer is where it lives now).
+4. **Short.** Depth — log tails, probe JSON, file lists, matrices — goes in `<details><summary>…`.
+   The visible message is a few lines.
+5. **Plain nouns, not system names.** "your Anthropic key is out of credit", not
+   "the provider call returned invalid_request_error". Name things by what the reader recognizes.
+
+## Template
+
+```
+🔴 **@owner — <the problem, in plain words>.**
+
+**Fix:** <the one concrete action>.
+
+<details><summary>details</summary>
+
+… log tail / JSON / file list …
+</details>
+
+<sub>🤖 <source> · <gate/mechanism + #NN> · <a href="…run">run log</a></sub>
+```
+
+## Before / after (the artifact-gate message that prompted this)
+
+**Before** — leads with the mechanism, buries the cause:
+> ⚠️ **Artifact-gate failed (#461).** @pmcp — this pi.dev run produced no deliverable: the pi
+> provider call failed — **the Anthropic account behind `PI_PROVIDER_KEY` is out of credit**.
+> **What to do:** Top up that account (Console → Billing; enable auto-reload), then re-dispatch.
+
+**After** — leads with the problem + fix; mechanism demoted:
+> 🔴 **@pmcp — this run produced nothing: the Anthropic key (`PI_PROVIDER_KEY`) is out of credit.**
+>
+> **Fix:** top up the account + re-dispatch.
+>
+> <sub>🤖 pi.dev harness (CI · mac-mini) · artifact-gate #461 fails a no-op run so it isn't
+> mistaken for done · [run log](…)</sub>
+
+## Don'ts
+
+- ❌ Don't lead with `Artifact-gate failed` / `Deploy job` / any step or gate name.
+- ❌ Don't lead with `(#NN)` — the issue/PR number is footer context, not the headline.
+- ❌ Don't suggest actions that contradict a standing decision (e.g. "enable auto-reload" — the
+  owner declined it, #1327; point at the key canary instead).
+- ❌ Don't paste a wall of log — collapse it in `<details>`.

--- a/.github/workflows/decompose-on-issue-pidev-hosted.yml
+++ b/.github/workflows/decompose-on-issue-pidev-hosted.yml
@@ -256,7 +256,7 @@ jobs:
             // The session JSONL (action export) replaces the mini's tee'd CLI log as
             // the failure-cause source (billing / error / underspecified — #1004 pc 3).
             const fs = require('fs')
-            let why = '', action = ''
+            let why = '', action = '', detail = ''
             const failed = process.env.PI_CONCLUSION !== 'true'
             try {
               const logFile = process.env.PI_EXEC_LOG
@@ -264,34 +264,31 @@ jobs:
                 const log = fs.readFileSync(logFile, 'utf8')
                 const tail = log.length > 600 ? log.slice(-600) : log
                 if (/credit balance is too low|insufficient.*(credit|balance|quota)|billing/i.test(log)) {
-                  why = 'the pi provider call failed — **the Anthropic account behind `PI_PROVIDER_KEY` is out of credit**'
-                  action = 'Top up that account (Console → Billing; enable auto-reload), then re-dispatch.'
+                  why = 'the Anthropic key (`PI_PROVIDER_KEY`) is out of credit'
+                  action = 'top up the account, then re-dispatch' // not "enable auto-reload" — owner declined it (#1327); the pi-key-canary workflow tracks key health
                 } else if (failed) {
-                  why = 'the pi agent step **errored** before producing a deliverable'
-                  action = 'Open the run log and fix the logged SDK/tooling error, then re-dispatch.'
-                  if (tail.trim()) why += `. Session tail:\n\n> ${tail.trim().replace(/\n/g, '\n> ')}`
+                  why = 'the pi agent step errored before it built anything'
+                  action = 'open the run log, fix the SDK/tooling error, then re-dispatch'
+                  if (tail.trim()) detail = tail.trim()
                 } else {
-                  why = 'pi finished its turn without opening a PR, creating sub-issues, or holding for sign-off'
-                  action = 'This usually means the issue is underspecified — add a concrete description + '
-                    + 'acceptance criteria so there is something to build, then re-dispatch.'
+                  why = 'pi finished without opening a PR, creating sub-issues, or holding for sign-off'
+                  action = 'the issue is likely underspecified — add a concrete description + acceptance criteria, then re-dispatch'
                 }
               }
             } catch (e) { core.warning(`artifact-gate: could not read pi session log: ${e.message}`) }
 
             if (!why && failed) {
-              why = 'the pi agent step **failed before producing anything** (often a billing/credit, API, or tooling error)'
-              action = 'Open the run log. If it says "Credit balance is too low", top up the Anthropic account '
-                + 'behind `PI_PROVIDER_KEY`. Otherwise fix the logged error, then re-dispatch.'
+              why = 'the pi agent step failed before producing anything (likely out of credit, or an API/tooling error)'
+              action = 'open the run log — if it says "credit balance is too low", top up `PI_PROVIDER_KEY`; otherwise fix the logged error, then re-dispatch'
             }
 
+            // Readable-on-mobile (epic #1336, .github/CI-MESSAGE-STYLE.md): problem + fix lead; mechanism in the footer.
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const foot = `\n\n<sub>🤖 pi.dev harness (CI · GitHub-hosted, #1072 spike) · artifact-gate #461 fails a no-op run so it isn't mistaken for done · <a href="${runUrl}">run log</a></sub>`
+            const det = detail ? `\n\n<details><summary>session tail</summary>\n\n\`\`\`\n${detail}\n\`\`\`\n</details>` : ''
             const body = why
-              ? `⚠️ **Artifact-gate failed (#461).** @pmcp — this pi.dev (GitHub-hosted, #1072 spike) run produced no deliverable: ${why}\n\n`
-                + `**What to do:** ${action}\n\n🔗 **Run log:** ${runUrl}`
-              : '⚠️ **Artifact-gate failed (#461).** @pmcp — this pi.dev (GitHub-hosted, #1072 spike) run produced no real '
-                + 'deliverable on this issue: no PR was opened, no sub-issues were created, and it is not held for sign-off '
-                + '(`status:blocked` + a review). The run is marked **failed** so it is not mistaken for done.\n\n'
-                + `🔗 **Run log:** ${runUrl}\n↻ Re-dispatch to retry.`
+              ? `🔴 **@pmcp — this run produced nothing: ${why}.**\n\n**Fix:** ${action}.${det}${foot}`
+              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold.\n\n**Fix:** re-dispatch; if it recurs the issue is underspecified — add a description + acceptance criteria.${foot}`
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: pi.dev hosted run on #${issue_number} produced no deliverable.`)

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -318,7 +318,7 @@ jobs:
             // billing/error/underspecified buckets). The most likely first-run cause is an
             // out-of-credit PI_PROVIDER_KEY, so detect that explicitly.
             const fs = require('fs')
-            let why = '', action = ''
+            let why = '', action = '', detail = ''
             const failed = process.env.CLAUDE_CONCLUSION === 'failure'
             try {
               const logFile = process.env.PI_EXEC_LOG
@@ -326,35 +326,33 @@ jobs:
                 const log = fs.readFileSync(logFile, 'utf8')
                 const tail = log.length > 600 ? log.slice(-600) : log
                 if (/credit balance is too low|insufficient.*(credit|balance|quota)|billing/i.test(log)) {
-                  why = 'the pi provider call failed — **the Anthropic account behind `PI_PROVIDER_KEY` is out of credit**'
-                  action = 'Top up that account (Console → Billing; enable auto-reload), then re-dispatch.'
+                  why = 'the Anthropic key (`PI_PROVIDER_KEY`) is out of credit'
+                  action = 'top up the account, then re-dispatch' // NB: not "enable auto-reload" — owner declined it (#1327); the pi-key-canary workflow tracks key health
                 } else if (failed) {
-                  why = 'the pi agent step **errored** before producing a deliverable'
-                  action = 'Open the run log and fix the logged SDK/tooling error, then re-dispatch.'
-                  if (tail.trim()) why += `. Log tail:\n\n> ${tail.trim().replace(/\n/g, '\n> ')}`
+                  why = 'the pi agent step errored before it built anything'
+                  action = 'open the run log, fix the SDK/tooling error, then re-dispatch'
+                  if (tail.trim()) detail = tail.trim()
                 } else {
-                  why = 'pi finished its turn without opening a PR, creating sub-issues, or holding for sign-off'
-                  action = 'This usually means the issue is underspecified — add a concrete description + '
-                    + 'acceptance criteria so there is something to build, then re-dispatch.'
+                  why = 'pi finished without opening a PR, creating sub-issues, or holding for sign-off'
+                  action = 'the issue is likely underspecified — add a concrete description + acceptance criteria, then re-dispatch'
                 }
               }
             } catch (e) { core.warning(`artifact-gate: could not read pi run log: ${e.message}`) }
 
             // Fallback when the log is unreadable but the step itself failed.
             if (!why && failed) {
-              why = 'the pi agent step **failed before producing anything** (often a billing/credit, API, or tooling error)'
-              action = 'Open the run log. If it says "Credit balance is too low", top up the Anthropic account '
-                + 'behind `PI_PROVIDER_KEY`. Otherwise fix the logged error, then re-dispatch.'
+              why = 'the pi agent step failed before producing anything (likely out of credit, or an API/tooling error)'
+              action = 'open the run log — if it says "credit balance is too low", top up `PI_PROVIDER_KEY`; otherwise fix the logged error, then re-dispatch'
             }
 
+            // Readable-on-mobile (epic #1336, .github/CI-MESSAGE-STYLE.md): lead with the problem
+            // + the one fix; the gate name / #461 / run link live in the footer; depth collapses.
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const foot = `\n\n<sub>🤖 pi.dev harness (CI · mac-mini) · artifact-gate #461 fails a no-op run so it isn't mistaken for done · <a href="${runUrl}">run log</a></sub>`
+            const det = detail ? `\n\n<details><summary>log tail</summary>\n\n\`\`\`\n${detail}\n\`\`\`\n</details>` : ''
             const body = why
-              ? `⚠️ **Artifact-gate failed (#461).** @pmcp — this pi.dev run produced no deliverable: ${why}\n\n`
-                + `**What to do:** ${action}\n\n🔗 **Run log:** ${runUrl}`
-              : '⚠️ **Artifact-gate failed (#461).** @pmcp — this pi.dev run produced no real deliverable on '
-                + 'this issue: no PR was opened, no sub-issues were created, and it is not held for sign-off '
-                + '(`status:blocked` + a review). The run is marked **failed** so it is not mistaken for done.\n\n'
-                + `🔗 **Run log:** ${runUrl}\n↻ Re-dispatch to retry.`
+              ? `🔴 **@pmcp — this run produced nothing: ${why}.**\n\n**Fix:** ${action}.${det}${foot}`
+              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold.\n\n**Fix:** re-dispatch; if it recurs the issue is underspecified — add a description + acceptance criteria.${foot}`
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: pi.dev run on #${issue_number} produced no deliverable.`)

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -200,8 +200,9 @@ jobs:
             // chasing the wrong thing when the real cause was a billing_error (#660). Read the
             // agent's execution log + step conclusion and name the actual cause + the fix.
             const fs = require('fs')
-            let why = ''      // human-readable cause
-            let action = ''   // what to do about it
+            let why = ''      // human-readable cause (leads the comment)
+            let action = ''   // the one fix
+            let detail = ''   // depth (agent's final message / error) → collapsed into <details>
             try {
               const execFile = process.env.CLAUDE_EXEC_FILE
               if (execFile && fs.existsSync(execFile)) {
@@ -210,31 +211,27 @@ jobs:
                 const text = result ? String(result.result || '') : ''
                 if (result && result.is_error) {
                   if (/credit balance|billing/i.test(text)) {
-                    why = `the Claude API call failed — **${text}**`
-                    action = 'The Anthropic account behind the `ANTHROPIC_API_KEY` secret is out of credit. '
-                      + 'Top it up (Console → Billing; enable auto-reload), then re-apply `delegate`.'
+                    why = 'the Anthropic key (`ANTHROPIC_API_KEY`) is out of credit'
+                    action = 'top up the account, then re-apply `delegate`' // not "enable auto-reload" — owner declined it (#1327)
                   } else {
-                    why = `the agent run errored — **${text || 'see the run log'}**`
-                    action = 'Check the run log for the SDK/tooling error, fix the cause, then re-apply `delegate`.'
+                    why = 'the agent run errored'
+                    action = 'check the run log for the SDK/tooling error, fix it, then re-apply `delegate`'
+                    if (text.trim()) detail = text.trim()
                   }
                 } else if (result) {
-                  // Ran to completion but produced nothing on the issue. DIAGNOSE the cause from the
-                  // agent's own final message — don't guess "underspecified" (#1210: that misdiagnosis
-                  // sent a human down the wrong path when the real cause was fire-and-forget).
+                  // Ran to completion but produced nothing. DIAGNOSE the cause from the agent's own
+                  // final message — don't guess "underspecified" (#1210: that misdiagnosis sent a
+                  // human down the wrong path when the real cause was fire-and-forget).
                   const snippet = text.length > 600 ? text.slice(0, 600) + '…' : text
-                  why = 'the agent finished its turn without opening a PR, creating sub-issues, or holding for sign-off'
                   const backgrounded = /in the background|i['’]?ll be notified|running in the background|notified when (it|the) .*complet/i.test(text)
                   if (backgrounded) {
-                    why = 'the agent **backgrounded its orchestration and exited** — in a one-shot CI job a '
-                      + 'backgrounded agent is killed when the job ends, so nothing persisted (fire-and-forget, #1210)'
-                    action = 'This is NOT an underspecified issue — it is a fire-and-forget bug. Spawned agents '
-                      + 'must run SYNCHRONOUSLY (`run_in_background: false`; see the `task-decompose` skill / #1210). '
-                      + 'Re-apply `delegate` once the pipeline fix is merged.'
+                    why = 'the agent backgrounded its work and exited — a one-shot CI job kills a backgrounded agent, so nothing persisted (fire-and-forget, #1210)'
+                    action = 'this is a fire-and-forget bug, NOT an underspecified issue — spawned agents must run synchronously (`run_in_background: false`; see the `task-decompose` skill / #1210); re-apply `delegate` once the pipeline fix is merged'
                   } else {
-                    action = 'This usually means the issue is underspecified — add a concrete description + '
-                      + 'acceptance criteria so there is something to build, then re-apply `delegate`.'
+                    why = 'the agent finished without opening a PR, creating sub-issues, or holding for sign-off'
+                    action = 'the issue is likely underspecified — add a concrete description + acceptance criteria, then re-apply `delegate`'
                   }
-                  if (snippet) why += `. Its final message was:\n\n> ${snippet.replace(/\n/g, '\n> ')}`
+                  if (snippet.trim()) detail = snippet.trim()
                 }
               }
             } catch (e) { core.warning(`artifact-gate: could not parse execution log: ${e.message}`) }
@@ -242,23 +239,18 @@ jobs:
             // Fallback when the log is unreadable but the agent step itself failed (e.g. a hard
             // billing/API error that aborts before writing the log) — still point at the likely cause.
             if (!why && process.env.CLAUDE_CONCLUSION === 'failure') {
-              why = 'the agent step **failed before producing anything** (often a billing/credit, API, or tooling error)'
-              action = 'Open the run log. If it says "Credit balance is too low", top up the Anthropic account '
-                + 'behind `ANTHROPIC_API_KEY` (enable auto-reload). Otherwise fix the logged error, then re-apply `delegate`.'
+              why = 'the agent step failed before producing anything (likely out of credit, or an API/tooling error)'
+              action = 'open the run log — if it says "credit balance is too low", top up `ANTHROPIC_API_KEY`; otherwise fix the logged error, then re-apply `delegate`'
             }
 
+            // Readable-on-mobile (epic #1336, .github/CI-MESSAGE-STYLE.md): lead with the problem
+            // + the one fix; the gate name / #461 / run link live in the footer; depth collapses.
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const foot = `\n\n<sub>🤖 Claude Code · agent pipeline (CI) · artifact-gate #461 fails a no-op run so it isn't mistaken for done · <a href="${runUrl}">run log</a></sub>`
+            const det = detail ? `\n\n<details><summary>agent's final message</summary>\n\n> ${detail.replace(/\n/g, '\n> ')}\n</details>` : ''
             const body = why
-              ? `⚠️ **Artifact-gate failed (#461).** @pmcp — this run produced no deliverable: ${why}\n\n`
-                + `**What to do:** ${action}\n\n`
-                + `🔗 **Run log:** ${runUrl}`
-              : '⚠️ **Artifact-gate failed (#461).** @pmcp — this run produced no real deliverable on '
-                + 'this issue: no PR was opened, and it is not held for sign-off (`status:blocked` + a review). '
-                + 'A bare progress comment ("spawning the worker…") does not count — the '
-                + '"narrate-the-plan-then-stop" no-op. The run is marked **failed** so it is not mistaken '
-                + 'for done.\n\n'
-                + `🔗 **Run log:** ${runUrl}\n`
-                + '↻ Re-apply the `delegate` label to retry.'
+              ? `🔴 **@pmcp — this run produced nothing: ${why}.**\n\n**Fix:** ${action}.${det}${foot}`
+              : `🔴 **@pmcp — this run produced nothing** — no PR, no sign-off hold (a bare "spawning the worker…" progress comment doesn't count).\n\n**Fix:** re-apply \`delegate\` to retry; if it recurs the issue is underspecified — add a description + acceptance criteria.${foot}`
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no PR, not held for sign-off).`)


### PR DESCRIPTION
Closes #1338 · part of epic #1336

## 👤 For humans
The message you flagged — `⚠️ Artifact-gate failed (#461). … produced no deliverable: … out of credit` — led with the internal gate name and buried the actual problem. Unreadable at a glance on a phone.

This establishes the **CI message style** (lead with a status emoji + the problem + the one fix; mechanism → small footer; depth → `<details>`) and proves it on the artifact-gate message across **all three** decompose variants.

**Before:** `⚠️ Artifact-gate failed (#461). @pmcp — this pi.dev run produced no deliverable: … out of credit. What to do: … enable auto-reload …`
**After:**
> 🔴 **@pmcp — this run produced nothing: the Anthropic key (`PI_PROVIDER_KEY`) is out of credit.**
> **Fix:** top up the account, then re-dispatch.
> <sub>🤖 pi.dev harness (CI · mac-mini) · artifact-gate #461 … · run log</sub>

Also drops the stale "enable auto-reload" advice (you declined it, #1327).

## 🤖 For agents
- `.github/CI-MESSAGE-STYLE.md` — the contract (5 rules, before/after, don'ts).
- `decompose-on-issue{,-pidev,-pidev-hosted}.yml` artifact-gate rewritten to it; log tail / agent final-message collapsed into `<details>`.
- WS2–WS5 (#1339–#1342) conform the remaining ~15 comment-posting workflows.

## 🧪 How to test
- YAML valid on all three (ruby YAML.load).
- Rendered the billing-case body in node → leads `🔴 @pmcp — this run produced nothing: the Anthropic key … is out of credit` + `Fix:` + footer.
- Live: the next artifact-gate failure (or re-dispatch on the dry key) posts the new format.