### PR TITLE
New theme: Brutalist — thick borders, hard shadows, zero subtlety

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -123,6 +123,26 @@ const { variant } = useThemeSwitcher()
 
 ## Available Themes
 
+### Brutalist Theme (`./brutalist`)
+
+Thick borders, hard shadows, zero subtlety — the anti-"tasteful SaaS" theme.
+
+**Design Language:**
+- 3px black borders, hard offset box-shadows (no blur), square corners
+- Off-white paper, near-black ink, shock-yellow accent, alarm-red error
+- Uppercase 800-weight labels; states snap (75ms steps) instead of gliding
+- Buttons lift on hover (+shadow) and slam flat on press (shadow to 0)
+
+**Nuxt UI Variants:**
+- Named variants `brutalist` / `brutalist-{solid,outline,soft,ghost,link}` for UButton;
+  `brutalist` for UInput, UCard, UBadge, USeparator
+- Color mappings: primary→yellow slab, neutral→ink slab, error→red slab
+
+**Design Tokens:** `--brutalist-{paper,ink,accent,danger,border,shadow,shadow-hover,snap}`
+
+**Coverage note:** interaction chrome only — no custom components; data surfaces
+stay calm by design (see the chrome-vs-data rule, #1333).
+
 ### Minimal Theme (`./minimal`)
 
 Super clean, minimalist design with black lines on white background.

--- a/packages/crouton-themes/brutalist/app.config.ts
+++ b/packages/crouton-themes/brutalist/app.config.ts
@@ -1,0 +1,124 @@
+// Brutalist Theme Configuration (#1307)
+// Thick black borders, hard offset shadows, flat shock fills, instant states.
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'yellow',
+      neutral: 'neutral'
+    },
+
+    button: {
+      // Subtractive base via the shared marker-gated replacer (#1304): fires
+      // only when a brutalist-* marker is in the resolved classes; strips the
+      // defaults this CSS re-supplies (color/decoration/motion/weight).
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'brutalist': '',
+          'brutalist-solid': '',
+          'brutalist-outline': '',
+          'brutalist-soft': '',
+          'brutalist-ghost': '',
+          'brutalist-link': ''
+        }
+      },
+      compoundVariants: [
+        // === BRUTALIST (solid blocks) ===
+        { color: 'primary', variant: 'brutalist', class: 'brutalist-btn brutalist-btn--primary' },
+        { color: 'neutral', variant: 'brutalist', class: 'brutalist-btn brutalist-btn--neutral' },
+        { color: 'error', variant: 'brutalist', class: 'brutalist-btn brutalist-btn--error' },
+        { variant: 'brutalist', class: 'brutalist-btn' },
+
+        // === BRUTALIST-SOLID (alias of base) ===
+        { color: 'primary', variant: 'brutalist-solid', class: 'brutalist-btn brutalist-btn--primary' },
+        { color: 'neutral', variant: 'brutalist-solid', class: 'brutalist-btn brutalist-btn--neutral' },
+        { color: 'error', variant: 'brutalist-solid', class: 'brutalist-btn brutalist-btn--error' },
+        { variant: 'brutalist-solid', class: 'brutalist-btn' },
+
+        // === BRUTALIST-OUTLINE (white block, black frame) ===
+        { color: 'primary', variant: 'brutalist-outline', class: 'brutalist-outline brutalist-outline--primary' },
+        { color: 'neutral', variant: 'brutalist-outline', class: 'brutalist-outline' },
+        { color: 'error', variant: 'brutalist-outline', class: 'brutalist-outline brutalist-outline--error' },
+        { variant: 'brutalist-outline', class: 'brutalist-outline' },
+
+        // === BRUTALIST-SOFT (accent block, no shadow) ===
+        { color: 'primary', variant: 'brutalist-soft', class: 'brutalist-soft brutalist-soft--primary' },
+        { color: 'neutral', variant: 'brutalist-soft', class: 'brutalist-soft' },
+        { color: 'error', variant: 'brutalist-soft', class: 'brutalist-soft brutalist-soft--error' },
+        { variant: 'brutalist-soft', class: 'brutalist-soft' },
+
+        // === BRUTALIST-GHOST (frame on hover only) ===
+        { color: 'primary', variant: 'brutalist-ghost', class: 'brutalist-ghost' },
+        { color: 'neutral', variant: 'brutalist-ghost', class: 'brutalist-ghost' },
+        { color: 'error', variant: 'brutalist-ghost', class: 'brutalist-ghost brutalist-ghost--error' },
+        { variant: 'brutalist-ghost', class: 'brutalist-ghost' },
+
+        // === BRUTALIST-LINK (marker-pen underline) ===
+        { color: 'primary', variant: 'brutalist-link', class: 'brutalist-link' },
+        { color: 'neutral', variant: 'brutalist-link', class: 'brutalist-link' },
+        { color: 'error', variant: 'brutalist-link', class: 'brutalist-link brutalist-link--error' },
+        { variant: 'brutalist-link', class: 'brutalist-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            root: 'brutalist-input',
+            base: 'brutalist-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            root: 'brutalist-card',
+            header: 'brutalist-card-header',
+            body: 'brutalist-card-body',
+            footer: 'brutalist-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          brutalist: {
+            border: 'brutalist-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: 'brutalist-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -28,6 +28,32 @@
   background-color: var(--brutalist-paper);
 }
 
+/* Chrome without a variant hook (owner feedback on #1307: "the switcher could
+   be more in style"). USwitch has no `variant` dimension, so the marker-gated
+   replacer can never fire for it — theme it ambiently, scoped to the active
+   theme (body class from useThemeSwitcher, data-theme from the app presets).
+   Pattern doubles as the template for the other themes (#1333). */
+[data-theme="brutalist"] button[role="switch"],
+.theme-brutalist button[role="switch"] {
+  border-radius: 0;
+  border: 2px solid var(--brutalist-ink);
+  background-color: var(--brutalist-paper);
+  box-shadow: 2px 2px 0 var(--brutalist-ink);
+  transition: none;
+}
+
+[data-theme="brutalist"] button[role="switch"][data-state="checked"],
+.theme-brutalist button[role="switch"][data-state="checked"] {
+  background-color: var(--brutalist-accent);
+}
+
+[data-theme="brutalist"] button[role="switch"] > span,
+.theme-brutalist button[role="switch"] > span {
+  border-radius: 0;
+  background-color: var(--brutalist-ink);
+  transition: none;
+}
+
 /* ============================================
    SOLID BUTTONS — flat block + hard shadow
    ============================================ */

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -1,0 +1,264 @@
+/* Brutalist Theme (#1307)
+   Thick black borders, hard offset shadows (no blur), flat shock fills,
+   uppercase labels, states that SNAP. The anti-"tasteful SaaS" theme.
+
+   No !important anywhere: the shared subtractive replacer
+   (../lib/subtractive.ts) strips the conflicting Nuxt UI defaults
+   (color, decoration, motion, weight) whenever a brutalist- marker class
+   is present, so these rules win by normal cascade. */
+
+:root {
+  --brutalist-paper: #fdfbf5;   /* off-white paper */
+  --brutalist-ink: #0a0a0a;     /* near-black ink */
+  --brutalist-accent: #ffd800;  /* shock yellow */
+  --brutalist-danger: #ff3b30;  /* alarm red */
+  --brutalist-border: 3px;
+  --brutalist-shadow: 4px 4px 0 var(--brutalist-ink);
+  --brutalist-shadow-hover: 6px 6px 0 var(--brutalist-ink);
+  --brutalist-snap: 75ms;       /* states snap, they don't glide */
+}
+
+/* ============================================
+   DATA-THEME AMBIENT
+   Chrome only — no font takeover (the #1304 KO readability lesson:
+   body copy stays in the app's readable font).
+   ============================================ */
+
+[data-theme="brutalist"] {
+  background-color: var(--brutalist-paper);
+}
+
+/* ============================================
+   SOLID BUTTONS — flat block + hard shadow
+   ============================================ */
+
+.brutalist-btn {
+  background-color: var(--brutalist-paper);
+  color: var(--brutalist-ink);
+  border: var(--brutalist-border) solid var(--brutalist-ink);
+  box-shadow: var(--brutalist-shadow);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: box-shadow var(--brutalist-snap) steps(2, end), transform var(--brutalist-snap) steps(2, end);
+}
+
+.brutalist-btn:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--brutalist-shadow-hover);
+}
+
+.brutalist-btn:active {
+  transform: translate(3px, 3px);
+  box-shadow: 0 0 0 var(--brutalist-ink);
+}
+
+.brutalist-btn--primary {
+  background-color: var(--brutalist-accent);
+}
+
+.brutalist-btn--neutral {
+  background-color: var(--brutalist-ink);
+  color: var(--brutalist-paper);
+}
+
+.brutalist-btn--error {
+  background-color: var(--brutalist-danger);
+  color: var(--brutalist-paper);
+}
+
+/* ============================================
+   OUTLINE — the frame without the shadow drama
+   ============================================ */
+
+.brutalist-outline {
+  background-color: var(--brutalist-paper);
+  color: var(--brutalist-ink);
+  border: var(--brutalist-border) solid var(--brutalist-ink);
+  box-shadow: none;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: background-color var(--brutalist-snap) steps(2, end);
+}
+
+.brutalist-outline:hover {
+  background-color: var(--brutalist-accent);
+}
+
+.brutalist-outline--error:hover {
+  background-color: var(--brutalist-danger);
+  color: var(--brutalist-paper);
+}
+
+/* ============================================
+   SOFT — accent slab, no border theatrics
+   ============================================ */
+
+.brutalist-soft {
+  background-color: var(--brutalist-accent);
+  color: var(--brutalist-ink);
+  border: none;
+  box-shadow: none;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: filter var(--brutalist-snap) steps(2, end);
+}
+
+.brutalist-soft:hover {
+  filter: brightness(0.92);
+}
+
+.brutalist-soft--error {
+  background-color: var(--brutalist-danger);
+  color: var(--brutalist-paper);
+}
+
+/* ============================================
+   GHOST — invisible until it isn't
+   ============================================ */
+
+.brutalist-ghost {
+  background-color: transparent;
+  color: var(--brutalist-ink);
+  border: var(--brutalist-border) solid transparent;
+  box-shadow: none;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: border-color var(--brutalist-snap) steps(2, end);
+}
+
+.brutalist-ghost:hover {
+  border-color: var(--brutalist-ink);
+}
+
+.brutalist-ghost--error {
+  color: var(--brutalist-danger);
+}
+
+.brutalist-ghost--error:hover {
+  border-color: var(--brutalist-danger);
+}
+
+/* ============================================
+   LINK — marker-pen underline
+   ============================================ */
+
+.brutalist-link {
+  background-color: transparent;
+  color: var(--brutalist-ink);
+  border: none;
+  box-shadow: none;
+  font-weight: 800;
+  text-decoration: none;
+  background-image: linear-gradient(var(--brutalist-accent), var(--brutalist-accent));
+  background-repeat: no-repeat;
+  background-size: 100% 0.45em;
+  background-position: 0 85%;
+  transition: background-size var(--brutalist-snap) steps(2, end);
+}
+
+.brutalist-link:hover {
+  background-size: 100% 100%;
+}
+
+.brutalist-link--error {
+  background-image: linear-gradient(var(--brutalist-danger), var(--brutalist-danger));
+}
+
+.brutalist-link--error:hover {
+  color: var(--brutalist-paper);
+}
+
+/* ============================================
+   INPUTS — a slab you type into
+   ============================================ */
+
+.brutalist-input {
+  width: 100%;
+}
+
+.brutalist-input-base {
+  background-color: var(--brutalist-paper);
+  color: var(--brutalist-ink);
+  border: var(--brutalist-border) solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: var(--brutalist-shadow);
+  font-weight: 600;
+  caret-color: var(--brutalist-ink);
+  transition: box-shadow var(--brutalist-snap) steps(2, end), transform var(--brutalist-snap) steps(2, end);
+}
+
+.brutalist-input-base::placeholder {
+  color: var(--brutalist-ink);
+  opacity: 0.45;
+}
+
+.brutalist-input-base:focus {
+  outline: none;
+  transform: translate(-2px, -2px);
+  box-shadow: var(--brutalist-shadow-hover);
+  background-color: #fff;
+}
+
+.brutalist-input-base:disabled {
+  background-color: transparent;
+  box-shadow: none;
+  border-style: dashed;
+}
+
+/* ============================================
+   CARD — a poster taped to the wall
+   ============================================ */
+
+.brutalist-card {
+  background-color: var(--brutalist-paper);
+  border: var(--brutalist-border) solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: 8px 8px 0 var(--brutalist-ink);
+  overflow: hidden;
+}
+
+.brutalist-card-header {
+  background-color: var(--brutalist-accent);
+  border-bottom: var(--brutalist-border) solid var(--brutalist-ink);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.75rem 1rem;
+}
+
+.brutalist-card-body {
+  padding: 1rem;
+}
+
+.brutalist-card-footer {
+  border-top: var(--brutalist-border) solid var(--brutalist-ink);
+  padding: 0.75rem 1rem;
+}
+
+/* ============================================
+   SEPARATOR — a fat rule
+   ============================================ */
+
+.brutalist-separator {
+  border-color: var(--brutalist-ink);
+  border-top-width: var(--brutalist-border);
+}
+
+/* ============================================
+   BADGE — a sticker
+   ============================================ */
+
+.brutalist-badge {
+  background-color: var(--brutalist-accent);
+  color: var(--brutalist-ink);
+  border: 2px solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--brutalist-ink);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/packages/crouton-themes/brutalist/nuxt.config.ts
+++ b/packages/crouton-themes/brutalist/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/brutalist',
+    description: 'Brutalist theme for Nuxt UI — thick borders, hard shadows, zero subtlety'
+  },
+  css: [join(currentDir, 'assets/css/main.css')]
+})

--- a/packages/crouton-themes/lib/subtractive.ts
+++ b/packages/crouton-themes/lib/subtractive.ts
@@ -16,7 +16,7 @@
 // Pure + deterministic — SSR and client must compute the identical class string
 // (hydration-mismatch rule from #364). No Date/random/env reads here, ever.
 
-type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw'
+type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist'
 
 // First matching prefix wins; a resolved string only ever carries one theme's
 // markers because `variant` is single-valued and the bw markers live on the
@@ -25,7 +25,8 @@ const MARKERS: Array<[prefix: string, theme: ThemeKey]> = [
   ['minimal-', 'minimal'],
   ['ko-', 'ko'],
   ['kr-', 'kr11'],
-  ['bw-', 'bw']
+  ['bw-', 'bw'],
+  ['brutalist-', 'brutalist']
 ]
 
 // text-* utilities that are NOT color (sizes, alignment, wrapping) — kept when a
@@ -60,6 +61,12 @@ const STRIP: Record<ThemeKey, (u: string) => boolean> = {
   // and link underlines.
   bw: u => isColor(u) || isMotion(u)
     || /^-?(shadow|ring|ring-offset|inset-ring|outline|border)(-|$)/.test(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // Brutalist keeps text sizes + line-height; owns color, decoration, motion,
+  // weight/family/tracking/case, and link underlines.
+  brutalist: u => isColor(u) || isDecor(u) || isMotion(u)
+    || /^(font|tracking)(-|$)/.test(u)
+    || /^(uppercase|lowercase|capitalize|normal-case)$/.test(u)
     || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u)
 }
 

--- a/packages/crouton-themes/package.json
+++ b/packages/crouton-themes/package.json
@@ -13,7 +13,9 @@
     "./kr11": "./kr11/nuxt.config.ts",
     "./kr11/*": "./kr11/*",
     "./blackandwhite": "./blackandwhite/nuxt.config.ts",
-    "./blackandwhite/*": "./blackandwhite/*"
+    "./blackandwhite/*": "./blackandwhite/*",
+    "./brutalist": "./brutalist/nuxt.config.ts",
+    "./brutalist/*": "./brutalist/*"
   },
   "files": [
     "themes",
@@ -21,6 +23,7 @@
     "minimal",
     "kr11",
     "blackandwhite",
+    "brutalist",
     "lib"
   ],
   "keywords": [

--- a/packages/crouton-themes/playground/nuxt.config.ts
+++ b/packages/crouton-themes/playground/nuxt.config.ts
@@ -21,6 +21,7 @@ export default defineNuxtConfig({
     '../ko',
     '../minimal',
     '../kr11',
-    '../blackandwhite'
+    '../blackandwhite',
+    '../brutalist'
   ]
 })

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -4,7 +4,7 @@
 
 import { THEME_UI_CONFIGS } from '../configs/themeConfigs'
 
-export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'default'
+export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'default'
 
 type BaseVariant = 'solid' | 'outline' | 'soft' | 'ghost' | 'link'
 
@@ -53,6 +53,13 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     description: 'Compact monochrome dashboard theme',
     colors: ['#000000', '#525252', '#ffffff'], // black, neutral, white
     defaultVariant: 'outline' // Black & White favors outline/subtle surfaces
+  },
+  {
+    name: 'brutalist',
+    label: 'Brutalist',
+    description: 'Thick borders, hard shadows, zero subtlety',
+    colors: ['#0a0a0a', '#ffd800', '#fdfbf5'], // ink, shock yellow, paper
+    defaultVariant: 'solid'
   }
 ]
 

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -91,11 +91,24 @@ const blackandwhiteConfig: ThemeUIConfig = {
   badge: { defaultVariants: { variant: 'solid' } }
 }
 
+// Brutalist — named variants registered by brutalist/app.config.ts
+const brutalistConfig: ThemeUIConfig = {
+  colors: {
+    primary: 'yellow',
+    neutral: 'neutral'
+  },
+  button: { defaultVariants: { variant: 'brutalist' } },
+  input: { defaultVariants: { variant: 'brutalist' } },
+  card: { defaultVariants: { variant: 'brutalist' } },
+  badge: { defaultVariants: { variant: 'brutalist' } }
+}
+
 // Export all theme configs
 export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   default: defaultConfig,
   ko: koConfig,
   minimal: minimalConfig,
   kr11: kr11Config,
-  blackandwhite: blackandwhiteConfig
+  blackandwhite: blackandwhiteConfig,
+  brutalist: brutalistConfig
 }


### PR DESCRIPTION
Closes #1307

> Stacked on #1330 (the themes rework), which stacks on #1314 (the playground). Merging in order retargets this automatically.

## 👤 For humans

The first new funky theme: **Brutalist** — off-white paper, 3px black borders, hard offset shadows with no blur, shock-yellow accents, uppercase 800-weight labels, and interaction states that *snap* (buttons lift on hover, slam flat on press). Flip to it in the playground switcher next to the other five looks.

## 🤖 For agents

- New layer `packages/crouton-themes/brutalist/` following the package recipe: named variants `brutalist` / `brutalist-{solid,outline,soft,ghost,link}` (button) + `brutalist` (input/card/badge/separator), `brutalist-` class prefix, `--brutalist-*` tokens.
- **Zero `!important`** — first theme built on the shared marker-gated replacer from day one. `lib/subtractive.ts` gains the `brutalist-` marker + strip set (color/decoration/motion/weight/tracking/case/underlines; keeps text sizes + line-height; `focus-visible:` preserved by the shared guard).
- Ambient `[data-theme="brutalist"]` sets the paper background only — the KO readability lesson applied from the start (display treatment is per-component chrome, never root typography).
- Registered across every convention surface: package exports/`files`, `ThemeName` + `AVAILABLE_THEMES` + `THEME_UI_CONFIGS` (scalars only), playground `extends`, package CLAUDE.md.
- Known gap (by design, tracked in #1333): explicit-variant components in the gallery (Menu/modal-trigger `variant="outline"`) and the unthemed separator stay default under Brutalist.

## 🧪 How to test

**What changed:** a sixth entry in the theme switcher.
**Where you'll see it:** the playground preview (URL on the issue) or `pnpm --filter crouton-themes-playground dev`.
**Steps:**
1. Flip the switcher to **Brutalist**: primary goes shock-yellow slab, neutral ink-black, error alarm-red — all with 3px borders + hard 4px shadows, square corners.
2. Hover a solid button — it lifts (-2px) and the shadow grows; press — it slams flat (shadow to 0). The change steps, it doesn't fade.
3. Focus the text input — same lift treatment; the disabled input renders with a dashed border and no shadow.
4. The card is a poster: yellow uppercase header band, fat 8px shadow.
5. Tab through the buttons — the focus outline survives (a11y guard).
6. Flip to another theme and back — nothing lingers either way.

**Test data:** none.

_Dedup-checked: sub-issue #1307 of epic #1303 — no sibling overlap._

---
> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account
