### PR TITLE
feat(root): readable messages — agent-gate family (WS2, #1339)

### DIFF
--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -68,5 +68,5 @@ jobs:
             try { await github.rest.reactions.createForIssueComment({ owner, repo, comment_id, content: 'rocket' }) } catch (e) {}
             const harness = label === 'delegate-pi' ? 'pi.dev' : 'claude'
             await github.rest.issues.createComment({ owner, repo, issue_number,
-              body: `▶️ Dispatched by comment — applied \`${label}\`, the ${harness} agent pipeline is picking up #${issue_number}.` })
+              body: `🟢 **On it — the ${harness} agent is picking this up now.**\n\n<sub>🤖 comment-dispatch · applied \`${label}\`</sub>` })
             core.info(`Dispatched #${issue_number} via comment (label: ${label}).`)

--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -47,7 +47,9 @@ jobs:
             const MAX = 3
             const { owner, repo } = context.repo
             const run = context.payload.workflow_run
-            const HEADER = '> 🤖 **Claude Code** · agent pipeline (CI) · _fix-bot (#338)_\n\n'
+            // Readable-on-mobile (epic #1336): messages lead with the problem + fix; this
+            // provenance/mechanism + run link is the footer.
+            const FOOTER = (url) => `\n\n<sub>🤖 Claude Code · fix-bot (#338) · <a href="${url}">failing run</a></sub>`
 
             // Resolve the open PR for this head branch.
             let pr = (run.pull_requests || [])[0]
@@ -76,14 +78,16 @@ jobs:
             const issueNumber = m ? Number(m[1]) : null
 
             if (attempts >= MAX) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body: HEADER +
-                `🛑 **Auto-fix gave up after ${attempts} attempts.** \`${run.name}\` is still failing on ` +
-                `\`${full.head.sha.slice(0, 7)}\`. @pmcp — this needs a human. [Failing run](${run.html_url}).` })
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body:
+                `🔴 **@pmcp — auto-fix gave up after ${attempts} tries; \`${run.name}\` is still failing** on \`${full.head.sha.slice(0, 7)}\`.\n\n` +
+                `**Fix:** this one needs a human — take a look, then push a fix or reply to resume.` +
+                FOOTER(run.html_url) })
               if (issueNumber) {
                 try { await github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: ['status:blocked'] }) } catch (e) { core.warning(`block #${issueNumber}: ${e.message}`) }
-                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body: HEADER +
-                  `🛑 The fix-bot tried ${attempts} times to get CI green on PR #${pr.number} and couldn't. ` +
-                  `@pmcp — reply here when you've had a look and the pipeline will resume. [Failing run](${run.html_url}).` })
+                await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body:
+                  `🔴 **@pmcp — auto-fix couldn't get CI green on PR #${pr.number} after ${attempts} tries.**\n\n` +
+                  `**Fix:** take a look, then reply here and the pipeline resumes.` +
+                  FOOTER(run.html_url) })
               }
               core.setOutput('proceed', 'false'); return
             }

--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -42,7 +42,6 @@ jobs:
             const { owner, repo } = context.repo
             const PR_STICKY = '<!-- crouton-pipeline-status -->'
             const EPIC_ROLLUP = '<!-- crouton-epic-rollup -->'
-            const HEADER = '> 🤖 **Claude Code** · agent pipeline (CI)'
             const now = new Date().toISOString().replace('T', ' ').slice(0, 16) + 'Z'
 
             // Upsert a marker-tagged comment: edit the existing one in place, else create.
@@ -93,12 +92,12 @@ jobs:
               if (st.pending) parts.push(`${st.pending} running`)
               if (st.failure) parts.push(`${st.failure} failing`)
               const body =
-                `${PR_STICKY}\n${HEADER} · _pipeline status (#337)_\n\n` +
+                `${PR_STICKY}\n` +
                 `### ${st.icon} CI ${st.word}\n` +
-                `${parts.join(' · ')}.\n\n` +
-                (fix ? `🔧 Auto-fix attempts: **${fix[1]}**\n\n` : '') +
-                `Branch \`${pr.head.ref}\` → \`${pr.base.ref}\` · ` +
-                `[checks](${pr.html_url}/checks) · _updated ${now}_`
+                `${parts.join(' · ')}.` +
+                (fix ? ` · 🔧 auto-fix ×${fix[1]}` : '') + `\n\n` +
+                `<sub>🤖 agent pipeline (#337) · \`${pr.head.ref}\` → \`${pr.base.ref}\` · ` +
+                `<a href="${pr.html_url}/checks">checks</a> · updated ${now}</sub>`
               await upsert(pr.number, PR_STICKY, body)
               const epicMatch = /^epic\/(\d+)-/.exec(pr.base.ref)
               if (epicMatch) await updateEpic(Number(epicMatch[1]))
@@ -121,9 +120,10 @@ jobs:
               const inProgress = open.filter(s => names(s).includes('status:in-progress')).length
               const queued = open.length - blocked - inProgress
               const body =
-                `${EPIC_ROLLUP}\n${HEADER} · _epic roll-up (#337)_\n\n` +
-                `**📊 ${done}/${total} done** · ▶️ ${inProgress} in progress · ` +
-                `⏸️ ${blocked} blocked · 🗒️ ${queued} queued. _Updated ${now}._`
+                `${EPIC_ROLLUP}\n` +
+                `### 📊 ${done}/${total} done\n` +
+                `▶️ ${inProgress} in progress · ⏸️ ${blocked} blocked · 🗒️ ${queued} queued.\n\n` +
+                `<sub>🤖 agent pipeline · epic roll-up (#337) · updated ${now}</sub>`
               await upsert(epicNumber, EPIC_ROLLUP, body)
             }
 

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -59,9 +59,9 @@ jobs:
             if (open) return
             const closer = issue.closed_by ? issue.closed_by.login : 'unknown'
             await github.rest.issues.createComment({ ...context.repo, issue_number,
-              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _resume skipped — issue already closed (#1253)_\n\n'
-                + `⚠️ This issue was **closed** (by ${closer}) just before your reply was picked up, so the resume did **not** run — `
-                + 'it looks superseded. Reply on the successor issue/PR instead, or **reopen this one and comment again** to retry.' })
+              body: `🚫 **Your reply didn't resume anything — this issue was closed (by ${closer}) just before it was picked up.**\n\n`
+                + '**Fix:** reply on the successor issue/PR, or reopen this one and comment again to retry.\n\n'
+                + '<sub>🤖 Claude Code · agent pipeline (CI) · resume skipped, issue already closed (#1253)</sub>' })
             core.info(`Issue #${issue_number} is closed — skipping the resume agent run.`)
 
       # Acknowledge the trigger comment immediately: 👀 = "picked up, working on it". The
@@ -262,10 +262,9 @@ jobs:
               return
             }
             await github.rest.issues.createComment({ ...context.repo, issue_number,
-              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _resume artifact-gate (#603)_\n\n'
-                + '⚠️ The resume ran but produced **nothing** (no sub-issues, no merged gate PR, no new '
-                + 'comment, not closed, and the block was cleared) — a silent no-op (the #590 failure mode). '
-                + 'Re-dispatch with `/delegate` to retry.' })
+              body: '🔴 **The resume ran but produced nothing** — no sub-issues, no merged PR, no new comment, and the block was cleared (a silent no-op).\n\n'
+                + '**Fix:** re-dispatch with `/delegate` to retry.\n\n'
+                + '<sub>🤖 Claude Code · agent pipeline (CI) · resume artifact-gate (#603/#590)</sub>' })
             core.setFailed(`Resume on #${issue_number} produced no artifact — likely a no-op; re-dispatch.`)
 
       # Final feedback on the trigger comment: clear the 👀 and stamp the outcome — 🚀 done /

--- a/.github/workflows/schedule-waves.yml
+++ b/.github/workflows/schedule-waves.yml
@@ -124,7 +124,7 @@ jobs:
               // 4) Release: apply `delegate` (as the PAT user → human-actor trigger).
               await github.rest.issues.addLabels({ owner, repo, issue_number: it.number, labels: ['delegate'] })
               await github.rest.issues.createComment({ owner, repo, issue_number: it.number,
-                body: `▶️ All blockers closed (#${done} just completed) — auto-dispatching this workstream `
-                  + `(applied \`delegate\`). Wave scheduler (#283).` })
+                body: `🟢 **Unblocked — starting this workstream now.** Its last blocker (#${done}) just closed.\n\n`
+                  + `<sub>🤖 wave scheduler (#283) · applied \`delegate\`</sub>` })
               core.info(`Released #${it.number}`)
             }


### PR DESCRIPTION
Closes #1339 · part of epic #1336 (WS1 style guide already merged)

## 👤 For humans
Conform the agent-pipeline CI comments to the [CI message style](.github/CI-MESSAGE-STYLE.md): first line = status emoji + what happened + the one fix; provenance/gate/#NN → small footer.

- **resume-on-comment**: `🚫 Your reply didn't resume anything — this issue was closed…` · `🔴 The resume produced nothing…`
- **schedule-waves / comment-dispatch**: `🟢 Unblocked — starting this workstream now` · `🟢 On it — the … agent is picking this up`
- **fix-ci-on-failure**: `🔴 @pmcp — auto-fix gave up after N tries; <run> is still failing` + **Fix:** line
- **pipeline-pr-status**: stickies lead with `### ✅ CI passing` / `### 📊 3/5 done`; branch/updated → footer

## 🤖 For agents
5 workflows, message bodies only (no logic change): `resume-on-comment`, `schedule-waves`, `comment-dispatch`, `fix-ci-on-failure` (HEADER→FOOTER), `pipeline-pr-status` (dropped the now-unused HEADER const). YAML validated on all five.

## 🧪 How to test
Trigger each path (reply-to-resume on a closed issue, a wave release, a `/delegate` comment, a fix-bot give-up, a PR status update) → the comment leads with the status/problem, mechanism in the `<sub>` footer.