### PR TITLE
feat(root): readable messages — deploy family (WS3, #1340)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -521,7 +521,7 @@ jobs:
             const login = (email && password)
               ? `\n\n🔑 **Test login** — paste straight in, no registration:\n\`\`\`\nEmail:    ${email}\nPassword: ${password}\n\`\`\`\n_Disposable account on this isolated, throwaway staging DB._`
               : ''
-            const body = `${marker}\n🚀 **${app}** staging deployed: ${url}${login}\n\n_Isolated, auto-provisioned Workers staging env (its own D1 + KV)._`
+            const body = `${marker}\n🚀 **${app}** deployed to staging: ${url}${login}\n\n<sub>🤖 isolated, auto-provisioned Workers staging env (its own D1 + KV)</sub>`
             const { owner, repo } = context.repo
             const issue_number = context.issue.number
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number })

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -211,11 +211,13 @@ jobs:
           script: |
             const body = [
               '<!-- deploy-bumped -->',
-              '> 🤖 **Claude Code** · agent pipeline (CI) · _preview-deploy queue notice_',
+              '⏳ **Preview deploy bumped, not broken — nothing about this PR failed.**',
               '',
-              '⏳ **Preview deploy bumped, not broken.** This PR\'s staging preview deploy was cancelled because a newer run took the shared per-app staging queue slot (one waiting run per app — usually a sibling PR or a merge to `main` deploying the same app). **Nothing about this PR failed.**',
+              'A newer run took the shared per-app staging queue slot (a sibling PR, or a merge to `main` deploying the same app), so this preview was cancelled.',
               '',
-              'To get the previews: re-run the failed jobs of the **Deploy Apps (Cloudflare Workers)** run for this PR, or push any commit. Context: #1150.'
+              '**To get the preview:** re-run the failed jobs of the **Deploy Apps** run, or push any commit.',
+              '',
+              '<sub>🤖 agent pipeline · preview-deploy queue notice (#1150)</sub>'
             ].join('\n')
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,

--- a/.github/workflows/report-failed-deploy.yml
+++ b/.github/workflows/report-failed-deploy.yml
@@ -71,10 +71,9 @@ jobs:
             const commitUrl = `https://github.com/${owner}/${repo}/commit/${run.head_sha}`
             const title = `🚨 ${run.name} failed on ${run.head_branch} (post-merge)`
             const body = [
-              HEADER,
+              `🔴 **@pmcp — a post-merge deploy failed: \`${run.name}\` broke on \`${run.head_branch}\`.**`,
               '',
-              `**A post-merge deploy failed.** \`${run.name}\` broke on \`${run.head_branch}\` — the change is`,
-              `already merged, so this is surfaced as a fresh ticket so it isn't lost. @pmcp`,
+              `The change is already merged, so this ticket exists so the breakage isn't lost.`,
               '',
               `- **Failing run:** ${run.html_url}`,
               `- **Landed commit:** [\`${sha7}\`](${commitUrl})${run.head_commit?.message ? ' — ' + run.head_commit.message.split('\n')[0] : ''}`,
@@ -85,6 +84,7 @@ jobs:
               `1. Reproduce: re-run \`${run.name}\` or run the app's deploy locally and watch for the same error.`,
               `2. Fix the cause on a branch, open a PR (\`Closes #<this>\`), and confirm the deploy goes green.`,
               '',
+              `<sub>${HEADER.replace(/^> /, '')}</sub>`,
               MARKER,
             ].filter(l => l !== null).join('\n')
 

--- a/.github/workflows/teardown-app.yml
+++ b/.github/workflows/teardown-app.yml
@@ -151,9 +151,9 @@ jobs:
             const issueNums = (process.env.ISSUES || '')
               .split(',').map(s => s.trim().replace(/^#/, '')).filter(Boolean)
             lines.push('', `### Issues / PRs (${issueNums.length})`)
-            const note = `> 🤖 **Claude Code** · teardown-app (CI), posted from the Harness App · _#618 /remove-app_\n\n`
-              + `🧹 **\`${app}\` torn down.** This issue/PR was closed as part of removing the app `
-              + `(code + Cloudflare resources + branches). See the teardown-app workflow run for details.`
+            const note = `🧹 **\`${app}\` was torn down** — this issue/PR is closed as part of removing the app `
+              + `(code + Cloudflare resources + branches).\n\n`
+              + `<sub>🤖 Claude Code · teardown-app (CI), posted from the Harness App · #618 /remove-app · see the workflow run for details</sub>`
             for (const n of issueNums) {
               if (dry) { lines.push(`- would close #${n} (with note)`); continue }
               try {


### PR DESCRIPTION
Closes #1340 · part of epic #1336

## 👤 For humans
Deploy CI comments now lead with the outcome/problem; mechanism → `<sub>` footer.
- **staging preview**: `🚀 <app> deployed to staging: <url>` (+ test login unchanged)
- **queue notice**: `⏳ Preview deploy bumped, not broken — nothing about this PR failed`
- **teardown**: `🧹 <app> was torn down`
- **post-merge failure ticket**: `🔴 @pmcp — a post-merge deploy failed: <run> broke on <branch>`

## 🤖 For agents
4 workflows, message bodies only: `deploy-app`, `deploy-apps`, `teardown-app`, `report-failed-deploy`. YAML validated on all four.

## 🧪 How to test
A staging deploy / bumped preview / teardown / post-merge deploy failure each posts a comment that leads with the status + the mechanism in a `<sub>` footer.