### PR TITLE
fix(crouton-cli): make regeneration non-destructive — preserve edits unless --force (#1260)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -281,6 +281,18 @@ crouton db-pull --config ./custom-wrangler.jsonc
 | `--no-tests` | Skip the per-collection tests — schema-smoke (#785) + API route handler test (#791); both emitted by default |
 | `--dry-run` | Preview without writing |
 
+### Regeneration is non-destructive (#1260)
+
+Re-running the generator over an existing collection **preserves files that already exist**
+by default — it never silently clobbers hand-edits — and reports what it skipped
+(`⏭ preserved N existing file(s) — use --force to overwrite`). Files that don't exist yet are
+always written, so a schema change still scaffolds new artifacts. Pass **`--force`** to overwrite
+existing scaffold files (this is what the generated files' *"regeneration requires --force flag"*
+note refers to). Only the per-collection scaffold files are guarded this way; derived
+machine-owned files (the schema index, type/query registries, `app.config.ts` entries) are
+rewritten every run regardless. Guarded by the write loop in `writeScaffold`
+(`lib/generate-collection.ts`); contract test: `tests/integration/regenerate-preserve.test.ts`.
+
 ## Key Files
 
 | File | Purpose |

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -1339,10 +1339,24 @@ async function writeScaffold({ layer, collection, fields, dialect, autoRelations
     ...(noTests ? [] : buildCollectionTestFiles({ base, data, config, cases, layerPascalCase }))
   ]
 
-  // Write all files
+  // Write all files. Per-collection scaffold files are user-editable, so regeneration
+  // must NOT silently clobber hand-edits: skip a file that already exists unless --force
+  // is set (which the generated files' own "regeneration requires --force" note promises).
+  // Files that don't exist yet are always written, so a schema change still scaffolds new
+  // artifacts. Derived machine-owned files (schema index, registries, app.config.ts) are
+  // written by later steps and keep always-rewriting — only these scaffold files are guarded.
+  const preserved: string[] = []
   for (const file of files) {
+    if (!force && existsSync(file.path)) {
+      preserved.push(file.path)
+      continue
+    }
     await fsp.writeFile(file.path, file.content, 'utf8')
     console.log(`  ✓ ${path.relative(base, file.path)}`)
+  }
+  if (preserved.length > 0) {
+    console.log(`  ⏭ preserved ${preserved.length} existing file(s) — use --force to overwrite:`)
+    for (const p of preserved) console.log(`     · ${path.relative(base, p)}`)
   }
 
   // Note: team-auth utility is now provided by @fyit/crouton package

--- a/packages/crouton-cli/tests/integration/regenerate-preserve.test.ts
+++ b/packages/crouton-cli/tests/integration/regenerate-preserve.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Behaviour contract for #1260 — regeneration must not silently destroy edits.
+ *
+ * crouton's promise is "you own the generated code and can edit it." The generated
+ * files even print "Safe to modify - regeneration requires --force flag." Today that
+ * promise is false: the writeScaffold() write loop overwrites every file unconditionally.
+ *
+ * These tests pin the INTENDED behaviour (currently failing):
+ *   - regenerate WITHOUT --force preserves a hand-edited file
+ *   - regenerate WITHOUT --force still (re)writes files that are absent
+ *   - regenerate WITH --force overwrites the hand-edited file
+ *   - the run reports which existing files it preserved (not silent)
+ *
+ * Subprocess-driven, mirroring tests/integration/commands.test.ts.
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { resolve, join } from 'node:path'
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+const exec = promisify(execFile)
+const CLI_PATH = resolve(__dirname, '../../bin/crouton-generate.js')
+
+function runCLI(args: string[], cwd: string) {
+  return exec('node', [CLI_PATH, ...args], {
+    cwd,
+    timeout: 60_000,
+    env: { ...process.env, NODE_ENV: 'test', FORCE_COLOR: '0' }
+  }).then(
+    ({ stdout, stderr }) => ({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode: 0 }),
+    (err: any) => ({
+      stdout: (err.stdout as string) ?? '',
+      stderr: (err.stderr as string) ?? '',
+      exitCode: typeof err.code === 'number' ? err.code : 1
+    })
+  )
+}
+
+const SCHEMA = JSON.stringify({
+  id: { type: 'uuid', meta: { primaryKey: true } },
+  title: { type: 'string', meta: { required: true, maxLength: 200 } },
+  price: { type: 'decimal', meta: { precision: 10, scale: 2 } }
+})
+
+// The dep check reads package.json `dependencies` (not node_modules) — declaring the
+// crouton deps here lets `generate` run WITHOUT --force, so --force is free to mean
+// exactly one thing in these tests: "overwrite existing files".
+const PKG_JSON = JSON.stringify({
+  name: 'regen-fixture',
+  private: true,
+  dependencies: { '@fyit/crouton': '*', '@fyit/crouton-i18n': '*' }
+})
+
+// The detector also requires the base layer to be EXTENDED in nuxt.config.ts, not just
+// present in package.json — otherwise it reports a critical "installed but not extended".
+const NUXT_CONFIG = `export default defineNuxtConfig({ extends: ['@fyit/crouton'] })\n`
+
+const POST_HANDLER =
+  'layers/shop/collections/widgets/server/api/teams/[id]/shop-widgets/index.post.ts'
+const MARKER = '// >>> HAND EDITED — MUST SURVIVE REGEN <<<'
+
+let dir: string
+
+// NOTE: the direct `generate` command currently exits 1 at the very end due to an
+// unrelated known bug (#1246, promptedConfigs ReferenceError) that throws AFTER all
+// files are written. So these tests assert on FILE STATE, not exit codes — the write
+// loop (and the skip-existing behaviour under test) completes before that crash.
+// `--noDb` (camelCase — citty reads `--no-db` as negating a `db` arg) skips the slow
+// migration/nuxt-prepare step, which would otherwise time out in a bare temp dir.
+async function generate(extraArgs: string[] = []) {
+  return runCLI(
+    ['generate', 'shop', 'widgets', '--fields-file=widget-schema.json', '--noDb', '--no-tests', ...extraArgs],
+    dir
+  )
+}
+
+async function editHandler() {
+  const p = join(dir, POST_HANDLER)
+  const src = await readFile(p, 'utf8')
+  await writeFile(p, `${MARKER}\n${src}`, 'utf8')
+}
+
+async function handlerHasEdit() {
+  return (await readFile(join(dir, POST_HANDLER), 'utf8')).includes(MARKER)
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'crouton-regen-'))
+  await writeFile(join(dir, 'package.json'), PKG_JSON, 'utf8')
+  await writeFile(join(dir, 'nuxt.config.ts'), NUXT_CONFIG, 'utf8')
+  await writeFile(join(dir, 'widget-schema.json'), SCHEMA, 'utf8')
+  // Baseline generation runs WITHOUT --force (deps satisfied above). We assert the
+  // scaffold was written (file state), not exit code — see the #1246 note above.
+  const first = await generate()
+  expect(existsSync(join(dir, POST_HANDLER)), `baseline generate did not write files:\n${first.stdout}\n${first.stderr}`).toBe(true)
+})
+
+afterEach(async () => {
+  if (dir && existsSync(dir)) await rm(dir, { recursive: true, force: true })
+})
+
+describe('regeneration preserves hand-edits (#1260)', () => {
+  it('regenerate WITHOUT --force keeps a hand-edited file untouched', async () => {
+    await editHandler()
+    await generate()
+    expect(await handlerHasEdit()).toBe(true) // currently FAILS: file is clobbered
+  })
+
+  it('regenerate WITHOUT --force reports the files it preserved (not silent)', async () => {
+    await editHandler()
+    const res = await generate()
+    expect(res.stdout + res.stderr).toMatch(/preserv|skip|already exists|--force to overwrite/i)
+  })
+
+  it('regenerate WITHOUT --force still (re)writes a file that is absent', async () => {
+    await editHandler()
+    await rm(join(dir, POST_HANDLER)) // simulate a file that needs to exist but doesn't
+    await generate()
+    expect(existsSync(join(dir, POST_HANDLER))).toBe(true) // absent file re-created
+  })
+
+  it('regenerate WITH --force overwrites the hand-edited file', async () => {
+    await editHandler()
+    await generate(['--force'])
+    expect(await handlerHasEdit()).toBe(false) // --force opts back into overwrite
+  })
+})


### PR DESCRIPTION
Closes #1260

## 👤 For humans

Re-running the crouton generator over an existing collection used to **silently overwrite every file**, wiping any hand-edits — even though the generated files themselves print *"Safe to modify — regeneration requires --force flag."* That promise was false: `--force` only gated the dependency check, not your files.

This makes the promise real. Regeneration now **preserves existing files by default** (and reports what it skipped), so crouton's "own your code" model actually holds. Pass `--force` to overwrite. Files that don't exist yet are still written, so a schema change still scaffolds new artifacts.

Surfaced while comparing crouton to [awecode/autoadmin](https://github.com/awecode/autoadmin) — its runtime-introspection model raised "how do customizations survive regeneration?", and testing it empirically revealed crouton's generator clobbered edits. This is "Direction A" (make regeneration safe); the larger autoadmin-style override layer (`before`/`after` hooks, `baseWhere`) is deliberately out of scope.

## 🤖 For agents

- `writeScaffold()` write loop (`lib/generate-collection.ts`): skip a file when `!force && existsSync(file.path)`; collect + log preserved files (`⏭ preserved N existing file(s) — use --force to overwrite`). Only the per-collection scaffold files are guarded; derived machine-owned files (schema index, type/query registries, `app.config.ts` entries) are written by later steps and keep always-rewriting.
- Contract test (test-first per #774, signed off): `tests/integration/regenerate-preserve.test.ts` — edit survives regen; absent file re-created; `--force` overwrites; run reports preserved files. Asserts on **file state**, not exit code (the direct `generate` path exits 1 via the unrelated #1246 crash that throws *after* all files are written).
- `CLAUDE.md`: added a "Regeneration is non-destructive" note.

## 🧪 How to test

1. Generate a collection in a fixture/app.
2. Hand-edit one generated file (add a marker comment).
3. Regenerate that collection **without** `--force` → marker still present; output reports the file was preserved.
4. Regenerate **with** `--force` → file regenerated, marker gone.
5. Delete a generated file, regenerate without `--force` → the absent file is re-created while edited files are preserved.

Full crouton-cli suite: **292 existing tests pass**, +4 new contract cases green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYEtYbCxXzRWibuk6nzQQx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYEtYbCxXzRWibuk6nzQQx)_