### PR TITLE
feat(root): readable messages — review / quality gates (WS4, #1341)

### DIFF
--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -111,11 +111,10 @@ jobs:
           BODY_FILE=$(mktemp)
           {
             echo "$MARKER"
-            echo "> 🤖 **Claude Code** · agent pipeline (CI) · _daily a11y deep sweep, updated ${DATE}_"
-            echo ""
-            echo "_Last run: [$DATE]($RUN_URL) · this issue is updated in place each day._"
-            echo ""
             head -c 60000 "$REPORT"
+            echo ""
+            echo ""
+            echo "<sub>🤖 agent pipeline (CI) · daily a11y deep sweep · last run [$DATE]($RUN_URL) · updated in place each day</sub>"
           } > "$BODY_FILE"
 
           # Find-or-create the rolling standing issue. Key off the EXACT title among open

--- a/.github/workflows/skill-freshness-pr.yml
+++ b/.github/workflows/skill-freshness-pr.yml
@@ -55,7 +55,7 @@ jobs:
             const { owner, repo } = context.repo
             const issue_number = context.payload.pull_request.number
             const MARKER = '<!-- skill-freshness-advisory -->'
-            const HEADER = '> 🤖 **Claude Code** · agent pipeline (CI) · _skill-freshness advisory_'
+            const FOOTER = '<sub>🤖 agent pipeline (CI) · skill-freshness advisory · not a merge gate</sub>'
 
             const data = JSON.parse(fs.readFileSync('skill-citations.json', 'utf8'))
             const skills = data.skills || []
@@ -69,8 +69,8 @@ jobs:
             // (don't add noise to unrelated PRs).
             if (!skills.length) {
               if (existing) {
-                const body = [MARKER, HEADER, '', '### 📚 Skill freshness',
-                  '✅ The latest revision changes no files cited by a knowledge skill.'].join('\n')
+                const body = [MARKER, '### 📚 Skill freshness', '',
+                  '✅ This revision changes no files cited by a knowledge skill.', '', FOOTER].join('\n')
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
               }
               core.info('No skill-cited files changed — nothing to advise.')
@@ -80,8 +80,6 @@ jobs:
             const n = skills.length
             const lines = [
               MARKER,
-              HEADER,
-              '',
               `### 📚 This PR changes files cited by ${n} knowledge skill${n === 1 ? '' : 's'}`,
               '',
               'These skills cite paths this PR touches. If the change alters what they document,',
@@ -95,7 +93,9 @@ jobs:
             }
             lines.push(
               '',
-              '_Advisory only — not a merge gate. After re-verifying, run `node scripts/skill-freshness.mjs --pretty` to confirm the skill reads clean._'
+              '_After re-verifying, run `node scripts/skill-freshness.mjs --pretty` to confirm the skill reads clean._',
+              '',
+              FOOTER
             )
             const body = lines.join('\n')
 

--- a/.github/workflows/warn-closes-blocked.yml
+++ b/.github/workflows/warn-closes-blocked.yml
@@ -63,9 +63,7 @@ jobs:
             const list = blocked.map(n => `#${n}`).join(', ')
             const plural = blocked.length > 1
             await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number,
-              body: `${marker}\n> 🤖 **Claude Code** · agent pipeline (CI) · _Closes-a-blocked-issue check (#1253)_\n\n`
-                + `⚠️ This PR's body \`Closes\` **${list}**, which ${plural ? 'are' : 'is'} \`status:blocked\` — `
-                + `merging will auto-close ${plural ? 'them' : 'it'} out from under a pending owner reply `
-                + '(the #1233 race). If this PR is a **root-cause fix** rather than the blocked work itself, '
-                + `use \`Refs ${list}\` instead of \`Closes\`. Warning only — not a required check.` })
+              body: `${marker}\n🚫 **On merge this PR auto-closes ${list} — but ${plural ? 'they are' : 'it is'} \`status:blocked\` (awaiting an owner reply).**\n\n`
+                + `**Fix:** if this is a root-cause fix rather than the blocked work itself, use \`Refs ${list}\` instead of \`Closes\` — so merging doesn't close ${plural ? 'them' : 'it'} out from under the pending reply (the #1233 race).\n\n`
+                + `<sub>🤖 agent pipeline (CI) · closes-a-blocked-issue check (#1253) · warning only, not a required check</sub>` })
             core.warning(`PR #${pr.number} Closes blocked issue(s): ${list}`)


### PR DESCRIPTION
Closes #1341 · part of epic #1336

## 👤 For humans
Review-gate CI comments now lead with the outcome/problem; mechanism → `<sub>` footer.
- **skill-freshness**: leads `### 📚 This PR changes files cited by N skills` (or `✅`)
- **warn-closes-blocked**: `🚫 On merge this PR auto-closes #N — but it is status:blocked` + **Fix:** use `Refs`
- **a11y-daily**: standing issue leads with the report; provenance/last-run → footer

## 🤖 For agents
3 workflows changed. **Not touched (already conformant):** `a11y.yml` / `frontend-review.yml` stickies are subagent-rendered severity-first (🔴/🟡/🔵) reports; `eval-scoreboard.yml` posts no human comment. YAML validated.

## 🧪 How to test
A skill-cited file change / a `Closes`-a-blocked-issue PR / the daily a11y sweep each posts a comment leading with the status, mechanism in the footer.