### PR TITLE
feat(root): readable messages — automerge / epic / advisor (WS5, #1342)

### DIFF
--- a/.github/workflows/automerge-epic-subpr.yml
+++ b/.github/workflows/automerge-epic-subpr.yml
@@ -126,11 +126,10 @@ jobs:
                 const list = sharedCode.slice(0, 10).map(f => `- \`${f.filename}\``).join('\n')
                 const more = sharedCode.length > 10 ? `\n…and ${sharedCode.length - 10} more.` : ''
                 await github.rest.issues.createComment({ owner, repo, issue_number: pull_number,
-                  body: '> 🤖 **Claude Code** · agent pipeline (CI) · _auto-merge shared-code guard (#339)_\n\n'
-                    + '⏸️ **Held — this build PR changes shared code under `packages/`.** Per the `packages/` '
-                    + 'HARD GATE (#350) a change here ripples across every consuming app, so it is **not** '
-                    + 'auto-merged. A human must review and merge it (and confirm `pnpm typecheck` across apps).\n\n'
-                    + `Shared-code files in this PR:\n${list}${more}` })
+                  body: '⏸️ **Held for a human — this build PR changes shared code under `packages/`.**\n\n'
+                    + '**Fix:** a change here ripples across every consuming app (the `packages/` HARD GATE, #350), so it is not auto-merged — review it, confirm `pnpm typecheck` across apps, then merge.\n\n'
+                    + `<details><summary>shared-code files (${sharedCode.length})</summary>\n\n${list}${more}\n</details>\n\n`
+                    + '<sub>🤖 agent pipeline (CI) · auto-merge shared-code guard (#339)</sub>' })
                 continue
               }
 

--- a/.github/workflows/close-epic-on-comment.yml
+++ b/.github/workflows/close-epic-on-comment.yml
@@ -90,7 +90,7 @@ jobs:
             }
             await github.rest.issues.createComment({
               ...context.repo, issue_number,
-              body: '> 🤖 **Claude Code** · agent pipeline (CI) · _close-epic on comment (#856)_\n\n'
-                + `✅ Epic closed via \`/close-epic\` by @${actor} (was \`status:ready-to-close\`).`,
+              body: `✅ **Epic closed** via \`/close-epic\` by @${actor}.\n\n`
+                + '<sub>🤖 agent pipeline (CI) · close-epic on comment (#856) · was status:ready-to-close</sub>',
             })
             core.info(`Closed epic #${issue_number} (requested by @${actor}).`)

--- a/.github/workflows/loop-station-advisor.yml
+++ b/.github/workflows/loop-station-advisor.yml
@@ -89,9 +89,11 @@ jobs:
             3. Keep it terse and skimmable. RECOMMEND only — do NOT edit `CLAUDE.md`,
                skills, agents, or any product code, and do NOT open a PR.
 
-            If you POST A COMMENT (when updating), lead it with the CI provenance header:
-            `> 🤖 **Claude Code** · agent pipeline (CI) · _Loop Station advisor_`
-            (Issue bodies are already clearly agent-authored — no header needed there.)
+            If you POST A COMMENT (when updating), follow `.github/CI-MESSAGE-STYLE.md`: LEAD with the
+            single most important finding/recommendation in plain words (a status emoji is fine), and put
+            the CI provenance in a small footer at the end:
+            `<sub>🤖 agent pipeline (CI) · Loop Station advisor</sub>`
+            (Issue bodies are already clearly agent-authored — no footer needed there.)
 
       # Outage visibility (#1037): the advisor's first real run died on billing_error and
       # the actionable findings evaporated with it. When the LLM step fails, classify why
@@ -112,13 +114,15 @@ jobs:
           set -euo pipefail
           BODY_FILE=$(mktemp)
           {
-            echo "> 🤖 **Claude Code** · agent pipeline (CI) · _Loop Station advisor — deterministic fallback (#1037)_"
+            echo "⚠️ **Loop Station advisor: the LLM step failed — posting the raw findings so they still reach you.**"
             echo ""
-            echo "The advisor's LLM step failed this week, but the deterministic gate found **actionable** findings — posting them raw so they still reach you. Human-phrased recommendations will arrive whenever the LLM step recovers; the outage is classified in [the run log]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            echo "The deterministic gate found **actionable** findings; human-phrased recommendations will arrive whenever the LLM step recovers."
             echo ""
             echo '```json'
             cat advisor-findings.json
             echo '```'
+            echo ""
+            echo "<sub>🤖 agent pipeline (CI) · Loop Station advisor — deterministic fallback (#1037) · [run log]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)</sub>"
           } > "$BODY_FILE"
           EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label loop-station-advisor --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then


### PR DESCRIPTION
Closes #1342 · **completes epic #1336**

## 👤 For humans
Final workstream — the automerge guard, epic-close ack, and loop-station advisor now lead with the outcome/problem; mechanism → `<sub>` footer.
- **automerge guard**: `⏸️ Held for a human — this build PR changes shared code under packages/` + **Fix:** line; files → `<details>`
- **close-epic**: `✅ Epic closed via /close-epic by @actor`
- **loop-station advisor**: fallback leads `⚠️ the LLM step failed — posting raw findings`; and the LLM prompt now points at the style guide

## 🤖 For agents
3 workflows. **Not touched (already conformant):** `housekeeping` posts a rendered digest (structured bands, 🧹 title leads). YAML validated.

## 🧪 How to test
A shared-code sub-PR / a `/close-epic` comment / a loop-station advisor LLM outage each posts a comment leading with the status, mechanism in the footer.