### PR TITLE
New theme: early MTV — day-glo blocks, clashing neon shadows, Memphis energy

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -123,6 +123,22 @@ const { variant } = useThemeSwitcher()
 
 ## Available Themes
 
+### MTV Theme (`./mtv`)
+
+Early-MTV (1981): day-glo color blocking, hard shadows in a CLASHING neon,
+a degree of tilt, stickers everywhere. Text stays ink-on-light — neon is for
+fills/shadows/accents only.
+
+**Design Language:**
+- Slabs with 2px ink borders and offset shadows in a *different* neon
+  (pink slab → cyan shadow, ink → pink, cyan → pink)
+- Shock palette: `--mtv-{ink,paper,pink,cyan,yellow,purple}`
+- Hover tilts ~1deg (disabled under `prefers-reduced-motion`); stickers pre-tilted
+- Card = taped-up promo (cyan header band, hazard-stripe footer); link = highlighter swipe
+
+**Nuxt UI Variants:** `mtv` / `mtv-{solid,outline,soft,ghost,link}` (UButton);
+`mtv` for UInput, UCard, UBadge, USeparator. USwitch themed ambiently.
+
 ### Brutalist Theme (`./brutalist`)
 
 Thick borders, hard shadows, zero subtlety — the anti-"tasteful SaaS" theme.

--- a/packages/crouton-themes/lib/subtractive.ts
+++ b/packages/crouton-themes/lib/subtractive.ts
@@ -16,7 +16,7 @@
 // Pure + deterministic — SSR and client must compute the identical class string
 // (hydration-mismatch rule from #364). No Date/random/env reads here, ever.
 
-type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist'
+type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv'
 
 // First matching prefix wins; a resolved string only ever carries one theme's
 // markers because `variant` is single-valued and the bw markers live on the
@@ -26,7 +26,8 @@ const MARKERS: Array<[prefix: string, theme: ThemeKey]> = [
   ['ko-', 'ko'],
   ['kr-', 'kr11'],
   ['bw-', 'bw'],
-  ['brutalist-', 'brutalist']
+  ['brutalist-', 'brutalist'],
+  ['mtv-', 'mtv']
 ]
 
 // text-* utilities that are NOT color (sizes, alignment, wrapping) — kept when a
@@ -65,6 +66,11 @@ const STRIP: Record<ThemeKey, (u: string) => boolean> = {
   // Brutalist keeps text sizes + line-height; owns color, decoration, motion,
   // weight/family/tracking/case, and link underlines.
   brutalist: u => isColor(u) || isDecor(u) || isMotion(u)
+    || /^(font|tracking)(-|$)/.test(u)
+    || /^(uppercase|lowercase|capitalize|normal-case)$/.test(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // MTV: same ownership profile as brutalist (slab formula with neon shadows).
+  mtv: u => isColor(u) || isDecor(u) || isMotion(u)
     || /^(font|tracking)(-|$)/.test(u)
     || /^(uppercase|lowercase|capitalize|normal-case)$/.test(u)
     || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u)

--- a/packages/crouton-themes/mtv/app.config.ts
+++ b/packages/crouton-themes/mtv/app.config.ts
@@ -1,0 +1,123 @@
+// Early-MTV Theme Configuration (#1346)
+// 1981: day-glo color blocking, hard shadows in a CLASHING neon, a degree of
+// tilt, stickers everywhere. Text stays ink-on-light (the KO readability rule).
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'fuchsia',
+      neutral: 'zinc'
+    },
+
+    button: {
+      // Subtractive base via the shared marker-gated replacer (#1304).
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'mtv': '',
+          'mtv-solid': '',
+          'mtv-outline': '',
+          'mtv-soft': '',
+          'mtv-ghost': '',
+          'mtv-link': ''
+        }
+      },
+      compoundVariants: [
+        // === MTV (day-glo slabs, clashing shadows) ===
+        { color: 'primary', variant: 'mtv', class: 'mtv-btn mtv-btn--pink' },
+        { color: 'neutral', variant: 'mtv', class: 'mtv-btn mtv-btn--ink' },
+        { color: 'error', variant: 'mtv', class: 'mtv-btn mtv-btn--cyan' },
+        { variant: 'mtv', class: 'mtv-btn' },
+
+        // === MTV-SOLID (alias of base) ===
+        { color: 'primary', variant: 'mtv-solid', class: 'mtv-btn mtv-btn--pink' },
+        { color: 'neutral', variant: 'mtv-solid', class: 'mtv-btn mtv-btn--ink' },
+        { color: 'error', variant: 'mtv-solid', class: 'mtv-btn mtv-btn--cyan' },
+        { variant: 'mtv-solid', class: 'mtv-btn' },
+
+        // === MTV-OUTLINE ===
+        { color: 'primary', variant: 'mtv-outline', class: 'mtv-outline mtv-outline--pink' },
+        { color: 'neutral', variant: 'mtv-outline', class: 'mtv-outline' },
+        { color: 'error', variant: 'mtv-outline', class: 'mtv-outline mtv-outline--cyan' },
+        { variant: 'mtv-outline', class: 'mtv-outline' },
+
+        // === MTV-SOFT (yellow sticker slab) ===
+        { color: 'primary', variant: 'mtv-soft', class: 'mtv-soft' },
+        { color: 'neutral', variant: 'mtv-soft', class: 'mtv-soft mtv-soft--purple' },
+        { color: 'error', variant: 'mtv-soft', class: 'mtv-soft mtv-soft--cyan' },
+        { variant: 'mtv-soft', class: 'mtv-soft' },
+
+        // === MTV-GHOST ===
+        { color: 'primary', variant: 'mtv-ghost', class: 'mtv-ghost' },
+        { color: 'neutral', variant: 'mtv-ghost', class: 'mtv-ghost' },
+        { color: 'error', variant: 'mtv-ghost', class: 'mtv-ghost mtv-ghost--cyan' },
+        { variant: 'mtv-ghost', class: 'mtv-ghost' },
+
+        // === MTV-LINK (highlighter swipe) ===
+        { color: 'primary', variant: 'mtv-link', class: 'mtv-link' },
+        { color: 'neutral', variant: 'mtv-link', class: 'mtv-link mtv-link--cyan' },
+        { color: 'error', variant: 'mtv-link', class: 'mtv-link mtv-link--yellow' },
+        { variant: 'mtv-link', class: 'mtv-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            root: 'mtv-input',
+            base: 'mtv-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            root: 'mtv-card',
+            header: 'mtv-card-header',
+            body: 'mtv-card-body',
+            footer: 'mtv-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          mtv: {
+            border: 'mtv-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: 'mtv-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/mtv/assets/css/main.css
+++ b/packages/crouton-themes/mtv/assets/css/main.css
@@ -1,0 +1,362 @@
+/* Early-MTV Theme (#1346)
+   1981: day-glo color blocking, hard offset shadows in a CLASHING neon
+   (pink slab, cyan shadow), a degree of tilt, zigzag rules, stickers.
+   Text stays ink-on-light everywhere — neon is for fills, shadows and
+   accents, never body copy (the #1304 KO readability rule).
+
+   No !important: the shared subtractive replacer (../lib/subtractive.ts)
+   strips the conflicting Nuxt UI defaults whenever an mtv- marker class
+   is present. */
+
+:root {
+  --mtv-ink: #17131f;
+  --mtv-paper: #f6f2ea;
+  --mtv-pink: #ff2d95;
+  --mtv-cyan: #00e5ff;
+  --mtv-yellow: #ffe600;
+  --mtv-purple: #7b2ff7;
+  --mtv-border: 2px;
+  --mtv-snap: 90ms;
+}
+
+/* ============================================
+   DATA-THEME AMBIENT — background only
+   ============================================ */
+
+[data-theme="mtv"],
+.theme-mtv {
+  background-color: var(--mtv-paper);
+}
+
+/* ============================================
+   SOLID BUTTONS — slab + clashing neon shadow
+   ============================================ */
+
+.mtv-btn {
+  background-color: var(--mtv-yellow);
+  color: var(--mtv-ink);
+  border: var(--mtv-border) solid var(--mtv-ink);
+  box-shadow: 4px 4px 0 var(--mtv-purple);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: transform var(--mtv-snap) ease-out, box-shadow var(--mtv-snap) ease-out;
+}
+
+.mtv-btn:hover {
+  transform: rotate(-1deg) translate(-1px, -1px);
+  box-shadow: 6px 6px 0 var(--mtv-purple);
+}
+
+.mtv-btn:active {
+  transform: rotate(0.5deg) translate(2px, 2px);
+  box-shadow: 1px 1px 0 var(--mtv-purple);
+}
+
+.mtv-btn--pink {
+  background-color: var(--mtv-pink);
+  color: var(--mtv-paper);
+  box-shadow: 4px 4px 0 var(--mtv-cyan);
+}
+
+.mtv-btn--pink:hover {
+  box-shadow: 6px 6px 0 var(--mtv-cyan);
+}
+
+.mtv-btn--pink:active {
+  box-shadow: 1px 1px 0 var(--mtv-cyan);
+}
+
+.mtv-btn--ink {
+  background-color: var(--mtv-ink);
+  color: var(--mtv-paper);
+  box-shadow: 4px 4px 0 var(--mtv-pink);
+}
+
+.mtv-btn--ink:hover {
+  box-shadow: 6px 6px 0 var(--mtv-pink);
+}
+
+.mtv-btn--ink:active {
+  box-shadow: 1px 1px 0 var(--mtv-pink);
+}
+
+.mtv-btn--cyan {
+  background-color: var(--mtv-cyan);
+  color: var(--mtv-ink);
+  box-shadow: 4px 4px 0 var(--mtv-pink);
+}
+
+.mtv-btn--cyan:hover {
+  box-shadow: 6px 6px 0 var(--mtv-pink);
+}
+
+.mtv-btn--cyan:active {
+  box-shadow: 1px 1px 0 var(--mtv-pink);
+}
+
+/* ============================================
+   OUTLINE — ink frame, neon flood on hover
+   ============================================ */
+
+.mtv-outline {
+  background-color: var(--mtv-paper);
+  color: var(--mtv-ink);
+  border: var(--mtv-border) solid var(--mtv-ink);
+  box-shadow: none;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: background-color var(--mtv-snap) ease-out, transform var(--mtv-snap) ease-out;
+}
+
+.mtv-outline:hover {
+  transform: rotate(-1deg);
+  background-color: var(--mtv-yellow);
+}
+
+.mtv-outline--pink:hover {
+  background-color: var(--mtv-pink);
+  color: var(--mtv-paper);
+}
+
+.mtv-outline--cyan:hover {
+  background-color: var(--mtv-cyan);
+}
+
+/* ============================================
+   SOFT — sticker slab, pre-tilted
+   ============================================ */
+
+.mtv-soft {
+  background-color: var(--mtv-yellow);
+  color: var(--mtv-ink);
+  border: none;
+  box-shadow: none;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transform: rotate(-1deg);
+  transition: transform var(--mtv-snap) ease-out;
+}
+
+.mtv-soft:hover {
+  transform: rotate(1deg) scale(1.04);
+}
+
+.mtv-soft--purple {
+  background-color: var(--mtv-purple);
+  color: var(--mtv-paper);
+}
+
+.mtv-soft--cyan {
+  background-color: var(--mtv-cyan);
+}
+
+/* ============================================
+   GHOST — quiet until it clashes
+   ============================================ */
+
+.mtv-ghost {
+  background-color: transparent;
+  color: var(--mtv-ink);
+  border: none;
+  box-shadow: none;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: color var(--mtv-snap) ease-out, background-color var(--mtv-snap) ease-out;
+}
+
+.mtv-ghost:hover {
+  background-color: var(--mtv-ink);
+  color: var(--mtv-yellow);
+}
+
+.mtv-ghost--cyan:hover {
+  color: var(--mtv-cyan);
+}
+
+/* ============================================
+   LINK — highlighter swipe
+   ============================================ */
+
+.mtv-link {
+  background-color: transparent;
+  color: var(--mtv-ink);
+  border: none;
+  box-shadow: none;
+  font-weight: 800;
+  text-decoration: none;
+  background-image: linear-gradient(var(--mtv-pink), var(--mtv-pink));
+  background-repeat: no-repeat;
+  background-size: 100% 0.4em;
+  background-position: 0 88%;
+  transition: background-size var(--mtv-snap) ease-out;
+}
+
+.mtv-link:hover {
+  background-size: 100% 100%;
+  color: var(--mtv-paper);
+}
+
+.mtv-link--cyan {
+  background-image: linear-gradient(var(--mtv-cyan), var(--mtv-cyan));
+}
+
+.mtv-link--cyan:hover {
+  color: var(--mtv-ink);
+}
+
+.mtv-link--yellow {
+  background-image: linear-gradient(var(--mtv-yellow), var(--mtv-yellow));
+}
+
+.mtv-link--yellow:hover {
+  color: var(--mtv-ink);
+}
+
+/* ============================================
+   INPUTS — a block you shout into
+   ============================================ */
+
+.mtv-input {
+  width: 100%;
+}
+
+.mtv-input-base {
+  background-color: #fff;
+  color: var(--mtv-ink);
+  border: var(--mtv-border) solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--mtv-cyan);
+  font-weight: 600;
+  caret-color: var(--mtv-pink);
+  transition: box-shadow var(--mtv-snap) ease-out;
+}
+
+.mtv-input-base::placeholder {
+  color: var(--mtv-ink);
+  opacity: 0.45;
+}
+
+.mtv-input-base:focus {
+  outline: none;
+  box-shadow: 4px 4px 0 var(--mtv-pink);
+}
+
+.mtv-input-base:disabled {
+  box-shadow: none;
+  border-style: dashed;
+  background-color: transparent;
+}
+
+/* ============================================
+   CARD — a taped-up promo
+   ============================================ */
+
+.mtv-card {
+  background-color: #fff;
+  border: var(--mtv-border) solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 8px 8px 0 var(--mtv-pink);
+  overflow: hidden;
+}
+
+.mtv-card-header {
+  background-color: var(--mtv-cyan);
+  border-bottom: var(--mtv-border) solid var(--mtv-ink);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.75rem 1rem;
+}
+
+.mtv-card-body {
+  padding: 1rem;
+}
+
+.mtv-card-footer {
+  border-top: var(--mtv-border) solid var(--mtv-ink);
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0 10px,
+    var(--mtv-yellow) 10px 20px
+  );
+  padding: 0.75rem 1rem;
+}
+
+/* ============================================
+   SEPARATOR — zigzag rule
+   ============================================ */
+
+.mtv-separator {
+  border: none;
+  height: 8px;
+  background-image: linear-gradient(135deg, var(--mtv-pink) 25%, transparent 25%),
+    linear-gradient(225deg, var(--mtv-pink) 25%, transparent 25%);
+  background-size: 16px 8px;
+  background-repeat: repeat-x;
+}
+
+/* ============================================
+   BADGE — a sticker, slightly askew
+   ============================================ */
+
+.mtv-badge {
+  background-color: var(--mtv-yellow);
+  color: var(--mtv-ink);
+  border: 2px solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--mtv-purple);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transform: rotate(-2deg);
+}
+
+/* ============================================
+   VARIANT-LESS CHROME — USwitch (#1333 pattern)
+   ============================================ */
+
+[data-theme="mtv"] button[role="switch"],
+.theme-mtv button[role="switch"] {
+  border-radius: 0;
+  border: var(--mtv-border) solid var(--mtv-ink);
+  background-color: #fff;
+  box-shadow: 2px 2px 0 var(--mtv-purple);
+  transition: background-color var(--mtv-snap) ease-out;
+}
+
+[data-theme="mtv"] button[role="switch"][data-state="checked"],
+.theme-mtv button[role="switch"][data-state="checked"] {
+  background-color: var(--mtv-pink);
+  box-shadow: 2px 2px 0 var(--mtv-cyan);
+}
+
+[data-theme="mtv"] button[role="switch"] > span,
+.theme-mtv button[role="switch"] > span {
+  border-radius: 0;
+  background-color: var(--mtv-ink);
+  transition: none;
+}
+
+/* ============================================
+   REDUCED MOTION — kill the wiggle, keep the look
+   ============================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .mtv-btn,
+  .mtv-outline,
+  .mtv-soft {
+    transition: none;
+  }
+
+  .mtv-btn:hover,
+  .mtv-btn:active,
+  .mtv-outline:hover,
+  .mtv-soft,
+  .mtv-soft:hover {
+    transform: none;
+  }
+}

--- a/packages/crouton-themes/mtv/nuxt.config.ts
+++ b/packages/crouton-themes/mtv/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/mtv',
+    description: 'Early-MTV theme for Nuxt UI — day-glo blocks, clashing neon shadows, Memphis energy'
+  },
+  css: [join(currentDir, 'assets/css/main.css')]
+})

--- a/packages/crouton-themes/package.json
+++ b/packages/crouton-themes/package.json
@@ -15,7 +15,9 @@
     "./blackandwhite": "./blackandwhite/nuxt.config.ts",
     "./blackandwhite/*": "./blackandwhite/*",
     "./brutalist": "./brutalist/nuxt.config.ts",
-    "./brutalist/*": "./brutalist/*"
+    "./brutalist/*": "./brutalist/*",
+    "./mtv": "./mtv/nuxt.config.ts",
+    "./mtv/*": "./mtv/*"
   },
   "files": [
     "themes",
@@ -24,6 +26,7 @@
     "kr11",
     "blackandwhite",
     "brutalist",
+    "mtv",
     "lib"
   ],
   "keywords": [

--- a/packages/crouton-themes/playground/nuxt.config.ts
+++ b/packages/crouton-themes/playground/nuxt.config.ts
@@ -22,6 +22,7 @@ export default defineNuxtConfig({
     '../minimal',
     '../kr11',
     '../blackandwhite',
-    '../brutalist'
+    '../brutalist',
+    '../mtv'
   ]
 })

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -4,7 +4,7 @@
 
 import { THEME_UI_CONFIGS } from '../configs/themeConfigs'
 
-export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'default'
+export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'default'
 
 type BaseVariant = 'solid' | 'outline' | 'soft' | 'ghost' | 'link'
 
@@ -59,6 +59,13 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     label: 'Brutalist',
     description: 'Thick borders, hard shadows, zero subtlety',
     colors: ['#0a0a0a', '#ffd800', '#fdfbf5'], // ink, shock yellow, paper
+    defaultVariant: 'solid'
+  },
+  {
+    name: 'mtv',
+    label: 'MTV',
+    description: 'Day-glo blocks, clashing neon shadows, Memphis energy',
+    colors: ['#ff2d95', '#00e5ff', '#ffe600'], // pink, cyan, yellow
     defaultVariant: 'solid'
   }
 ]

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -103,6 +103,18 @@ const brutalistConfig: ThemeUIConfig = {
   badge: { defaultVariants: { variant: 'brutalist' } }
 }
 
+// MTV — named variants registered by mtv/app.config.ts
+const mtvConfig: ThemeUIConfig = {
+  colors: {
+    primary: 'fuchsia',
+    neutral: 'zinc'
+  },
+  button: { defaultVariants: { variant: 'mtv' } },
+  input: { defaultVariants: { variant: 'mtv' } },
+  card: { defaultVariants: { variant: 'mtv' } },
+  badge: { defaultVariants: { variant: 'mtv' } }
+}
+
 // Export all theme configs
 export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   default: defaultConfig,
@@ -110,5 +122,6 @@ export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   minimal: minimalConfig,
   kr11: kr11Config,
   blackandwhite: blackandwhiteConfig,
-  brutalist: brutalistConfig
+  brutalist: brutalistConfig,
+  mtv: mtvConfig
 }


### PR DESCRIPTION
Closes #1346

> Top of the stack: #1349 (KR-11 fidelity) → #1344 (Brutalist) → #1330 (themes rework) → #1314 (playground).

## 👤 For humans

1981 in a theme: hot pink, electric cyan, acid yellow and purple crashing into each other. The signature move is shadows in a **different** neon than the fill (pink slab → cyan shadow); stickers sit askew, hovers tilt a degree, the card footer is hazard-striped, links get a highlighter swipe. Loud on purpose — but text stays black-on-light, so it's readable (the KO lesson).

## 🤖 For agents

- New layer `packages/crouton-themes/mtv/` per the recipe; named variants `mtv` / `mtv-*`; `--mtv-*` tokens; zero `!important` (marker + strip set in `lib/subtractive.ts`).
- ~1deg hover tilt with a `prefers-reduced-motion` kill switch; ambient rule = background only; USwitch themed ambiently (the #1333 pattern).
- Registered across all convention surfaces; typecheck green; verified in the playground.

## 🧪 How to test

Playground preview → switch to **MTV**: primary is a pink slab with a cyan shadow, neutral ink-with-pink, error cyan-with-pink; Soft is a yellow sticker; the card header is a cyan band over a hazard-stripe footer; the badge tilts; the toggle goes pink. Hover a button — it tilts a degree and the shadow grows. Enable "reduce motion" in OS settings — the tilt disappears, the look stays.

_Dedup-checked: sub-issue #1346 of epic #1303 (owner-requested; distinct from the #1311 vaporwave pitch)._

---
> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account