### PR TITLE
New theme: Terminal/CRT — phosphor on black, scanlines, inverse video

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -123,6 +123,20 @@ const { variant } = useThemeSwitcher()
 
 ## Available Themes
 
+### Terminal Theme (`./terminal`)
+
+Green phosphor on near-black — monospace everything, faint glow, inverse-video
+states, subtle scanline overlay. Amber is the alert channel.
+
+**Design Language:** `--term-{bg,bg-raised,phosphor,phosphor-dim,phosphor-soft,amber,glow}`;
+primary = inverse video, neutral = framed, error = amber; ghost renders a `> ` prompt;
+links use dashed underscores. The ambient rule sets the tube background, readable light
+text AND `--ui-bg` (so app shells painting with the Nuxt UI surface token go dark too).
+
+**Nuxt UI Variants:** `terminal` / `terminal-{solid,outline,soft,ghost,link}` (UButton);
+`terminal` for UInput, UCard, UBadge, USeparator. USwitch themed ambiently (phosphor LED).
+Built on replacers per the #1305 spike verdict — not `unstyled`.
+
 ### MTV Theme (`./mtv`)
 
 Early-MTV (1981): day-glo color blocking, hard shadows in a CLASHING neon,

--- a/packages/crouton-themes/lib/subtractive.ts
+++ b/packages/crouton-themes/lib/subtractive.ts
@@ -16,7 +16,7 @@
 // Pure + deterministic — SSR and client must compute the identical class string
 // (hydration-mismatch rule from #364). No Date/random/env reads here, ever.
 
-type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv'
+type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv' | 'terminal'
 
 // First matching prefix wins; a resolved string only ever carries one theme's
 // markers because `variant` is single-valued and the bw markers live on the
@@ -27,7 +27,8 @@ const MARKERS: Array<[prefix: string, theme: ThemeKey]> = [
   ['kr-', 'kr11'],
   ['bw-', 'bw'],
   ['brutalist-', 'brutalist'],
-  ['mtv-', 'mtv']
+  ['mtv-', 'mtv'],
+  ['term-', 'terminal']
 ]
 
 // text-* utilities that are NOT color (sizes, alignment, wrapping) — kept when a
@@ -73,6 +74,10 @@ const STRIP: Record<ThemeKey, (u: string) => boolean> = {
   mtv: u => isColor(u) || isDecor(u) || isMotion(u)
     || /^(font|tracking)(-|$)/.test(u)
     || /^(uppercase|lowercase|capitalize|normal-case)$/.test(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // Terminal: monospace phosphor — owns typography wholesale (like ko/kr11)
+  // plus color, decoration, motion and underlines.
+  terminal: u => isColor(u) || /^text-/.test(u) || isDecor(u) || isMotion(u) || isType(u)
     || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u)
 }
 

--- a/packages/crouton-themes/package.json
+++ b/packages/crouton-themes/package.json
@@ -17,7 +17,9 @@
     "./brutalist": "./brutalist/nuxt.config.ts",
     "./brutalist/*": "./brutalist/*",
     "./mtv": "./mtv/nuxt.config.ts",
-    "./mtv/*": "./mtv/*"
+    "./mtv/*": "./mtv/*",
+    "./terminal": "./terminal/nuxt.config.ts",
+    "./terminal/*": "./terminal/*"
   },
   "files": [
     "themes",
@@ -27,6 +29,7 @@
     "blackandwhite",
     "brutalist",
     "mtv",
+    "terminal",
     "lib"
   ],
   "keywords": [

--- a/packages/crouton-themes/playground/nuxt.config.ts
+++ b/packages/crouton-themes/playground/nuxt.config.ts
@@ -23,6 +23,7 @@ export default defineNuxtConfig({
     '../kr11',
     '../blackandwhite',
     '../brutalist',
-    '../mtv'
+    '../mtv',
+    '../terminal'
   ]
 })

--- a/packages/crouton-themes/terminal/app.config.ts
+++ b/packages/crouton-themes/terminal/app.config.ts
@@ -1,0 +1,122 @@
+// Terminal / CRT Theme Configuration (#1308)
+// Green phosphor on near-black, monospace, glow, inverse-video states.
+// Built on replacers per the #1305 spike verdict (NOT unstyled-native).
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'green',
+      neutral: 'zinc'
+    },
+
+    button: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'terminal': '',
+          'terminal-solid': '',
+          'terminal-outline': '',
+          'terminal-soft': '',
+          'terminal-ghost': '',
+          'terminal-link': ''
+        }
+      },
+      compoundVariants: [
+        // === TERMINAL (inverse-video primary, bracketed others) ===
+        { color: 'primary', variant: 'terminal', class: 'term-btn term-btn--inverse' },
+        { color: 'neutral', variant: 'terminal', class: 'term-btn' },
+        { color: 'error', variant: 'terminal', class: 'term-btn term-btn--amber' },
+        { variant: 'terminal', class: 'term-btn' },
+
+        // === TERMINAL-SOLID (alias) ===
+        { color: 'primary', variant: 'terminal-solid', class: 'term-btn term-btn--inverse' },
+        { color: 'neutral', variant: 'terminal-solid', class: 'term-btn' },
+        { color: 'error', variant: 'terminal-solid', class: 'term-btn term-btn--amber' },
+        { variant: 'terminal-solid', class: 'term-btn' },
+
+        // === TERMINAL-OUTLINE (double-frame) ===
+        { color: 'primary', variant: 'terminal-outline', class: 'term-outline' },
+        { color: 'neutral', variant: 'terminal-outline', class: 'term-outline' },
+        { color: 'error', variant: 'terminal-outline', class: 'term-outline term-outline--amber' },
+        { variant: 'terminal-outline', class: 'term-outline' },
+
+        // === TERMINAL-SOFT (dim field) ===
+        { color: 'primary', variant: 'terminal-soft', class: 'term-soft' },
+        { color: 'neutral', variant: 'terminal-soft', class: 'term-soft' },
+        { color: 'error', variant: 'terminal-soft', class: 'term-soft term-soft--amber' },
+        { variant: 'terminal-soft', class: 'term-soft' },
+
+        // === TERMINAL-GHOST (bare prompt) ===
+        { color: 'primary', variant: 'terminal-ghost', class: 'term-ghost' },
+        { color: 'neutral', variant: 'terminal-ghost', class: 'term-ghost' },
+        { color: 'error', variant: 'terminal-ghost', class: 'term-ghost term-ghost--amber' },
+        { variant: 'terminal-ghost', class: 'term-ghost' },
+
+        // === TERMINAL-LINK (underscore cursor) ===
+        { color: 'primary', variant: 'terminal-link', class: 'term-link' },
+        { color: 'neutral', variant: 'terminal-link', class: 'term-link' },
+        { color: 'error', variant: 'terminal-link', class: 'term-link term-link--amber' },
+        { variant: 'terminal-link', class: 'term-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            root: 'term-input',
+            base: 'term-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            root: 'term-card',
+            header: 'term-card-header',
+            body: 'term-card-body',
+            footer: 'term-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          terminal: {
+            border: 'term-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: 'term-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/terminal/assets/css/main.css
+++ b/packages/crouton-themes/terminal/assets/css/main.css
@@ -1,0 +1,333 @@
+/* Terminal / CRT Theme (#1308)
+   Green phosphor on near-black, monospace everything, faint glow,
+   inverse-video states, scanline overlay. Amber is the alert channel.
+   Built on the shared subtractive replacer (../lib/subtractive.ts) per the
+   #1305 spike verdict — no !important, no unstyled:true. */
+
+:root {
+  --term-bg: #0a0f0a;
+  --term-bg-raised: #101710;
+  --term-phosphor: #33ff66;
+  --term-phosphor-dim: #1d9e44;
+  --term-phosphor-soft: #bfe8c9;   /* readable body text on the dark tube */
+  --term-amber: #ffb000;
+  --term-glow: 0 0 6px rgba(51, 255, 102, 0.45);
+  --term-glow-amber: 0 0 6px rgba(255, 176, 0, 0.45);
+  --term-font: ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+}
+
+/* ============================================
+   DATA-THEME AMBIENT — the tube
+   A dark theme must also set readable base text color (this is surface
+   color, not a font takeover — the #1304 rule concerns typography).
+   ============================================ */
+
+[data-theme="terminal"],
+.theme-terminal {
+  background-color: var(--term-bg);
+  color: var(--term-phosphor-soft);
+  /* Drive Nuxt UI's surface token too — app shells (incl. the playground
+     wrapper) paint with var(--ui-bg), which would otherwise stay light. */
+  --ui-bg: var(--term-bg);
+}
+
+/* Scanlines: subtle, pure-CSS, on a non-interactive overlay. */
+[data-theme="terminal"] body::after,
+body.theme-terminal::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.14) 0 1px,
+    transparent 1px 3px
+  );
+}
+
+/* ============================================
+   BUTTONS — [ LABEL ] energy
+   ============================================ */
+
+.term-btn {
+  font-family: var(--term-font);
+  background-color: var(--term-bg-raised);
+  color: var(--term-phosphor);
+  border: 1px solid var(--term-phosphor);
+  border-radius: 0;
+  text-shadow: var(--term-glow);
+  box-shadow: none;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.term-btn:hover {
+  background-color: var(--term-phosphor);
+  color: var(--term-bg);
+  text-shadow: none;
+  box-shadow: var(--term-glow);
+}
+
+.term-btn--inverse {
+  background-color: var(--term-phosphor);
+  color: var(--term-bg);
+  text-shadow: none;
+  box-shadow: var(--term-glow);
+}
+
+.term-btn--inverse:hover {
+  background-color: var(--term-bg-raised);
+  color: var(--term-phosphor);
+  text-shadow: var(--term-glow);
+}
+
+.term-btn--amber {
+  color: var(--term-amber);
+  border-color: var(--term-amber);
+  text-shadow: var(--term-glow-amber);
+}
+
+.term-btn--amber:hover {
+  background-color: var(--term-amber);
+  color: var(--term-bg);
+  text-shadow: none;
+  box-shadow: var(--term-glow-amber);
+}
+
+/* ============================================
+   OUTLINE — double frame
+   ============================================ */
+
+.term-outline {
+  font-family: var(--term-font);
+  background-color: transparent;
+  color: var(--term-phosphor);
+  border: 1px solid var(--term-phosphor);
+  outline: 1px solid var(--term-phosphor-dim);
+  outline-offset: 2px;
+  border-radius: 0;
+  text-shadow: var(--term-glow);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.term-outline:hover {
+  background-color: rgba(51, 255, 102, 0.12);
+}
+
+.term-outline--amber {
+  color: var(--term-amber);
+  border-color: var(--term-amber);
+  outline-color: rgba(255, 176, 0, 0.5);
+  text-shadow: var(--term-glow-amber);
+}
+
+/* ============================================
+   SOFT — dim field
+   ============================================ */
+
+.term-soft {
+  font-family: var(--term-font);
+  background-color: rgba(51, 255, 102, 0.14);
+  color: var(--term-phosphor);
+  border: none;
+  border-radius: 0;
+  text-shadow: var(--term-glow);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.term-soft:hover {
+  background-color: rgba(51, 255, 102, 0.24);
+}
+
+.term-soft--amber {
+  background-color: rgba(255, 176, 0, 0.14);
+  color: var(--term-amber);
+  text-shadow: var(--term-glow-amber);
+}
+
+/* ============================================
+   GHOST — bare prompt
+   ============================================ */
+
+.term-ghost {
+  font-family: var(--term-font);
+  background-color: transparent;
+  color: var(--term-phosphor-dim);
+  border: none;
+  border-radius: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.term-ghost:hover {
+  color: var(--term-phosphor);
+  text-shadow: var(--term-glow);
+}
+
+.term-ghost::before {
+  content: '> ';
+}
+
+.term-ghost--amber:hover {
+  color: var(--term-amber);
+  text-shadow: var(--term-glow-amber);
+}
+
+/* ============================================
+   LINK — underscore cursor
+   ============================================ */
+
+.term-link {
+  font-family: var(--term-font);
+  background-color: transparent;
+  color: var(--term-phosphor);
+  border: none;
+  border-radius: 0;
+  text-shadow: var(--term-glow);
+  text-decoration: underline;
+  text-decoration-style: dashed;
+  text-underline-offset: 4px;
+  transition: none;
+}
+
+.term-link:hover {
+  text-decoration-style: solid;
+  background-color: rgba(51, 255, 102, 0.12);
+}
+
+.term-link--amber {
+  color: var(--term-amber);
+  text-shadow: var(--term-glow-amber);
+}
+
+/* ============================================
+   INPUTS — the prompt line
+   ============================================ */
+
+.term-input {
+  width: 100%;
+}
+
+.term-input-base {
+  font-family: var(--term-font);
+  background-color: var(--term-bg);
+  color: var(--term-phosphor);
+  border: 1px solid var(--term-phosphor-dim);
+  border-radius: 0;
+  caret-color: var(--term-phosphor);
+  text-shadow: var(--term-glow);
+  box-shadow: inset 0 0 12px rgba(51, 255, 102, 0.07);
+  transition: none;
+}
+
+.term-input-base::placeholder {
+  color: var(--term-phosphor-dim);
+  text-shadow: none;
+}
+
+.term-input-base:focus {
+  outline: none;
+  border-color: var(--term-phosphor);
+  box-shadow:
+    inset 0 0 12px rgba(51, 255, 102, 0.12),
+    var(--term-glow);
+}
+
+.term-input-base:disabled {
+  color: var(--term-phosphor-dim);
+  border-style: dashed;
+  text-shadow: none;
+}
+
+/* ============================================
+   CARD — a framed readout
+   ============================================ */
+
+.term-card {
+  font-family: var(--term-font);
+  background-color: var(--term-bg-raised);
+  border: 1px solid var(--term-phosphor-dim);
+  border-radius: 0;
+  box-shadow: inset 0 0 24px rgba(51, 255, 102, 0.05);
+}
+
+.term-card-header {
+  color: var(--term-phosphor);
+  border-bottom: 1px dashed var(--term-phosphor-dim);
+  text-shadow: var(--term-glow);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.75rem 1rem;
+}
+
+.term-card-body {
+  color: var(--term-phosphor-soft);
+  padding: 1rem;
+}
+
+.term-card-footer {
+  border-top: 1px dashed var(--term-phosphor-dim);
+  padding: 0.75rem 1rem;
+}
+
+/* ============================================
+   SEPARATOR — a dashed rule
+   ============================================ */
+
+.term-separator {
+  border-style: dashed;
+  border-color: var(--term-phosphor-dim);
+}
+
+/* ============================================
+   BADGE — a status flag
+   ============================================ */
+
+.term-badge {
+  font-family: var(--term-font);
+  background-color: transparent;
+  color: var(--term-phosphor);
+  border: 1px solid var(--term-phosphor);
+  border-radius: 0;
+  text-shadow: var(--term-glow);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ============================================
+   VARIANT-LESS CHROME — USwitch (#1333 pattern)
+   ============================================ */
+
+[data-theme="terminal"] button[role="switch"],
+.theme-terminal button[role="switch"] {
+  border-radius: 0;
+  border: 1px solid var(--term-phosphor-dim);
+  background-color: var(--term-bg-raised);
+  transition: none;
+}
+
+[data-theme="terminal"] button[role="switch"][data-state="checked"],
+.theme-terminal button[role="switch"][data-state="checked"] {
+  border-color: var(--term-phosphor);
+  background-color: rgba(51, 255, 102, 0.18);
+  box-shadow: var(--term-glow);
+}
+
+[data-theme="terminal"] button[role="switch"] > span,
+.theme-terminal button[role="switch"] > span {
+  border-radius: 0;
+  background-color: var(--term-phosphor-dim);
+  transition: none;
+}
+
+[data-theme="terminal"] button[role="switch"][data-state="checked"] > span,
+.theme-terminal button[role="switch"][data-state="checked"] > span {
+  background-color: var(--term-phosphor);
+}

--- a/packages/crouton-themes/terminal/nuxt.config.ts
+++ b/packages/crouton-themes/terminal/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/terminal',
+    description: 'Terminal/CRT theme for Nuxt UI — phosphor on black, scanlines, block cursors'
+  },
+  css: [join(currentDir, 'assets/css/main.css')]
+})

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -4,7 +4,7 @@
 
 import { THEME_UI_CONFIGS } from '../configs/themeConfigs'
 
-export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'default'
+export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'terminal' | 'default'
 
 type BaseVariant = 'solid' | 'outline' | 'soft' | 'ghost' | 'link'
 
@@ -66,6 +66,13 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     label: 'MTV',
     description: 'Day-glo blocks, clashing neon shadows, Memphis energy',
     colors: ['#ff2d95', '#00e5ff', '#ffe600'], // pink, cyan, yellow
+    defaultVariant: 'solid'
+  },
+  {
+    name: 'terminal',
+    label: 'Terminal',
+    description: 'Green phosphor on black, scanlines, inverse video',
+    colors: ['#33ff66', '#0a0f0a', '#ffb000'], // phosphor, tube, amber
     defaultVariant: 'solid'
   }
 ]

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -115,6 +115,18 @@ const mtvConfig: ThemeUIConfig = {
   badge: { defaultVariants: { variant: 'mtv' } }
 }
 
+// Terminal — named variants registered by terminal/app.config.ts
+const terminalConfig: ThemeUIConfig = {
+  colors: {
+    primary: 'green',
+    neutral: 'zinc'
+  },
+  button: { defaultVariants: { variant: 'terminal' } },
+  input: { defaultVariants: { variant: 'terminal' } },
+  card: { defaultVariants: { variant: 'terminal' } },
+  badge: { defaultVariants: { variant: 'terminal' } }
+}
+
 // Export all theme configs
 export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   default: defaultConfig,
@@ -123,5 +135,6 @@ export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   kr11: kr11Config,
   blackandwhite: blackandwhiteConfig,
   brutalist: brutalistConfig,
-  mtv: mtvConfig
+  mtv: mtvConfig,
+  terminal: terminalConfig
 }


### PR DESCRIPTION
Closes #1308

## 👤 For humans
Green phosphor on a near-black tube: monospace, faint glow, scanlines, inverse-video primary, a `> ` prompt on ghost buttons, amber alerts, a phosphor-LED toggle. Built on replacers per the #1305 spike verdict.

## 🧪 How to test
Playground preview → switch to **Terminal**: the whole page goes dark tube (scanlines included); tab through controls — focus rings survive; inputs read as prompt lines with a phosphor caret; the disabled input goes dashed; the card is a framed readout.

Owner approval standing (epic #1303, "keep building the list, and merge them", 2026-07-10).

_Dedup-checked: sub-issue #1308 of epic #1303._

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account