### PR TITLE
New theme: Braun/Rams hi-fi — cream chassis, hairlines, one orange accent

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -123,6 +123,17 @@ const { variant } = useThemeSwitcher()
 
 ## Available Themes
 
+### Braun Theme (`./braun`)
+
+Warm analog hi-fi (Dieter Rams): cream chassis, 1px hairlines, very soft real
+shadows, machined 3px radii, small letterspaced silkscreen labels, and the ONE
+signature orange. The calm sibling of KO/KR-11.
+
+**Nuxt UI Variants:** `braun` / `braun-{solid,outline,soft,ghost,link}` (UButton);
+`braun` for UInput, UCard, UBadge, USeparator. USwitch = the sliding pill toggle
+(ambient). **Custom components:** `<BraunKnob>` (drag dial with orange index),
+`<BraunLabel>` (silkscreen label). Tokens: `--braun-{cream,cream-raised,charcoal,hairline,orange,red,text,label,radius,shadow,shadow-pressed,ease}`.
+
 ### Terminal Theme (`./terminal`)
 
 Green phosphor on near-black — monospace everything, faint glow, inverse-video

--- a/packages/crouton-themes/braun/app.config.ts
+++ b/packages/crouton-themes/braun/app.config.ts
@@ -1,0 +1,122 @@
+// Braun / Rams Hi-Fi Theme Configuration (#1309)
+// Warm analog hardware: cream chassis, precise hairlines, machined radii,
+// the one signature orange. As little design as possible — but tactile.
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'orange',
+      neutral: 'stone'
+    },
+
+    button: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'braun': '',
+          'braun-solid': '',
+          'braun-outline': '',
+          'braun-soft': '',
+          'braun-ghost': '',
+          'braun-link': ''
+        }
+      },
+      compoundVariants: [
+        // === BRAUN (machined keys) ===
+        { color: 'primary', variant: 'braun', class: 'braun-btn braun-btn--orange' },
+        { color: 'neutral', variant: 'braun', class: 'braun-btn braun-btn--charcoal' },
+        { color: 'error', variant: 'braun', class: 'braun-btn braun-btn--red' },
+        { variant: 'braun', class: 'braun-btn' },
+
+        // === BRAUN-SOLID (alias) ===
+        { color: 'primary', variant: 'braun-solid', class: 'braun-btn braun-btn--orange' },
+        { color: 'neutral', variant: 'braun-solid', class: 'braun-btn braun-btn--charcoal' },
+        { color: 'error', variant: 'braun-solid', class: 'braun-btn braun-btn--red' },
+        { variant: 'braun-solid', class: 'braun-btn' },
+
+        // === BRAUN-OUTLINE (hairline key) ===
+        { color: 'primary', variant: 'braun-outline', class: 'braun-outline braun-outline--orange' },
+        { color: 'neutral', variant: 'braun-outline', class: 'braun-outline' },
+        { color: 'error', variant: 'braun-outline', class: 'braun-outline braun-outline--red' },
+        { variant: 'braun-outline', class: 'braun-outline' },
+
+        // === BRAUN-SOFT (recessed key) ===
+        { color: 'primary', variant: 'braun-soft', class: 'braun-soft braun-soft--orange' },
+        { color: 'neutral', variant: 'braun-soft', class: 'braun-soft' },
+        { color: 'error', variant: 'braun-soft', class: 'braun-soft braun-soft--red' },
+        { variant: 'braun-soft', class: 'braun-soft' },
+
+        // === BRAUN-GHOST (silkscreen label) ===
+        { color: 'primary', variant: 'braun-ghost', class: 'braun-ghost braun-ghost--orange' },
+        { color: 'neutral', variant: 'braun-ghost', class: 'braun-ghost' },
+        { color: 'error', variant: 'braun-ghost', class: 'braun-ghost braun-ghost--red' },
+        { variant: 'braun-ghost', class: 'braun-ghost' },
+
+        // === BRAUN-LINK (index line) ===
+        { color: 'primary', variant: 'braun-link', class: 'braun-link braun-link--orange' },
+        { color: 'neutral', variant: 'braun-link', class: 'braun-link' },
+        { color: 'error', variant: 'braun-link', class: 'braun-link braun-link--red' },
+        { variant: 'braun-link', class: 'braun-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            root: 'braun-input',
+            base: 'braun-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            root: 'braun-card',
+            header: 'braun-card-header',
+            body: 'braun-card-body',
+            footer: 'braun-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          braun: {
+            border: 'braun-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: 'braun-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/braun/assets/css/main.css
+++ b/packages/crouton-themes/braun/assets/css/main.css
@@ -1,0 +1,324 @@
+/* Braun / Rams Hi-Fi Theme (#1309)
+   Warm analog hardware — cream chassis, 1px hairlines, very soft REAL
+   shadows (unlike brutalist's hard ones), machined 3px radii, small
+   letterspaced silkscreen labels, the ONE signature orange.
+   No !important: built on the shared subtractive replacer. */
+
+:root {
+  --braun-cream: #f2efe9;        /* chassis */
+  --braun-cream-raised: #faf8f4; /* key faces */
+  --braun-charcoal: #2e2c29;     /* ink + dark keys */
+  --braun-hairline: #d5d0c7;     /* 1px machine lines */
+  --braun-orange: #f26c1d;       /* THE accent */
+  --braun-red: #b8452f;          /* muted alert */
+  --braun-text: #3a3835;
+  --braun-label: #8a857d;        /* silkscreen gray */
+  --braun-radius: 3px;
+  --braun-shadow: 0 1px 2px rgba(46, 44, 41, 0.12), 0 2px 6px rgba(46, 44, 41, 0.06);
+  --braun-shadow-pressed: inset 0 1px 3px rgba(46, 44, 41, 0.18);
+  --braun-ease: 120ms ease;
+}
+
+/* ============================================
+   DATA-THEME AMBIENT — the chassis
+   ============================================ */
+
+[data-theme="braun"],
+.theme-braun {
+  background-color: var(--braun-cream);
+  --ui-bg: var(--braun-cream);
+}
+
+/* ============================================
+   BUTTONS — machined keys
+   ============================================ */
+
+.braun-btn {
+  background-color: var(--braun-cream-raised);
+  color: var(--braun-text);
+  border: 1px solid var(--braun-hairline);
+  border-radius: var(--braun-radius);
+  box-shadow: var(--braun-shadow);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: box-shadow var(--braun-ease), background-color var(--braun-ease);
+}
+
+.braun-btn:hover {
+  background-color: #fff;
+}
+
+.braun-btn:active {
+  box-shadow: var(--braun-shadow-pressed);
+}
+
+.braun-btn--orange {
+  background-color: var(--braun-orange);
+  color: #fff;
+  border-color: transparent;
+}
+
+.braun-btn--orange:hover {
+  background-color: #e2600f;
+}
+
+.braun-btn--charcoal {
+  background-color: var(--braun-charcoal);
+  color: var(--braun-cream);
+  border-color: transparent;
+}
+
+.braun-btn--charcoal:hover {
+  background-color: #3c3a36;
+}
+
+.braun-btn--red {
+  background-color: var(--braun-red);
+  color: #fff;
+  border-color: transparent;
+}
+
+.braun-btn--red:hover {
+  background-color: #a63c28;
+}
+
+/* ============================================
+   OUTLINE — hairline key
+   ============================================ */
+
+.braun-outline {
+  background-color: transparent;
+  color: var(--braun-text);
+  border: 1px solid var(--braun-charcoal);
+  border-radius: var(--braun-radius);
+  box-shadow: none;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: background-color var(--braun-ease);
+}
+
+.braun-outline:hover {
+  background-color: var(--braun-cream-raised);
+}
+
+.braun-outline--orange {
+  color: var(--braun-orange);
+  border-color: var(--braun-orange);
+}
+
+.braun-outline--red {
+  color: var(--braun-red);
+  border-color: var(--braun-red);
+}
+
+/* ============================================
+   SOFT — recessed key
+   ============================================ */
+
+.braun-soft {
+  background-color: rgba(46, 44, 41, 0.06);
+  color: var(--braun-text);
+  border: none;
+  border-radius: var(--braun-radius);
+  box-shadow: var(--braun-shadow-pressed);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: background-color var(--braun-ease);
+}
+
+.braun-soft:hover {
+  background-color: rgba(46, 44, 41, 0.1);
+}
+
+.braun-soft--orange {
+  background-color: rgba(242, 108, 29, 0.14);
+  color: var(--braun-orange);
+}
+
+.braun-soft--red {
+  background-color: rgba(184, 69, 47, 0.12);
+  color: var(--braun-red);
+}
+
+/* ============================================
+   GHOST — silkscreen label
+   ============================================ */
+
+.braun-ghost {
+  background-color: transparent;
+  color: var(--braun-label);
+  border: none;
+  border-radius: var(--braun-radius);
+  box-shadow: none;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: color var(--braun-ease);
+}
+
+.braun-ghost:hover {
+  color: var(--braun-text);
+}
+
+.braun-ghost--orange:hover {
+  color: var(--braun-orange);
+}
+
+.braun-ghost--red:hover {
+  color: var(--braun-red);
+}
+
+/* ============================================
+   LINK — index line
+   ============================================ */
+
+.braun-link {
+  background-color: transparent;
+  color: var(--braun-text);
+  border: none;
+  box-shadow: none;
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid var(--braun-hairline);
+  border-radius: 0;
+  transition: border-color var(--braun-ease), color var(--braun-ease);
+}
+
+.braun-link:hover {
+  color: var(--braun-orange);
+  border-bottom-color: var(--braun-orange);
+}
+
+.braun-link--orange {
+  color: var(--braun-orange);
+  border-bottom-color: var(--braun-orange);
+}
+
+.braun-link--red {
+  color: var(--braun-red);
+  border-bottom-color: var(--braun-red);
+}
+
+/* ============================================
+   INPUTS — a calibrated field
+   ============================================ */
+
+.braun-input {
+  width: 100%;
+}
+
+.braun-input-base {
+  background-color: var(--braun-cream-raised);
+  color: var(--braun-text);
+  border: 1px solid var(--braun-hairline);
+  border-radius: var(--braun-radius);
+  box-shadow: var(--braun-shadow-pressed);
+  caret-color: var(--braun-orange);
+  transition: border-color var(--braun-ease);
+}
+
+.braun-input-base::placeholder {
+  color: var(--braun-label);
+}
+
+.braun-input-base:focus {
+  outline: none;
+  border-color: var(--braun-orange);
+}
+
+.braun-input-base:disabled {
+  background-color: transparent;
+  box-shadow: none;
+  border-style: dashed;
+}
+
+/* ============================================
+   CARD — a faceplate
+   ============================================ */
+
+.braun-card {
+  background-color: var(--braun-cream-raised);
+  border: 1px solid var(--braun-hairline);
+  border-radius: calc(var(--braun-radius) * 2);
+  box-shadow: var(--braun-shadow);
+}
+
+.braun-card-header {
+  color: var(--braun-label);
+  border-bottom: 1px solid var(--braun-hairline);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.75rem 1rem;
+}
+
+.braun-card-body {
+  color: var(--braun-text);
+  padding: 1rem;
+}
+
+.braun-card-footer {
+  border-top: 1px solid var(--braun-hairline);
+  padding: 0.75rem 1rem;
+}
+
+/* ============================================
+   SEPARATOR — a machine line
+   ============================================ */
+
+.braun-separator {
+  border-color: var(--braun-hairline);
+}
+
+/* ============================================
+   BADGE — an engraved chip
+   ============================================ */
+
+.braun-badge {
+  background-color: transparent;
+  color: var(--braun-label);
+  border: 1px solid var(--braun-hairline);
+  border-radius: var(--braun-radius);
+  font-weight: 600;
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ============================================
+   VARIANT-LESS CHROME — USwitch as the sliding toggle
+   (rounded stays — the Braun toggle is a pill, not a slab)
+   ============================================ */
+
+[data-theme="braun"] button[role="switch"],
+.theme-braun button[role="switch"] {
+  border: 1px solid var(--braun-hairline);
+  background-color: var(--braun-cream-raised);
+  box-shadow: var(--braun-shadow-pressed);
+  transition: background-color var(--braun-ease);
+}
+
+[data-theme="braun"] button[role="switch"][data-state="checked"],
+.theme-braun button[role="switch"][data-state="checked"] {
+  background-color: var(--braun-orange);
+  border-color: transparent;
+}
+
+[data-theme="braun"] button[role="switch"] > span,
+.theme-braun button[role="switch"] > span {
+  background-color: var(--braun-charcoal);
+  transition: background-color var(--braun-ease);
+}
+
+[data-theme="braun"] button[role="switch"][data-state="checked"] > span,
+.theme-braun button[role="switch"][data-state="checked"] > span {
+  background-color: #fff;
+}

--- a/packages/crouton-themes/braun/components/Knob.vue
+++ b/packages/crouton-themes/braun/components/Knob.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+// The iconic Braun dial — adapted from the KO knob's drag interaction (#1309).
+interface Props {
+  modelValue?: number
+  min?: number
+  max?: number
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: 0,
+  min: 0,
+  max: 100,
+  size: 'md'
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number]
+}>()
+
+const isDragging = ref(false)
+const startY = ref(0)
+const startValue = ref(0)
+
+const rotation = computed(() => {
+  const range = props.max - props.min
+  const normalized = (props.modelValue - props.min) / range
+  return -135 + (normalized * 270)
+})
+
+const sizeClasses = {
+  sm: 'w-10 h-10',
+  md: 'w-14 h-14',
+  lg: 'w-20 h-20'
+}
+
+const handleMouseDown = (e: MouseEvent) => {
+  isDragging.value = true
+  startY.value = e.clientY
+  startValue.value = props.modelValue
+  window.addEventListener('mousemove', handleMouseMove)
+  window.addEventListener('mouseup', handleMouseUp)
+}
+
+const handleMouseMove = (e: MouseEvent) => {
+  if (!isDragging.value) return
+  const deltaY = startY.value - e.clientY
+  const range = props.max - props.min
+  const sensitivity = range / 100
+  const newValue = Math.min(props.max, Math.max(props.min, startValue.value + deltaY * sensitivity))
+  emit('update:modelValue', Math.round(newValue))
+}
+
+const handleMouseUp = () => {
+  isDragging.value = false
+  window.removeEventListener('mousemove', handleMouseMove)
+  window.removeEventListener('mouseup', handleMouseUp)
+}
+</script>
+
+<template>
+  <div
+    class="braun-knob"
+    :class="sizeClasses[props.size]"
+    @mousedown="handleMouseDown"
+  >
+    <div
+      class="braun-knob__dial"
+      :style="{ transform: `rotate(${rotation}deg)` }"
+    >
+      <div class="braun-knob__index" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.braun-knob {
+  position: relative;
+  border-radius: 50%;
+  cursor: grab;
+  user-select: none;
+  background: var(--braun-cream-raised);
+  border: 1px solid var(--braun-hairline);
+  box-shadow: var(--braun-shadow), inset 0 1px 0 #fff;
+}
+
+.braun-knob:active {
+  cursor: grabbing;
+}
+
+.braun-knob__dial {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transition: transform 0.05s ease-out;
+}
+
+.braun-knob__index {
+  position: absolute;
+  top: 8%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 26%;
+  background-color: var(--braun-orange);
+  border-radius: 1px;
+}
+</style>

--- a/packages/crouton-themes/braun/components/Label.vue
+++ b/packages/crouton-themes/braun/components/Label.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+// Silkscreen label — small, gray, letterspaced, exactly where it should be.
+interface Props {
+  variant?: 'default' | 'orange'
+}
+
+withDefaults(defineProps<Props>(), {
+  variant: 'default'
+})
+</script>
+
+<template>
+  <span class="braun-label" :class="`braun-label--${variant}`">
+    <slot />
+  </span>
+</template>
+
+<style scoped>
+.braun-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--braun-label);
+}
+
+.braun-label--orange {
+  color: var(--braun-orange);
+}
+</style>

--- a/packages/crouton-themes/braun/nuxt.config.ts
+++ b/packages/crouton-themes/braun/nuxt.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/braun',
+    description: 'Braun/Rams hi-fi theme for Nuxt UI — cream chassis, hairlines, one orange accent'
+  },
+  css: [join(currentDir, 'assets/css/main.css')],
+  components: {
+    dirs: [{
+      path: join(currentDir, 'components'),
+      prefix: 'Braun',
+      global: true
+    }]
+  }
+})

--- a/packages/crouton-themes/lib/subtractive.ts
+++ b/packages/crouton-themes/lib/subtractive.ts
@@ -16,7 +16,7 @@
 // Pure + deterministic — SSR and client must compute the identical class string
 // (hydration-mismatch rule from #364). No Date/random/env reads here, ever.
 
-type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv' | 'terminal'
+type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv' | 'terminal' | 'braun'
 
 // First matching prefix wins; a resolved string only ever carries one theme's
 // markers because `variant` is single-valued and the bw markers live on the
@@ -28,7 +28,8 @@ const MARKERS: Array<[prefix: string, theme: ThemeKey]> = [
   ['bw-', 'bw'],
   ['brutalist-', 'brutalist'],
   ['mtv-', 'mtv'],
-  ['term-', 'terminal']
+  ['term-', 'terminal'],
+  ['braun-', 'braun']
 ]
 
 // text-* utilities that are NOT color (sizes, alignment, wrapping) — kept when a
@@ -78,6 +79,10 @@ const STRIP: Record<ThemeKey, (u: string) => boolean> = {
   // Terminal: monospace phosphor — owns typography wholesale (like ko/kr11)
   // plus color, decoration, motion and underlines.
   terminal: u => isColor(u) || /^text-/.test(u) || isDecor(u) || isMotion(u) || isType(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // Braun: owns typography wholesale (small silkscreen labels) plus color,
+  // decoration, motion and underlines — like ko/kr11/terminal.
+  braun: u => isColor(u) || /^text-/.test(u) || isDecor(u) || isMotion(u) || isType(u)
     || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u)
 }
 

--- a/packages/crouton-themes/package.json
+++ b/packages/crouton-themes/package.json
@@ -19,7 +19,9 @@
     "./mtv": "./mtv/nuxt.config.ts",
     "./mtv/*": "./mtv/*",
     "./terminal": "./terminal/nuxt.config.ts",
-    "./terminal/*": "./terminal/*"
+    "./terminal/*": "./terminal/*",
+    "./braun": "./braun/nuxt.config.ts",
+    "./braun/*": "./braun/*"
   },
   "files": [
     "themes",
@@ -30,6 +32,7 @@
     "brutalist",
     "mtv",
     "terminal",
+    "braun",
     "lib"
   ],
   "keywords": [

--- a/packages/crouton-themes/playground/nuxt.config.ts
+++ b/packages/crouton-themes/playground/nuxt.config.ts
@@ -24,6 +24,7 @@ export default defineNuxtConfig({
     '../blackandwhite',
     '../brutalist',
     '../mtv',
-    '../terminal'
+    '../terminal',
+    '../braun'
   ]
 })

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -4,7 +4,7 @@
 
 import { THEME_UI_CONFIGS } from '../configs/themeConfigs'
 
-export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'terminal' | 'default'
+export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'default'
 
 type BaseVariant = 'solid' | 'outline' | 'soft' | 'ghost' | 'link'
 
@@ -73,6 +73,13 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     label: 'Terminal',
     description: 'Green phosphor on black, scanlines, inverse video',
     colors: ['#33ff66', '#0a0f0a', '#ffb000'], // phosphor, tube, amber
+    defaultVariant: 'solid'
+  },
+  {
+    name: 'braun',
+    label: 'Braun',
+    description: 'Warm analog hi-fi — cream, hairlines, one orange accent',
+    colors: ['#f2efe9', '#f26c1d', '#2e2c29'], // cream, orange, charcoal
     defaultVariant: 'solid'
   }
 ]

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -127,6 +127,18 @@ const terminalConfig: ThemeUIConfig = {
   badge: { defaultVariants: { variant: 'terminal' } }
 }
 
+// Braun — named variants registered by braun/app.config.ts
+const braunConfig: ThemeUIConfig = {
+  colors: {
+    primary: 'orange',
+    neutral: 'stone'
+  },
+  button: { defaultVariants: { variant: 'braun' } },
+  input: { defaultVariants: { variant: 'braun' } },
+  card: { defaultVariants: { variant: 'braun' } },
+  badge: { defaultVariants: { variant: 'braun' } }
+}
+
 // Export all theme configs
 export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   default: defaultConfig,
@@ -136,5 +148,6 @@ export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   blackandwhite: blackandwhiteConfig,
   brutalist: brutalistConfig,
   mtv: mtvConfig,
-  terminal: terminalConfig
+  terminal: terminalConfig,
+  braun: braunConfig
 }


### PR DESCRIPTION
Closes #1309

## 👤 For humans
Dieter Rams energy: cream chassis, 1px hairlines, soft real shadows, machined corners, silkscreen labels, exactly one orange. Includes `<BraunKnob>` (draggable dial with the orange index line) and `<BraunLabel>`, plus the iconic orange sliding toggle.

## 🧪 How to test
Playground preview → **Braun**: orange/charcoal/muted-red machined keys, hairline outline, recessed soft, silkscreen ghost; input focus turns the hairline orange; the toggle slides orange. Calm next to KO — same family, quieter sibling.

Owner approval standing (epic #1303, 2026-07-10). _Dedup-checked: sub-issue #1309 of epic #1303._

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account