### PR TITLE
New theme: Game Boy LCD — the whole UI in 4 shades of olive green

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -123,6 +123,17 @@ const { variant } = useThemeSwitcher()
 
 ## Available Themes
 
+### Game Boy Theme (`./gameboy`)
+
+The original DMG LCD: FOUR shades of olive green (`--gb-0..3`) and nothing else.
+Square corners, chunky 3px "pixel" borders, RPG dialog-box cards (double frame),
+a `▶` cursor on ghost hover. Error/warning map onto the shades via inversion +
+hazard stripes — never hue. Body copy is always gb-0-on-gb-3/gb-2 (the AA pair);
+other shade pairs are decorative-only.
+
+**Nuxt UI Variants:** `gameboy` / `gameboy-{solid,outline,soft,ghost,link}` (UButton);
+`gameboy` for UInput, UCard, UBadge, USeparator. USwitch themed ambiently.
+
 ### Braun Theme (`./braun`)
 
 Warm analog hi-fi (Dieter Rams): cream chassis, 1px hairlines, very soft real

--- a/packages/crouton-themes/gameboy/app.config.ts
+++ b/packages/crouton-themes/gameboy/app.config.ts
@@ -1,0 +1,123 @@
+// Game Boy LCD Theme Configuration (#1310)
+// The original DMG screen: FOUR shades of olive green, and nothing else.
+// Semantic colors (error/warning) map onto the shades via inversion and
+// pattern, never hue — the constraint IS the theme.
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'green',
+      neutral: 'stone'
+    },
+
+    button: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'gameboy': '',
+          'gameboy-solid': '',
+          'gameboy-outline': '',
+          'gameboy-soft': '',
+          'gameboy-ghost': '',
+          'gameboy-link': ''
+        }
+      },
+      compoundVariants: [
+        // === GAMEBOY (chunky sprite buttons) ===
+        { color: 'primary', variant: 'gameboy', class: 'gb-btn gb-btn--dark' },
+        { color: 'neutral', variant: 'gameboy', class: 'gb-btn' },
+        { color: 'error', variant: 'gameboy', class: 'gb-btn gb-btn--alert' },
+        { variant: 'gameboy', class: 'gb-btn' },
+
+        // === GAMEBOY-SOLID (alias) ===
+        { color: 'primary', variant: 'gameboy-solid', class: 'gb-btn gb-btn--dark' },
+        { color: 'neutral', variant: 'gameboy-solid', class: 'gb-btn' },
+        { color: 'error', variant: 'gameboy-solid', class: 'gb-btn gb-btn--alert' },
+        { variant: 'gameboy-solid', class: 'gb-btn' },
+
+        // === GAMEBOY-OUTLINE ===
+        { color: 'primary', variant: 'gameboy-outline', class: 'gb-outline' },
+        { color: 'neutral', variant: 'gameboy-outline', class: 'gb-outline' },
+        { color: 'error', variant: 'gameboy-outline', class: 'gb-outline gb-outline--alert' },
+        { variant: 'gameboy-outline', class: 'gb-outline' },
+
+        // === GAMEBOY-SOFT (mid-shade fill) ===
+        { color: 'primary', variant: 'gameboy-soft', class: 'gb-soft' },
+        { color: 'neutral', variant: 'gameboy-soft', class: 'gb-soft' },
+        { color: 'error', variant: 'gameboy-soft', class: 'gb-soft gb-soft--alert' },
+        { variant: 'gameboy-soft', class: 'gb-soft' },
+
+        // === GAMEBOY-GHOST (cursor arrow) ===
+        { color: 'primary', variant: 'gameboy-ghost', class: 'gb-ghost' },
+        { color: 'neutral', variant: 'gameboy-ghost', class: 'gb-ghost' },
+        { color: 'error', variant: 'gameboy-ghost', class: 'gb-ghost' },
+        { variant: 'gameboy-ghost', class: 'gb-ghost' },
+
+        // === GAMEBOY-LINK ===
+        { color: 'primary', variant: 'gameboy-link', class: 'gb-link' },
+        { color: 'neutral', variant: 'gameboy-link', class: 'gb-link' },
+        { color: 'error', variant: 'gameboy-link', class: 'gb-link' },
+        { variant: 'gameboy-link', class: 'gb-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            root: 'gb-input',
+            base: 'gb-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            root: 'gb-card',
+            header: 'gb-card-header',
+            body: 'gb-card-body',
+            footer: 'gb-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          gameboy: {
+            border: 'gb-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: 'gb-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/gameboy/assets/css/main.css
+++ b/packages/crouton-themes/gameboy/assets/css/main.css
@@ -1,0 +1,287 @@
+/* Game Boy LCD Theme (#1310)
+   The original DMG screen: FOUR shades of olive green — #0f380f, #306230,
+   #8bac0f, #9bbc0e — and nothing else. Square corners, chunky pixel steps,
+   error/warning map to shades via inversion, never hue.
+   No !important: built on the shared subtractive replacer.
+
+   A11y note (#1310): text always uses gb-0 (darkest) on gb-3/gb-2 (lightest)
+   or inverted — the darkest-on-lightest pair is the only body-copy combo;
+   gb-1-on-gb-2 style pairs are decorative-only. */
+
+:root {
+  --gb-0: #0f380f;   /* darkest — ink */
+  --gb-1: #306230;   /* dark — shadows, secondary */
+  --gb-2: #8bac0f;   /* light — active fills */
+  --gb-3: #9bbc0e;   /* lightest — the screen */
+  --gb-step: 3px;    /* the pixel */
+}
+
+/* ============================================
+   DATA-THEME AMBIENT — the LCD
+   ============================================ */
+
+[data-theme="gameboy"],
+.theme-gameboy {
+  background-color: var(--gb-3);
+  color: var(--gb-0);
+  --ui-bg: var(--gb-3);
+}
+
+/* ============================================
+   BUTTONS — chunky sprites
+   Pixel-step "corners" via layered box-shadows (cheap, no images).
+   ============================================ */
+
+.gb-btn {
+  background-color: var(--gb-2);
+  color: var(--gb-0);
+  border: var(--gb-step) solid var(--gb-0);
+  border-radius: 0;
+  box-shadow: var(--gb-step) var(--gb-step) 0 var(--gb-1);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.gb-btn:hover {
+  background-color: var(--gb-3);
+}
+
+.gb-btn:active {
+  transform: translate(var(--gb-step), var(--gb-step));
+  box-shadow: none;
+}
+
+.gb-btn--dark {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+}
+
+.gb-btn--dark:hover {
+  background-color: var(--gb-1);
+}
+
+/* "Error" in a 4-shade world: inverted + hazard underline, not red. */
+.gb-btn--alert {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0 6px,
+    var(--gb-1) 6px 12px
+  );
+}
+
+/* ============================================
+   OUTLINE
+   ============================================ */
+
+.gb-outline {
+  background-color: transparent;
+  color: var(--gb-0);
+  border: var(--gb-step) solid var(--gb-0);
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.gb-outline:hover {
+  background-color: var(--gb-2);
+}
+
+.gb-outline--alert {
+  border-style: dashed;
+}
+
+/* ============================================
+   SOFT — mid-shade fill
+   ============================================ */
+
+.gb-soft {
+  background-color: var(--gb-2);
+  color: var(--gb-0);
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.gb-soft:hover {
+  background-color: var(--gb-1);
+  color: var(--gb-3);
+}
+
+.gb-soft--alert {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0 6px,
+    rgba(15, 56, 15, 0.25) 6px 12px
+  );
+}
+
+/* ============================================
+   GHOST — the menu cursor
+   ============================================ */
+
+.gb-ghost {
+  background-color: transparent;
+  color: var(--gb-0);
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: none;
+}
+
+.gb-ghost::before {
+  content: '▶ ';
+  visibility: hidden;
+}
+
+.gb-ghost:hover::before {
+  visibility: visible;
+}
+
+/* ============================================
+   LINK — selected menu row
+   ============================================ */
+
+.gb-link {
+  background-color: transparent;
+  color: var(--gb-0);
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  font-weight: 700;
+  text-decoration: none;
+  transition: none;
+}
+
+.gb-link:hover {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+}
+
+/* ============================================
+   INPUTS — a dialog box field
+   ============================================ */
+
+.gb-input {
+  width: 100%;
+}
+
+.gb-input-base {
+  background-color: var(--gb-3);
+  color: var(--gb-0);
+  border: var(--gb-step) solid var(--gb-0);
+  border-radius: 0;
+  box-shadow: inset var(--gb-step) var(--gb-step) 0 rgba(15, 56, 15, 0.15);
+  caret-color: var(--gb-0);
+  font-weight: 600;
+  transition: none;
+}
+
+.gb-input-base::placeholder {
+  color: var(--gb-1);
+}
+
+.gb-input-base:focus {
+  outline: none;
+  background-color: #a6c514;
+}
+
+.gb-input-base:disabled {
+  border-style: dashed;
+  box-shadow: none;
+  color: var(--gb-1);
+}
+
+/* ============================================
+   CARD — an RPG dialog box
+   ============================================ */
+
+.gb-card {
+  background-color: var(--gb-3);
+  border: var(--gb-step) solid var(--gb-0);
+  border-radius: 0;
+  /* double frame, like every dialog box since 1989 */
+  outline: 1px solid var(--gb-0);
+  outline-offset: 3px;
+  box-shadow: none;
+}
+
+.gb-card-header {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.6rem 1rem;
+}
+
+.gb-card-body {
+  color: var(--gb-0);
+  padding: 1rem;
+}
+
+.gb-card-footer {
+  border-top: var(--gb-step) solid var(--gb-0);
+  padding: 0.6rem 1rem;
+}
+
+/* ============================================
+   SEPARATOR — a sprite rule
+   ============================================ */
+
+.gb-separator {
+  border-style: dotted;
+  border-color: var(--gb-0);
+  border-top-width: var(--gb-step);
+}
+
+/* ============================================
+   BADGE — an item tag
+   ============================================ */
+
+.gb-badge {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+  border: none;
+  border-radius: 0;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ============================================
+   VARIANT-LESS CHROME — USwitch (#1333 pattern)
+   ============================================ */
+
+[data-theme="gameboy"] button[role="switch"],
+.theme-gameboy button[role="switch"] {
+  border-radius: 0;
+  border: 2px solid var(--gb-0);
+  background-color: var(--gb-3);
+  transition: none;
+}
+
+[data-theme="gameboy"] button[role="switch"][data-state="checked"],
+.theme-gameboy button[role="switch"][data-state="checked"] {
+  background-color: var(--gb-2);
+}
+
+[data-theme="gameboy"] button[role="switch"] > span,
+.theme-gameboy button[role="switch"] > span {
+  border-radius: 0;
+  background-color: var(--gb-0);
+  transition: none;
+}

--- a/packages/crouton-themes/gameboy/nuxt.config.ts
+++ b/packages/crouton-themes/gameboy/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/gameboy',
+    description: 'Game Boy LCD theme for Nuxt UI — the whole UI in 4 shades of olive green'
+  },
+  css: [join(currentDir, 'assets/css/main.css')]
+})

--- a/packages/crouton-themes/lib/subtractive.ts
+++ b/packages/crouton-themes/lib/subtractive.ts
@@ -16,7 +16,7 @@
 // Pure + deterministic — SSR and client must compute the identical class string
 // (hydration-mismatch rule from #364). No Date/random/env reads here, ever.
 
-type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv' | 'terminal' | 'braun'
+type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'gameboy'
 
 // First matching prefix wins; a resolved string only ever carries one theme's
 // markers because `variant` is single-valued and the bw markers live on the
@@ -29,7 +29,8 @@ const MARKERS: Array<[prefix: string, theme: ThemeKey]> = [
   ['brutalist-', 'brutalist'],
   ['mtv-', 'mtv'],
   ['term-', 'terminal'],
-  ['braun-', 'braun']
+  ['braun-', 'braun'],
+  ['gb-', 'gameboy']
 ]
 
 // text-* utilities that are NOT color (sizes, alignment, wrapping) — kept when a
@@ -83,6 +84,12 @@ const STRIP: Record<ThemeKey, (u: string) => boolean> = {
   // Braun: owns typography wholesale (small silkscreen labels) plus color,
   // decoration, motion and underlines — like ko/kr11/terminal.
   braun: u => isColor(u) || /^text-/.test(u) || isDecor(u) || isMotion(u) || isType(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // Game Boy: the 4-shade constraint — owns color, decoration, motion and
+  // weight/tracking/case; keeps text sizes + line-height.
+  gameboy: u => isColor(u) || isDecor(u) || isMotion(u)
+    || /^(font|tracking)(-|$)/.test(u)
+    || /^(uppercase|lowercase|capitalize|normal-case)$/.test(u)
     || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u)
 }
 

--- a/packages/crouton-themes/package.json
+++ b/packages/crouton-themes/package.json
@@ -21,7 +21,9 @@
     "./terminal": "./terminal/nuxt.config.ts",
     "./terminal/*": "./terminal/*",
     "./braun": "./braun/nuxt.config.ts",
-    "./braun/*": "./braun/*"
+    "./braun/*": "./braun/*",
+    "./gameboy": "./gameboy/nuxt.config.ts",
+    "./gameboy/*": "./gameboy/*"
   },
   "files": [
     "themes",
@@ -33,6 +35,7 @@
     "mtv",
     "terminal",
     "braun",
+    "gameboy",
     "lib"
   ],
   "keywords": [

--- a/packages/crouton-themes/playground/nuxt.config.ts
+++ b/packages/crouton-themes/playground/nuxt.config.ts
@@ -25,6 +25,7 @@ export default defineNuxtConfig({
     '../brutalist',
     '../mtv',
     '../terminal',
-    '../braun'
+    '../braun',
+    '../gameboy'
   ]
 })

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -4,7 +4,7 @@
 
 import { THEME_UI_CONFIGS } from '../configs/themeConfigs'
 
-export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'default'
+export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'gameboy' | 'default'
 
 type BaseVariant = 'solid' | 'outline' | 'soft' | 'ghost' | 'link'
 
@@ -80,6 +80,13 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     label: 'Braun',
     description: 'Warm analog hi-fi — cream, hairlines, one orange accent',
     colors: ['#f2efe9', '#f26c1d', '#2e2c29'], // cream, orange, charcoal
+    defaultVariant: 'solid'
+  },
+  {
+    name: 'gameboy',
+    label: 'Game Boy',
+    description: 'Four shades of olive green, chunky pixels',
+    colors: ['#0f380f', '#8bac0f', '#9bbc0e'], // ink, light, screen
     defaultVariant: 'solid'
   }
 ]

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -139,6 +139,18 @@ const braunConfig: ThemeUIConfig = {
   badge: { defaultVariants: { variant: 'braun' } }
 }
 
+// Game Boy — named variants registered by gameboy/app.config.ts
+const gameboyConfig: ThemeUIConfig = {
+  colors: {
+    primary: 'green',
+    neutral: 'stone'
+  },
+  button: { defaultVariants: { variant: 'gameboy' } },
+  input: { defaultVariants: { variant: 'gameboy' } },
+  card: { defaultVariants: { variant: 'gameboy' } },
+  badge: { defaultVariants: { variant: 'gameboy' } }
+}
+
 // Export all theme configs
 export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   default: defaultConfig,
@@ -149,5 +161,6 @@ export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   brutalist: brutalistConfig,
   mtv: mtvConfig,
   terminal: terminalConfig,
-  braun: braunConfig
+  braun: braunConfig,
+  gameboy: gameboyConfig
 }


### PR DESCRIPTION
Closes #1310

## 👤 For humans
The DMG constraint as a theme: four olive shades and nothing else. Chunky pixel borders, RPG dialog cards, ▶ menu cursors — and error states done by inversion + hazard stripes because a Game Boy has no red.

## 🧪 How to test
Playground preview → **Game Boy**: squint — it should read like a DMG screenshot. Trigger the error button — still in palette (striped, inverted). Tab through — focus rings survive.

Owner approval standing (epic #1303, 2026-07-10). _Dedup-checked: sub-issue #1310 of epic #1303._

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account