### PR TITLE
Wildcard themes: Risograph + E-ink + Blueprint

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -123,6 +123,24 @@ const { variant } = useThemeSwitcher()
 
 ## Available Themes
 
+### Riso / E-ink / Blueprint Themes (`./riso`, `./eink`, `./blueprint`) — #1311
+
+The wildcard trio (owner's picks):
+- **Riso** (`riso-`): two-color risograph — fluoro pink + teal on warm paper,
+  misregistration shadows (each "ink layer" slightly off), SVG-turbulence grain,
+  wavy-underline links. Tokens `--riso-*`.
+- **E-ink** (`eink-`): greyscale reading mode — ZERO motion (states flip like a
+  page refresh), underline-only inputs, double-rule newspaper cards with serif
+  headers, small-caps badges. Tokens `--eink-*`.
+- **Blueprint** (`bp-`): cyanotype drafting sheet — white line-work on deep blue,
+  faint 24px grid ambient, double-frame drawn parts, dashed dimension separators,
+  a pencil-yellow accent for alerts/callouts. Dark ambient drives `--ui-bg` +
+  light text. Tokens `--bp-*`.
+
+All three: named variants `<name>` / `<name>-{solid,outline,soft,ghost,link}`
+(button) + `<name>` for input/card/badge/separator; ambient USwitch chrome; zero
+`!important` via the shared replacer.
+
 ### Game Boy Theme (`./gameboy`)
 
 The original DMG LCD: FOUR shades of olive green (`--gb-0..3`) and nothing else.

--- a/packages/crouton-themes/blueprint/app.config.ts
+++ b/packages/crouton-themes/blueprint/app.config.ts
@@ -1,0 +1,115 @@
+// Blueprint Theme Configuration (#1311)
+// Cyanotype blue, white line-work, dimension rules, drafting annotations.
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'sky',
+      neutral: 'slate'
+    },
+
+    button: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'blueprint': '',
+          'blueprint-solid': '',
+          'blueprint-outline': '',
+          'blueprint-soft': '',
+          'blueprint-ghost': '',
+          'blueprint-link': ''
+        }
+      },
+      compoundVariants: [
+        { color: 'primary', variant: 'blueprint', class: 'bp-btn bp-btn--primary' },
+        { color: 'neutral', variant: 'blueprint', class: 'bp-btn' },
+        { color: 'error', variant: 'blueprint', class: 'bp-btn bp-btn--alert' },
+        { variant: 'blueprint', class: 'bp-btn' },
+
+        { color: 'primary', variant: 'blueprint-solid', class: 'bp-btn bp-btn--primary' },
+        { color: 'neutral', variant: 'blueprint-solid', class: 'bp-btn' },
+        { color: 'error', variant: 'blueprint-solid', class: 'bp-btn bp-btn--alert' },
+        { variant: 'blueprint-solid', class: 'bp-btn' },
+
+        { color: 'primary', variant: 'blueprint-outline', class: 'bp-outline bp-outline--primary' },
+        { color: 'neutral', variant: 'blueprint-outline', class: 'bp-outline' },
+        { color: 'error', variant: 'blueprint-outline', class: 'bp-outline bp-outline--alert' },
+        { variant: 'blueprint-outline', class: 'bp-outline' },
+
+        { color: 'primary', variant: 'blueprint-soft', class: 'bp-soft bp-soft--primary' },
+        { color: 'neutral', variant: 'blueprint-soft', class: 'bp-soft' },
+        { color: 'error', variant: 'blueprint-soft', class: 'bp-soft bp-soft--alert' },
+        { variant: 'blueprint-soft', class: 'bp-soft' },
+
+        { color: 'primary', variant: 'blueprint-ghost', class: 'bp-ghost bp-ghost--primary' },
+        { color: 'neutral', variant: 'blueprint-ghost', class: 'bp-ghost' },
+        { color: 'error', variant: 'blueprint-ghost', class: 'bp-ghost' },
+        { variant: 'blueprint-ghost', class: 'bp-ghost' },
+
+        { color: 'primary', variant: 'blueprint-link', class: 'bp-link bp-link--primary' },
+        { color: 'neutral', variant: 'blueprint-link', class: 'bp-link' },
+        { color: 'error', variant: 'blueprint-link', class: 'bp-link' },
+        { variant: 'blueprint-link', class: 'bp-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            root: 'bp-input',
+            base: 'bp-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            root: 'bp-card',
+            header: 'bp-card-header',
+            body: 'bp-card-body',
+            footer: 'bp-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          blueprint: {
+            border: 'bp-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: 'bp-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/blueprint/assets/css/main.css
+++ b/packages/crouton-themes/blueprint/assets/css/main.css
@@ -1,0 +1,273 @@
+/* Blueprint Theme (#1311)
+   A cyanotype technical drawing: deep blueprint blue, white line-work,
+   dashed dimension rules, drafting annotations, a faint grid.
+   No !important: built on the shared subtractive replacer. */
+
+:root {
+  --bp-blue: #123a63;
+  --bp-blue-deep: #0d2c4d;
+  --bp-line: #dce9f5;
+  --bp-line-dim: #7fa3c4;
+  --bp-accent: #ffd66b;   /* the surveyor's pencil mark */
+  --bp-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+}
+
+/* ============================================
+   AMBIENT — the sheet (faint drafting grid)
+   ============================================ */
+
+[data-theme="blueprint"],
+.theme-blueprint {
+  background-color: var(--bp-blue);
+  background-image:
+    linear-gradient(rgba(220, 233, 245, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(220, 233, 245, 0.05) 1px, transparent 1px);
+  background-size: 24px 24px;
+  color: var(--bp-line);
+  --ui-bg: var(--bp-blue);
+}
+
+/* ============================================
+   BUTTONS — drawn parts
+   ============================================ */
+
+.bp-btn {
+  font-family: var(--bp-mono);
+  background-color: transparent;
+  color: var(--bp-line);
+  border: 1px solid var(--bp-line);
+  border-radius: 0;
+  box-shadow: inset 0 0 0 3px var(--bp-blue), inset 0 0 0 4px var(--bp-line-dim);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition: background-color 100ms ease;
+}
+
+.bp-btn:hover {
+  background-color: rgba(220, 233, 245, 0.12);
+}
+
+.bp-btn--primary {
+  background-color: var(--bp-line);
+  color: var(--bp-blue);
+  box-shadow: none;
+}
+
+.bp-btn--primary:hover {
+  background-color: #fff;
+}
+
+.bp-btn--alert {
+  border-style: dashed;
+  color: var(--bp-accent);
+  border-color: var(--bp-accent);
+  box-shadow: none;
+}
+
+/* ============================================
+   OUTLINE / SOFT / GHOST / LINK
+   ============================================ */
+
+.bp-outline {
+  font-family: var(--bp-mono);
+  background-color: transparent;
+  color: var(--bp-line);
+  border: 1px dashed var(--bp-line-dim);
+  border-radius: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition: border-color 100ms ease;
+}
+
+.bp-outline:hover {
+  border-color: var(--bp-line);
+  border-style: solid;
+}
+
+.bp-outline--primary {
+  border-color: var(--bp-line);
+}
+
+.bp-outline--alert {
+  color: var(--bp-accent);
+  border-color: var(--bp-accent);
+}
+
+.bp-soft {
+  font-family: var(--bp-mono);
+  background-color: rgba(220, 233, 245, 0.12);
+  color: var(--bp-line);
+  border: none;
+  border-radius: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition: background-color 100ms ease;
+}
+
+.bp-soft:hover {
+  background-color: rgba(220, 233, 245, 0.2);
+}
+
+.bp-soft--alert {
+  color: var(--bp-accent);
+  background-color: rgba(255, 214, 107, 0.12);
+}
+
+.bp-ghost {
+  font-family: var(--bp-mono);
+  background-color: transparent;
+  color: var(--bp-line-dim);
+  border: none;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition: color 100ms ease;
+}
+
+.bp-ghost:hover {
+  color: var(--bp-line);
+}
+
+.bp-link {
+  font-family: var(--bp-mono);
+  background-color: transparent;
+  color: var(--bp-line);
+  border: none;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 4px;
+  transition: color 100ms ease;
+}
+
+.bp-link:hover {
+  color: #fff;
+  text-decoration-style: solid;
+}
+
+.bp-link--primary {
+  color: var(--bp-accent);
+}
+
+/* ============================================
+   INPUTS — an annotation field
+   ============================================ */
+
+.bp-input {
+  width: 100%;
+}
+
+.bp-input-base {
+  font-family: var(--bp-mono);
+  background-color: var(--bp-blue-deep);
+  color: var(--bp-line);
+  border: 1px solid var(--bp-line-dim);
+  border-radius: 0;
+  caret-color: var(--bp-accent);
+  transition: border-color 100ms ease;
+}
+
+.bp-input-base::placeholder {
+  color: var(--bp-line-dim);
+}
+
+.bp-input-base:focus {
+  outline: none;
+  border-color: var(--bp-line);
+}
+
+.bp-input-base:disabled {
+  border-style: dashed;
+  color: var(--bp-line-dim);
+}
+
+/* ============================================
+   CARD — a drawing frame with title block
+   ============================================ */
+
+.bp-card {
+  background-color: var(--bp-blue);
+  border: 1px solid var(--bp-line);
+  border-radius: 0;
+  box-shadow: inset 0 0 0 4px var(--bp-blue), inset 0 0 0 5px var(--bp-line-dim);
+}
+
+.bp-card-header {
+  font-family: var(--bp-mono);
+  color: var(--bp-line);
+  border-bottom: 1px solid var(--bp-line-dim);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.75rem 1.25rem;
+}
+
+.bp-card-body {
+  color: var(--bp-line);
+  padding: 1rem 1.25rem;
+}
+
+/* the title block */
+.bp-card-footer {
+  font-family: var(--bp-mono);
+  border-top: 1px solid var(--bp-line);
+  color: var(--bp-line-dim);
+  padding: 0.6rem 1.25rem;
+}
+
+/* ============================================
+   SEPARATOR — a dimension line
+   ============================================ */
+
+.bp-separator {
+  border-style: dashed;
+  border-color: var(--bp-line-dim);
+}
+
+/* ============================================
+   BADGE — a callout bubble
+   ============================================ */
+
+.bp-badge {
+  font-family: var(--bp-mono);
+  background-color: transparent;
+  color: var(--bp-accent);
+  border: 1px solid var(--bp-accent);
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ============================================
+   VARIANT-LESS CHROME — USwitch
+   ============================================ */
+
+[data-theme="blueprint"] button[role="switch"],
+.theme-blueprint button[role="switch"] {
+  border-radius: 0;
+  border: 1px solid var(--bp-line-dim);
+  background-color: var(--bp-blue-deep);
+  transition: none;
+}
+
+[data-theme="blueprint"] button[role="switch"][data-state="checked"],
+.theme-blueprint button[role="switch"][data-state="checked"] {
+  border-color: var(--bp-line);
+  background-color: rgba(220, 233, 245, 0.2);
+}
+
+[data-theme="blueprint"] button[role="switch"] > span,
+.theme-blueprint button[role="switch"] > span {
+  border-radius: 0;
+  background-color: var(--bp-line-dim);
+  transition: none;
+}
+
+[data-theme="blueprint"] button[role="switch"][data-state="checked"] > span,
+.theme-blueprint button[role="switch"][data-state="checked"] > span {
+  background-color: var(--bp-accent);
+}

--- a/packages/crouton-themes/blueprint/nuxt.config.ts
+++ b/packages/crouton-themes/blueprint/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/blueprint',
+    description: 'blueprint theme for Nuxt UI'
+  },
+  css: [join(currentDir, 'assets/css/main.css')]
+})

--- a/packages/crouton-themes/eink/app.config.ts
+++ b/packages/crouton-themes/eink/app.config.ts
@@ -1,0 +1,115 @@
+// E-ink Theme Configuration (#1311)
+// Pure greyscale, zero motion, newspaper typography. A reading mode.
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'neutral',
+      neutral: 'neutral'
+    },
+
+    button: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'eink': '',
+          'eink-solid': '',
+          'eink-outline': '',
+          'eink-soft': '',
+          'eink-ghost': '',
+          'eink-link': ''
+        }
+      },
+      compoundVariants: [
+        { color: 'primary', variant: 'eink', class: 'eink-btn eink-btn--primary' },
+        { color: 'neutral', variant: 'eink', class: 'eink-btn' },
+        { color: 'error', variant: 'eink', class: 'eink-btn eink-btn--alert' },
+        { variant: 'eink', class: 'eink-btn' },
+
+        { color: 'primary', variant: 'eink-solid', class: 'eink-btn eink-btn--primary' },
+        { color: 'neutral', variant: 'eink-solid', class: 'eink-btn' },
+        { color: 'error', variant: 'eink-solid', class: 'eink-btn eink-btn--alert' },
+        { variant: 'eink-solid', class: 'eink-btn' },
+
+        { color: 'primary', variant: 'eink-outline', class: 'eink-outline eink-outline--primary' },
+        { color: 'neutral', variant: 'eink-outline', class: 'eink-outline' },
+        { color: 'error', variant: 'eink-outline', class: 'eink-outline eink-outline--alert' },
+        { variant: 'eink-outline', class: 'eink-outline' },
+
+        { color: 'primary', variant: 'eink-soft', class: 'eink-soft eink-soft--primary' },
+        { color: 'neutral', variant: 'eink-soft', class: 'eink-soft' },
+        { color: 'error', variant: 'eink-soft', class: 'eink-soft eink-soft--alert' },
+        { variant: 'eink-soft', class: 'eink-soft' },
+
+        { color: 'primary', variant: 'eink-ghost', class: 'eink-ghost eink-ghost--primary' },
+        { color: 'neutral', variant: 'eink-ghost', class: 'eink-ghost' },
+        { color: 'error', variant: 'eink-ghost', class: 'eink-ghost' },
+        { variant: 'eink-ghost', class: 'eink-ghost' },
+
+        { color: 'primary', variant: 'eink-link', class: 'eink-link eink-link--primary' },
+        { color: 'neutral', variant: 'eink-link', class: 'eink-link' },
+        { color: 'error', variant: 'eink-link', class: 'eink-link' },
+        { variant: 'eink-link', class: 'eink-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            root: 'eink-input',
+            base: 'eink-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            root: 'eink-card',
+            header: 'eink-card-header',
+            body: 'eink-card-body',
+            footer: 'eink-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          eink: {
+            border: 'eink-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: 'eink-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/eink/assets/css/main.css
+++ b/packages/crouton-themes/eink/assets/css/main.css
@@ -1,0 +1,241 @@
+/* E-ink Theme (#1311)
+   A reading device: pure greyscale, ZERO motion (state changes flip, they
+   never animate — like a page refresh), newspaper typography for headers,
+   generous hairlines. The calmest theme in the set.
+   No !important: built on the shared subtractive replacer. */
+
+:root {
+  --eink-paper: #f4f2ee;
+  --eink-ink: #1c1c1c;
+  --eink-gray: #6b6b6b;
+  --eink-hairline: #cfccc6;
+  --eink-serif: Georgia, 'Times New Roman', serif;
+}
+
+/* ============================================
+   AMBIENT — the display
+   ============================================ */
+
+[data-theme="eink"],
+.theme-eink {
+  background-color: var(--eink-paper);
+  --ui-bg: var(--eink-paper);
+}
+
+/* ============================================
+   BUTTONS — no motion, states FLIP
+   ============================================ */
+
+.eink-btn {
+  background-color: var(--eink-paper);
+  color: var(--eink-ink);
+  border: 1px solid var(--eink-ink);
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: 600;
+  transition: none;
+}
+
+.eink-btn:hover {
+  background-color: var(--eink-ink);
+  color: var(--eink-paper);
+}
+
+.eink-btn--primary {
+  background-color: var(--eink-ink);
+  color: var(--eink-paper);
+}
+
+.eink-btn--primary:hover {
+  background-color: var(--eink-paper);
+  color: var(--eink-ink);
+}
+
+.eink-btn--alert {
+  border-width: 1px;
+  border-bottom-width: 4px;
+  border-bottom-style: double;
+}
+
+/* ============================================
+   OUTLINE / SOFT / GHOST / LINK
+   ============================================ */
+
+.eink-outline {
+  background-color: transparent;
+  color: var(--eink-ink);
+  border: 1px solid var(--eink-gray);
+  border-radius: 0;
+  font-weight: 600;
+  transition: none;
+}
+
+.eink-outline:hover {
+  border-color: var(--eink-ink);
+}
+
+.eink-outline--alert {
+  border-style: dashed;
+}
+
+.eink-soft {
+  background-color: rgba(28, 28, 28, 0.07);
+  color: var(--eink-ink);
+  border: none;
+  border-radius: 0;
+  font-weight: 600;
+  transition: none;
+}
+
+.eink-soft:hover {
+  background-color: rgba(28, 28, 28, 0.14);
+}
+
+.eink-soft--alert {
+  background-image: repeating-linear-gradient(-45deg, transparent 0 6px, rgba(28, 28, 28, 0.08) 6px 12px);
+}
+
+.eink-ghost {
+  background-color: transparent;
+  color: var(--eink-gray);
+  border: none;
+  font-weight: 600;
+  transition: none;
+}
+
+.eink-ghost:hover {
+  color: var(--eink-ink);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.eink-link {
+  background-color: transparent;
+  color: var(--eink-ink);
+  border: none;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: none;
+}
+
+.eink-link:hover {
+  background-color: var(--eink-ink);
+  color: var(--eink-paper);
+  text-decoration: none;
+}
+
+/* ============================================
+   INPUTS — a form on paper
+   ============================================ */
+
+.eink-input {
+  width: 100%;
+}
+
+.eink-input-base {
+  background-color: transparent;
+  color: var(--eink-ink);
+  border: none;
+  border-bottom: 1px solid var(--eink-ink);
+  border-radius: 0;
+  caret-color: var(--eink-ink);
+  transition: none;
+}
+
+.eink-input-base::placeholder {
+  color: var(--eink-gray);
+  font-style: italic;
+}
+
+.eink-input-base:focus {
+  outline: none;
+  border-bottom-width: 2px;
+}
+
+.eink-input-base:disabled {
+  border-bottom-style: dotted;
+  color: var(--eink-gray);
+}
+
+/* ============================================
+   CARD — a newspaper clipping
+   ============================================ */
+
+.eink-card {
+  background-color: var(--eink-paper);
+  border-top: 3px double var(--eink-ink);
+  border-bottom: 3px double var(--eink-ink);
+  border-left: none;
+  border-right: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.eink-card-header {
+  font-family: var(--eink-serif);
+  color: var(--eink-ink);
+  border-bottom: 1px solid var(--eink-hairline);
+  font-weight: 700;
+  font-size: 1.05rem;
+  padding: 0.75rem 1rem;
+}
+
+.eink-card-body {
+  color: var(--eink-ink);
+  padding: 1rem;
+}
+
+.eink-card-footer {
+  border-top: 1px solid var(--eink-hairline);
+  color: var(--eink-gray);
+  padding: 0.6rem 1rem;
+}
+
+/* ============================================
+   SEPARATOR + BADGE
+   ============================================ */
+
+.eink-separator {
+  border-color: var(--eink-ink);
+  border-top-width: 3px;
+  border-style: double;
+}
+
+.eink-badge {
+  background-color: transparent;
+  color: var(--eink-ink);
+  border: 1px solid var(--eink-ink);
+  border-radius: 0;
+  font-weight: 600;
+  font-variant: small-caps;
+}
+
+/* ============================================
+   VARIANT-LESS CHROME — USwitch (flips, no glide)
+   ============================================ */
+
+[data-theme="eink"] button[role="switch"],
+.theme-eink button[role="switch"] {
+  border-radius: 0;
+  border: 1px solid var(--eink-ink);
+  background-color: var(--eink-paper);
+  transition: none;
+}
+
+[data-theme="eink"] button[role="switch"][data-state="checked"],
+.theme-eink button[role="switch"][data-state="checked"] {
+  background-color: var(--eink-ink);
+}
+
+[data-theme="eink"] button[role="switch"] > span,
+.theme-eink button[role="switch"] > span {
+  border-radius: 0;
+  background-color: var(--eink-ink);
+  transition: none;
+}
+
+[data-theme="eink"] button[role="switch"][data-state="checked"] > span,
+.theme-eink button[role="switch"][data-state="checked"] > span {
+  background-color: var(--eink-paper);
+}

--- a/packages/crouton-themes/eink/nuxt.config.ts
+++ b/packages/crouton-themes/eink/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/eink',
+    description: 'eink theme for Nuxt UI'
+  },
+  css: [join(currentDir, 'assets/css/main.css')]
+})

--- a/packages/crouton-themes/lib/subtractive.ts
+++ b/packages/crouton-themes/lib/subtractive.ts
@@ -16,7 +16,7 @@
 // Pure + deterministic — SSR and client must compute the identical class string
 // (hydration-mismatch rule from #364). No Date/random/env reads here, ever.
 
-type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'gameboy'
+type ThemeKey = 'minimal' | 'ko' | 'kr11' | 'bw' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'gameboy' | 'riso' | 'eink' | 'blueprint'
 
 // First matching prefix wins; a resolved string only ever carries one theme's
 // markers because `variant` is single-valued and the bw markers live on the
@@ -30,7 +30,10 @@ const MARKERS: Array<[prefix: string, theme: ThemeKey]> = [
   ['mtv-', 'mtv'],
   ['term-', 'terminal'],
   ['braun-', 'braun'],
-  ['gb-', 'gameboy']
+  ['gb-', 'gameboy'],
+  ['riso-', 'riso'],
+  ['eink-', 'eink'],
+  ['bp-', 'blueprint']
 ]
 
 // text-* utilities that are NOT color (sizes, alignment, wrapping) — kept when a
@@ -90,6 +93,17 @@ const STRIP: Record<ThemeKey, (u: string) => boolean> = {
   gameboy: u => isColor(u) || isDecor(u) || isMotion(u)
     || /^(font|tracking)(-|$)/.test(u)
     || /^(uppercase|lowercase|capitalize|normal-case)$/.test(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // Riso: slab formula (like brutalist/mtv) — color, decoration, motion, weight.
+  riso: u => isColor(u) || isDecor(u) || isMotion(u)
+    || /^(font|tracking)(-|$)/.test(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // E-ink: greyscale reading mode — color, decoration, motion, weight, underlines.
+  eink: u => isColor(u) || isDecor(u) || isMotion(u)
+    || /^(font|tracking)(-|$)/.test(u)
+    || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u),
+  // Blueprint: technical mono — owns typography wholesale plus the rest.
+  blueprint: u => isColor(u) || /^text-/.test(u) || isDecor(u) || isMotion(u) || isType(u)
     || /^(no-)?underline(-|$)/.test(u) || /^underline-offset(-|$)/.test(u)
 }
 

--- a/packages/crouton-themes/package.json
+++ b/packages/crouton-themes/package.json
@@ -23,7 +23,13 @@
     "./braun": "./braun/nuxt.config.ts",
     "./braun/*": "./braun/*",
     "./gameboy": "./gameboy/nuxt.config.ts",
-    "./gameboy/*": "./gameboy/*"
+    "./gameboy/*": "./gameboy/*",
+    "./riso": "./riso/nuxt.config.ts",
+    "./riso/*": "./riso/*",
+    "./eink": "./eink/nuxt.config.ts",
+    "./eink/*": "./eink/*",
+    "./blueprint": "./blueprint/nuxt.config.ts",
+    "./blueprint/*": "./blueprint/*"
   },
   "files": [
     "themes",
@@ -36,6 +42,9 @@
     "terminal",
     "braun",
     "gameboy",
+    "riso",
+    "eink",
+    "blueprint",
     "lib"
   ],
   "keywords": [

--- a/packages/crouton-themes/playground/nuxt.config.ts
+++ b/packages/crouton-themes/playground/nuxt.config.ts
@@ -26,6 +26,9 @@ export default defineNuxtConfig({
     '../mtv',
     '../terminal',
     '../braun',
-    '../gameboy'
+    '../gameboy',
+    '../riso',
+    '../eink',
+    '../blueprint'
   ]
 })

--- a/packages/crouton-themes/riso/app.config.ts
+++ b/packages/crouton-themes/riso/app.config.ts
@@ -1,0 +1,115 @@
+// Risograph Theme Configuration (#1311)
+// Grainy 2-color overprint: fluoro pink + teal, misregistration offsets, paper.
+
+import { subtractThemeDefaults } from '../lib/subtractive'
+
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'pink',
+      neutral: 'stone'
+    },
+
+    button: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          'riso': '',
+          'riso-solid': '',
+          'riso-outline': '',
+          'riso-soft': '',
+          'riso-ghost': '',
+          'riso-link': ''
+        }
+      },
+      compoundVariants: [
+        { color: 'primary', variant: 'riso', class: 'riso-btn riso-btn--primary' },
+        { color: 'neutral', variant: 'riso', class: 'riso-btn' },
+        { color: 'error', variant: 'riso', class: 'riso-btn riso-btn--alert' },
+        { variant: 'riso', class: 'riso-btn' },
+
+        { color: 'primary', variant: 'riso-solid', class: 'riso-btn riso-btn--primary' },
+        { color: 'neutral', variant: 'riso-solid', class: 'riso-btn' },
+        { color: 'error', variant: 'riso-solid', class: 'riso-btn riso-btn--alert' },
+        { variant: 'riso-solid', class: 'riso-btn' },
+
+        { color: 'primary', variant: 'riso-outline', class: 'riso-outline riso-outline--primary' },
+        { color: 'neutral', variant: 'riso-outline', class: 'riso-outline' },
+        { color: 'error', variant: 'riso-outline', class: 'riso-outline riso-outline--alert' },
+        { variant: 'riso-outline', class: 'riso-outline' },
+
+        { color: 'primary', variant: 'riso-soft', class: 'riso-soft riso-soft--primary' },
+        { color: 'neutral', variant: 'riso-soft', class: 'riso-soft' },
+        { color: 'error', variant: 'riso-soft', class: 'riso-soft riso-soft--alert' },
+        { variant: 'riso-soft', class: 'riso-soft' },
+
+        { color: 'primary', variant: 'riso-ghost', class: 'riso-ghost riso-ghost--primary' },
+        { color: 'neutral', variant: 'riso-ghost', class: 'riso-ghost' },
+        { color: 'error', variant: 'riso-ghost', class: 'riso-ghost' },
+        { variant: 'riso-ghost', class: 'riso-ghost' },
+
+        { color: 'primary', variant: 'riso-link', class: 'riso-link riso-link--primary' },
+        { color: 'neutral', variant: 'riso-link', class: 'riso-link' },
+        { color: 'error', variant: 'riso-link', class: 'riso-link' },
+        { variant: 'riso-link', class: 'riso-link' }
+      ]
+    },
+
+    input: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            root: 'riso-input',
+            base: 'riso-input-base'
+          }
+        }
+      }
+    },
+
+    card: {
+      slots: {
+        root: subtractThemeDefaults,
+        header: subtractThemeDefaults,
+        body: subtractThemeDefaults,
+        footer: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            root: 'riso-card',
+            header: 'riso-card-header',
+            body: 'riso-card-body',
+            footer: 'riso-card-footer'
+          }
+        }
+      }
+    },
+
+    separator: {
+      variants: {
+        variant: {
+          riso: {
+            border: 'riso-separator'
+          }
+        }
+      }
+    },
+
+    badge: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: 'riso-badge'
+        }
+      }
+    }
+  }
+})

--- a/packages/crouton-themes/riso/assets/css/main.css
+++ b/packages/crouton-themes/riso/assets/css/main.css
@@ -1,0 +1,273 @@
+/* Risograph Theme (#1311)
+   A two-color riso print: fluoro pink + teal on warm paper, deliberate
+   misregistration (each ink layer slightly off), grain in the fills.
+   No !important: built on the shared subtractive replacer. */
+
+:root {
+  --riso-paper: #f7f3e8;
+  --riso-ink: #2f2b27;
+  --riso-pink: #ff48b0;
+  --riso-teal: #00887a;
+  --riso-pink-soft: rgba(255, 72, 176, 0.18);
+  --riso-teal-soft: rgba(0, 136, 122, 0.16);
+  /* Grain: tiny SVG turbulence tile, self-contained (CSP-safe data URI). */
+  --riso-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* ============================================
+   AMBIENT — the paper
+   ============================================ */
+
+[data-theme="riso"],
+.theme-riso {
+  background-color: var(--riso-paper);
+  background-image: var(--riso-grain);
+  --ui-bg: var(--riso-paper);
+}
+
+/* ============================================
+   BUTTONS — misregistered ink blocks
+   The second color prints slightly OFF — that's the whole charm.
+   ============================================ */
+
+.riso-btn {
+  background-color: var(--riso-teal);
+  background-image: var(--riso-grain);
+  color: var(--riso-paper);
+  border: none;
+  border-radius: 2px;
+  box-shadow: 3px 3px 0 var(--riso-pink-soft), -2px -2px 0 var(--riso-teal-soft);
+  font-weight: 700;
+  transition: box-shadow 100ms ease;
+}
+
+.riso-btn:hover {
+  box-shadow: 5px 5px 0 var(--riso-pink-soft), -3px -3px 0 var(--riso-teal-soft);
+}
+
+.riso-btn:active {
+  box-shadow: 1px 1px 0 var(--riso-pink-soft);
+}
+
+.riso-btn--primary {
+  background-color: var(--riso-pink);
+  color: var(--riso-ink);
+  box-shadow: 3px 3px 0 var(--riso-teal-soft), -2px -2px 0 var(--riso-pink-soft);
+}
+
+.riso-btn--primary:hover {
+  box-shadow: 5px 5px 0 var(--riso-teal-soft), -3px -3px 0 var(--riso-pink-soft);
+}
+
+/* Overprint alert: both inks at once. */
+.riso-btn--alert {
+  background-color: var(--riso-pink);
+  color: var(--riso-paper);
+  background-image: var(--riso-grain), linear-gradient(var(--riso-teal-soft), var(--riso-teal-soft));
+}
+
+/* ============================================
+   OUTLINE — a keyline pass
+   ============================================ */
+
+.riso-outline {
+  background-color: transparent;
+  color: var(--riso-teal);
+  border: 2px solid var(--riso-teal);
+  border-radius: 2px;
+  box-shadow: 2px 2px 0 var(--riso-pink-soft);
+  font-weight: 700;
+  transition: background-color 100ms ease;
+}
+
+.riso-outline:hover {
+  background-color: var(--riso-teal-soft);
+}
+
+.riso-outline--primary {
+  color: var(--riso-pink);
+  border-color: var(--riso-pink);
+  box-shadow: 2px 2px 0 var(--riso-teal-soft);
+}
+
+.riso-outline--primary:hover {
+  background-color: var(--riso-pink-soft);
+}
+
+.riso-outline--alert {
+  border-style: dashed;
+}
+
+/* ============================================
+   SOFT — a light ink wash
+   ============================================ */
+
+.riso-soft {
+  background-color: var(--riso-pink-soft);
+  background-image: var(--riso-grain);
+  color: var(--riso-ink);
+  border: none;
+  border-radius: 2px;
+  font-weight: 700;
+  transition: background-color 100ms ease;
+}
+
+.riso-soft:hover {
+  background-color: rgba(255, 72, 176, 0.28);
+}
+
+.riso-soft--primary {
+  background-color: var(--riso-teal-soft);
+}
+
+.riso-soft--alert {
+  background-image: var(--riso-grain), repeating-linear-gradient(-45deg, transparent 0 8px, var(--riso-teal-soft) 8px 16px);
+}
+
+/* ============================================
+   GHOST + LINK
+   ============================================ */
+
+.riso-ghost {
+  background-color: transparent;
+  color: var(--riso-ink);
+  border: none;
+  font-weight: 700;
+  transition: color 100ms ease, text-shadow 100ms ease;
+}
+
+.riso-ghost:hover {
+  color: var(--riso-pink);
+  text-shadow: 1px 1px 0 var(--riso-teal-soft);
+}
+
+.riso-ghost--primary:hover {
+  color: var(--riso-teal);
+  text-shadow: 1px 1px 0 var(--riso-pink-soft);
+}
+
+.riso-link {
+  background-color: transparent;
+  color: var(--riso-ink);
+  border: none;
+  font-weight: 700;
+  text-decoration: underline wavy var(--riso-pink);
+  text-underline-offset: 4px;
+  transition: color 100ms ease;
+}
+
+.riso-link:hover {
+  color: var(--riso-teal);
+  text-decoration-color: var(--riso-teal);
+}
+
+.riso-link--primary {
+  color: var(--riso-pink);
+  text-decoration-color: var(--riso-teal);
+}
+
+/* ============================================
+   INPUTS — a printed field
+   ============================================ */
+
+.riso-input {
+  width: 100%;
+}
+
+.riso-input-base {
+  background-color: #fffdf6;
+  color: var(--riso-ink);
+  border: 2px solid var(--riso-ink);
+  border-radius: 2px;
+  box-shadow: 3px 3px 0 var(--riso-pink-soft);
+  caret-color: var(--riso-pink);
+  transition: box-shadow 100ms ease;
+}
+
+.riso-input-base::placeholder {
+  color: rgba(47, 43, 39, 0.45);
+}
+
+.riso-input-base:focus {
+  outline: none;
+  box-shadow: 3px 3px 0 var(--riso-teal-soft), -2px -2px 0 var(--riso-pink-soft);
+}
+
+.riso-input-base:disabled {
+  border-style: dashed;
+  box-shadow: none;
+  background-color: transparent;
+}
+
+/* ============================================
+   CARD — a zine page
+   ============================================ */
+
+.riso-card {
+  background-color: #fffdf6;
+  background-image: var(--riso-grain);
+  border: 2px solid var(--riso-ink);
+  border-radius: 2px;
+  box-shadow: 6px 6px 0 var(--riso-pink-soft), -3px -3px 0 var(--riso-teal-soft);
+}
+
+.riso-card-header {
+  background-color: var(--riso-pink);
+  background-image: var(--riso-grain);
+  color: var(--riso-ink);
+  border-bottom: 2px solid var(--riso-ink);
+  font-weight: 800;
+  padding: 0.75rem 1rem;
+}
+
+.riso-card-body {
+  color: var(--riso-ink);
+  padding: 1rem;
+}
+
+.riso-card-footer {
+  border-top: 2px dashed var(--riso-teal);
+  padding: 0.75rem 1rem;
+}
+
+/* ============================================
+   SEPARATOR + BADGE
+   ============================================ */
+
+.riso-separator {
+  border-color: var(--riso-pink);
+  border-top-width: 2px;
+  border-style: dotted;
+}
+
+.riso-badge {
+  background-color: var(--riso-teal);
+  background-image: var(--riso-grain);
+  color: var(--riso-paper);
+  border: none;
+  border-radius: 2px;
+  box-shadow: 2px 2px 0 var(--riso-pink-soft);
+  font-weight: 700;
+}
+
+/* ============================================
+   VARIANT-LESS CHROME — USwitch
+   ============================================ */
+
+[data-theme="riso"] button[role="switch"],
+.theme-riso button[role="switch"] {
+  border: 2px solid var(--riso-ink);
+  background-color: #fffdf6;
+  box-shadow: 2px 2px 0 var(--riso-teal-soft);
+  transition: background-color 100ms ease;
+}
+
+[data-theme="riso"] button[role="switch"][data-state="checked"],
+.theme-riso button[role="switch"][data-state="checked"] {
+  background-color: var(--riso-pink);
+}
+
+[data-theme="riso"] button[role="switch"] > span,
+.theme-riso button[role="switch"] > span {
+  background-color: var(--riso-ink);
+}

--- a/packages/crouton-themes/riso/nuxt.config.ts
+++ b/packages/crouton-themes/riso/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineNuxtConfig({
+  $meta: {
+    name: 'crouton-themes/riso',
+    description: 'riso theme for Nuxt UI'
+  },
+  css: [join(currentDir, 'assets/css/main.css')]
+})

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -4,7 +4,7 @@
 
 import { THEME_UI_CONFIGS } from '../configs/themeConfigs'
 
-export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'gameboy' | 'default'
+export type ThemeName = 'ko' | 'minimal' | 'kr11' | 'blackandwhite' | 'brutalist' | 'mtv' | 'terminal' | 'braun' | 'gameboy' | 'riso' | 'eink' | 'blueprint' | 'default'
 
 type BaseVariant = 'solid' | 'outline' | 'soft' | 'ghost' | 'link'
 
@@ -87,6 +87,27 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     label: 'Game Boy',
     description: 'Four shades of olive green, chunky pixels',
     colors: ['#0f380f', '#8bac0f', '#9bbc0e'], // ink, light, screen
+    defaultVariant: 'solid'
+  },
+  {
+    name: 'riso',
+    label: 'Riso',
+    description: 'Two-color riso print — fluoro pink + teal, misregistered',
+    colors: ['#ff48b0', '#00887a', '#f7f3e8'], // pink, teal, paper
+    defaultVariant: 'solid'
+  },
+  {
+    name: 'eink',
+    label: 'E-ink',
+    description: 'Greyscale reading mode — zero motion, newspaper type',
+    colors: ['#1c1c1c', '#6b6b6b', '#f4f2ee'], // ink, gray, paper
+    defaultVariant: 'outline'
+  },
+  {
+    name: 'blueprint',
+    label: 'Blueprint',
+    description: 'Cyanotype drafting sheet — white line-work on blue',
+    colors: ['#123a63', '#dce9f5', '#ffd66b'], // blue, line, pencil
     defaultVariant: 'solid'
   }
 ]

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -151,6 +151,31 @@ const gameboyConfig: ThemeUIConfig = {
   badge: { defaultVariants: { variant: 'gameboy' } }
 }
 
+// Riso / E-ink / Blueprint — named variants registered by their layers (#1311)
+const risoConfig: ThemeUIConfig = {
+  colors: { primary: 'pink', neutral: 'stone' },
+  button: { defaultVariants: { variant: 'riso' } },
+  input: { defaultVariants: { variant: 'riso' } },
+  card: { defaultVariants: { variant: 'riso' } },
+  badge: { defaultVariants: { variant: 'riso' } }
+}
+
+const einkConfig: ThemeUIConfig = {
+  colors: { primary: 'neutral', neutral: 'neutral' },
+  button: { defaultVariants: { variant: 'eink' } },
+  input: { defaultVariants: { variant: 'eink' } },
+  card: { defaultVariants: { variant: 'eink' } },
+  badge: { defaultVariants: { variant: 'eink' } }
+}
+
+const blueprintConfig: ThemeUIConfig = {
+  colors: { primary: 'sky', neutral: 'slate' },
+  button: { defaultVariants: { variant: 'blueprint' } },
+  input: { defaultVariants: { variant: 'blueprint' } },
+  card: { defaultVariants: { variant: 'blueprint' } },
+  badge: { defaultVariants: { variant: 'blueprint' } }
+}
+
 // Export all theme configs
 export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   default: defaultConfig,
@@ -162,5 +187,8 @@ export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {
   mtv: mtvConfig,
   terminal: terminalConfig,
   braun: braunConfig,
-  gameboy: gameboyConfig
+  gameboy: gameboyConfig,
+  riso: risoConfig,
+  eink: einkConfig,
+  blueprint: blueprintConfig
 }


### PR DESCRIPTION
Closes #1311

## 👤 For humans
The owner's three picks, each a full theme: **Riso** (misregistered pink+teal print on grainy paper), **E-ink** (greyscale reading mode, zero motion), **Blueprint** (cyanotype drafting sheet with a faint grid and pencil-yellow callouts). Vaporwave rejected — too close to MTV.

## 🧪 How to test
Playground preview → flip Riso / E-ink / Blueprint. Riso: shadows are offset in the *other* ink; links are wavy. E-ink: nothing animates, ever — states flip; inputs are just underlines. Blueprint: double-frame buttons, dashed dimension separators, the whole sheet is gridded.

Owner approval standing (epic #1303, 2026-07-10). _Dedup-checked: sub-issue #1311 of epic #1303._

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account