### PR TITLE
Source the team Look-and-Feel presets from crouton-themes — all twelve looks, installed-only

### DIFF
--- a/apps/fanfare/nuxt.config.ts
+++ b/apps/fanfare/nuxt.config.ts
@@ -25,6 +25,11 @@ export default defineNuxtConfig({
     '@fyit/crouton-pages',
     '@fyit/crouton-printing',
     '@fyit/crouton-sales',
+    // Theme layers under test (#1303/#1332): the team Look-and-Feel presets
+    // inject ko-*/bw-* classes at runtime, but without these layers the CSS
+    // behind those classes never ships — presets were palette-only before.
+    '@fyit/crouton-themes/ko',
+    '@fyit/crouton-themes/blackandwhite',
     './layers/sales',
     './layers/pages'
   ],

--- a/apps/fanfare/package.json
+++ b/apps/fanfare/package.json
@@ -32,6 +32,7 @@
     "@fyit/crouton-pages": "workspace:*",
     "@fyit/crouton-printing": "workspace:*",
     "@fyit/crouton-sales": "workspace:*",
+    "@fyit/crouton-themes": "workspace:*",
     "@libsql/client": "catalog:",
     "drizzle-orm": "catalog:",
     "nuxt": "catalog:",

--- a/packages/crouton-admin/app/components/TeamThemeSettings.vue
+++ b/packages/crouton-admin/app/components/TeamThemeSettings.vue
@@ -13,6 +13,7 @@ import {
   NEUTRAL_COLORS,
   DEFAULT_THEME,
   THEME_PRESETS,
+  useAvailableThemePresets,
   type ThemePreset,
   type TeamThemeSettings
 } from '../composables/useTeamTheme'
@@ -120,7 +121,12 @@ function revertChanges() {
   localTheme.allowUserThemes = theme.value.allowUserThemes
 }
 
-const presetEntries = Object.entries(THEME_PRESETS) as [ThemePreset, (typeof THEME_PRESETS)[ThemePreset]][]
+// Only presets whose theme layer this app actually extends (#1332) — a
+// preset without its layer would apply palette-only (inert classes).
+const availablePresets = useAvailableThemePresets()
+const presetEntries = computed(() =>
+  Object.entries(availablePresets.value) as [ThemePreset, (typeof THEME_PRESETS)['custom']][]
+)
 </script>
 
 <template>

--- a/packages/crouton-admin/app/composables/useTeamTheme.ts
+++ b/packages/crouton-admin/app/composables/useTeamTheme.ts
@@ -17,7 +17,8 @@
  * ```
  */
 import { computed, watch, readonly } from 'vue'
-import { updateAppConfig } from '#imports'
+import { updateAppConfig, useAppConfig } from '#imports'
+import { THEME_PRESET_REGISTRY, type ThemePresetName } from '@fyit/crouton-themes/themes/configs/presets'
 
 /**
  * Primary color options (Tailwind CSS colors)
@@ -38,9 +39,10 @@ export type ThemeNeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone'
 export type ThemeRadius = 0 | 0.125 | 0.25 | 0.375 | 0.5
 
 /**
- * Named theme presets
+ * Named theme presets: 'custom' plus every theme in crouton-themes'
+ * THEME_PRESET_REGISTRY (#1332 — single source, no more hand-copied configs).
  */
-export type ThemePreset = 'custom' | 'blackandwhite' | 'ko'
+export type ThemePreset = 'custom' | ThemePresetName
 
 /**
  * Team theme settings
@@ -128,92 +130,28 @@ export const THEME_PRESETS: Record<ThemePreset, ThemePresetConfig> = {
     previewNeutral: '#64748b', // slate-500
     ui: {} // handled via individual color/radius settings
   },
-  blackandwhite: {
-    label: 'Black & White',
-    description: 'Compact, monochrome dashboard with subtle form variants',
-    previewPrimary: '#171717', // neutral-900
-    previewNeutral: '#737373', // neutral-500
-    ui: {
-      colors: { primary: 'neutral', neutral: 'neutral' },
-      theme: { defaultVariants: { size: 'sm' } },
-      // Override button variant base classes to inject bw-* CSS classes.
-      // The blackandwhite layer bundles main.css which defines these with
-      // !important to reliably override Nuxt UI's CSS-variable-based defaults
-      // and ensure proper contrast in both light and dark modes.
-      button: {
-        defaultVariants: { variant: 'solid' },
-        variants: {
-          variant: {
-            solid: 'bw-solid',
-            outline: 'bw-outline',
-            soft: 'bw-soft',
-            ghost: 'bw-ghost',
-            link: 'bw-link'
-          }
-        }
-      },
-      input: { defaultVariants: { variant: 'subtle' } },
-      select: { defaultVariants: { variant: 'subtle' } },
-      card: { defaultVariants: { variant: 'outline' } },
-      alert: { defaultVariants: { variant: 'subtle' } },
-      textarea: { defaultVariants: { variant: 'subtle' } }
-    }
-  },
+  // Every crouton theme, derived from the themes package (label, swatches and
+  // a scalars-only `ui` payload — see THEME_PRESET_REGISTRY for why arrays
+  // must never be written through updateAppConfig).
+  ...THEME_PRESET_REGISTRY
+}
 
-  ko: {
-    label: 'KO',
-    description: 'Hardware-inspired with tactile bezels and orange accents',
-    previewPrimary: '#FA5F28', // ko-accent-orange
-    previewNeutral: '#78716c', // stone-500
-    ui: {
-      colors: { primary: 'orange', neutral: 'stone' },
-      theme: { defaultVariants: { size: 'md' } },
-      button: {
-        defaultVariants: { variant: 'ko' },
-        variants: {
-          variant: {
-            ko: '',
-            'ko-solid': '',
-            'ko-outline': '',
-            'ko-soft': '',
-            'ko-ghost': '',
-            'ko-link': ''
-          }
-        },
-        compoundVariants: [
-          { color: 'primary', variant: 'ko', class: 'ko-bezel ko-bezel--orange' },
-          { color: 'neutral', variant: 'ko', class: 'ko-bezel ko-bezel--dark' },
-          { color: 'error', variant: 'ko', class: 'ko-bezel ko-bezel--red' },
-          { color: 'secondary', variant: 'ko', class: 'ko-bezel ko-bezel--pink' },
-          { color: 'info', variant: 'ko', class: 'ko-bezel ko-bezel--blue' },
-          { variant: 'ko', class: 'ko-bezel' },
-          { variant: 'ko-solid', color: 'primary', class: 'ko-bezel ko-bezel--orange' },
-          { variant: 'ko-solid', color: 'neutral', class: 'ko-bezel ko-bezel--dark' },
-          { variant: 'ko-solid', class: 'ko-bezel' },
-          { variant: 'ko-outline', color: 'primary', class: 'ko-outline ko-outline--orange' },
-          { variant: 'ko-outline', color: 'neutral', class: 'ko-outline ko-outline--dark' },
-          { variant: 'ko-outline', class: 'ko-outline' },
-          { variant: 'ko-soft', color: 'primary', class: 'ko-soft ko-soft--orange' },
-          { variant: 'ko-soft', color: 'neutral', class: 'ko-soft ko-soft--dark' },
-          { variant: 'ko-soft', class: 'ko-soft' },
-          { variant: 'ko-ghost', color: 'primary', class: 'ko-ghost ko-ghost--orange' },
-          { variant: 'ko-ghost', color: 'neutral', class: 'ko-ghost ko-ghost--dark' },
-          { variant: 'ko-ghost', class: 'ko-ghost' },
-          { variant: 'ko-link', color: 'primary', class: 'ko-link ko-link--orange' },
-          { variant: 'ko-link', color: 'neutral', class: 'ko-link ko-link--dark' },
-          { variant: 'ko-link', class: 'ko-link' }
-        ]
-      },
-      input: {
-        defaultVariants: { variant: 'ko' },
-        variants: { variant: { ko: { root: 'ko-input', base: 'ko-input-base' } } }
-      },
-      card: {
-        defaultVariants: { variant: 'ko' },
-        variants: { variant: { ko: { root: 'ko-card', header: 'ko-card-header', body: 'ko-card-body', footer: 'ko-card-footer' } } }
-      }
-    }
-  }
+/**
+ * Presets actually USABLE in this app: a theme's classes/CSS ship only when
+ * its layer is extended (build-time), so filter by whether the theme's named
+ * variant exists in the built app config. 'custom' is always available.
+ */
+export function useAvailableThemePresets() {
+  const appConfig = useAppConfig()
+  return computed<Partial<Record<ThemePreset, ThemePresetConfig>>>(() => {
+    const registered = (appConfig as any)?.ui?.button?.variants?.variant ?? {}
+    const entries = Object.entries(THEME_PRESETS).filter(([name, preset]) => {
+      if (name === 'custom') return true
+      const check = THEME_PRESET_REGISTRY[name as ThemePresetName]?.checkVariant
+      return !!check && check in registered
+    })
+    return Object.fromEntries(entries)
+  })
 }
 
 /**
@@ -225,7 +163,15 @@ export function applyThemeSettings(settings: TeamThemeSettings) {
   const radius = settings.radius ?? DEFAULT_THEME.radius
 
   if (preset !== 'custom') {
-    updateAppConfig({ ui: THEME_PRESETS[preset].ui })
+    const entry = THEME_PRESETS[preset]
+    if (!entry) {
+      // Persisted preset whose layer is no longer extended — fall back to
+      // structural defaults rather than crashing or half-applying.
+      updateAppConfig({ ui: { ...NUXT_UI_STRUCTURAL_DEFAULTS } as any })
+    }
+    else {
+      updateAppConfig({ ui: entry.ui as any })
+    }
   }
   else {
     const primary = settings.primary ?? DEFAULT_THEME.primary

--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -605,6 +605,16 @@ to own every structural class up front — not a routine crouton theme.
 
 Spikes: #364 (replacer), #1305 (unstyled); rollout to all themes: #1304.
 
+### Presets for apps (`themes/configs/presets.ts`) — #1332
+
+`THEME_PRESET_REGISTRY` derives an admin-facing preset per theme (label,
+description, preview swatches, scalars-only `ui` payload, and a `checkVariant`
+whose presence in the built app config proves the theme's layer is extended).
+crouton-admin's team Look-and-Feel picker consumes it via
+`useAvailableThemePresets()` — add a theme here, and every app that extends its
+layer gets it in the picker automatically. Never add arrays to the payload
+(next section).
+
 ### Runtime switching swaps SCALARS only (deepAssign hazard) — #1304
 
 `updateAppConfig()` merges with Nuxt's `deepAssign`, which merges **arrays by

--- a/packages/crouton-themes/themes/configs/presets.ts
+++ b/packages/crouton-themes/themes/configs/presets.ts
@@ -1,0 +1,51 @@
+// Theme preset registry — the SINGLE SOURCE for "themes available in apps"
+// (#1332). crouton-admin's team Look-and-Feel picker consumes this instead of
+// hand-copying theme configs (the old copy drifted: only bw/ko existed, its ko
+// entry wrote compoundVariants at runtime — the deepAssign array hazard — and
+// presets didn't reset each other's keys).
+//
+// Derived, not duplicated: metadata comes from AVAILABLE_THEMES, the applied
+// `ui` payload IS the scalars-only THEME_UI_CONFIGS entry (colors +
+// defaultVariants.variant per component — every config sets every owned key,
+// so switching any preset to any other leaves nothing behind).
+
+import { AVAILABLE_THEMES, type ThemeName } from '../composables/useThemeSwitcher'
+import { THEME_UI_CONFIGS, type ThemeUIConfig } from './themeConfigs'
+
+export interface ThemePresetEntry {
+  /** Human label for the picker card */
+  label: string
+  /** One-line description for the picker card */
+  description: string
+  /** Hex swatches for the preview dots */
+  previewPrimary: string
+  previewNeutral: string
+  /**
+   * The named button variant this preset resolves to. Presence of this key in
+   * the built app config's `ui.button.variants.variant` proves the theme's
+   * LAYER is extended by the app — the preset is only usable then (classes and
+   * CSS ship at build time; the runtime swap is scalars-only).
+   */
+  checkVariant: string
+  /** Scalars-only payload for updateAppConfig({ ui }) */
+  ui: ThemeUIConfig
+}
+
+export type ThemePresetName = Exclude<ThemeName, 'default'>
+
+export const THEME_PRESET_REGISTRY: Record<ThemePresetName, ThemePresetEntry>
+  = Object.fromEntries(
+    AVAILABLE_THEMES
+      .filter(t => t.name !== 'default')
+      .map((t) => {
+        const ui = THEME_UI_CONFIGS[t.name]
+        return [t.name, {
+          label: t.label,
+          description: t.description ?? '',
+          previewPrimary: t.colors[0] ?? '#000000',
+          previewNeutral: t.colors[1] ?? '#666666',
+          checkVariant: ui?.button?.defaultVariants?.variant ?? t.name,
+          ui: ui ?? {}
+        } satisfies ThemePresetEntry]
+      })
+  ) as Record<ThemePresetName, ThemePresetEntry>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@fyit/crouton-sales':
         specifier: workspace:*
         version: link:../../packages/crouton-sales
+      '@fyit/crouton-themes':
+        specifier: workspace:*
+        version: link:../../packages/crouton-themes
       '@libsql/client':
         specifier: 'catalog:'
         version: 0.17.4


### PR DESCRIPTION
Closes #1332

## 👤 For humans
The team theme picker now lists every crouton theme automatically — but only the ones the app actually ships (extends the layer), so a preset can never apply as inert palette-only styling. fanfare opts into KO + Black & White as the first consumer.

## 🤖 For agents
Registry `themes/configs/presets.ts` derived from AVAILABLE_THEMES + THEME_UI_CONFIGS (scalars-only payloads); `useAvailableThemePresets()` filters by the theme's named variant existing in the built app config; `applyThemeSettings` guards removed-layer presets. Kills the old ko preset's runtime `compoundVariants` write (the deepAssign index-clobber) and the no-reset-between-presets bug.

## 🧪 How to test
On fanfare (extends ko+bw): admin → Uiterlijk shows exactly **Custom / KO / Black & White**; apply KO → tactile bezels everywhere (verified live); switch KO → Custom → nothing lingers. Extend another theme layer in the app → its preset appears with no admin change.

Owner approval standing (epic #1303, 2026-07-10). _Dedup-checked: sub-issue #1332 of epic #1303._

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account