### PR TITLE
Crouton-surfaces coverage page + select/textarea chrome for eight themes

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -465,6 +465,24 @@ Use theme-prefixed CSS custom properties:
 }
 ```
 
+## Chrome vs data (#1333)
+
+Themes style the **interaction chrome** — buttons, inputs, selects, textareas,
+switches, badges, cards, separators — and deliberately leave **dense data
+surfaces** (table rows, long forms' layout) calm and readable. Skeuomorphic
+chrome on five hundred table cells is bad ergonomics and bad paint performance;
+the hardware/print/CRT character belongs on the controls around the data. The
+playground's `/crouton` page is the check: a generated-CRUD-shaped composition
+(tabs, table, pagination, form with select/textarea/switch, edit modal) where
+every theme must look intentional — themed chrome, calm table.
+
+Coverage status: all 8 post-#1304 themes (brutalist, mtv, terminal, braun,
+gameboy, riso, eink, blueprint) register `select` + `textarea` variants reusing
+their input classes. The 4 originals (ko, kr11, minimal, blackandwhite) pass on
+select/textarea for now (their runtime configs reset those to Nuxt UI defaults);
+UTabs/UPagination/UTable are a deliberate pass everywhere — they read as data
+surfaces.
+
 ## Nuxt UI Theming Pattern
 
 The key insight for Nuxt UI 4 theming:

--- a/packages/crouton-themes/blueprint/app.config.ts
+++ b/packages/crouton-themes/blueprint/app.config.ts
@@ -72,6 +72,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: 'bp-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            root: 'bp-input',
+            base: 'bp-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/braun/app.config.ts
+++ b/packages/crouton-themes/braun/app.config.ts
@@ -79,6 +79,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: 'braun-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            root: 'braun-input',
+            base: 'braun-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/brutalist/app.config.ts
+++ b/packages/crouton-themes/brutalist/app.config.ts
@@ -81,6 +81,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: 'brutalist-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            root: 'brutalist-input',
+            base: 'brutalist-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/eink/app.config.ts
+++ b/packages/crouton-themes/eink/app.config.ts
@@ -72,6 +72,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: 'eink-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            root: 'eink-input',
+            base: 'eink-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/gameboy/app.config.ts
+++ b/packages/crouton-themes/gameboy/app.config.ts
@@ -80,6 +80,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: 'gb-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            root: 'gb-input',
+            base: 'gb-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/mtv/app.config.ts
+++ b/packages/crouton-themes/mtv/app.config.ts
@@ -80,6 +80,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: 'mtv-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            root: 'mtv-input',
+            base: 'mtv-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/playground/app/app.vue
+++ b/packages/crouton-themes/playground/app/app.vue
@@ -2,7 +2,8 @@
 // crouton-themes playground (#1306) — the daily dev surface AND the theme
 // gallery this epic (#1303) uses for ui-proposal sign-off. Pages:
 //   /    the gallery — every themed component once, restyled by the switcher
-//   /ko  the original ko-ui hardware showcase, resurrected (#1304)
+//   /ko       the original ko-ui hardware showcase, resurrected (#1304)
+//   /crouton  a generated-CRUD-shaped page — theme coverage check (#1333)
 </script>
 
 <template>
@@ -19,6 +20,7 @@
         <nav class="flex gap-4 text-sm">
           <NuxtLink to="/" class="underline underline-offset-2">Gallery</NuxtLink>
           <NuxtLink to="/ko" class="underline underline-offset-2">KO hardware showcase</NuxtLink>
+          <NuxtLink to="/crouton" class="underline underline-offset-2">Crouton surfaces</NuxtLink>
         </nav>
       </div>
       <ThemeSwitcher />

--- a/packages/crouton-themes/playground/app/pages/crouton.vue
+++ b/packages/crouton-themes/playground/app/pages/crouton.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+// Crouton surfaces (#1333) — a realistic generated-CRUD composition, so every
+// theme's coverage gaps are visible at sign-off time instead of discovered in
+// an app. The chrome-vs-data rule: controls follow the theme; dense data
+// surfaces (the table) stay calm and readable under every theme.
+const { getVariant } = useThemeSwitcher()
+
+const rows = [
+  { id: 1, name: 'Frisdrank', price: '€ 2,00', status: 'active', stock: 140 },
+  { id: 2, name: 'Pils', price: '€ 2,50', status: 'active', stock: 96 },
+  { id: 3, name: 'Wijn', price: '€ 4,00', status: 'low', stock: 7 },
+  { id: 4, name: 'Koffie', price: '€ 2,20', status: 'active', stock: 55 },
+  { id: 5, name: 'Soep', price: '€ 3,50', status: 'inactive', stock: 0 }
+]
+
+const columns = [
+  { accessorKey: 'name', header: 'Product' },
+  { accessorKey: 'price', header: 'Prijs' },
+  { accessorKey: 'status', header: 'Status' },
+  { accessorKey: 'stock', header: 'Voorraad' }
+]
+
+const tabItems = [
+  { label: 'Producten', value: 'products' },
+  { label: 'Categorieën', value: 'categories' },
+  { label: 'Instellingen', value: 'settings' }
+]
+
+const categories = ['Dranken', 'Eten', 'Merch']
+
+const form = reactive({
+  name: '',
+  category: 'Dranken',
+  description: '',
+  active: true
+})
+
+const page = ref(1)
+const isEditOpen = ref(false)
+</script>
+
+<template>
+  <div class="space-y-10">
+    <section class="space-y-3">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Collection list (table stays calm by design)
+      </h2>
+      <UTabs :items="tabItems" default-value="products" class="max-w-md" />
+      <UTable :data="rows" :columns="columns" class="max-w-2xl" />
+      <div class="flex items-center justify-between max-w-2xl">
+        <UPagination v-model:page="page" :total="42" :items-per-page="10" />
+        <UButton color="primary" @click="isEditOpen = true">Nieuw product</UButton>
+      </div>
+    </section>
+
+    <section class="space-y-3 max-w-md">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Collection form
+      </h2>
+      <UFormField label="Naam" name="name">
+        <UInput v-model="form.name" placeholder="Productnaam" />
+      </UFormField>
+      <UFormField label="Categorie" name="category">
+        <USelect v-model="form.category" :items="categories" />
+      </UFormField>
+      <UFormField label="Omschrijving" name="description">
+        <UTextarea v-model="form.description" placeholder="Korte omschrijving..." :rows="3" />
+      </UFormField>
+      <div class="flex items-center justify-between">
+        <USwitch v-model="form.active" label="Actief" />
+        <div class="flex gap-2">
+          <UButton color="neutral" :variant="getVariant('ghost')">Annuleren</UButton>
+          <UButton color="primary">Opslaan</UButton>
+        </div>
+      </div>
+    </section>
+
+    <UModal v-model:open="isEditOpen" title="Product bewerken">
+      <template #body>
+        <div class="space-y-4">
+          <UFormField label="Naam" name="edit-name">
+            <UInput placeholder="Productnaam" />
+          </UFormField>
+          <UFormField label="Categorie" name="edit-category">
+            <USelect :items="categories" :model-value="'Dranken'" />
+          </UFormField>
+        </div>
+      </template>
+      <template #footer>
+        <UButton color="neutral" :variant="getVariant('outline')" @click="isEditOpen = false">
+          Sluiten
+        </UButton>
+        <UButton color="primary" @click="isEditOpen = false">Bewaren</UButton>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/packages/crouton-themes/riso/app.config.ts
+++ b/packages/crouton-themes/riso/app.config.ts
@@ -72,6 +72,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: 'riso-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            root: 'riso-input',
+            base: 'riso-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/terminal/app.config.ts
+++ b/packages/crouton-themes/terminal/app.config.ts
@@ -79,6 +79,32 @@ export default defineAppConfig({
       }
     },
 
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: 'term-input-base'
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            root: 'term-input',
+            base: 'term-input-base'
+          }
+        }
+      }
+    },
+
     card: {
       slots: {
         root: subtractThemeDefaults,

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -24,6 +24,8 @@ export interface ThemeUIConfig {
   input?: { defaultVariants?: { variant?: string } }
   card?: { defaultVariants?: { variant?: string } }
   badge?: { defaultVariants?: { variant?: string } }
+  select?: { defaultVariants?: { variant?: string } }
+  textarea?: { defaultVariants?: { variant?: string } }
 }
 
 // Every config sets EVERY key the swap owns, so switching A → B never leaves
@@ -38,7 +40,9 @@ const defaultConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'solid' } },
   input: { defaultVariants: { variant: 'outline' } },
   card: { defaultVariants: { variant: 'outline' } },
-  badge: { defaultVariants: { variant: 'solid' } }
+  badge: { defaultVariants: { variant: 'solid' } },
+  select: { defaultVariants: { variant: 'outline' } },
+  textarea: { defaultVariants: { variant: 'outline' } }
 }
 
 // KO — named variants registered by ko/app.config.ts (variant="ko" etc.)
@@ -50,7 +54,9 @@ const koConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'ko' } },
   input: { defaultVariants: { variant: 'ko' } },
   card: { defaultVariants: { variant: 'ko' } },
-  badge: { defaultVariants: { variant: 'solid' } }
+  badge: { defaultVariants: { variant: 'solid' } },
+  select: { defaultVariants: { variant: 'outline' } },
+  textarea: { defaultVariants: { variant: 'outline' } }
 }
 
 // Minimal — named variants registered by minimal/app.config.ts
@@ -62,7 +68,9 @@ const minimalConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'minimal' } },
   input: { defaultVariants: { variant: 'minimal' } },
   card: { defaultVariants: { variant: 'minimal' } },
-  badge: { defaultVariants: { variant: 'solid' } }
+  badge: { defaultVariants: { variant: 'solid' } },
+  select: { defaultVariants: { variant: 'outline' } },
+  textarea: { defaultVariants: { variant: 'outline' } }
 }
 
 // KR-11 — named variants registered by kr11/app.config.ts
@@ -74,7 +82,9 @@ const kr11Config: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'kr11' } },
   input: { defaultVariants: { variant: 'kr11' } },
   card: { defaultVariants: { variant: 'kr11' } },
-  badge: { defaultVariants: { variant: 'kr11' } }
+  badge: { defaultVariants: { variant: 'kr11' } },
+  select: { defaultVariants: { variant: 'outline' } },
+  textarea: { defaultVariants: { variant: 'outline' } }
 }
 
 // Black & White — named bw-* variants registered by blackandwhite/app.config.ts
@@ -88,7 +98,9 @@ const blackandwhiteConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'bw-solid' } },
   input: { defaultVariants: { variant: 'subtle' } },
   card: { defaultVariants: { variant: 'outline' } },
-  badge: { defaultVariants: { variant: 'solid' } }
+  badge: { defaultVariants: { variant: 'solid' } },
+  select: { defaultVariants: { variant: 'subtle' } },
+  textarea: { defaultVariants: { variant: 'subtle' } }
 }
 
 // Brutalist — named variants registered by brutalist/app.config.ts
@@ -100,7 +112,9 @@ const brutalistConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'brutalist' } },
   input: { defaultVariants: { variant: 'brutalist' } },
   card: { defaultVariants: { variant: 'brutalist' } },
-  badge: { defaultVariants: { variant: 'brutalist' } }
+  badge: { defaultVariants: { variant: 'brutalist' } },
+  select: { defaultVariants: { variant: 'brutalist' } },
+  textarea: { defaultVariants: { variant: 'brutalist' } }
 }
 
 // MTV — named variants registered by mtv/app.config.ts
@@ -112,7 +126,9 @@ const mtvConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'mtv' } },
   input: { defaultVariants: { variant: 'mtv' } },
   card: { defaultVariants: { variant: 'mtv' } },
-  badge: { defaultVariants: { variant: 'mtv' } }
+  badge: { defaultVariants: { variant: 'mtv' } },
+  select: { defaultVariants: { variant: 'mtv' } },
+  textarea: { defaultVariants: { variant: 'mtv' } }
 }
 
 // Terminal — named variants registered by terminal/app.config.ts
@@ -124,7 +140,9 @@ const terminalConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'terminal' } },
   input: { defaultVariants: { variant: 'terminal' } },
   card: { defaultVariants: { variant: 'terminal' } },
-  badge: { defaultVariants: { variant: 'terminal' } }
+  badge: { defaultVariants: { variant: 'terminal' } },
+  select: { defaultVariants: { variant: 'terminal' } },
+  textarea: { defaultVariants: { variant: 'terminal' } }
 }
 
 // Braun — named variants registered by braun/app.config.ts
@@ -136,7 +154,9 @@ const braunConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'braun' } },
   input: { defaultVariants: { variant: 'braun' } },
   card: { defaultVariants: { variant: 'braun' } },
-  badge: { defaultVariants: { variant: 'braun' } }
+  badge: { defaultVariants: { variant: 'braun' } },
+  select: { defaultVariants: { variant: 'braun' } },
+  textarea: { defaultVariants: { variant: 'braun' } }
 }
 
 // Game Boy — named variants registered by gameboy/app.config.ts
@@ -148,7 +168,9 @@ const gameboyConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'gameboy' } },
   input: { defaultVariants: { variant: 'gameboy' } },
   card: { defaultVariants: { variant: 'gameboy' } },
-  badge: { defaultVariants: { variant: 'gameboy' } }
+  badge: { defaultVariants: { variant: 'gameboy' } },
+  select: { defaultVariants: { variant: 'gameboy' } },
+  textarea: { defaultVariants: { variant: 'gameboy' } }
 }
 
 // Riso / E-ink / Blueprint — named variants registered by their layers (#1311)
@@ -157,7 +179,9 @@ const risoConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'riso' } },
   input: { defaultVariants: { variant: 'riso' } },
   card: { defaultVariants: { variant: 'riso' } },
-  badge: { defaultVariants: { variant: 'riso' } }
+  badge: { defaultVariants: { variant: 'riso' } },
+  select: { defaultVariants: { variant: 'riso' } },
+  textarea: { defaultVariants: { variant: 'riso' } }
 }
 
 const einkConfig: ThemeUIConfig = {
@@ -165,7 +189,9 @@ const einkConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'eink' } },
   input: { defaultVariants: { variant: 'eink' } },
   card: { defaultVariants: { variant: 'eink' } },
-  badge: { defaultVariants: { variant: 'eink' } }
+  badge: { defaultVariants: { variant: 'eink' } },
+  select: { defaultVariants: { variant: 'eink' } },
+  textarea: { defaultVariants: { variant: 'eink' } }
 }
 
 const blueprintConfig: ThemeUIConfig = {
@@ -173,7 +199,9 @@ const blueprintConfig: ThemeUIConfig = {
   button: { defaultVariants: { variant: 'blueprint' } },
   input: { defaultVariants: { variant: 'blueprint' } },
   card: { defaultVariants: { variant: 'blueprint' } },
-  badge: { defaultVariants: { variant: 'blueprint' } }
+  badge: { defaultVariants: { variant: 'blueprint' } },
+  select: { defaultVariants: { variant: 'blueprint' } },
+  textarea: { defaultVariants: { variant: 'blueprint' } }
 }
 
 // Export all theme configs


### PR DESCRIPTION
Closes #1333

## 👤 For humans
A new playground page shaped like a real generated CRUD screen (tabs, table, pagination, form, edit modal) makes every theme's coverage visible; eight themes gain themed selects and textareas; the table stays calm under every theme — that's the documented chrome-vs-data rule.

## 🧪 How to test
Playground preview → **Crouton surfaces** → flip themes: the form controls follow the theme, the table stays readable. Open the edit modal per theme.

Owner approval standing (epic #1303, 2026-07-10). _Dedup-checked: sub-issue #1333 of epic #1303._

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account