### PR TITLE
fix(root): real bound preview URL + stop masking dead-preview failures (#1369)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -273,8 +273,24 @@ jobs:
           else
             URL="${{ inputs['staging-url'] }}"
           fi
-          if [ -z "$URL" ]; then
-            URL=$(grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' deploy.log | tail -1 || true)
+          # The workers.dev URL wrangler ACTUALLY published (empty for a real custom-domain deploy).
+          WORKERS_URL=$(grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' deploy.log | tail -1 || true)
+          # #1369: a configured custom-domain URL is only REAL if wrangler bound its route. A POC
+          # scaffolded without --domain has NO route in wrangler.jsonc, so <app>.pmcp.dev never
+          # resolves (HTTP 000) even though the Worker serves fine at *.workers.dev. Trusting the
+          # configured URL blindly then advertised a dead link AND pointed the login-seed + smoke at
+          # it (they masked the failure) — a green-but-broken "Potemkin" preview. So: use the
+          # configured URL only if it RESOLVES; otherwise fall back to the workers.dev URL wrangler
+          # published. Every downstream step (comment, seed-login, smoke) reads steps.deploy.outputs.url,
+          # so this one check makes them all point at the reachable deploy.
+          if [ -n "$URL" ]; then
+            code=$(curl -s -o /dev/null -w '%{http_code}' -m 20 "$URL" 2>/dev/null || echo 000)
+            if [ "$code" = "000" ] && [ -n "$WORKERS_URL" ]; then
+              echo "::warning::Configured URL $URL is unreachable (HTTP 000 — no bound route). Using the deployed $WORKERS_URL instead (#1369)."
+              URL="$WORKERS_URL"
+            fi
+          elif [ -n "$WORKERS_URL" ]; then
+            URL="$WORKERS_URL"
           fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "Deployed: ${URL:-<url not parsed>}"
@@ -420,18 +436,25 @@ jobs:
           # Attach the review login to the SEEDED demo team (#832) so the advertised
           # login lands in the team the content seed populated (test1 → seed:org:test1),
           # not an empty fresh org. Staging-only step → production is untouched.
-          node scripts/seed-review-login.mjs --url "$DEPLOY_URL" --email "$EMAIL" --password "$PW" \
-            --seed-team test1 --db "${APP}-staging-db" || true
-          # Surface for the PR comment + the run summary (the password is masked in logs).
-          echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
-          echo "password=$PW" >> "$GITHUB_OUTPUT"
-          {
-            echo "### 🔑 Review test login (${APP})"
-            echo "- **URL:** $DEPLOY_URL"
-            echo "- **Email:** \`$EMAIL\`"
-            echo "- **Password:** \`$PW\`"
-            echo "_Disposable account on an isolated, throwaway staging DB._"
-          } >> "$GITHUB_STEP_SUMMARY"
+          # #1369: DON'T mask the seed with `|| true` and then advertise the creds anyway — that
+          # printed a working-looking login for a user that was never created (the seed POSTed to a
+          # dead URL → failed silently → 401 on login). Only surface the creds when the seed actually
+          # succeeded; otherwise emit a loud warning and NO login (a broken preview must look broken).
+          if node scripts/seed-review-login.mjs --url "$DEPLOY_URL" --email "$EMAIL" --password "$PW" \
+               --seed-team test1 --db "${APP}-staging-db"; then
+            echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
+            echo "password=$PW" >> "$GITHUB_OUTPUT"
+            {
+              echo "### 🔑 Review test login (${APP})"
+              echo "- **URL:** $DEPLOY_URL"
+              echo "- **Email:** \`$EMAIL\`"
+              echo "- **Password:** \`$PW\`"
+              echo "_Disposable account on an isolated, throwaway staging DB._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Review-login seed FAILED for ${APP} at ${DEPLOY_URL} — not advertising a login that doesn't work (#1369)."
+            echo "### ⚠️ Review login unavailable (${APP}) — the seed step failed; no working login for this preview." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # Prove the DEPLOYED preview actually works — log in with the seeded account, run
       # any app-declared CRUD + public read, and screenshot it (#293). This is the


### PR DESCRIPTION
Closes #1369 · part of epic #1367

## 👤 For humans
Dogfooding the snippets UI sign-off (#1318) surfaced that POC previews are **Potemkin**: the deploy is green but the advertised URL is dead (`snippets.pmcp.dev` → HTTP 000) and the posted login is rejected (401) — because the pipeline trusted the configured `stagingUrl` even though a POC (no `--domain`) has no route for it, so wrangler served at `*.workers.dev` and `pmcp.dev` was never provisioned. The login-seed + smoke then drove that dead URL but **masked** their failures.

This makes the deploy honest:
- **Resolve the real URL** — if the configured URL doesn't respond (HTTP 000), use the `*.workers.dev` URL wrangler actually published. Every downstream step reads `steps.deploy.outputs.url`, so the PR comment, the login-seed, and the smoke all now point at the reachable deploy.
- **Stop masking** — a failed login-seed no longer prints fake creds; it emits a loud warning and no login.

## 🤖 For agents
`deploy-app.yml`: (1) deploy step adds a `curl` reachability check + workers.dev fallback; (2) seed-login drops `|| true`, gating the cred outputs on real success. No `packages/` changes.

## 🧪 How to test
Re-deploy the snippets POC preview: the PR comment should advertise `https://snippets-staging.<sub>.workers.dev` (which serves 200), the login should actually work, and a genuinely-broken deploy should now fail its login-seed loudly instead of printing dead creds.