### PR TITLE
fix(root): seed collection + demo data on POC staging previews (#1370)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -392,6 +392,23 @@ jobs:
             printf '%s' "$(openssl rand -hex 32)" | npx wrangler secret put BETTER_AUTH_SECRET $ENV_FLAG
           fi
 
+      # Seed the app's COLLECTION fixtures + package demo data into the staging D1 so the
+      # preview isn't an empty shell (#1370): the generated seed.json rows (#298) + the demo
+      # team `test1` (seed:org:test1) the review login below attaches to. Runs BEFORE the
+      # review-login step for exactly that reason — the login lands in a populated team, not a
+      # phantom one. Idempotent (crouton-seed upserts by stable id → a redeploy re-seed is a
+      # no-op); best-effort — warns, never reds the deploy. Skipped cleanly when the app doesn't
+      # depend on @fyit/crouton-cli (crouton-seed unresolvable via pnpm exec). Staging only.
+      - name: Seed collection + demo data (staging only, #1370)
+        if: ${{ inputs.environment != 'production' }}
+        working-directory: ${{ inputs.workspace }}/${{ inputs.app }}
+        run: |
+          if pnpm exec crouton-seed --db "${{ inputs.app }}-staging-db" --remote; then
+            echo "✓ seeded ${{ inputs.app }}-staging-db (collection fixtures + demo team)"
+          else
+            echo "::warning::content seed skipped/failed for ${{ inputs.app }} — crouton-seed unresolvable or errored; the preview may be empty (#1370)."
+          fi
+
       # Seed a throwaway, loginable test account on the (isolated, staging-only)
       # preview so a reviewer can open the URL and be inside the app in one step —
       # no register → create-team wall (#608). Drives the app's own HTTP auth on the


### PR DESCRIPTION
Closes #1370 · part of epic #1367

## 👤 For humans
Even with a working URL + login (WS1, #1372), a POC preview opened to an **empty list** — the generated `seed.json` sample rows (#298) and the demo team `test1` the review login attaches to were never applied on deploy. Now the staging deploy seeds them, so a reviewer lands on real content.

## 🤖 For agents
`deploy-app.yml`: new **"Seed collection + demo data"** step (staging only) placed **before** the review-login step — the login attaches to team `test1` (`seed:org:test1`), which only exists once the content seed runs. `pnpm exec crouton-seed --db <app>-staging-db --remote`; idempotent (stable-id upsert → redeploy re-seed is a no-op), best-effort (warns, never reds the deploy), and skipped cleanly when the app has no `@fyit/crouton-cli` dep. Touches only `deploy-app.yml` (independent of WS1's regions).

## 🧪 How to test
Re-deploy the snippets POC → the list shows the 3 generated sample rows and the review login lands in the populated `test1` team, not an empty one.