### PR TITLE
fix(crouton-cli): scaffold a correct deploy.config.json (#1371)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -206,6 +206,7 @@ NOT Cloudflare Pages. Generated artifacts:
 | File | Purpose |
 |------|---------|
 | `wrangler.jsonc` | Workers config, **id-less** D1+KV (top-level + `env.staging`) so the first deploy auto-provisions them; `name`/`assets`/`main` injected by the `cloudflare_module` preset at build |
+| `deploy.config.json` | The opt-in the generic **Deploy Apps/POCs** pipeline reads (#481/#638) — `layerPackages` + the deploy URLs. #1367/#1371: `stagingUrl`/`productionUrl` are emitted **only with `--domain`** (= exactly when the matching custom-domain routes are written), so staging is `https://<name>-staging.<zone>` (NOT the prod pattern). **Without `--domain` → `stagingUrl: ""`**, and the deploy resolves the real `*.workers.dev` URL (#1369) rather than advertising an alias that was never bound (the dead-preview bug). `tmplDeployConfig` in `lib/scaffold-app.ts` |
 | `scripts/sync-wrangler-ids.mjs` | After provisioning, queries `wrangler d1 list`/`kv namespace list` and writes the ids back into `wrangler.jsonc` (D1 by `database_name`, KV by the deterministic `<worker>-<binding>` title). Idempotent, comment-preserving |
 | `scripts/inject-wrangler-env.mjs` | Re-injects the `env` block Nitro strips from `.output/server/wrangler.json` (nitro#3429) + drops the redirect so `--env staging` deploys work |
 | `drizzle.config.ts` | Resolves the bundled schema path (`.nuxt/` or the cache buildDir) so `db:generate` works unedited |

--- a/packages/crouton-cli/lib/scaffold-app.ts
+++ b/packages/crouton-cli/lib/scaffold-app.ts
@@ -277,6 +277,26 @@ ${featuresStr ? featuresStr + '\n' : ''}  },
 `
 }
 
+// deploy.config.json — the opt-in the generic "Deploy Apps/POCs" pipeline reads (#481/#638).
+// #1367/#1371: emit CORRECT URLs so nobody hand-guesses them (the dead-preview bug: an agent
+// wrote `stagingUrl: <name>.pmcp.dev` with no matching route → HTTP 000). stagingUrl/productionUrl
+// are set ONLY when `--domain` was passed — which is exactly when tmplWranglerJsonc also writes the
+// matching custom-domain ROUTES (`<name>-staging.<zone>` / `<name>.<zone>`). Without `--domain`
+// there is no route, so the Worker serves at *.workers.dev: we leave stagingUrl EMPTY and the
+// deploy resolves the real published URL (#1369) instead of advertising an alias that was never
+// bound. Note the staging subdomain is `<name>-staging.<zone>` (matches the route), NOT `<name>`.
+export function tmplDeployConfig(vars: ScaffoldVars): string {
+  const config: Record<string, string> = {}
+  if (vars.domain) {
+    config.stagingUrl = `https://${vars.name}-staging.${vars.domain}`
+    config.productionUrl = `https://${vars.name}.${vars.domain}`
+  } else {
+    config.stagingUrl = ''
+  }
+  config.layerPackages = vars.extends.join(' ')
+  return JSON.stringify(config, null, 2) + '\n'
+}
+
 function tmplWranglerJsonc(vars: ScaffoldVars): string {
   // Workers (static-assets), id-LESS so the first `pnpm cf:deploy` auto-provisions D1+KV;
   // `sync-wrangler-ids.mjs` writes the ids back (bootstrap → committed). With `--domain`,
@@ -637,6 +657,7 @@ async function buildScaffoldFiles(ctx: ScaffoldContext, outDir: string | undefin
   ])
   files.push(
     { path: 'wrangler.jsonc', content: tmplWranglerJsonc(vars) },
+    { path: 'deploy.config.json', content: tmplDeployConfig(vars) },
     { path: 'drizzle.config.ts', content: tmplDrizzleConfig() },
     { path: 'scripts/inject-wrangler-env.mjs', content: injectScript },
     { path: 'scripts/sync-wrangler-ids.mjs', content: syncScript },

--- a/packages/crouton-cli/tests/unit/scaffold-deploy-config.test.ts
+++ b/packages/crouton-cli/tests/unit/scaffold-deploy-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { tmplDeployConfig } from '../../lib/scaffold-app'
+
+// #1367/#1371 — the scaffold must emit a deploy.config.json whose stagingUrl MATCHES what
+// wrangler will actually bind, so nobody hand-guesses a <name>.pmcp.dev alias that has no
+// route (the dead-preview bug). URLs are set only when --domain is passed (which is exactly
+// when the wrangler custom-domain routes are written).
+const vars = (over: Record<string, unknown>) =>
+  ({ name: 'snippets', extends: ['@fyit/crouton-core', '@fyit/crouton'], ...over }) as any
+
+describe('tmplDeployConfig', () => {
+  it('no --domain → empty stagingUrl (deploy resolves the real *.workers.dev URL), no productionUrl', () => {
+    const cfg = JSON.parse(tmplDeployConfig(vars({ domain: undefined })))
+    expect(cfg.stagingUrl).toBe('')
+    expect(cfg.productionUrl).toBeUndefined()
+    expect(cfg.layerPackages).toBe('@fyit/crouton-core @fyit/crouton')
+  })
+
+  it('--domain pmcp.dev → staging uses the <name>-staging.<zone> subdomain (NOT the prod pattern)', () => {
+    const cfg = JSON.parse(tmplDeployConfig(vars({ domain: 'pmcp.dev' })))
+    // The exact bug: the agent wrote snippets.pmcp.dev (prod pattern) for staging.
+    expect(cfg.stagingUrl).toBe('https://snippets-staging.pmcp.dev')
+    expect(cfg.stagingUrl).not.toBe('https://snippets.pmcp.dev')
+    expect(cfg.productionUrl).toBe('https://snippets.pmcp.dev')
+  })
+
+  it('stagingUrl always matches the wrangler staging route pattern <name>-staging.<zone>', () => {
+    const cfg = JSON.parse(tmplDeployConfig(vars({ name: 'velo', domain: 'friendlyinter.net' })))
+    expect(cfg.stagingUrl).toBe('https://velo-staging.friendlyinter.net')
+    expect(cfg.productionUrl).toBe('https://velo.friendlyinter.net')
+  })
+})


### PR DESCRIPTION
Closes #1371 · part of epic #1367

## 👤 For humans
The scaffold **never emitted a `deploy.config.json`**, so whoever wants the deploy pipeline (an agent, usually) hand-writes one and **guesses the URL**. The snippets POC got `stagingUrl: snippets.pmcp.dev` — a custom domain with no matching route → dead preview (the whole #1367 bug). Now the scaffold emits it with a URL that matches what wrangler will actually bind.

## 🤖 For agents
- `lib/scaffold-app.ts`: new `tmplDeployConfig(vars)`, added to the cf file set. `stagingUrl`/`productionUrl` are set **only with `--domain`** (exactly when the custom-domain routes are written); staging uses `<name>-staging.<zone>` (matching the wrangler staging route — **not** the prod pattern the agent guessed). Without `--domain` → `stagingUrl: ""`, and `deploy-app.yml` resolves the real `*.workers.dev` URL (#1369).
- Test: 3 cases (no-domain → empty; domain → staging subdomain, not prod; second zone). CLI CLAUDE.md updated. `packages/` edit approved by the owner; gate re-engaged after.

## 🧪 How to test
`pnpm --filter @fyit/crouton-cli test` → `scaffold-deploy-config.test.ts` (3) green. A `crouton init <name> --domain pmcp.dev` now writes `stagingUrl: https://<name>-staging.pmcp.dev`; without `--domain`, an empty stagingUrl.