### PR TITLE
fix(root): dead-preview fallback on any non-serving code, not just 000 (#1369)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -285,10 +285,19 @@ jobs:
           # so this one check makes them all point at the reachable deploy.
           if [ -n "$URL" ]; then
             code=$(curl -s -o /dev/null -w '%{http_code}' -m 20 "$URL" 2>/dev/null || echo 000)
-            if [ "$code" = "000" ] && [ -n "$WORKERS_URL" ]; then
-              echo "::warning::Configured URL $URL is unreachable (HTTP 000 — no bound route). Using the deployed $WORKERS_URL instead (#1369)."
-              URL="$WORKERS_URL"
-            fi
+            # "Reachable" = the deployed app ANSWERS: 2xx/3xx, or 401 (its auth wall). Anything
+            # else means the configured URL isn't actually serving — 000 (no DNS) OR a Cloudflare
+            # error for a domain with no bound route (404/522/530/1xxx). The earlier ==000-only
+            # check missed those CF codes, so a dead <name>.pmcp.dev alias survived (#1369, the
+            # snippets dogfood). Fall back to the workers.dev URL wrangler actually published.
+            case "$code" in
+              2??|3??|401) : ;;  # serving → keep the configured URL
+              *)
+                if [ -n "$WORKERS_URL" ]; then
+                  echo "::warning::Configured URL $URL returned HTTP $code (not serving — likely no bound route). Using the deployed $WORKERS_URL instead (#1369)."
+                  URL="$WORKERS_URL"
+                fi ;;
+            esac
           elif [ -n "$WORKERS_URL" ]; then
             URL="$WORKERS_URL"
           fi


### PR DESCRIPTION
Reopens/finishes #1369 · epic #1367

## 👤 For humans
The dogfood re-deploy proved the first fix too narrow: it only fell back on HTTP `000`, but a dead Cloudflare custom domain (no bound route) returns a **CF error code** (`404`/`522`/`530`/`1016`), not `000` — so snippets still advertised the dead `snippets.pmcp.dev`. Now the deploy keeps the configured URL only if it actually **serves** (2xx/3xx/401), else uses the real `*.workers.dev`.

## 🤖 For agents
`deploy-app.yml`: `[ "$code" = "000" ]` → a `case` matcher (`2??|3??|401` keep, `*` fall back). Verified locally: `200/302/401` keep; `000/404/522/530/1016` fall back.

## 🧪 How to test
An app with a `stagingUrl` whose custom domain has no route → the deploy now advertises the workers.dev URL wrangler published, not the dead alias.