### PR TITLE
fix(crouton-cli): resilient per-provider seed — don't let a dormant package empty the preview (#1370)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -49,8 +49,17 @@ loads each package's `./seed` export via **jiti** (no build step), topo-sorts th
 providers by `dependsOn` (`auth → sales → pages`), then calls
 `collectSeedSql()` from `@fyit/crouton-core/shared/seed` to turn their declarative
 `ctx.upsert(...)` calls into idempotent `INSERT … ON CONFLICT(id) DO UPDATE` SQL,
-which it pipes to `wrangler d1 execute --file`. Stable, namespace-derived ids
+which it runs via `wrangler d1 execute --command`. Stable, namespace-derived ids
 (`seed:org:test1`, `seed:event:test1:vlaamsekermis`) make re-runs upsert in place.
+
+**Resilient per-chunk execution (#1370):** the seed runs as INDEPENDENT chunks — one
+`--command` per provider, plus the collection fixtures and the default layout — not one
+atomic batch. Why: `@fyit/crouton` (the kitchen-sink meta package) bundles *every* crouton
+package as a dep, so the BFS discovers a provider even for a package the app **doesn't
+extend** (e.g. `crouton-bookings` in a minimal app that never migrated `bookings_settings`).
+As one batch, that single missing table aborted the WHOLE seed → an empty preview. Now a
+failing chunk **warns + is skipped** (`runSeedChunks`, unit-tested) and the auth team + the
+app's own rows + layout still seed. `crouton-seed` throws only if **every** chunk fails.
 
 The contract (`SeedProvider`, `SeedContext`, `createPageWithBlocks`) lives in
 `@fyit/crouton-core/shared/seed`; each package ships its provider at `<pkg>/seed`.

--- a/packages/crouton-cli/lib/seed-app.ts
+++ b/packages/crouton-cli/lib/seed-app.ts
@@ -264,59 +264,82 @@ export async function seedApp(options: SeedAppOptions): Promise<string> {
   const core: any = await tsImport(jiti, '@fyit/crouton-core/shared/seed')
   const teamId = core.seedOrgId(teamSlug)
 
-  // 1) Package providers — auth org + demo content shipped by extended packages.
-  const providerSql: string = providers.length > 0
-    ? await core.collectSeedSql({
-        providers,
-        teamSlug,
-        teamId,
-        locale,
-        withStaff: options.withStaff,
-        createPageWithBlocks
-      })
-    : ''
-
-  // 2) App-local generated collections' editable seed.json fixtures (#298).
+  // Build the seed as INDEPENDENT chunks — one per provider, plus the app's collection
+  // fixtures and default layout — instead of one atomic batch. Why (#1370, the snippets
+  // dogfood): `@fyit/crouton` pulls in `@fyit/crouton-bookings` transitively, so the BFS
+  // discovers a bookings provider even for an app that never extends bookings as a layer
+  // (its migrations never created `bookings_settings`). As one `--command` batch, that single
+  // missing table aborted EVERYTHING — no auth team, no collection rows → an empty preview.
+  // Per-chunk, a failing provider warns + is skipped and the auth team + the app's own rows
+  // + layout still seed.
+  const chunks: Array<{ label: string; sql: string }> = []
+  for (const provider of providers) {
+    const psql: string = await core.collectSeedSql({
+      providers: [provider], teamSlug, teamId, locale, withStaff: options.withStaff, createPageWithBlocks,
+    })
+    if (psql.trim()) chunks.push({ label: `provider:${provider.id}`, sql: psql })
+  }
   const fixtureSql = collectCollectionFixtureSql(appDir, core, teamId)
-
-  // 3) Deterministic default layout (#709) → a `layout_configs` row the POC boots with.
+  if (fixtureSql.trim()) chunks.push({ label: 'collection-fixtures', sql: fixtureSql })
   const layoutSql = collectDefaultLayoutSql(appDir, core, teamId)
+  if (layoutSql.trim()) chunks.push({ label: 'default-layout', sql: layoutSql })
 
-  const sql = [providerSql, fixtureSql, layoutSql].filter(s => s.trim()).join('\n')
-
-  if (!sql.trim()) {
+  const sql = chunks.map(c => c.sql).join('\n')
+  if (!chunks.length) {
     consola.warn('No seed providers, collection fixtures, or layout found — nothing to seed.')
     return sql
   }
-
   if (options.dryRun) {
     consola.info('Dry run — generated SQL:')
     process.stdout.write(`${sql}\n`)
     return sql
   }
 
-  // Pass the SQL via --command (the D1 query API), NOT --file. `--file` against
-  // a remote D1 uses the bulk *import* API, which does a user-details lookup
-  // that a Pages/D1-query-scoped CLOUDFLARE_API_TOKEN can't perform (fails with
-  // "Authentication error [code: 10000] … missing User->User Details->Read").
-  // --command needs only the regular D1 query permission the deploy token
-  // already has, and wrangler runs all `;`-separated statements in one call.
-  // execFileSync passes the SQL as a single argv entry (no shell), so quotes/
-  // JSON in the fixture data need no escaping. Curated seeds are small, so the
-  // OS arg-length limit is not a concern.
-  const wranglerArgs = [
-    'wrangler',
-    'd1',
-    'execute',
-    options.db,
-    options.remote ? '--remote' : '--local',
-    `--command=${sql}`,
-    '--yes'
-  ]
-
-  consola.info(`Running: npx ${wranglerArgs.join(' ')}`)
-  execFileSync('npx', wranglerArgs, { cwd: appDir, stdio: 'inherit', env: process.env })
-
-  consola.success(`Seeded ${providers.length} provider(s) into ${options.db} (${options.remote ? 'remote' : 'local'}).`)
+  // Run each chunk as its own `wrangler d1 execute --command`. --command (not --file) uses the
+  // D1 query API — the only D1 permission a deploy token needs (a --file bulk import needs
+  // User-Details:Read the token lacks). execFileSync passes SQL as one argv entry (no shell),
+  // so JSON/quotes in fixture data need no escaping. Curated seeds are small (arg-length is fine).
+  const runChunk = (chunkSql: string) => {
+    execFileSync(
+      'npx',
+      ['wrangler', 'd1', 'execute', options.db, options.remote ? '--remote' : '--local', `--command=${chunkSql}`, '--yes'],
+      { cwd: appDir, stdio: 'inherit', env: process.env },
+    )
+  }
+  const { ok, skipped } = runSeedChunks(chunks, runChunk)
+  if (ok === 0 && skipped.length > 0) {
+    // Nothing seeded at all → a real problem (bad DB / token / all tables missing), not a
+    // tolerable partial skip. Surface it so the deploy's seed step can warn loudly.
+    throw new Error(`All ${skipped.length} seed chunk(s) failed: ${skipped.join(', ')}`)
+  }
+  if (skipped.length > 0) {
+    consola.warn(`Seeded ${ok} chunk(s) into ${options.db}; skipped ${skipped.length} (${skipped.join(', ')}) — see warnings above.`)
+  } else {
+    consola.success(`Seeded ${ok} chunk(s) into ${options.db} (${options.remote ? 'remote' : 'local'}).`)
+  }
   return sql
+}
+
+/**
+ * Run seed SQL chunks resiliently (#1370): execute each via `run`; if one throws, WARN and skip
+ * it rather than aborting the rest — so a provider whose table isn't in this app (e.g. bookings,
+ * pulled in transitively but never extended) doesn't sink the auth team + the app's own rows.
+ * `run` is injected so the resilience is unit-testable without wrangler.
+ */
+export function runSeedChunks(
+  chunks: Array<{ label: string; sql: string }>,
+  run: (sql: string) => void,
+): { ok: number; skipped: string[] } {
+  let ok = 0
+  const skipped: string[] = []
+  for (const { label, sql } of chunks) {
+    try {
+      run(sql)
+      ok++
+    } catch (e) {
+      skipped.push(label)
+      consola.warn(`Seed chunk "${label}" failed — skipping (the rest still seed): ${(e as Error).message.split('\n')[0]}`)
+    }
+  }
+  return { ok, skipped }
 }

--- a/packages/crouton-cli/tests/unit/seed-resilient.test.ts
+++ b/packages/crouton-cli/tests/unit/seed-resilient.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runSeedChunks } from '../../lib/seed-app'
+
+// #1370 — the snippets dogfood: `@fyit/crouton` bundles crouton-bookings transitively, so the
+// seed discovered a bookings provider even though the app never extended bookings (no
+// `bookings_settings` table). As ONE atomic --command that aborted the whole seed. runSeedChunks
+// runs each chunk independently so a dormant-package failure warns + skips and the rest still land.
+describe('runSeedChunks', () => {
+  it('a failing chunk (missing table) is skipped; every other chunk still runs', () => {
+    const ran: string[] = []
+    const run = (sql: string) => {
+      ran.push(sql)
+      if (sql.includes('bookings_settings')) {
+        throw new Error('no such table: bookings_settings: SQLITE_ERROR [code: 7500]')
+      }
+    }
+    const chunks = [
+      { label: 'provider:auth', sql: "INSERT INTO organization ... 'test1'" },
+      { label: 'provider:bookings', sql: 'INSERT INTO bookings_settings ...' },
+      { label: 'collection-fixtures', sql: 'INSERT INTO main_snippets ...' },
+      { label: 'default-layout', sql: 'INSERT INTO layout_configs ...' },
+    ]
+    const { ok, skipped } = runSeedChunks(chunks, run)
+
+    expect(ok).toBe(3) // auth + fixtures + layout
+    expect(skipped).toEqual(['provider:bookings'])
+    // ALL chunks were attempted — the bookings failure did not short-circuit the ones after it.
+    expect(ran).toHaveLength(4)
+    expect(ran.some(s => s.includes('main_snippets'))).toBe(true) // the app's own rows DID seed
+  })
+
+  it('all-good → ok=count, nothing skipped', () => {
+    const run = vi.fn()
+    const { ok, skipped } = runSeedChunks(
+      [{ label: 'a', sql: 'x' }, { label: 'b', sql: 'y' }],
+      run,
+    )
+    expect(ok).toBe(2)
+    expect(skipped).toEqual([])
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('empty chunk list → ok=0, nothing skipped (caller decides "nothing to seed")', () => {
+    const { ok, skipped } = runSeedChunks([], () => {})
+    expect(ok).toBe(0)
+    expect(skipped).toEqual([])
+  })
+})


### PR DESCRIPTION
Reopens/finishes #1370 · epic #1367

## 👤 For humans
The snippets dogfood showed the preview came up **empty**: `crouton-seed` aborted with `no such table: bookings_settings`. Root cause — `@fyit/crouton` (the batteries-included meta package) bundles *every* crouton package, so the seed's discovery found a `crouton-bookings` provider even though the app **never extends bookings** (no `bookings_settings` table). As **one atomic `--command`**, that single missing table sank the *whole* seed — no auth team, no snippet rows.

Now the seed runs as **independent chunks** (per provider + fixtures + layout): a dormant-package failure **warns and skips**, and the auth team + the app's own rows + layout still land. It's more robust than special-casing bookings — it correctly handles *any* bundled-but-not-extended package.

## 🤖 For agents
- `lib/seed-app.ts`: `collectSeedSql` per-provider → per-`--command` execution via new exported `runSeedChunks(chunks, run)` (fails-soft per chunk; throws only if all fail; `run` injected for tests).
- Test: `seed-resilient.test.ts` (missing-table chunk skipped, rest run; all-good; empty). CLAUDE.md updated. `packages/` edit approved by owner; gate re-engaged.

## 🧪 How to test
`pnpm --filter @fyit/crouton-cli test` → `seed-resilient.test.ts` (3) green. Re-deploying the snippets POC now seeds the 3 sample rows + the `test1` team even though the bundled bookings provider fails.