### PR TITLE
Fanfare ships every crouton theme — full Look-and-Feel picker

### DIFF
--- a/apps/fanfare/nuxt.config.ts
+++ b/apps/fanfare/nuxt.config.ts
@@ -30,6 +30,16 @@ export default defineNuxtConfig({
     // behind those classes never ships — presets were palette-only before.
     '@fyit/crouton-themes/ko',
     '@fyit/crouton-themes/blackandwhite',
+    '@fyit/crouton-themes/minimal',
+    '@fyit/crouton-themes/kr11',
+    '@fyit/crouton-themes/brutalist',
+    '@fyit/crouton-themes/mtv',
+    '@fyit/crouton-themes/terminal',
+    '@fyit/crouton-themes/braun',
+    '@fyit/crouton-themes/gameboy',
+    '@fyit/crouton-themes/riso',
+    '@fyit/crouton-themes/eink',
+    '@fyit/crouton-themes/blueprint',
     './layers/sales',
     './layers/pages'
   ],


### PR DESCRIPTION
Closes #1383

One-file change: fanfare extends all 12 theme layers; the #1332 preset registry does the rest. Typecheck green locally; the preset apply path was verified live on this app in #1332.

## 🧪 How to test
kassa.pmcp.dev → admin → team → Uiterlijk → the picker lists Custom + all 12 themes; apply a few — each restyles the whole admin and persists per team.

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account