### PR TITLE
Theme presets: pin the color scheme on apply + accept all preset slugs on save

### DIFF
--- a/packages/crouton-admin/app/composables/useTeamTheme.ts
+++ b/packages/crouton-admin/app/composables/useTeamTheme.ts
@@ -158,7 +158,9 @@ export function useAvailableThemePresets() {
  * Apply theme settings to Nuxt UI via updateAppConfig.
  * Exported as a standalone function so the plugin can use it too.
  */
-export function applyThemeSettings(settings: TeamThemeSettings) {
+// `colorMode` is passed in by callers that captured it in setup scope
+// (watch/refresh callbacks lose the Nuxt context, #1387).
+export function applyThemeSettings(settings: TeamThemeSettings, colorMode?: { preference: string }) {
   const preset = settings.preset ?? 'custom'
   const radius = settings.radius ?? DEFAULT_THEME.radius
 
@@ -171,6 +173,11 @@ export function applyThemeSettings(settings: TeamThemeSettings) {
     }
     else {
       updateAppConfig({ ui: entry.ui as any })
+      // Pin the scheme the theme was designed for (#1387).
+      const scheme = THEME_PRESET_REGISTRY[preset as ThemePresetName]?.colorMode
+      if (scheme && colorMode) {
+        colorMode.preference = scheme
+      }
     }
   }
   else {
@@ -200,6 +207,7 @@ export function applyThemeSettings(settings: TeamThemeSettings) {
 
 export function useTeamTheme() {
   const { teamId } = useTeamContext()
+  const colorMode = useColorMode()
 
   // Shared state with the plugin (populated during SSR)
   const themeData = useState<TeamThemeSettings>('team-theme-data', () => ({}))
@@ -219,7 +227,7 @@ export function useTeamTheme() {
 
   // Watch for live theme changes (e.g. admin editing theme settings)
   watch(theme, (newTheme) => {
-    applyThemeSettings(newTheme)
+    applyThemeSettings(newTheme, colorMode)
   })
 
   // Refresh theme from API
@@ -231,7 +239,7 @@ export function useTeamTheme() {
       )
       themeData.value = data ?? {}
       themeFetched.value = true
-      applyThemeSettings(theme.value)
+      applyThemeSettings(theme.value, colorMode)
     }
     catch {
       themeFetched.value = true
@@ -274,6 +282,6 @@ export function useTeamTheme() {
     resetTheme,
     refresh,
     /** Apply theme settings immediately (for live preview) */
-    applyTheme: applyThemeSettings
+    applyTheme: (settings: TeamThemeSettings) => applyThemeSettings(settings, colorMode)
   }
 }

--- a/packages/crouton-admin/app/plugins/team-theme.ts
+++ b/packages/crouton-admin/app/plugins/team-theme.ts
@@ -33,7 +33,7 @@ export default defineNuxtPlugin({
       themeFetched.value = true
     }
 
-    applyThemeSettings(themeState.value)
+    applyThemeSettings(themeState.value, useColorMode())
 
     // Expose the allowUserThemes flag so crouton-auth components can read it
     // without importing from crouton-admin. Defaults to true when not set.

--- a/packages/crouton-auth/server/database/schema/auth.ts
+++ b/packages/crouton-auth/server/database/schema/auth.ts
@@ -591,7 +591,9 @@ export type ThemeNeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone'
 export type ThemeRadius = 0 | 0.125 | 0.25 | 0.375 | 0.5
 
 /** Named theme presets */
-export type ThemePreset = 'custom' | 'blackandwhite' | 'ko'
+// Any theme slug — 'custom' plus whatever crouton-themes ships. Kept loose
+// so adding a theme never needs a schema change (#1387).
+export type ThemePreset = 'custom' | (string & {})
 
 /**
  * Site settings for public site configuration

--- a/packages/crouton-core/server/api/teams/[id]/settings/theme.patch.ts
+++ b/packages/crouton-core/server/api/teams/[id]/settings/theme.patch.ts
@@ -11,7 +11,10 @@ import { teamSettings, type TeamThemeSettings } from '@fyit/crouton-auth/server/
 
 // Validation schema for theme settings
 const themeSettingsSchema = z.object({
-  preset: z.enum(['custom', 'blackandwhite', 'ko']).optional(),
+  // Any theme slug ('custom' + whatever crouton-themes ships). Kept
+  // deliberately loose so adding a theme never needs a crouton-core change
+  // (#1387 — the old enum 400'd every post-#1303 preset save).
+  preset: z.string().regex(/^[a-z0-9-]{1,32}$/).optional(),
   primary: z.enum([
     'red', 'orange', 'amber', 'yellow', 'lime', 'green',
     'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo',

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -16,6 +16,12 @@ export interface ThemeConfig {
   colors: string[]
   /** Default base variant for this theme (solid, outline, ghost, etc.) */
   defaultVariant: BaseVariant
+  /**
+   * The color scheme this theme is designed for. Applying the theme pins the
+   * app's color mode to it (#1387 — a light-paper theme under dark-mode text
+   * tokens washes out). Omit for themes that adapt to both (blackandwhite).
+   */
+  colorMode?: 'light' | 'dark'
 }
 
 export const AVAILABLE_THEMES: ThemeConfig[] = [
@@ -31,21 +37,24 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     label: 'KO',
     description: 'Hardware-inspired (Teenage Engineering)',
     colors: ['#f97316', '#1c1917', '#faf5f0'], // orange, dark, cream
-    defaultVariant: 'solid' // KO uses solid tactile buttons
+    defaultVariant: 'solid', // KO uses solid tactile buttons
+    colorMode: 'light'
   },
   {
     name: 'minimal',
     label: 'Minimal',
     description: 'Clean, Bauhaus-inspired',
     colors: ['#000000', '#ffffff', '#e5e5e5'], // black, white, light gray
-    defaultVariant: 'outline' // Minimal uses clean outlined style
+    defaultVariant: 'outline', // Minimal uses clean outlined style
+    colorMode: 'light'
   },
   {
     name: 'kr11',
     label: 'KR-11',
     description: 'Friendly drum machine aesthetic',
     colors: ['#b8e9d2', '#e9d227', '#f7d3ca'], // play-mint, FILL-yellow, pad-1 salmon (#1347)
-    defaultVariant: 'soft' // KR-11 uses soft tactile pads
+    defaultVariant: 'soft', // KR-11 uses soft tactile pads
+    colorMode: 'light'
   },
   {
     name: 'blackandwhite',
@@ -59,56 +68,64 @@ export const AVAILABLE_THEMES: ThemeConfig[] = [
     label: 'Brutalist',
     description: 'Thick borders, hard shadows, zero subtlety',
     colors: ['#0a0a0a', '#ffd800', '#fdfbf5'], // ink, shock yellow, paper
-    defaultVariant: 'solid'
+    defaultVariant: 'solid',
+    colorMode: 'light'
   },
   {
     name: 'mtv',
     label: 'MTV',
     description: 'Day-glo blocks, clashing neon shadows, Memphis energy',
     colors: ['#ff2d95', '#00e5ff', '#ffe600'], // pink, cyan, yellow
-    defaultVariant: 'solid'
+    defaultVariant: 'solid',
+    colorMode: 'light'
   },
   {
     name: 'terminal',
     label: 'Terminal',
     description: 'Green phosphor on black, scanlines, inverse video',
     colors: ['#33ff66', '#0a0f0a', '#ffb000'], // phosphor, tube, amber
-    defaultVariant: 'solid'
+    defaultVariant: 'solid',
+    colorMode: 'dark'
   },
   {
     name: 'braun',
     label: 'Braun',
     description: 'Warm analog hi-fi — cream, hairlines, one orange accent',
     colors: ['#f2efe9', '#f26c1d', '#2e2c29'], // cream, orange, charcoal
-    defaultVariant: 'solid'
+    defaultVariant: 'solid',
+    colorMode: 'light'
   },
   {
     name: 'gameboy',
     label: 'Game Boy',
     description: 'Four shades of olive green, chunky pixels',
     colors: ['#0f380f', '#8bac0f', '#9bbc0e'], // ink, light, screen
-    defaultVariant: 'solid'
+    defaultVariant: 'solid',
+    colorMode: 'light'
   },
   {
     name: 'riso',
     label: 'Riso',
     description: 'Two-color riso print — fluoro pink + teal, misregistered',
     colors: ['#ff48b0', '#00887a', '#f7f3e8'], // pink, teal, paper
-    defaultVariant: 'solid'
+    defaultVariant: 'solid',
+    colorMode: 'light'
   },
   {
     name: 'eink',
     label: 'E-ink',
     description: 'Greyscale reading mode — zero motion, newspaper type',
     colors: ['#1c1c1c', '#6b6b6b', '#f4f2ee'], // ink, gray, paper
-    defaultVariant: 'outline'
+    defaultVariant: 'outline',
+    colorMode: 'light'
   },
   {
     name: 'blueprint',
     label: 'Blueprint',
     description: 'Cyanotype drafting sheet — white line-work on blue',
     colors: ['#123a63', '#dce9f5', '#ffd66b'], // blue, line, pencil
-    defaultVariant: 'solid'
+    defaultVariant: 'solid',
+    colorMode: 'dark'
   }
 ]
 
@@ -116,6 +133,8 @@ const STORAGE_KEY = 'nuxt-crouton-theme'
 
 export function useThemeSwitcher() {
   const appConfig = useAppConfig()
+  // Captured in setup scope so setTheme can pin it from event handlers (#1387).
+  const colorMode = useColorMode()
 
   // Reactive theme state - uses useState for SSR compatibility
   const currentTheme = useState<ThemeName>('crouton-theme', () => 'default')
@@ -168,6 +187,13 @@ export function useThemeSwitcher() {
       updateAppConfig({
         ui: themeUIConfig as any
       })
+    }
+
+    // Pin the scheme the theme was designed for (#1387); adaptive themes
+    // (blackandwhite, default) leave the user's preference untouched.
+    const scheme = AVAILABLE_THEMES.find(t => t.name === theme)?.colorMode
+    if (scheme) {
+      colorMode.preference = scheme
     }
   }
 

--- a/packages/crouton-themes/themes/configs/presets.ts
+++ b/packages/crouton-themes/themes/configs/presets.ts
@@ -29,6 +29,8 @@ export interface ThemePresetEntry {
   checkVariant: string
   /** Scalars-only payload for updateAppConfig({ ui }) */
   ui: ThemeUIConfig
+  /** The scheme the theme is designed for (pin on apply, #1387) */
+  colorMode?: 'light' | 'dark'
 }
 
 export type ThemePresetName = Exclude<ThemeName, 'default'>
@@ -45,7 +47,8 @@ export const THEME_PRESET_REGISTRY: Record<ThemePresetName, ThemePresetEntry>
           previewPrimary: t.colors[0] ?? '#000000',
           previewNeutral: t.colors[1] ?? '#666666',
           checkVariant: ui?.button?.defaultVariants?.variant ?? t.name,
-          ui: ui ?? {}
+          ui: ui ?? {},
+          colorMode: t.colorMode
         } satisfies ThemePresetEntry]
       })
   ) as Record<ThemePresetName, ThemePresetEntry>


### PR DESCRIPTION
Closes #1387

Both staging findings from the owner's test: light themes wash out under dark mode (now each theme pins its designed scheme on apply; B&W stays adaptive) and preset saves 400'd on the server's stale 3-value enum (now slug-validated, decoupled from the theme list).

## 🧪 How to test
Browser in dark mode → kassa admin → Uiterlijk → apply MTV: page flips light, all text readable → **Wijzigingen opslaan** saves without the 400 toast → apply Terminal: full dark. Reload: persisted preset comes back with its scheme.

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account