### PR TITLE
Tune Nuxt UI semantic tokens per theme ambient — readable app surfaces under every theme

### DIFF
--- a/packages/crouton-themes/blueprint/assets/css/main.css
+++ b/packages/crouton-themes/blueprint/assets/css/main.css
@@ -271,3 +271,22 @@
 .theme-blueprint button[role="switch"][data-state="checked"] > span {
   background-color: var(--bp-accent);
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the sheet.
+   ============================================ */
+
+[data-theme="blueprint"] body,
+body.theme-blueprint {
+  --ui-text-dimmed: #7fa3c4;
+  --ui-text-muted: #9db9d4;
+  --ui-text-toned: #c3d6e8;
+  --ui-text: #dce9f5;
+  --ui-text-highlighted: #ffffff;
+  --ui-bg-muted: #10344f;
+  --ui-bg-elevated: #0d2c4d;
+  --ui-bg-accented: #1a4570;
+  --ui-border: #7fa3c4;
+  --ui-border-muted: #2c567e;
+  --ui-border-accented: #dce9f5;
+}

--- a/packages/crouton-themes/braun/assets/css/main.css
+++ b/packages/crouton-themes/braun/assets/css/main.css
@@ -322,3 +322,22 @@
 .theme-braun button[role="switch"][data-state="checked"] > span {
   background-color: #fff;
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the cream chassis.
+   ============================================ */
+
+[data-theme="braun"] body,
+body.theme-braun {
+  --ui-text-dimmed: #8f8a80;
+  --ui-text-muted: #7a756c;
+  --ui-text-toned: #55524c;
+  --ui-text: #3a3835;
+  --ui-text-highlighted: #2e2c29;
+  --ui-bg-muted: #f6f4ef;
+  --ui-bg-elevated: #faf8f4;
+  --ui-bg-accented: #eae6de;
+  --ui-border: #d5d0c7;
+  --ui-border-muted: #e2ded6;
+  --ui-border-accented: #b5afa2;
+}

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -288,3 +288,22 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the paper.
+   ============================================ */
+
+[data-theme="brutalist"] body,
+body.theme-brutalist {
+  --ui-text-dimmed: #75716a;
+  --ui-text-muted: #5c5952;
+  --ui-text-toned: #33312c;
+  --ui-text: #0a0a0a;
+  --ui-text-highlighted: #0a0a0a;
+  --ui-bg-muted: #f5f2e9;
+  --ui-bg-elevated: #f3f0e6;
+  --ui-bg-accented: #ebe7da;
+  --ui-border: #0a0a0a;
+  --ui-border-muted: #d9d5c9;
+  --ui-border-accented: #0a0a0a;
+}

--- a/packages/crouton-themes/eink/assets/css/main.css
+++ b/packages/crouton-themes/eink/assets/css/main.css
@@ -239,3 +239,22 @@
 .theme-eink button[role="switch"][data-state="checked"] > span {
   background-color: var(--eink-paper);
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the display.
+   ============================================ */
+
+[data-theme="eink"] body,
+body.theme-eink {
+  --ui-text-dimmed: #8a8a8a;
+  --ui-text-muted: #6b6b6b;
+  --ui-text-toned: #3d3d3d;
+  --ui-text: #1c1c1c;
+  --ui-text-highlighted: #1c1c1c;
+  --ui-bg-muted: #eeece7;
+  --ui-bg-elevated: #ecebe6;
+  --ui-bg-accented: #e2e0da;
+  --ui-border: #cfccc6;
+  --ui-border-muted: #dedbd4;
+  --ui-border-accented: #1c1c1c;
+}

--- a/packages/crouton-themes/gameboy/assets/css/main.css
+++ b/packages/crouton-themes/gameboy/assets/css/main.css
@@ -285,3 +285,25 @@
   background-color: var(--gb-0);
   transition: none;
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390)
+   Nuxt UI text/surface/border tokens tuned to the LCD so app surfaces
+   (muted copy, elevated panels, borders) stay in-palette and readable.
+   Scoped to body: inherited custom properties win over :root/.dark.
+   ============================================ */
+
+[data-theme="gameboy"] body,
+body.theme-gameboy {
+  --ui-text-dimmed: #3f6d3f;
+  --ui-text-muted: #2f5d2f;
+  --ui-text-toned: #1d4a1d;
+  --ui-text: #0f380f;
+  --ui-text-highlighted: #0f380f;
+  --ui-bg-muted: #a4c414;
+  --ui-bg-elevated: #a8c61e;
+  --ui-bg-accented: #8bac0f;
+  --ui-border: #306230;
+  --ui-border-muted: #558042;
+  --ui-border-accented: #0f380f;
+}

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -853,3 +853,21 @@
 .ko-link.ko-link--blue {
   color: var(--ko-accent-blue);
 }
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the chassis gray.
+   ============================================ */
+
+[data-theme="ko"] body,
+body.theme-ko {
+  --ui-text-dimmed: #6b6763;
+  --ui-text-muted: #57534f;
+  --ui-text-toned: #4a4744;
+  --ui-text: #403e3d;
+  --ui-text-highlighted: #2b2927;
+  --ui-bg-muted: #cdc9c6;
+  --ui-bg-elevated: #d3cfcc;
+  --ui-bg-accented: #bdb9b6;
+  --ui-border: #908e8d;
+  --ui-border-muted: #aeaba9;
+  --ui-border-accented: #545251;
+}

--- a/packages/crouton-themes/kr11/assets/css/main.css
+++ b/packages/crouton-themes/kr11/assets/css/main.css
@@ -677,3 +677,22 @@
     inset 0 1px 1px rgba(0, 0, 0, 0.15),
     0 0 6px rgba(76, 217, 100, 0.7);
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the white chassis.
+   ============================================ */
+
+[data-theme="kr11"] body,
+body.theme-kr11 {
+  --ui-text-dimmed: #8a8a86;
+  --ui-text-muted: #666663;
+  --ui-text-toned: #4c4c49;
+  --ui-text: #3d3d3d;
+  --ui-text-highlighted: #2a2a28;
+  --ui-bg-muted: #ececea;
+  --ui-bg-elevated: #fafaf9;
+  --ui-bg-accented: #e5e5e2;
+  --ui-border: #d3d3d0;
+  --ui-border-muted: #e0e0dd;
+  --ui-border-accented: #aaa8a3;
+}

--- a/packages/crouton-themes/mtv/assets/css/main.css
+++ b/packages/crouton-themes/mtv/assets/css/main.css
@@ -360,3 +360,22 @@
     transform: none;
   }
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the paper.
+   ============================================ */
+
+[data-theme="mtv"] body,
+body.theme-mtv {
+  --ui-text-dimmed: #7f7685;
+  --ui-text-muted: #675f6d;
+  --ui-text-toned: #3d3644;
+  --ui-text: #17131f;
+  --ui-text-highlighted: #17131f;
+  --ui-bg-muted: #efeae1;
+  --ui-bg-elevated: #eee8de;
+  --ui-bg-accented: #e6dfd3;
+  --ui-border: #d9d2c8;
+  --ui-border-muted: #e4ded4;
+  --ui-border-accented: #17131f;
+}

--- a/packages/crouton-themes/riso/assets/css/main.css
+++ b/packages/crouton-themes/riso/assets/css/main.css
@@ -271,3 +271,22 @@
 .theme-riso button[role="switch"] > span {
   background-color: var(--riso-ink);
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the paper.
+   ============================================ */
+
+[data-theme="riso"] body,
+body.theme-riso {
+  --ui-text-dimmed: #857c6d;
+  --ui-text-muted: #6d6558;
+  --ui-text-toned: #4a443b;
+  --ui-text: #2f2b27;
+  --ui-text-highlighted: #2f2b27;
+  --ui-bg-muted: #f1ecdf;
+  --ui-bg-elevated: #efe9db;
+  --ui-bg-accented: #e7e0cf;
+  --ui-border: #d8d0bf;
+  --ui-border-muted: #e2dbcc;
+  --ui-border-accented: #b5ab96;
+}

--- a/packages/crouton-themes/terminal/assets/css/main.css
+++ b/packages/crouton-themes/terminal/assets/css/main.css
@@ -331,3 +331,22 @@ body.theme-terminal::after {
 .theme-terminal button[role="switch"][data-state="checked"] > span {
   background-color: var(--term-phosphor);
 }
+
+/* ============================================
+   SEMANTIC TOKENS (#1390) — tuned to the tube.
+   ============================================ */
+
+[data-theme="terminal"] body,
+body.theme-terminal {
+  --ui-text-dimmed: #3a8a53;
+  --ui-text-muted: #4fae6a;
+  --ui-text-toned: #8fd4a4;
+  --ui-text: #bfe8c9;
+  --ui-text-highlighted: #33ff66;
+  --ui-bg-muted: #0e140e;
+  --ui-bg-elevated: #101710;
+  --ui-bg-accented: #16241a;
+  --ui-border: #1d9e44;
+  --ui-border-muted: #14522b;
+  --ui-border-accented: #33ff66;
+}


### PR DESCRIPTION
Closes #1390 (WS1 of epic #1392)

Muted text, panels and borders now derive from each theme's palette instead of the stock light/dark tokens — fixes the washout in all three owner screenshots. Component-coverage gaps (tabs/radios/alerts) continue in #1393; app conformance in #1394; dual-scheme in #1395.

## 🧪 How to test
kassa staging (after deploy) → event workspace under Game Boy: explainer text readable dark-green, panels in-palette; playground /crouton page same under Riso/Terminal/Blueprint.

> 🤖 **Claude Code** · interactive agent session · PR opened from @pmcp's account