### PR TITLE
feat(crouton-themes): full Nuxt UI component coverage per theme (#1393)

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -476,12 +476,54 @@ playground's `/crouton` page is the check: a generated-CRUD-shaped composition
 (tabs, table, pagination, form with select/textarea/switch, edit modal) where
 every theme must look intentional — themed chrome, calm table.
 
-Coverage status: all 8 post-#1304 themes (brutalist, mtv, terminal, braun,
-gameboy, riso, eink, blueprint) register `select` + `textarea` variants reusing
-their input classes. The 4 originals (ko, kr11, minimal, blackandwhite) pass on
-select/textarea for now (their runtime configs reset those to Nuxt UI defaults);
-UTabs/UPagination/UTable are a deliberate pass everywhere — they read as data
-surfaces.
+Coverage status (#1393, Themes 2.1): **11 of 12 themes cover the full
+interaction-chrome set** — button, input, select, selectMenu, textarea, card,
+badge, tabs, checkbox, radioGroup, alert (named variants) plus switch,
+modal/slideover, toast, pagination (ambient). The exception is
+**blackandwhite: a documented deliberate pass** — bw's design IS Nuxt UI's
+standard variants under a strict neutral palette, so only buttons carry named
+bw-* variants and everything else stays stock. UTable stays a deliberate pass
+everywhere — it reads as a data surface.
+
+## Component coverage mechanics (#1393)
+
+Two mechanisms, chosen by whether the component has a `variant` dimension:
+
+1. **Named variants** (tabs, checkbox, radioGroup, alert, select, selectMenu,
+   textarea — plus the original button/input/card/badge set): register the
+   theme-named variant in the layer app.config with marker classes per slot,
+   wire the shared subtractive replacer on those slots, add the scalar
+   `defaultVariants.variant` entry in `themes/configs/themeConfigs.ts`.
+   Class naming is uniform across themes: `<p>-tabs-{list,trigger,indicator}`,
+   `<p>-check-{box,indicator}`, `<p>-radio-{box,indicator}`,
+   `<p>-alert(-title)` + `<p>-alert--{primary,warning,error,neutral}`.
+   - **Tabs**: the sliding indicator is hidden (`display:none`) and active
+     state lives on `[data-state="active"]` triggers — the pill/link
+     positioning compoundVariants never fire for a named variant, and instant
+     snaps fit the themes anyway.
+   - **Alert**: color styling lives in compoundVariants keyed to the STANDARD
+     variants, so a named variant starts blank — each theme supplies its own
+     `{ color, variant }` compounds.
+   - **Checkbox/radio**: the `color` dimension fires regardless of variant
+     (`indicator: bg-primary` etc.) — that's why the indicator slot carries a
+     marker class too, so the replacer can strip it.
+
+2. **Ambient theme-scoped CSS** (USwitch, UModal/USlideover, UToast,
+   UPagination — no `variant` dimension, so the marker-gated replacer can
+   never fire): selectors scoped to BOTH activation paths —
+   `[data-theme="x"] …` (app presets) and `.theme-x …` (useThemeSwitcher body
+   class). Verified DOM hooks:
+   - Switch: `button[role="switch"]` (+ `[data-state="checked"]`, thumb `> span`)
+   - Dialogs (modal + slideover share chrome): `[role="dialog"][data-slot="content"]`,
+     title `[role="dialog"] [data-slot="title"]`, plus `[data-slot="overlay"]`
+   - Toast: `li[data-slot="base"]` — NOT `data-slot="root"`; the root slot's
+     classes land on an `li` whose data-slot attr is `base`
+   - Pagination: `nav[data-slot="root"] button`, current page
+     `button[data-selected]` (buttons get explicit outline/solid variants from
+     Pagination props, so named variants can't reach them)
+
+   Toasts require the app to be wrapped in `<UApp>` (hosts the Toaster) — the
+   playground got this in #1393.
 
 ## Nuxt UI Theming Pattern
 

--- a/packages/crouton-themes/blueprint/app.config.ts
+++ b/packages/crouton-themes/blueprint/app.config.ts
@@ -136,6 +136,90 @@ export default defineAppConfig({
           blueprint: 'bp-badge'
         }
       }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: "bp-input-base"
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            list: "bp-tabs-list",
+            trigger: "bp-tabs-trigger",
+            indicator: "bp-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            base: "bp-check-box",
+            indicator: "bp-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            base: "bp-radio-box",
+            indicator: "bp-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            root: "bp-alert",
+            title: "bp-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "blueprint", class: { root: "bp-alert--primary" } },
+        { color: "warning", variant: "blueprint", class: { root: "bp-alert--warning" } },
+        { color: "error", variant: "blueprint", class: { root: "bp-alert--error" } },
+        { color: "neutral", variant: "blueprint", class: { root: "bp-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/blueprint/assets/css/main.css
+++ b/packages/crouton-themes/blueprint/assets/css/main.css
@@ -290,3 +290,194 @@ body.theme-blueprint {
   --ui-border-muted: #2c567e;
   --ui-border-accented: #dce9f5;
 }
+
+/* ============================================
+   TABS (#1393) — drawing sheet index; active carries the pencil mark
+   ============================================ */
+
+.bp-tabs-list {
+  background-color: transparent;
+  border-bottom: 1px solid var(--bp-line-dim);
+  gap: 0.5rem;
+  padding: 0;
+}
+
+.bp-tabs-trigger {
+  font-family: var(--bp-mono);
+  background-color: transparent;
+  color: var(--bp-line-dim);
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.9rem;
+  transition: color 100ms ease;
+}
+
+.bp-tabs-trigger:hover {
+  color: var(--bp-line);
+}
+
+.bp-tabs-trigger[data-state="active"] {
+  color: var(--bp-blue-deep);
+  background-color: var(--bp-accent);
+  border-color: var(--bp-line);
+}
+
+.bp-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — survey marks on the sheet
+   ============================================ */
+
+.bp-check-box,
+.bp-radio-box {
+  background-color: transparent;
+  border: 1px solid var(--bp-line-dim);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.bp-radio-box {
+  border-radius: 9999px;
+}
+
+.bp-check-indicator {
+  background-color: var(--bp-accent);
+  color: var(--bp-blue-deep);
+}
+
+.bp-radio-indicator {
+  background-color: transparent;
+  border-radius: 9999px;
+}
+
+.bp-radio-indicator::after {
+  background-color: var(--bp-accent);
+  border-radius: 9999px;
+  width: 55%;
+  height: 55%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a note block on the drawing
+   ============================================ */
+
+.bp-alert {
+  font-family: var(--bp-mono);
+  background-color: var(--bp-blue);
+  color: var(--bp-line);
+  border: 1px solid var(--bp-line);
+  border-radius: 0;
+  box-shadow: inset 0 0 0 4px var(--bp-blue), inset 0 0 0 5px var(--bp-line-dim);
+}
+
+.bp-alert-title {
+  font-family: var(--bp-mono);
+  color: var(--bp-line);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.bp-alert--primary {
+  border-style: solid;
+}
+
+.bp-alert--warning {
+  border: 1px dashed var(--bp-accent);
+  color: var(--bp-accent);
+  box-shadow: none;
+}
+
+.bp-alert--warning .bp-alert-title {
+  color: var(--bp-accent);
+}
+
+.bp-alert--error {
+  border: 1px dashed var(--bp-accent);
+  color: var(--bp-accent);
+  box-shadow: none;
+}
+
+.bp-alert--error .bp-alert-title {
+  color: var(--bp-accent);
+}
+
+.bp-alert--neutral {
+  border: 1px solid var(--bp-line-dim);
+  box-shadow: none;
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths like the switch)
+   ============================================ */
+
+[data-theme="blueprint"] [role="dialog"][data-slot="content"],
+.theme-blueprint [role="dialog"][data-slot="content"] {
+  background-color: var(--bp-blue);
+  border: 1px solid var(--bp-line);
+  border-radius: 0;
+  box-shadow: inset 0 0 0 4px var(--bp-blue), inset 0 0 0 5px var(--bp-line-dim);
+}
+
+[data-theme="blueprint"] [role="dialog"] [data-slot="title"],
+.theme-blueprint [role="dialog"] [data-slot="title"] {
+  font-family: var(--bp-mono);
+  color: var(--bp-line);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+[data-theme="blueprint"] [data-slot="overlay"],
+.theme-blueprint [data-slot="overlay"] {
+  background-color: rgb(13 44 77 / 0.7);
+}
+
+[data-theme="blueprint"] li[data-slot="base"],
+.theme-blueprint li[data-slot="base"] {
+  font-family: var(--bp-mono);
+  background-color: var(--bp-blue);
+  border: 1px solid var(--bp-line);
+  border-radius: 0;
+  box-shadow: inset 0 0 0 3px var(--bp-blue), inset 0 0 0 4px var(--bp-line-dim);
+}
+
+[data-theme="blueprint"] li[data-slot="base"] [data-slot="title"],
+.theme-blueprint li[data-slot="base"] [data-slot="title"] {
+  font-family: var(--bp-mono);
+  color: var(--bp-line);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+[data-theme="blueprint"] nav[data-slot="root"] button,
+.theme-blueprint nav[data-slot="root"] button {
+  font-family: var(--bp-mono);
+  background-color: transparent;
+  color: var(--bp-line-dim);
+  border: 1px solid var(--bp-line-dim);
+  border-radius: 0;
+  box-shadow: none;
+  transition: color 100ms ease;
+}
+
+[data-theme="blueprint"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-blueprint nav[data-slot="root"] button:hover:not(:disabled) {
+  color: var(--bp-line);
+  border-color: var(--bp-line);
+}
+
+[data-theme="blueprint"] nav[data-slot="root"] button[data-selected],
+.theme-blueprint nav[data-slot="root"] button[data-selected] {
+  background-color: var(--bp-accent);
+  color: var(--bp-blue-deep);
+  border-color: var(--bp-accent);
+}

--- a/packages/crouton-themes/braun/app.config.ts
+++ b/packages/crouton-themes/braun/app.config.ts
@@ -143,6 +143,90 @@ export default defineAppConfig({
           braun: 'braun-badge'
         }
       }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: "braun-input-base"
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            list: "braun-tabs-list",
+            trigger: "braun-tabs-trigger",
+            indicator: "braun-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            base: "braun-check-box",
+            indicator: "braun-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            base: "braun-radio-box",
+            indicator: "braun-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            root: "braun-alert",
+            title: "braun-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "braun", class: { root: "braun-alert--primary" } },
+        { color: "warning", variant: "braun", class: { root: "braun-alert--warning" } },
+        { color: "error", variant: "braun", class: { root: "braun-alert--error" } },
+        { color: "neutral", variant: "braun", class: { root: "braun-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/braun/assets/css/main.css
+++ b/packages/crouton-themes/braun/assets/css/main.css
@@ -341,3 +341,186 @@ body.theme-braun {
   --ui-border-muted: #e2ded6;
   --ui-border-accented: #b5afa2;
 }
+
+/* ============================================
+   TABS (#1393) — a key row; the active key is pressed
+   ============================================ */
+
+.braun-tabs-list {
+  background-color: var(--braun-cream);
+  border: 1px solid var(--braun-hairline);
+  border-radius: calc(var(--braun-radius) * 2);
+  gap: 0.25rem;
+  padding: 0.25rem;
+}
+
+.braun-tabs-trigger {
+  background-color: transparent;
+  color: var(--braun-label);
+  border: 1px solid transparent;
+  border-radius: var(--braun-radius);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.45rem 0.9rem;
+  transition: all var(--braun-ease);
+}
+
+.braun-tabs-trigger:hover {
+  color: var(--braun-text);
+}
+
+.braun-tabs-trigger[data-state="active"] {
+  background-color: var(--braun-cream-raised);
+  color: var(--braun-charcoal);
+  border-color: var(--braun-hairline);
+  box-shadow: var(--braun-shadow);
+}
+
+.braun-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — precise switches; the dot is orange
+   ============================================ */
+
+.braun-check-box,
+.braun-radio-box {
+  background-color: var(--braun-cream-raised);
+  border: 1px solid var(--braun-hairline);
+  box-shadow: var(--braun-shadow);
+}
+
+.braun-check-box {
+  border-radius: var(--braun-radius);
+}
+
+.braun-check-indicator {
+  background-color: var(--braun-orange);
+  color: #fff;
+  border-radius: calc(var(--braun-radius) - 1px);
+}
+
+.braun-radio-indicator {
+  background-color: var(--braun-cream-raised);
+}
+
+.braun-radio-indicator::after {
+  background-color: var(--braun-orange);
+  border-radius: 9999px;
+  width: 55%;
+  height: 55%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — an instrument label, orange when it matters
+   ============================================ */
+
+.braun-alert {
+  background-color: var(--braun-cream-raised);
+  color: var(--braun-text);
+  border: 1px solid var(--braun-hairline);
+  border-left: 4px solid var(--braun-orange);
+  border-radius: calc(var(--braun-radius) * 2);
+  box-shadow: var(--braun-shadow);
+}
+
+.braun-alert-title {
+  color: var(--braun-charcoal);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.braun-alert--primary {
+  border-left-color: var(--braun-orange);
+}
+
+.braun-alert--warning {
+  border-left-color: var(--braun-orange);
+  background-color: #fdf4ec;
+}
+
+.braun-alert--error {
+  border-left-color: var(--braun-red);
+  background-color: #f9efec;
+}
+
+.braun-alert--neutral {
+  border-left-color: var(--braun-charcoal);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths like the switch)
+   ============================================ */
+
+[data-theme="braun"] [role="dialog"][data-slot="content"],
+.theme-braun [role="dialog"][data-slot="content"] {
+  background-color: var(--braun-cream-raised);
+  border: 1px solid var(--braun-hairline);
+  border-radius: calc(var(--braun-radius) * 3);
+  box-shadow: 0 8px 30px rgba(46, 44, 41, 0.18);
+}
+
+[data-theme="braun"] [role="dialog"] [data-slot="title"],
+.theme-braun [role="dialog"] [data-slot="title"] {
+  color: var(--braun-charcoal);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+}
+
+[data-theme="braun"] [data-slot="overlay"],
+.theme-braun [data-slot="overlay"] {
+  background-color: rgb(46 44 41 / 0.35);
+}
+
+[data-theme="braun"] li[data-slot="base"],
+.theme-braun li[data-slot="base"] {
+  background-color: var(--braun-cream-raised);
+  border: 1px solid var(--braun-hairline);
+  border-left: 4px solid var(--braun-orange);
+  border-radius: calc(var(--braun-radius) * 2);
+  box-shadow: 0 4px 16px rgba(46, 44, 41, 0.14);
+}
+
+[data-theme="braun"] li[data-slot="base"] [data-slot="title"],
+.theme-braun li[data-slot="base"] [data-slot="title"] {
+  color: var(--braun-charcoal);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+
+[data-theme="braun"] nav[data-slot="root"] button,
+.theme-braun nav[data-slot="root"] button {
+  background-color: var(--braun-cream-raised);
+  color: var(--braun-text);
+  border: 1px solid var(--braun-hairline);
+  border-radius: var(--braun-radius);
+  box-shadow: var(--braun-shadow);
+  font-weight: 600;
+  transition: all var(--braun-ease);
+}
+
+[data-theme="braun"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-braun nav[data-slot="root"] button:hover:not(:disabled) {
+  color: var(--braun-charcoal);
+  box-shadow: var(--braun-shadow-pressed);
+}
+
+[data-theme="braun"] nav[data-slot="root"] button[data-selected],
+.theme-braun nav[data-slot="root"] button[data-selected] {
+  background-color: var(--braun-charcoal);
+  color: var(--braun-cream-raised);
+  border-color: var(--braun-charcoal);
+}

--- a/packages/crouton-themes/brutalist/app.config.ts
+++ b/packages/crouton-themes/brutalist/app.config.ts
@@ -92,6 +92,17 @@ export default defineAppConfig({
       }
     },
 
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: 'brutalist-input-base'
+        }
+      }
+    },
+
     textarea: {
       slots: {
         root: subtractThemeDefaults,
@@ -145,6 +156,80 @@ export default defineAppConfig({
           brutalist: 'brutalist-badge'
         }
       }
+    },
+
+    // #1393 component coverage. Tabs: the sliding indicator is hidden (CSS)
+    // and active state lives on the trigger — brutalist states snap, they
+    // don't glide. The positioning compoundVariants only fire for pill/link,
+    // so a named variant must own indicator geometry anyway.
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            list: 'brutalist-tabs-list',
+            trigger: 'brutalist-tabs-trigger',
+            indicator: 'brutalist-tabs-indicator'
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            base: 'brutalist-check-box',
+            indicator: 'brutalist-check-indicator'
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            base: 'brutalist-radio-box',
+            indicator: 'brutalist-radio-indicator'
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            root: 'brutalist-alert',
+            title: 'brutalist-alert-title'
+          }
+        }
+      },
+      compoundVariants: [
+        { color: 'primary', variant: 'brutalist', class: { root: 'brutalist-alert--primary' } },
+        { color: 'warning', variant: 'brutalist', class: { root: 'brutalist-alert--primary' } },
+        { color: 'error', variant: 'brutalist', class: { root: 'brutalist-alert--error' } },
+        { color: 'neutral', variant: 'brutalist', class: { root: 'brutalist-alert--neutral' } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -290,6 +290,175 @@
 }
 
 /* ============================================
+   TABS (#1393) — slabs, no gliding indicator
+   ============================================ */
+
+.brutalist-tabs-list {
+  background-color: transparent;
+  border-bottom: var(--brutalist-border) solid var(--brutalist-ink);
+  gap: 0.375rem;
+  padding: 0;
+}
+
+.brutalist-tabs-trigger {
+  background-color: transparent;
+  color: var(--brutalist-ink);
+  border: var(--brutalist-border) solid transparent;
+  border-bottom: none;
+  border-radius: 0;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.5rem 1rem;
+  transition: none;
+}
+
+.brutalist-tabs-trigger:hover {
+  border-color: var(--brutalist-ink);
+}
+
+.brutalist-tabs-trigger[data-state="active"] {
+  background-color: var(--brutalist-accent);
+  border-color: var(--brutalist-ink);
+}
+
+.brutalist-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — stamps, not dots.
+   The radio stays announced as a radio; the square is just brutalism.
+   ============================================ */
+
+.brutalist-check-box,
+.brutalist-radio-box {
+  background-color: var(--brutalist-paper);
+  border: 2px solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--brutalist-ink);
+}
+
+.brutalist-check-indicator {
+  background-color: var(--brutalist-accent);
+  color: var(--brutalist-ink);
+}
+
+.brutalist-radio-indicator {
+  background-color: var(--brutalist-accent);
+}
+
+.brutalist-radio-indicator::after {
+  background-color: var(--brutalist-ink);
+  border-radius: 0;
+  width: 50%;
+  height: 50%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a pasted-up notice
+   ============================================ */
+
+.brutalist-alert {
+  background-color: var(--brutalist-paper);
+  color: var(--brutalist-ink);
+  border: var(--brutalist-border) solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: var(--brutalist-shadow);
+}
+
+.brutalist-alert-title {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.brutalist-alert--primary {
+  background-color: var(--brutalist-accent);
+}
+
+.brutalist-alert--error {
+  background-color: var(--brutalist-danger);
+  color: var(--brutalist-paper);
+}
+
+.brutalist-alert--neutral {
+  background-color: var(--brutalist-ink);
+  color: var(--brutalist-paper);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — components without a variant hook
+   (modal/slideover, toast, pagination), scoped to both activation
+   paths like the switch above.
+   ============================================ */
+
+/* Dialogs (modal + slideover): a poster slammed onto the table. */
+[data-theme="brutalist"] [role="dialog"][data-slot="content"],
+.theme-brutalist [role="dialog"][data-slot="content"] {
+  background-color: var(--brutalist-paper);
+  border: var(--brutalist-border) solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: 8px 8px 0 var(--brutalist-ink);
+}
+
+[data-theme="brutalist"] [role="dialog"] [data-slot="title"],
+.theme-brutalist [role="dialog"] [data-slot="title"] {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+[data-theme="brutalist"] [data-slot="overlay"],
+.theme-brutalist [data-slot="overlay"] {
+  background-color: rgb(10 10 10 / 0.55);
+  backdrop-filter: none;
+}
+
+/* Toast: a telegram. */
+[data-theme="brutalist"] li[data-slot="base"],
+.theme-brutalist li[data-slot="base"] {
+  background-color: var(--brutalist-paper);
+  border: var(--brutalist-border) solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: var(--brutalist-shadow);
+}
+
+[data-theme="brutalist"] li[data-slot="base"] [data-slot="title"],
+.theme-brutalist li[data-slot="base"] [data-slot="title"] {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Pagination: page numbers are stamps; the current page is inked. */
+[data-theme="brutalist"] nav[data-slot="root"] button,
+.theme-brutalist nav[data-slot="root"] button {
+  background-color: var(--brutalist-paper);
+  color: var(--brutalist-ink);
+  border: 2px solid var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: 800;
+  transition: none;
+}
+
+[data-theme="brutalist"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-brutalist nav[data-slot="root"] button:hover:not(:disabled) {
+  background-color: var(--brutalist-accent);
+}
+
+[data-theme="brutalist"] nav[data-slot="root"] button[data-selected],
+.theme-brutalist nav[data-slot="root"] button[data-selected] {
+  background-color: var(--brutalist-ink);
+  color: var(--brutalist-paper);
+  box-shadow: 2px 2px 0 var(--brutalist-ink);
+}
+
+/* ============================================
    SEMANTIC TOKENS (#1390) — tuned to the paper.
    ============================================ */
 

--- a/packages/crouton-themes/eink/app.config.ts
+++ b/packages/crouton-themes/eink/app.config.ts
@@ -136,6 +136,90 @@ export default defineAppConfig({
           eink: 'eink-badge'
         }
       }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: "eink-input-base"
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            list: "eink-tabs-list",
+            trigger: "eink-tabs-trigger",
+            indicator: "eink-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            base: "eink-check-box",
+            indicator: "eink-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            base: "eink-radio-box",
+            indicator: "eink-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            root: "eink-alert",
+            title: "eink-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "eink", class: { root: "eink-alert--primary" } },
+        { color: "warning", variant: "eink", class: { root: "eink-alert--warning" } },
+        { color: "error", variant: "eink", class: { root: "eink-alert--error" } },
+        { color: "neutral", variant: "eink", class: { root: "eink-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/eink/assets/css/main.css
+++ b/packages/crouton-themes/eink/assets/css/main.css
@@ -258,3 +258,182 @@ body.theme-eink {
   --ui-border-muted: #dedbd4;
   --ui-border-accented: #1c1c1c;
 }
+
+/* ============================================
+   TABS (#1393) — chapter heads; the open one is underlined in ink
+   ============================================ */
+
+.eink-tabs-list {
+  background-color: transparent;
+  border-bottom: 1px solid var(--eink-hairline);
+  gap: 1rem;
+  padding: 0;
+}
+
+.eink-tabs-trigger {
+  font-family: var(--eink-serif);
+  background-color: transparent;
+  color: var(--eink-gray);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 0.5rem 0.25rem;
+  transition: none;
+}
+
+.eink-tabs-trigger:hover {
+  color: var(--eink-ink);
+}
+
+.eink-tabs-trigger[data-state="active"] {
+  color: var(--eink-ink);
+  border-bottom-color: var(--eink-ink);
+  font-weight: 700;
+}
+
+.eink-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — ballot boxes
+   ============================================ */
+
+.eink-check-box,
+.eink-radio-box {
+  background-color: var(--eink-paper);
+  border: 1px solid var(--eink-ink);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.eink-radio-box {
+  border-radius: 9999px;
+}
+
+.eink-check-indicator {
+  background-color: var(--eink-ink);
+  color: var(--eink-paper);
+}
+
+.eink-radio-indicator {
+  background-color: var(--eink-paper);
+  border-radius: 9999px;
+}
+
+.eink-radio-indicator::after {
+  background-color: var(--eink-ink);
+  border-radius: 9999px;
+  width: 55%;
+  height: 55%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a printed notice; errors are inverse
+   ============================================ */
+
+.eink-alert {
+  background-color: var(--eink-paper);
+  color: var(--eink-ink);
+  border-top: 3px double var(--eink-ink);
+  border-bottom: 3px double var(--eink-ink);
+  border-left: none;
+  border-right: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.eink-alert-title {
+  font-family: var(--eink-serif);
+  font-weight: 700;
+}
+
+.eink-alert--primary {
+  background-color: var(--eink-paper);
+}
+
+.eink-alert--warning {
+  border-top-style: solid;
+  border-bottom-style: solid;
+  border-top-width: 1px;
+  border-bottom-width: 4px;
+  border-bottom-style: double;
+}
+
+.eink-alert--error {
+  background-color: var(--eink-ink);
+  color: var(--eink-paper);
+}
+
+.eink-alert--neutral {
+  border-top: 1px solid var(--eink-hairline);
+  border-bottom: 1px solid var(--eink-hairline);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths like the switch)
+   ============================================ */
+
+[data-theme="eink"] [role="dialog"][data-slot="content"],
+.theme-eink [role="dialog"][data-slot="content"] {
+  background-color: var(--eink-paper);
+  border: 1px solid var(--eink-ink);
+  border-radius: 0;
+  box-shadow: none;
+  outline: 1px solid var(--eink-hairline);
+  outline-offset: 4px;
+}
+
+[data-theme="eink"] [role="dialog"] [data-slot="title"],
+.theme-eink [role="dialog"] [data-slot="title"] {
+  font-family: var(--eink-serif);
+  color: var(--eink-ink);
+  font-weight: 700;
+}
+
+[data-theme="eink"] [data-slot="overlay"],
+.theme-eink [data-slot="overlay"] {
+  background-color: rgb(28 28 28 / 0.3);
+  backdrop-filter: none;
+}
+
+[data-theme="eink"] li[data-slot="base"],
+.theme-eink li[data-slot="base"] {
+  background-color: var(--eink-paper);
+  border: 1px solid var(--eink-ink);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+[data-theme="eink"] li[data-slot="base"] [data-slot="title"],
+.theme-eink li[data-slot="base"] [data-slot="title"] {
+  font-family: var(--eink-serif);
+  color: var(--eink-ink);
+  font-weight: 700;
+}
+
+[data-theme="eink"] nav[data-slot="root"] button,
+.theme-eink nav[data-slot="root"] button {
+  background-color: var(--eink-paper);
+  color: var(--eink-ink);
+  border: 1px solid var(--eink-hairline);
+  border-radius: 0;
+  box-shadow: none;
+  transition: none;
+}
+
+[data-theme="eink"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-eink nav[data-slot="root"] button:hover:not(:disabled) {
+  border-color: var(--eink-ink);
+}
+
+[data-theme="eink"] nav[data-slot="root"] button[data-selected],
+.theme-eink nav[data-slot="root"] button[data-selected] {
+  background-color: var(--eink-ink);
+  color: var(--eink-paper);
+  border-color: var(--eink-ink);
+}

--- a/packages/crouton-themes/gameboy/app.config.ts
+++ b/packages/crouton-themes/gameboy/app.config.ts
@@ -144,6 +144,90 @@ export default defineAppConfig({
           gameboy: 'gb-badge'
         }
       }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: "gb-input-base"
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            list: "gb-tabs-list",
+            trigger: "gb-tabs-trigger",
+            indicator: "gb-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            base: "gb-check-box",
+            indicator: "gb-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            base: "gb-radio-box",
+            indicator: "gb-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            root: "gb-alert",
+            title: "gb-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "gameboy", class: { root: "gb-alert--primary" } },
+        { color: "warning", variant: "gameboy", class: { root: "gb-alert--warning" } },
+        { color: "error", variant: "gameboy", class: { root: "gb-alert--error" } },
+        { color: "neutral", variant: "gameboy", class: { root: "gb-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/gameboy/assets/css/main.css
+++ b/packages/crouton-themes/gameboy/assets/css/main.css
@@ -307,3 +307,175 @@ body.theme-gameboy {
   --ui-border-muted: #558042;
   --ui-border-accented: #0f380f;
 }
+
+/* ============================================
+   TABS (#1393) — menu row; the active entry is inked
+   ============================================ */
+
+.gb-tabs-list {
+  background-color: transparent;
+  border-bottom: var(--gb-step) solid var(--gb-0);
+  gap: 0.25rem;
+  padding: 0;
+}
+
+.gb-tabs-trigger {
+  background-color: transparent;
+  color: var(--gb-0);
+  border: var(--gb-step) solid transparent;
+  border-bottom: none;
+  border-radius: 0;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.5rem 0.9rem;
+  transition: none;
+}
+
+.gb-tabs-trigger:hover {
+  background-color: var(--gb-2);
+}
+
+.gb-tabs-trigger[data-state="active"] {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+  border-color: var(--gb-0);
+}
+
+.gb-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — 4 shades, square pixels
+   ============================================ */
+
+.gb-check-box,
+.gb-radio-box {
+  background-color: var(--gb-3);
+  border: 2px solid var(--gb-0);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.gb-check-indicator {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+}
+
+.gb-radio-indicator {
+  background-color: var(--gb-3);
+}
+
+.gb-radio-indicator::after {
+  background-color: var(--gb-0);
+  border-radius: 0;
+  width: 50%;
+  height: 50%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a dialog box since 1989
+   ============================================ */
+
+.gb-alert {
+  background-color: var(--gb-3);
+  color: var(--gb-0);
+  border: var(--gb-step) solid var(--gb-0);
+  border-radius: 0;
+  outline: 1px solid var(--gb-0);
+  outline-offset: 3px;
+}
+
+.gb-alert-title {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.gb-alert--primary {
+  background-color: var(--gb-2);
+}
+
+.gb-alert--warning {
+  background-color: var(--gb-2);
+}
+
+.gb-alert--error {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+  outline-color: var(--gb-1);
+}
+
+.gb-alert--neutral {
+  background-color: var(--gb-3);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths like the switch)
+   ============================================ */
+
+[data-theme="gameboy"] [role="dialog"][data-slot="content"],
+.theme-gameboy [role="dialog"][data-slot="content"] {
+  background-color: var(--gb-3);
+  border: var(--gb-step) solid var(--gb-0);
+  border-radius: 0;
+  outline: 1px solid var(--gb-0);
+  outline-offset: 3px;
+  box-shadow: 6px 6px 0 var(--gb-1);
+}
+
+[data-theme="gameboy"] [role="dialog"] [data-slot="title"],
+.theme-gameboy [role="dialog"] [data-slot="title"] {
+  color: var(--gb-0);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+[data-theme="gameboy"] [data-slot="overlay"],
+.theme-gameboy [data-slot="overlay"] {
+  background-color: rgb(15 56 15 / 0.6);
+}
+
+[data-theme="gameboy"] li[data-slot="base"],
+.theme-gameboy li[data-slot="base"] {
+  background-color: var(--gb-3);
+  border: var(--gb-step) solid var(--gb-0);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--gb-1);
+}
+
+[data-theme="gameboy"] li[data-slot="base"] [data-slot="title"],
+.theme-gameboy li[data-slot="base"] [data-slot="title"] {
+  color: var(--gb-0);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+[data-theme="gameboy"] nav[data-slot="root"] button,
+.theme-gameboy nav[data-slot="root"] button {
+  background-color: var(--gb-3);
+  color: var(--gb-0);
+  border: 2px solid var(--gb-0);
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: 700;
+  transition: none;
+}
+
+[data-theme="gameboy"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-gameboy nav[data-slot="root"] button:hover:not(:disabled) {
+  background-color: var(--gb-2);
+}
+
+[data-theme="gameboy"] nav[data-slot="root"] button[data-selected],
+.theme-gameboy nav[data-slot="root"] button[data-selected] {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+}

--- a/packages/crouton-themes/ko/app.config.ts
+++ b/packages/crouton-themes/ko/app.config.ts
@@ -145,6 +145,118 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1333-deferred coverage, landed with #1393: selects + textarea reuse the
+    // ko-input chrome.
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: "ko-input-base"
+        }
+      }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: "ko-input-base"
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: {
+            root: "ko-input",
+            base: "ko-input-base"
+          }
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: {
+            list: "ko-tabs-list",
+            trigger: "ko-tabs-trigger",
+            indicator: "ko-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: {
+            base: "ko-check-box",
+            indicator: "ko-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: {
+            base: "ko-radio-box",
+            indicator: "ko-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: {
+            root: "ko-alert",
+            title: "ko-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "ko", class: { root: "ko-alert--primary" } },
+        { color: "warning", variant: "ko", class: { root: "ko-alert--warning" } },
+        { color: "error", variant: "ko", class: { root: "ko-alert--error" } },
+        { color: "neutral", variant: "ko", class: { root: "ko-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -871,3 +871,207 @@ body.theme-ko {
   --ui-border-muted: #aeaba9;
   --ui-border-accented: #545251;
 }
+
+/* ============================================
+   TABS (#1393) — a mode row; the active mode is on the display
+   ============================================ */
+
+.ko-tabs-list {
+  background-color: var(--ko-surface-recess);
+  border-radius: var(--ko-button-radius);
+  gap: 0.25rem;
+  padding: 0.25rem;
+}
+
+.ko-tabs-trigger {
+  font-family: 'ko-tech', monospace;
+  font-size: 0.8rem;
+  background-color: transparent;
+  color: var(--ko-text-muted);
+  border: none;
+  border-radius: calc(var(--ko-button-radius) - 3px);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.45rem 0.9rem;
+  transition: color 100ms ease;
+}
+
+.ko-tabs-trigger:hover {
+  color: var(--ko-highlight-light);
+}
+
+.ko-tabs-trigger[data-state="active"] {
+  background-color: var(--ko-surface-panel);
+  color: var(--ko-accent-orange);
+  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.ko-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — chassis keys with LED states
+   ============================================ */
+
+.ko-check-box,
+.ko-radio-box {
+  background-color: var(--ko-surface-light);
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: 4px;
+  box-shadow: inset 0 1px 0 var(--ko-highlight-light), 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.ko-radio-box {
+  border-radius: 9999px;
+}
+
+.ko-check-indicator {
+  background-color: var(--ko-accent-orange);
+  color: var(--ko-surface-panel);
+  border-radius: 3px;
+}
+
+.ko-radio-indicator {
+  background-color: var(--ko-surface-light);
+  border-radius: 9999px;
+}
+
+.ko-radio-indicator::after {
+  background-color: var(--ko-accent-orange);
+  box-shadow: 0 0 4px var(--ko-highlight-orange);
+  border-radius: 9999px;
+  width: 55%;
+  height: 55%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a display readout
+   ============================================ */
+
+.ko-alert {
+  font-family: 'ko-tech', monospace;
+  background-color: var(--ko-surface-panel);
+  color: var(--ko-text-muted);
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: var(--ko-button-radius);
+  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+.ko-alert-title {
+  color: var(--ko-accent-orange);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.ko-alert--primary .ko-alert-title {
+  color: var(--ko-accent-orange);
+}
+
+.ko-alert--warning .ko-alert-title {
+  color: var(--ko-accent-pink);
+}
+
+.ko-alert--error .ko-alert-title {
+  color: var(--ko-accent-red);
+}
+
+.ko-alert--error {
+  border-color: var(--ko-accent-red);
+}
+
+.ko-alert--neutral .ko-alert-title {
+  color: var(--ko-text-light);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination, switch
+   (no variant hook; scoped to both activation paths)
+   ============================================ */
+
+[data-theme="ko"] button[role="switch"],
+.theme-ko button[role="switch"] {
+  border: 1px solid var(--ko-surface-recess);
+  background-color: var(--ko-surface-mid);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
+  transition: background-color 100ms ease;
+}
+
+[data-theme="ko"] button[role="switch"][data-state="checked"],
+.theme-ko button[role="switch"][data-state="checked"] {
+  background-color: var(--ko-accent-orange);
+}
+
+[data-theme="ko"] button[role="switch"] > span,
+.theme-ko button[role="switch"] > span {
+  background-color: var(--ko-surface-light);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="ko"] [role="dialog"][data-slot="content"],
+.theme-ko [role="dialog"][data-slot="content"] {
+  background-color: var(--ko-surface-light);
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: var(--ko-button-radius);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45), inset 0 1px 0 var(--ko-highlight-light);
+}
+
+[data-theme="ko"] [role="dialog"] [data-slot="title"],
+.theme-ko [role="dialog"] [data-slot="title"] {
+  font-family: 'ko-tech', monospace;
+  color: var(--ko-text-dark);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+[data-theme="ko"] [data-slot="overlay"],
+.theme-ko [data-slot="overlay"] {
+  background-color: rgb(23 23 23 / 0.6);
+}
+
+[data-theme="ko"] li[data-slot="base"],
+.theme-ko li[data-slot="base"] {
+  font-family: 'ko-tech', monospace;
+  background-color: var(--ko-surface-panel);
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: var(--ko-button-radius);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="ko"] li[data-slot="base"] [data-slot="title"],
+.theme-ko li[data-slot="base"] [data-slot="title"] {
+  color: var(--ko-accent-orange);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+[data-theme="ko"] li[data-slot="base"] [data-slot="description"],
+.theme-ko li[data-slot="base"] [data-slot="description"] {
+  color: var(--ko-text-muted);
+}
+
+[data-theme="ko"] nav[data-slot="root"] button,
+.theme-ko nav[data-slot="root"] button {
+  font-family: 'ko-tech', monospace;
+  background-color: var(--ko-surface-light);
+  color: var(--ko-text-dark);
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: 4px;
+  box-shadow: inset 0 1px 0 var(--ko-highlight-light), 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: none;
+}
+
+[data-theme="ko"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-ko nav[data-slot="root"] button:hover:not(:disabled) {
+  background-color: var(--ko-highlight-dark);
+}
+
+[data-theme="ko"] nav[data-slot="root"] button[data-selected],
+.theme-ko nav[data-slot="root"] button[data-selected] {
+  background-color: var(--ko-surface-panel);
+  color: var(--ko-accent-orange);
+  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.4);
+}

--- a/packages/crouton-themes/kr11/app.config.ts
+++ b/packages/crouton-themes/kr11/app.config.ts
@@ -117,6 +117,118 @@ export default defineAppConfig({
           kr11: 'kr-badge'
         }
       }
+    },
+
+    // #1333-deferred coverage, landed with #1393: selects + textarea reuse the
+    // kr-input chrome.
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: "kr-input-base"
+        }
+      }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: "kr-input-base"
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: {
+            root: "kr-input",
+            base: "kr-input-base"
+          }
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: {
+            list: "kr-tabs-list",
+            trigger: "kr-tabs-trigger",
+            indicator: "kr-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: {
+            base: "kr-check-box",
+            indicator: "kr-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: {
+            base: "kr-radio-box",
+            indicator: "kr-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: {
+            root: "kr-alert",
+            title: "kr-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "kr11", class: { root: "kr-alert--primary" } },
+        { color: "warning", variant: "kr11", class: { root: "kr-alert--warning" } },
+        { color: "error", variant: "kr11", class: { root: "kr-alert--error" } },
+        { color: "neutral", variant: "kr11", class: { root: "kr-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/kr11/assets/css/main.css
+++ b/packages/crouton-themes/kr11/assets/css/main.css
@@ -696,3 +696,185 @@ body.theme-kr11 {
   --ui-border-muted: #e0e0dd;
   --ui-border-accented: #aaa8a3;
 }
+
+/* ============================================
+   TABS (#1393) — a pad row; the active pad reads out on the display
+   ============================================ */
+
+.kr-tabs-list {
+  background-color: var(--kr-chassis);
+  border: 1px solid var(--kr-chassis-dark);
+  border-radius: var(--kr-button-radius);
+  gap: 0.25rem;
+  padding: 0.25rem;
+}
+
+.kr-tabs-trigger {
+  font-family: var(--kr-font);
+  font-size: 0.8rem;
+  font-weight: 600;
+  background-color: var(--kr-pad-cream);
+  color: var(--kr-text-dark);
+  border: 1px solid var(--kr-pad-keyline);
+  border-radius: calc(var(--kr-button-radius) - 2px);
+  padding: 0.45rem 0.9rem;
+  transition: all var(--kr-transition, 120ms ease);
+}
+
+.kr-tabs-trigger:hover {
+  background-color: var(--kr-pad-cream-pressed);
+}
+
+.kr-tabs-trigger[data-state="active"] {
+  background-color: var(--kr-display-bg);
+  color: var(--kr-display-red);
+  border-color: var(--kr-display-bg);
+  text-shadow: 0 0 6px var(--kr-display-red-glow);
+}
+
+.kr-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — pads with LED confirmation
+   ============================================ */
+
+.kr-check-box,
+.kr-radio-box {
+  background-color: var(--kr-pad-cream);
+  border: 1px solid var(--kr-pad-keyline);
+  border-radius: 4px;
+  box-shadow: inset 0 -1px 0 var(--kr-chassis-shadow);
+}
+
+.kr-radio-box {
+  border-radius: 9999px;
+}
+
+.kr-check-indicator {
+  background-color: var(--kr-pad-mint-pressed);
+  color: var(--kr-text-dark);
+  border-radius: 3px;
+}
+
+.kr-radio-indicator {
+  background-color: var(--kr-pad-cream);
+  border-radius: 9999px;
+}
+
+.kr-radio-indicator::after {
+  background-color: var(--kr-display-red);
+  box-shadow: 0 0 5px var(--kr-display-red-glow);
+  border-radius: 9999px;
+  width: 50%;
+  height: 50%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — chassis card, pad-colored by mood
+   ============================================ */
+
+.kr-alert {
+  font-family: var(--kr-font);
+  background-color: var(--kr-chassis-light);
+  color: var(--kr-text-dark);
+  border: 1px solid var(--kr-pad-keyline);
+  border-radius: var(--kr-button-radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.kr-alert-title {
+  font-weight: 700;
+}
+
+.kr-alert--primary {
+  background-color: var(--kr-pad-mint);
+}
+
+.kr-alert--warning {
+  background-color: var(--kr-led-yellow);
+}
+
+.kr-alert--error {
+  background-color: var(--kr-pad-coral);
+  border-color: var(--kr-pad-coral-rim);
+}
+
+.kr-alert--neutral {
+  background-color: var(--kr-pad-cream);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (switch already themed above; scoped to both activation paths)
+   ============================================ */
+
+[data-theme="kr11"] [role="dialog"][data-slot="content"],
+.theme-kr11 [role="dialog"][data-slot="content"] {
+  background-color: var(--kr-chassis-light);
+  border: 1px solid var(--kr-chassis-dark);
+  border-radius: var(--kr-card-radius, 12px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+}
+
+[data-theme="kr11"] [role="dialog"] [data-slot="title"],
+.theme-kr11 [role="dialog"] [data-slot="title"] {
+  font-family: var(--kr-font);
+  color: var(--kr-text-dark);
+  font-weight: 700;
+}
+
+[data-theme="kr11"] [data-slot="overlay"],
+.theme-kr11 [data-slot="overlay"] {
+  background-color: rgb(61 61 61 / 0.4);
+}
+
+/* Toast: the LED display speaks. */
+[data-theme="kr11"] li[data-slot="base"],
+.theme-kr11 li[data-slot="base"] {
+  background-color: var(--kr-display-bg);
+  border: 2px solid var(--kr-chassis-dark);
+  border-radius: var(--kr-display-radius, 4px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="kr11"] li[data-slot="base"] [data-slot="title"],
+.theme-kr11 li[data-slot="base"] [data-slot="title"] {
+  color: var(--kr-display-red);
+  text-shadow: 0 0 6px var(--kr-display-red-glow);
+  font-weight: 700;
+}
+
+[data-theme="kr11"] li[data-slot="base"] [data-slot="description"],
+.theme-kr11 li[data-slot="base"] [data-slot="description"] {
+  color: #cfcfcf;
+}
+
+[data-theme="kr11"] nav[data-slot="root"] button,
+.theme-kr11 nav[data-slot="root"] button {
+  font-family: var(--kr-font);
+  background-color: var(--kr-pad-cream);
+  color: var(--kr-text-dark);
+  border: 1px solid var(--kr-pad-keyline);
+  border-radius: 4px;
+  box-shadow: inset 0 -1px 0 var(--kr-chassis-shadow);
+  font-weight: 600;
+  transition: background-color 100ms ease;
+}
+
+[data-theme="kr11"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-kr11 nav[data-slot="root"] button:hover:not(:disabled) {
+  background-color: var(--kr-pad-cream-pressed);
+}
+
+[data-theme="kr11"] nav[data-slot="root"] button[data-selected],
+.theme-kr11 nav[data-slot="root"] button[data-selected] {
+  background-color: var(--kr-display-bg);
+  color: var(--kr-display-red);
+  border-color: var(--kr-display-bg);
+  text-shadow: 0 0 6px var(--kr-display-red-glow);
+}

--- a/packages/crouton-themes/minimal/app.config.ts
+++ b/packages/crouton-themes/minimal/app.config.ts
@@ -102,6 +102,118 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1333-deferred coverage, landed with #1393: selects + textarea reuse the
+    // minimal-input chrome.
+    select: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: "minimal-input-base"
+        }
+      }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: "minimal-input-base"
+        }
+      }
+    },
+
+    textarea: {
+      slots: {
+        root: subtractThemeDefaults,
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: {
+            root: "minimal-input",
+            base: "minimal-input-base"
+          }
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: {
+            list: "minimal-tabs-list",
+            trigger: "minimal-tabs-trigger",
+            indicator: "minimal-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: {
+            base: "minimal-check-box",
+            indicator: "minimal-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: {
+            base: "minimal-radio-box",
+            indicator: "minimal-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: {
+            root: "minimal-alert",
+            title: "minimal-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "minimal", class: { root: "minimal-alert--primary" } },
+        { color: "warning", variant: "minimal", class: { root: "minimal-alert--warning" } },
+        { color: "error", variant: "minimal", class: { root: "minimal-alert--error" } },
+        { color: "neutral", variant: "minimal", class: { root: "minimal-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/minimal/assets/css/main.css
+++ b/packages/crouton-themes/minimal/assets/css/main.css
@@ -434,3 +434,200 @@
 .minimal-link.minimal-link--error {
   color: #dc2626 !important;
 }
+
+/* ============================================
+   TABS (#1393) — an underline, nothing else
+   ============================================ */
+
+.minimal-tabs-list {
+  background-color: transparent;
+  border-bottom: var(--minimal-border-width-thick) solid var(--minimal-black);
+  gap: 1rem;
+  padding: 0;
+  border-radius: 0;
+}
+
+.minimal-tabs-trigger {
+  font-family: var(--minimal-font);
+  font-size: 0.875rem;
+  background-color: transparent;
+  color: var(--minimal-gray-500);
+  border: none;
+  border-radius: 0;
+  padding: 0.5rem 0.25rem;
+  transition: color var(--minimal-transition);
+}
+
+.minimal-tabs-trigger:hover {
+  color: var(--minimal-black);
+}
+
+.minimal-tabs-trigger[data-state="active"] {
+  color: var(--minimal-black);
+  font-weight: 600;
+  box-shadow: inset 0 -2px 0 var(--minimal-black);
+}
+
+.minimal-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — a square and a circle
+   ============================================ */
+
+.minimal-check-box,
+.minimal-radio-box {
+  background-color: var(--minimal-white);
+  border: var(--minimal-border-width-thick) solid var(--minimal-black);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.minimal-radio-box {
+  border-radius: 9999px;
+}
+
+.minimal-check-indicator {
+  background-color: var(--minimal-black);
+  color: var(--minimal-white);
+}
+
+.minimal-radio-indicator {
+  background-color: var(--minimal-white);
+  border-radius: 9999px;
+}
+
+.minimal-radio-indicator::after {
+  background-color: var(--minimal-black);
+  border-radius: 9999px;
+  width: 50%;
+  height: 50%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a framed note; errors invert
+   ============================================ */
+
+.minimal-alert {
+  font-family: var(--minimal-font);
+  background-color: var(--minimal-white);
+  color: var(--minimal-black);
+  border: var(--minimal-border-width-thick) solid var(--minimal-black);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.minimal-alert-title {
+  font-weight: 600;
+}
+
+.minimal-alert--primary {
+  background-color: var(--minimal-white);
+}
+
+.minimal-alert--warning {
+  border-style: dashed;
+}
+
+.minimal-alert--error {
+  background-color: var(--minimal-black);
+  color: var(--minimal-white);
+}
+
+.minimal-alert--neutral {
+  border-width: var(--minimal-border-width);
+  border-color: var(--minimal-gray-300);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — switch, modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths)
+   ============================================ */
+
+[data-theme="minimal"] button[role="switch"],
+.theme-minimal button[role="switch"] {
+  border-radius: 9999px;
+  border: var(--minimal-border-width-thick) solid var(--minimal-black);
+  background-color: var(--minimal-white);
+  box-shadow: none;
+  transition: background-color var(--minimal-transition);
+}
+
+[data-theme="minimal"] button[role="switch"][data-state="checked"],
+.theme-minimal button[role="switch"][data-state="checked"] {
+  background-color: var(--minimal-black);
+}
+
+[data-theme="minimal"] button[role="switch"] > span,
+.theme-minimal button[role="switch"] > span {
+  background-color: var(--minimal-black);
+  box-shadow: none;
+}
+
+[data-theme="minimal"] button[role="switch"][data-state="checked"] > span,
+.theme-minimal button[role="switch"][data-state="checked"] > span {
+  background-color: var(--minimal-white);
+}
+
+[data-theme="minimal"] [role="dialog"][data-slot="content"],
+.theme-minimal [role="dialog"][data-slot="content"] {
+  background-color: var(--minimal-white);
+  border: var(--minimal-border-width-thick) solid var(--minimal-black);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+[data-theme="minimal"] [role="dialog"] [data-slot="title"],
+.theme-minimal [role="dialog"] [data-slot="title"] {
+  font-family: var(--minimal-font);
+  color: var(--minimal-black);
+  font-weight: 600;
+}
+
+[data-theme="minimal"] [data-slot="overlay"],
+.theme-minimal [data-slot="overlay"] {
+  background-color: rgb(0 0 0 / 0.35);
+  backdrop-filter: none;
+}
+
+[data-theme="minimal"] li[data-slot="base"],
+.theme-minimal li[data-slot="base"] {
+  background-color: var(--minimal-white);
+  border: var(--minimal-border-width-thick) solid var(--minimal-black);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+[data-theme="minimal"] li[data-slot="base"] [data-slot="title"],
+.theme-minimal li[data-slot="base"] [data-slot="title"] {
+  font-family: var(--minimal-font);
+  color: var(--minimal-black);
+  font-weight: 600;
+}
+
+[data-theme="minimal"] nav[data-slot="root"] button,
+.theme-minimal nav[data-slot="root"] button {
+  font-family: var(--minimal-font);
+  background-color: var(--minimal-white);
+  color: var(--minimal-black);
+  border: var(--minimal-border-width) solid var(--minimal-gray-300);
+  border-radius: 0;
+  box-shadow: none;
+  transition: border-color var(--minimal-transition);
+}
+
+[data-theme="minimal"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-minimal nav[data-slot="root"] button:hover:not(:disabled) {
+  border-color: var(--minimal-black);
+}
+
+[data-theme="minimal"] nav[data-slot="root"] button[data-selected],
+.theme-minimal nav[data-slot="root"] button[data-selected] {
+  background-color: var(--minimal-black);
+  color: var(--minimal-white);
+  border-color: var(--minimal-black);
+}

--- a/packages/crouton-themes/mtv/app.config.ts
+++ b/packages/crouton-themes/mtv/app.config.ts
@@ -91,6 +91,17 @@ export default defineAppConfig({
       }
     },
 
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: 'mtv-input-base'
+        }
+      }
+    },
+
     textarea: {
       slots: {
         root: subtractThemeDefaults,
@@ -144,6 +155,79 @@ export default defineAppConfig({
           mtv: 'mtv-badge'
         }
       }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (states snap like the rest of the theme; the pill/link
+    // positioning compounds never fire for a named variant anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            list: 'mtv-tabs-list',
+            trigger: 'mtv-tabs-trigger',
+            indicator: 'mtv-tabs-indicator'
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            base: 'mtv-check-box',
+            indicator: 'mtv-check-indicator'
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            base: 'mtv-radio-box',
+            indicator: 'mtv-radio-indicator'
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            root: 'mtv-alert',
+            title: 'mtv-alert-title'
+          }
+        }
+      },
+      compoundVariants: [
+        { color: 'primary', variant: 'mtv', class: { root: 'mtv-alert--primary' } },
+        { color: 'warning', variant: 'mtv', class: { root: 'mtv-alert--warning' } },
+        { color: 'error', variant: 'mtv', class: { root: 'mtv-alert--error' } },
+        { color: 'neutral', variant: 'mtv', class: { root: 'mtv-alert--neutral' } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/mtv/assets/css/main.css
+++ b/packages/crouton-themes/mtv/assets/css/main.css
@@ -342,6 +342,184 @@
 }
 
 /* ============================================
+   TABS (#1393) — channel buttons; no gliding indicator
+   ============================================ */
+
+.mtv-tabs-list {
+  background-color: transparent;
+  border-bottom: var(--mtv-border) solid var(--mtv-ink);
+  gap: 0.375rem;
+  padding: 0;
+}
+
+.mtv-tabs-trigger {
+  background-color: transparent;
+  color: var(--mtv-ink);
+  border: var(--mtv-border) solid transparent;
+  border-bottom: none;
+  border-radius: 0;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 1rem;
+  transition: background-color var(--mtv-snap) ease-out;
+}
+
+.mtv-tabs-trigger:hover {
+  border-color: var(--mtv-ink);
+  background-color: var(--mtv-yellow);
+}
+
+.mtv-tabs-trigger[data-state="active"] {
+  background-color: var(--mtv-pink);
+  color: var(--mtv-paper);
+  border-color: var(--mtv-ink);
+  box-shadow: 3px -3px 0 var(--mtv-cyan);
+}
+
+.mtv-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — stickers you punch
+   ============================================ */
+
+.mtv-check-box,
+.mtv-radio-box {
+  background-color: #fff;
+  border: 2px solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--mtv-purple);
+}
+
+.mtv-check-indicator {
+  background-color: var(--mtv-pink);
+  color: var(--mtv-paper);
+}
+
+.mtv-radio-indicator {
+  background-color: var(--mtv-pink);
+}
+
+.mtv-radio-indicator::after {
+  background-color: var(--mtv-paper);
+  border-radius: 0;
+  width: 50%;
+  height: 50%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a station bumper card
+   ============================================ */
+
+.mtv-alert {
+  background-color: var(--mtv-paper);
+  color: var(--mtv-ink);
+  border: var(--mtv-border) solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--mtv-purple);
+}
+
+.mtv-alert-title {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mtv-alert--primary {
+  background-color: var(--mtv-pink);
+  color: var(--mtv-paper);
+  box-shadow: 4px 4px 0 var(--mtv-cyan);
+}
+
+.mtv-alert--warning {
+  background-color: var(--mtv-yellow);
+  box-shadow: 4px 4px 0 var(--mtv-pink);
+}
+
+.mtv-alert--error {
+  background-color: var(--mtv-cyan);
+  box-shadow: 4px 4px 0 var(--mtv-pink);
+}
+
+.mtv-alert--neutral {
+  background-color: var(--mtv-ink);
+  color: var(--mtv-paper);
+  box-shadow: 4px 4px 0 var(--mtv-pink);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths like the switch)
+   ============================================ */
+
+/* Dialogs: the video window. */
+[data-theme="mtv"] [role="dialog"][data-slot="content"],
+.theme-mtv [role="dialog"][data-slot="content"] {
+  background-color: var(--mtv-paper);
+  border: var(--mtv-border) solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 8px 8px 0 var(--mtv-purple);
+}
+
+[data-theme="mtv"] [role="dialog"] [data-slot="title"],
+.theme-mtv [role="dialog"] [data-slot="title"] {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+[data-theme="mtv"] [data-slot="overlay"],
+.theme-mtv [data-slot="overlay"] {
+  background-color: rgb(123 47 247 / 0.4);
+  backdrop-filter: none;
+}
+
+/* Toast: a lower-third bumper. */
+[data-theme="mtv"] li[data-slot="base"],
+.theme-mtv li[data-slot="base"] {
+  background-color: var(--mtv-paper);
+  border: var(--mtv-border) solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--mtv-pink);
+}
+
+[data-theme="mtv"] li[data-slot="base"] [data-slot="title"],
+.theme-mtv li[data-slot="base"] [data-slot="title"] {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Pagination: track numbers; the current one is on air. */
+[data-theme="mtv"] nav[data-slot="root"] button,
+.theme-mtv nav[data-slot="root"] button {
+  background-color: #fff;
+  color: var(--mtv-ink);
+  border: 2px solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: none;
+  font-weight: 800;
+  transition: background-color var(--mtv-snap) ease-out;
+}
+
+[data-theme="mtv"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-mtv nav[data-slot="root"] button:hover:not(:disabled) {
+  background-color: var(--mtv-yellow);
+}
+
+[data-theme="mtv"] nav[data-slot="root"] button[data-selected],
+.theme-mtv nav[data-slot="root"] button[data-selected] {
+  background-color: var(--mtv-pink);
+  color: var(--mtv-paper);
+  box-shadow: 2px 2px 0 var(--mtv-cyan);
+}
+
+/* ============================================
    REDUCED MOTION — kill the wiggle, keep the look
    ============================================ */
 

--- a/packages/crouton-themes/playground/app/app.vue
+++ b/packages/crouton-themes/playground/app/app.vue
@@ -7,25 +7,29 @@
 </script>
 
 <template>
-  <div class="min-h-screen bg-[var(--ui-bg,white)] p-6 max-w-5xl mx-auto space-y-10">
-    <header class="flex flex-wrap items-center justify-between gap-4">
-      <div class="space-y-1">
-        <h1 class="text-2xl font-semibold tracking-tight">
-          crouton-themes playground
-        </h1>
-        <p class="text-sm text-neutral-500">
-          Every current theme, one component set. Switch themes to compare —
-          nothing here is hand-drawn per theme, it's the same markup restyled.
-        </p>
-        <nav class="flex gap-4 text-sm">
-          <NuxtLink to="/" class="underline underline-offset-2">Gallery</NuxtLink>
-          <NuxtLink to="/ko" class="underline underline-offset-2">KO hardware showcase</NuxtLink>
-          <NuxtLink to="/crouton" class="underline underline-offset-2">Crouton surfaces</NuxtLink>
-        </nav>
-      </div>
-      <ThemeSwitcher />
-    </header>
+  <!-- UApp hosts the Toaster/overlay providers — required for the #1393 toast
+       coverage check (real crouton apps are always wrapped in UApp). -->
+  <UApp>
+    <div class="min-h-screen bg-[var(--ui-bg,white)] p-6 max-w-5xl mx-auto space-y-10">
+      <header class="flex flex-wrap items-center justify-between gap-4">
+        <div class="space-y-1">
+          <h1 class="text-2xl font-semibold tracking-tight">
+            crouton-themes playground
+          </h1>
+          <p class="text-sm text-neutral-500">
+            Every current theme, one component set. Switch themes to compare —
+            nothing here is hand-drawn per theme, it's the same markup restyled.
+          </p>
+          <nav class="flex gap-4 text-sm">
+            <NuxtLink to="/" class="underline underline-offset-2">Gallery</NuxtLink>
+            <NuxtLink to="/ko" class="underline underline-offset-2">KO hardware showcase</NuxtLink>
+            <NuxtLink to="/crouton" class="underline underline-offset-2">Crouton surfaces</NuxtLink>
+          </nav>
+        </div>
+        <ThemeSwitcher />
+      </header>
 
-    <NuxtPage />
-  </div>
+      <NuxtPage />
+    </div>
+  </UApp>
 </template>

--- a/packages/crouton-themes/playground/app/pages/crouton.vue
+++ b/packages/crouton-themes/playground/app/pages/crouton.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
-// Crouton surfaces (#1333) — a realistic generated-CRUD composition, so every
-// theme's coverage gaps are visible at sign-off time instead of discovered in
-// an app. The chrome-vs-data rule: controls follow the theme; dense data
-// surfaces (the table) stay calm and readable under every theme.
+// Crouton surfaces (#1333, extended in #1393) — a realistic generated-CRUD
+// composition, so every theme's coverage gaps are visible at sign-off time
+// instead of discovered in an app. The chrome-vs-data rule: controls follow
+// the theme; dense data surfaces (the table) stay calm and readable under
+// every theme.
+//
+// #1393 acceptance matrix: tabs, select/selectMenu/textarea, switch, checkbox,
+// radio cards, alerts, modal, slideover, toast, pagination — nothing on this
+// page may render stock under a theme (or the pass must be documented).
 const { getVariant } = useThemeSwitcher()
+const toast = useToast()
 
 const rows = [
   { id: 1, name: 'Frisdrank', price: '€ 2,00', status: 'active', stock: 140 },
@@ -27,16 +33,35 @@ const tabItems = [
 ]
 
 const categories = ['Dranken', 'Eten', 'Merch']
+const locations = ['Kassa 1', 'Kassa 2', 'Bar']
+
+const paymentOptions = [
+  { label: 'Cash', value: 'cash', description: 'Fysiek geld in de lade' },
+  { label: 'Payconiq', value: 'payconiq', description: 'QR-code betaling' },
+  { label: 'Bonnetjes', value: 'tickets', description: 'Vooraf verkochte bonnen' }
+]
 
 const form = reactive({
   name: '',
   category: 'Dranken',
+  location: 'Kassa 1',
   description: '',
-  active: true
+  active: true,
+  payment: 'cash',
+  channels: { kassa: true, webshop: false }
 })
 
 const page = ref(1)
 const isEditOpen = ref(false)
+const isPanelOpen = ref(false)
+
+function notify(type: 'success' | 'error') {
+  if (type === 'success') {
+    toast.add({ title: 'Product bewaard', description: 'De wijzigingen staan online.', color: 'success' })
+  } else {
+    toast.add({ title: 'Bewaren mislukt', description: 'Voorraad mag niet negatief zijn.', color: 'error' })
+  }
+}
 </script>
 
 <template>
@@ -53,6 +78,24 @@ const isEditOpen = ref(false)
       </div>
     </section>
 
+    <section class="space-y-3 max-w-2xl">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+        Alerts
+      </h2>
+      <UAlert
+        color="primary"
+        title="Nieuwe bestelronde gestart"
+        description="Bestellingen worden weer aangenomen."
+        icon="i-lucide-info"
+      />
+      <UAlert
+        color="error"
+        title="Printer offline"
+        description="Bonnetjes worden gebufferd tot de printer terug is."
+        icon="i-lucide-alert-triangle"
+      />
+    </section>
+
     <section class="space-y-3 max-w-md">
       <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
         Collection form
@@ -63,19 +106,39 @@ const isEditOpen = ref(false)
       <UFormField label="Categorie" name="category">
         <USelect v-model="form.category" :items="categories" />
       </UFormField>
+      <UFormField label="Locatie" name="location">
+        <USelectMenu v-model="form.location" :items="locations" />
+      </UFormField>
       <UFormField label="Omschrijving" name="description">
         <UTextarea v-model="form.description" placeholder="Korte omschrijving..." :rows="3" />
+      </UFormField>
+      <UFormField label="Betaalmethode" name="payment">
+        <URadioGroup v-model="form.payment" :items="paymentOptions" />
+      </UFormField>
+      <UFormField label="Kanalen" name="channels">
+        <div class="flex gap-6">
+          <UCheckbox v-model="form.channels.kassa" label="Kassa" />
+          <UCheckbox v-model="form.channels.webshop" label="Webshop" />
+        </div>
       </UFormField>
       <div class="flex items-center justify-between">
         <USwitch v-model="form.active" label="Actief" />
         <div class="flex gap-2">
           <UButton color="neutral" :variant="getVariant('ghost')">Annuleren</UButton>
-          <UButton color="primary">Opslaan</UButton>
+          <UButton color="primary" @click="notify('success')">Opslaan</UButton>
         </div>
+      </div>
+      <div class="flex gap-2">
+        <UButton color="neutral" :variant="getVariant('outline')" @click="isPanelOpen = true">
+          Open detailpaneel
+        </UButton>
+        <UButton color="error" :variant="getVariant('outline')" @click="notify('error')">
+          Trigger fout-toast
+        </UButton>
       </div>
     </section>
 
-    <UModal v-model:open="isEditOpen" title="Product bewerken">
+    <UModal v-model:open="isEditOpen" title="Product bewerken" description="Pas de productgegevens aan.">
       <template #body>
         <div class="space-y-4">
           <UFormField label="Naam" name="edit-name">
@@ -93,5 +156,21 @@ const isEditOpen = ref(false)
         <UButton color="primary" @click="isEditOpen = false">Bewaren</UButton>
       </template>
     </UModal>
+
+    <USlideover v-model:open="isPanelOpen" title="Product detail" description="Voorraad en verkoop per locatie.">
+      <template #body>
+        <div class="space-y-4">
+          <UFormField label="Voorraad" name="panel-stock">
+            <UInput type="number" :model-value="96" />
+          </UFormField>
+          <UFormField label="Locatie" name="panel-location">
+            <USelect :items="locations" :model-value="'Kassa 1'" />
+          </UFormField>
+        </div>
+      </template>
+      <template #footer>
+        <UButton color="primary" @click="isPanelOpen = false">Klaar</UButton>
+      </template>
+    </USlideover>
   </div>
 </template>

--- a/packages/crouton-themes/riso/app.config.ts
+++ b/packages/crouton-themes/riso/app.config.ts
@@ -136,6 +136,90 @@ export default defineAppConfig({
           riso: 'riso-badge'
         }
       }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: "riso-input-base"
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            list: "riso-tabs-list",
+            trigger: "riso-tabs-trigger",
+            indicator: "riso-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            base: "riso-check-box",
+            indicator: "riso-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            base: "riso-radio-box",
+            indicator: "riso-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            root: "riso-alert",
+            title: "riso-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "riso", class: { root: "riso-alert--primary" } },
+        { color: "warning", variant: "riso", class: { root: "riso-alert--warning" } },
+        { color: "error", variant: "riso", class: { root: "riso-alert--error" } },
+        { color: "neutral", variant: "riso", class: { root: "riso-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/riso/assets/css/main.css
+++ b/packages/crouton-themes/riso/assets/css/main.css
@@ -290,3 +290,169 @@ body.theme-riso {
   --ui-border-muted: #e2dbcc;
   --ui-border-accented: #b5ab96;
 }
+
+/* ============================================
+   TABS (#1393) — an overprinted index; active gets the pink pass
+   ============================================ */
+
+.riso-tabs-list {
+  background-color: transparent;
+  border-bottom: 2px solid var(--riso-ink);
+  gap: 0.375rem;
+  padding: 0;
+}
+
+.riso-tabs-trigger {
+  background-color: transparent;
+  color: var(--riso-ink);
+  border: 2px solid transparent;
+  border-bottom: none;
+  border-radius: 2px 2px 0 0;
+  font-weight: 700;
+  padding: 0.5rem 1rem;
+  transition: background-color 100ms ease;
+}
+
+.riso-tabs-trigger:hover {
+  background-color: var(--riso-teal-soft);
+}
+
+.riso-tabs-trigger[data-state="active"] {
+  background-color: var(--riso-pink-soft);
+  background-image: var(--riso-grain);
+  color: var(--riso-ink);
+  border-color: var(--riso-ink);
+}
+
+.riso-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — registration marks
+   ============================================ */
+
+.riso-check-box,
+.riso-radio-box {
+  background-color: #fffdf6;
+  border: 2px solid var(--riso-ink);
+  border-radius: 2px;
+  box-shadow: 2px 2px 0 var(--riso-pink-soft);
+}
+
+.riso-check-indicator {
+  background-color: var(--riso-pink);
+  color: var(--riso-paper);
+}
+
+.riso-radio-indicator {
+  background-color: #fffdf6;
+}
+
+.riso-radio-indicator::after {
+  background-color: var(--riso-teal);
+  border-radius: 9999px;
+  width: 55%;
+  height: 55%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a misregistered notice card
+   ============================================ */
+
+.riso-alert {
+  background-color: #fffdf6;
+  background-image: var(--riso-grain);
+  color: var(--riso-ink);
+  border: 2px solid var(--riso-ink);
+  border-radius: 2px;
+  box-shadow: 5px 5px 0 var(--riso-pink-soft), -3px -3px 0 var(--riso-teal-soft);
+}
+
+.riso-alert-title {
+  font-weight: 800;
+}
+
+.riso-alert--primary {
+  background-image: var(--riso-grain), linear-gradient(var(--riso-pink-soft), var(--riso-pink-soft));
+}
+
+.riso-alert--warning {
+  background-image: var(--riso-grain), linear-gradient(var(--riso-pink-soft), var(--riso-pink-soft));
+}
+
+.riso-alert--error {
+  background-color: var(--riso-pink);
+  color: var(--riso-paper);
+  box-shadow: 5px 5px 0 var(--riso-teal-soft);
+}
+
+.riso-alert--neutral {
+  background-image: var(--riso-grain), linear-gradient(var(--riso-teal-soft), var(--riso-teal-soft));
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths like the switch)
+   ============================================ */
+
+[data-theme="riso"] [role="dialog"][data-slot="content"],
+.theme-riso [role="dialog"][data-slot="content"] {
+  background-color: #fffdf6;
+  background-image: var(--riso-grain);
+  border: 2px solid var(--riso-ink);
+  border-radius: 2px;
+  box-shadow: 8px 8px 0 var(--riso-pink-soft), -4px -4px 0 var(--riso-teal-soft);
+}
+
+[data-theme="riso"] [role="dialog"] [data-slot="title"],
+.theme-riso [role="dialog"] [data-slot="title"] {
+  color: var(--riso-ink);
+  font-weight: 800;
+}
+
+[data-theme="riso"] [data-slot="overlay"],
+.theme-riso [data-slot="overlay"] {
+  background-color: rgb(47 43 39 / 0.45);
+}
+
+[data-theme="riso"] li[data-slot="base"],
+.theme-riso li[data-slot="base"] {
+  background-color: #fffdf6;
+  background-image: var(--riso-grain);
+  border: 2px solid var(--riso-ink);
+  border-radius: 2px;
+  box-shadow: 4px 4px 0 var(--riso-pink-soft);
+}
+
+[data-theme="riso"] li[data-slot="base"] [data-slot="title"],
+.theme-riso li[data-slot="base"] [data-slot="title"] {
+  color: var(--riso-ink);
+  font-weight: 800;
+}
+
+[data-theme="riso"] nav[data-slot="root"] button,
+.theme-riso nav[data-slot="root"] button {
+  background-color: #fffdf6;
+  color: var(--riso-ink);
+  border: 2px solid var(--riso-ink);
+  border-radius: 2px;
+  box-shadow: none;
+  font-weight: 700;
+  transition: background-color 100ms ease;
+}
+
+[data-theme="riso"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-riso nav[data-slot="root"] button:hover:not(:disabled) {
+  background-color: var(--riso-teal-soft);
+}
+
+[data-theme="riso"] nav[data-slot="root"] button[data-selected],
+.theme-riso nav[data-slot="root"] button[data-selected] {
+  background-color: var(--riso-pink);
+  color: var(--riso-paper);
+  box-shadow: 2px 2px 0 var(--riso-teal-soft);
+}

--- a/packages/crouton-themes/terminal/app.config.ts
+++ b/packages/crouton-themes/terminal/app.config.ts
@@ -143,6 +143,90 @@ export default defineAppConfig({
           terminal: 'term-badge'
         }
       }
+    },
+
+    selectMenu: {
+      slots: {
+        base: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: "term-input-base"
+        }
+      }
+    },
+
+    // #1393 component coverage — indicator hidden, active state on the
+    // trigger (the pill/link positioning compounds never fire for a named
+    // variant, and instant state changes fit the theme anyway).
+    tabs: {
+      slots: {
+        list: subtractThemeDefaults,
+        trigger: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            list: "term-tabs-list",
+            trigger: "term-tabs-trigger",
+            indicator: "term-tabs-indicator"
+          }
+        }
+      }
+    },
+
+    checkbox: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            base: "term-check-box",
+            indicator: "term-check-indicator"
+          }
+        }
+      }
+    },
+
+    radioGroup: {
+      slots: {
+        base: subtractThemeDefaults,
+        indicator: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            base: "term-radio-box",
+            indicator: "term-radio-indicator"
+          }
+        }
+      }
+    },
+
+    // Alert colors live in compoundVariants keyed to the STANDARD variants,
+    // so a named variant starts blank — the theme supplies its own compounds.
+    alert: {
+      slots: {
+        root: subtractThemeDefaults,
+        title: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            root: "term-alert",
+            title: "term-alert-title"
+          }
+        }
+      },
+      compoundVariants: [
+        { color: "primary", variant: "terminal", class: { root: "term-alert--primary" } },
+        { color: "warning", variant: "terminal", class: { root: "term-alert--warning" } },
+        { color: "error", variant: "terminal", class: { root: "term-alert--error" } },
+        { color: "neutral", variant: "terminal", class: { root: "term-alert--neutral" } }
+      ]
     }
   }
 })

--- a/packages/crouton-themes/terminal/assets/css/main.css
+++ b/packages/crouton-themes/terminal/assets/css/main.css
@@ -350,3 +350,203 @@ body.theme-terminal {
   --ui-border-muted: #14522b;
   --ui-border-accented: #33ff66;
 }
+
+/* ============================================
+   TABS (#1393) — screen tabs; active is inverse video
+   ============================================ */
+
+.term-tabs-list {
+  background-color: transparent;
+  border-bottom: 1px solid var(--term-phosphor-dim);
+  gap: 0.25rem;
+  padding: 0;
+}
+
+.term-tabs-trigger {
+  font-family: var(--term-font);
+  font-size: 0.8rem;
+  background-color: transparent;
+  color: var(--term-phosphor-dim);
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.5rem 0.7rem;
+  transition: none;
+}
+
+.term-tabs-trigger:hover {
+  color: var(--term-phosphor);
+  text-shadow: var(--term-glow);
+}
+
+.term-tabs-trigger[data-state="active"] {
+  background-color: var(--term-phosphor);
+  color: var(--term-bg);
+  border-color: var(--term-phosphor);
+  box-shadow: var(--term-glow);
+  text-shadow: none;
+}
+
+.term-tabs-indicator {
+  display: none;
+}
+
+/* ============================================
+   CHECKBOX / RADIO (#1393) — toggle bits on the tube
+   ============================================ */
+
+.term-check-box,
+.term-radio-box {
+  background-color: var(--term-bg-raised);
+  border: 1px solid var(--term-phosphor-dim);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.term-check-indicator {
+  background-color: var(--term-phosphor);
+  color: var(--term-bg);
+  box-shadow: var(--term-glow);
+}
+
+.term-radio-indicator {
+  background-color: var(--term-phosphor);
+  box-shadow: var(--term-glow);
+}
+
+.term-radio-indicator::after {
+  background-color: var(--term-bg);
+  border-radius: 0;
+  width: 40%;
+  height: 40%;
+  content: '';
+  display: block;
+  margin: auto;
+}
+
+/* ============================================
+   ALERT (#1393) — a system message
+   ============================================ */
+
+.term-alert {
+  font-family: var(--term-font);
+  background-color: var(--term-bg-raised);
+  color: var(--term-phosphor-soft);
+  border: 1px solid var(--term-phosphor-dim);
+  border-left: 4px solid var(--term-phosphor);
+  border-radius: 0;
+  box-shadow: inset 0 0 24px rgba(51, 255, 102, 0.05);
+}
+
+.term-alert-title {
+  font-family: var(--term-font);
+  color: var(--term-phosphor);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-shadow: var(--term-glow);
+}
+
+.term-alert--primary {
+  border-left-color: var(--term-phosphor);
+}
+
+.term-alert--warning {
+  border-left-color: var(--term-amber);
+}
+
+.term-alert--warning .term-alert-title {
+  color: var(--term-amber);
+  text-shadow: var(--term-glow-amber);
+}
+
+.term-alert--error {
+  border-left-color: var(--term-amber);
+  border-color: var(--term-amber);
+}
+
+.term-alert--error .term-alert-title {
+  color: var(--term-amber);
+  text-shadow: var(--term-glow-amber);
+}
+
+.term-alert--neutral {
+  border-left-color: var(--term-phosphor-dim);
+}
+
+.term-alert--neutral .term-alert-title {
+  color: var(--term-phosphor-soft);
+  text-shadow: none;
+}
+
+/* ============================================
+   AMBIENT CHROME (#1393) — modal/slideover, toast, pagination
+   (no variant hook; scoped to both activation paths like the switch)
+   ============================================ */
+
+[data-theme="terminal"] [role="dialog"][data-slot="content"],
+.theme-terminal [role="dialog"][data-slot="content"] {
+  background-color: var(--term-bg);
+  border: 1px solid var(--term-phosphor);
+  border-radius: 0;
+  box-shadow: var(--term-glow), inset 0 0 24px rgba(51, 255, 102, 0.05);
+}
+
+[data-theme="terminal"] [role="dialog"] [data-slot="title"],
+.theme-terminal [role="dialog"] [data-slot="title"] {
+  font-family: var(--term-font);
+  color: var(--term-phosphor);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-shadow: var(--term-glow);
+}
+
+[data-theme="terminal"] [data-slot="overlay"],
+.theme-terminal [data-slot="overlay"] {
+  background-color: rgb(4 8 4 / 0.8);
+  backdrop-filter: none;
+}
+
+[data-theme="terminal"] li[data-slot="base"],
+.theme-terminal li[data-slot="base"] {
+  font-family: var(--term-font);
+  background-color: var(--term-bg-raised);
+  border: 1px solid var(--term-phosphor);
+  border-radius: 0;
+  box-shadow: var(--term-glow);
+}
+
+[data-theme="terminal"] li[data-slot="base"] [data-slot="title"],
+.theme-terminal li[data-slot="base"] [data-slot="title"] {
+  font-family: var(--term-font);
+  color: var(--term-phosphor);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+[data-theme="terminal"] nav[data-slot="root"] button,
+.theme-terminal nav[data-slot="root"] button {
+  font-family: var(--term-font);
+  background-color: transparent;
+  color: var(--term-phosphor-dim);
+  border: 1px solid var(--term-phosphor-dim);
+  border-radius: 0;
+  box-shadow: none;
+  transition: none;
+}
+
+[data-theme="terminal"] nav[data-slot="root"] button:hover:not(:disabled),
+.theme-terminal nav[data-slot="root"] button:hover:not(:disabled) {
+  color: var(--term-phosphor);
+  border-color: var(--term-phosphor);
+  text-shadow: var(--term-glow);
+}
+
+[data-theme="terminal"] nav[data-slot="root"] button[data-selected],
+.theme-terminal nav[data-slot="root"] button[data-selected] {
+  background-color: var(--term-phosphor);
+  color: var(--term-bg);
+  border-color: var(--term-phosphor);
+  box-shadow: var(--term-glow);
+}

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -12,6 +12,11 @@
 //     variant-less usage resolves to, e.g. <UButton> → variant "ko"
 // Explicitly-set variants are the author's choice and are not remapped; use
 // useThemeSwitcher().getVariant('outline') to follow the active theme.
+//
+// Components WITHOUT a `variant` dimension (USwitch, UModal, USlideover,
+// UToast, UPagination) are themed AMBIENTLY instead — theme-scoped CSS in each
+// theme's main.css covering both activation paths ([data-theme="x"] from app
+// presets, .theme-x body class from useThemeSwitcher). See #1307/#1393.
 
 import type { ThemeName } from '../composables/useThemeSwitcher'
 
@@ -25,11 +30,38 @@ export interface ThemeUIConfig {
   card?: { defaultVariants?: { variant?: string } }
   badge?: { defaultVariants?: { variant?: string } }
   select?: { defaultVariants?: { variant?: string } }
+  selectMenu?: { defaultVariants?: { variant?: string } }
   textarea?: { defaultVariants?: { variant?: string } }
+  tabs?: { defaultVariants?: { variant?: string } }
+  checkbox?: { defaultVariants?: { variant?: string } }
+  radioGroup?: { defaultVariants?: { variant?: string } }
+  alert?: { defaultVariants?: { variant?: string } }
 }
 
 // Every config sets EVERY key the swap owns, so switching A → B never leaves
 // A's value behind (deepAssign only overwrites what the new object names).
+
+// Builds the common shape: every component key set to the SAME named variant.
+// Nuxt UI's own defaults (the reset values) are in defaultConfig below.
+const namedVariantConfig = (
+  variant: string,
+  colors: { primary: string, neutral: string },
+  overrides: Partial<ThemeUIConfig> = {}
+): ThemeUIConfig => ({
+  colors,
+  button: { defaultVariants: { variant } },
+  input: { defaultVariants: { variant } },
+  card: { defaultVariants: { variant } },
+  badge: { defaultVariants: { variant } },
+  select: { defaultVariants: { variant } },
+  selectMenu: { defaultVariants: { variant } },
+  textarea: { defaultVariants: { variant } },
+  tabs: { defaultVariants: { variant } },
+  checkbox: { defaultVariants: { variant } },
+  radioGroup: { defaultVariants: { variant } },
+  alert: { defaultVariants: { variant } },
+  ...overrides
+})
 
 // Default theme — Nuxt UI's own defaults, restated as the reset values.
 const defaultConfig: ThemeUIConfig = {
@@ -42,167 +74,68 @@ const defaultConfig: ThemeUIConfig = {
   card: { defaultVariants: { variant: 'outline' } },
   badge: { defaultVariants: { variant: 'solid' } },
   select: { defaultVariants: { variant: 'outline' } },
-  textarea: { defaultVariants: { variant: 'outline' } }
+  selectMenu: { defaultVariants: { variant: 'outline' } },
+  textarea: { defaultVariants: { variant: 'outline' } },
+  tabs: { defaultVariants: { variant: 'pill' } },
+  checkbox: { defaultVariants: { variant: 'list' } },
+  radioGroup: { defaultVariants: { variant: 'list' } },
+  alert: { defaultVariants: { variant: 'solid' } }
 }
 
 // KO — named variants registered by ko/app.config.ts (variant="ko" etc.)
-const koConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'orange',
-    neutral: 'stone'
-  },
-  button: { defaultVariants: { variant: 'ko' } },
-  input: { defaultVariants: { variant: 'ko' } },
-  card: { defaultVariants: { variant: 'ko' } },
-  badge: { defaultVariants: { variant: 'solid' } },
-  select: { defaultVariants: { variant: 'outline' } },
-  textarea: { defaultVariants: { variant: 'outline' } }
-}
+// Badge keeps Nuxt UI's solid: the semantic palette does the work (no ko badge
+// variant registered in the layer).
+const koConfig = namedVariantConfig('ko', { primary: 'orange', neutral: 'stone' }, {
+  badge: { defaultVariants: { variant: 'solid' } }
+})
 
-// Minimal — named variants registered by minimal/app.config.ts
-const minimalConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'zinc',
-    neutral: 'zinc'
-  },
-  button: { defaultVariants: { variant: 'minimal' } },
-  input: { defaultVariants: { variant: 'minimal' } },
-  card: { defaultVariants: { variant: 'minimal' } },
-  badge: { defaultVariants: { variant: 'solid' } },
-  select: { defaultVariants: { variant: 'outline' } },
-  textarea: { defaultVariants: { variant: 'outline' } }
-}
+// Minimal — named variants registered by minimal/app.config.ts (badge: same
+// deliberate pass as ko).
+const minimalConfig = namedVariantConfig('minimal', { primary: 'zinc', neutral: 'zinc' }, {
+  badge: { defaultVariants: { variant: 'solid' } }
+})
 
 // KR-11 — named variants registered by kr11/app.config.ts
-const kr11Config: ThemeUIConfig = {
-  colors: {
-    primary: 'emerald',
-    neutral: 'stone'
-  },
-  button: { defaultVariants: { variant: 'kr11' } },
-  input: { defaultVariants: { variant: 'kr11' } },
-  card: { defaultVariants: { variant: 'kr11' } },
-  badge: { defaultVariants: { variant: 'kr11' } },
-  select: { defaultVariants: { variant: 'outline' } },
-  textarea: { defaultVariants: { variant: 'outline' } }
-}
+const kr11Config = namedVariantConfig('kr11', { primary: 'emerald', neutral: 'stone' })
 
-// Black & White — named bw-* variants registered by blackandwhite/app.config.ts
-// (the layer also sets defaultVariants itself, so single-theme bw apps need no
-// runtime swap; these values are for switching TO bw in a multi-theme app).
+// Black & White — a DELIBERATE pass on named chrome (#1393): bw's design IS
+// Nuxt UI's standard variants under a strict neutral/neutral palette; only
+// buttons carry named bw-* variants. Everything else stays on the standard
+// variants the layer's own defaultVariants point at.
 const blackandwhiteConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'neutral',
-    neutral: 'neutral'
-  },
+  colors: { primary: 'neutral', neutral: 'neutral' },
   button: { defaultVariants: { variant: 'bw-solid' } },
   input: { defaultVariants: { variant: 'subtle' } },
   card: { defaultVariants: { variant: 'outline' } },
   badge: { defaultVariants: { variant: 'solid' } },
   select: { defaultVariants: { variant: 'subtle' } },
-  textarea: { defaultVariants: { variant: 'subtle' } }
+  selectMenu: { defaultVariants: { variant: 'subtle' } },
+  textarea: { defaultVariants: { variant: 'subtle' } },
+  tabs: { defaultVariants: { variant: 'pill' } },
+  checkbox: { defaultVariants: { variant: 'list' } },
+  radioGroup: { defaultVariants: { variant: 'list' } },
+  alert: { defaultVariants: { variant: 'subtle' } }
 }
 
 // Brutalist — named variants registered by brutalist/app.config.ts
-const brutalistConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'yellow',
-    neutral: 'neutral'
-  },
-  button: { defaultVariants: { variant: 'brutalist' } },
-  input: { defaultVariants: { variant: 'brutalist' } },
-  card: { defaultVariants: { variant: 'brutalist' } },
-  badge: { defaultVariants: { variant: 'brutalist' } },
-  select: { defaultVariants: { variant: 'brutalist' } },
-  textarea: { defaultVariants: { variant: 'brutalist' } }
-}
+const brutalistConfig = namedVariantConfig('brutalist', { primary: 'yellow', neutral: 'neutral' })
 
 // MTV — named variants registered by mtv/app.config.ts
-const mtvConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'fuchsia',
-    neutral: 'zinc'
-  },
-  button: { defaultVariants: { variant: 'mtv' } },
-  input: { defaultVariants: { variant: 'mtv' } },
-  card: { defaultVariants: { variant: 'mtv' } },
-  badge: { defaultVariants: { variant: 'mtv' } },
-  select: { defaultVariants: { variant: 'mtv' } },
-  textarea: { defaultVariants: { variant: 'mtv' } }
-}
+const mtvConfig = namedVariantConfig('mtv', { primary: 'fuchsia', neutral: 'zinc' })
 
 // Terminal — named variants registered by terminal/app.config.ts
-const terminalConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'green',
-    neutral: 'zinc'
-  },
-  button: { defaultVariants: { variant: 'terminal' } },
-  input: { defaultVariants: { variant: 'terminal' } },
-  card: { defaultVariants: { variant: 'terminal' } },
-  badge: { defaultVariants: { variant: 'terminal' } },
-  select: { defaultVariants: { variant: 'terminal' } },
-  textarea: { defaultVariants: { variant: 'terminal' } }
-}
+const terminalConfig = namedVariantConfig('terminal', { primary: 'green', neutral: 'zinc' })
 
 // Braun — named variants registered by braun/app.config.ts
-const braunConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'orange',
-    neutral: 'stone'
-  },
-  button: { defaultVariants: { variant: 'braun' } },
-  input: { defaultVariants: { variant: 'braun' } },
-  card: { defaultVariants: { variant: 'braun' } },
-  badge: { defaultVariants: { variant: 'braun' } },
-  select: { defaultVariants: { variant: 'braun' } },
-  textarea: { defaultVariants: { variant: 'braun' } }
-}
+const braunConfig = namedVariantConfig('braun', { primary: 'orange', neutral: 'stone' })
 
 // Game Boy — named variants registered by gameboy/app.config.ts
-const gameboyConfig: ThemeUIConfig = {
-  colors: {
-    primary: 'green',
-    neutral: 'stone'
-  },
-  button: { defaultVariants: { variant: 'gameboy' } },
-  input: { defaultVariants: { variant: 'gameboy' } },
-  card: { defaultVariants: { variant: 'gameboy' } },
-  badge: { defaultVariants: { variant: 'gameboy' } },
-  select: { defaultVariants: { variant: 'gameboy' } },
-  textarea: { defaultVariants: { variant: 'gameboy' } }
-}
+const gameboyConfig = namedVariantConfig('gameboy', { primary: 'green', neutral: 'stone' })
 
 // Riso / E-ink / Blueprint — named variants registered by their layers (#1311)
-const risoConfig: ThemeUIConfig = {
-  colors: { primary: 'pink', neutral: 'stone' },
-  button: { defaultVariants: { variant: 'riso' } },
-  input: { defaultVariants: { variant: 'riso' } },
-  card: { defaultVariants: { variant: 'riso' } },
-  badge: { defaultVariants: { variant: 'riso' } },
-  select: { defaultVariants: { variant: 'riso' } },
-  textarea: { defaultVariants: { variant: 'riso' } }
-}
-
-const einkConfig: ThemeUIConfig = {
-  colors: { primary: 'neutral', neutral: 'neutral' },
-  button: { defaultVariants: { variant: 'eink' } },
-  input: { defaultVariants: { variant: 'eink' } },
-  card: { defaultVariants: { variant: 'eink' } },
-  badge: { defaultVariants: { variant: 'eink' } },
-  select: { defaultVariants: { variant: 'eink' } },
-  textarea: { defaultVariants: { variant: 'eink' } }
-}
-
-const blueprintConfig: ThemeUIConfig = {
-  colors: { primary: 'sky', neutral: 'slate' },
-  button: { defaultVariants: { variant: 'blueprint' } },
-  input: { defaultVariants: { variant: 'blueprint' } },
-  card: { defaultVariants: { variant: 'blueprint' } },
-  badge: { defaultVariants: { variant: 'blueprint' } },
-  select: { defaultVariants: { variant: 'blueprint' } },
-  textarea: { defaultVariants: { variant: 'blueprint' } }
-}
+const risoConfig = namedVariantConfig('riso', { primary: 'pink', neutral: 'stone' })
+const einkConfig = namedVariantConfig('eink', { primary: 'neutral', neutral: 'neutral' })
+const blueprintConfig = namedVariantConfig('blueprint', { primary: 'sky', neutral: 'slate' })
 
 // Export all theme configs
 export const THEME_UI_CONFIGS: Record<ThemeName, ThemeUIConfig> = {


### PR DESCRIPTION
Closes #1393

## 👤 For humans

Every theme now covers the components real crouton apps actually render: **tabs, checkboxes, radio cards, alerts, modal/slideover chrome, toasts and pagination** — the stock-Nuxt-UI seams the kassa/pages screenshots exposed. The four originals (ko/kr11/minimal/bw) also close the select/textarea gap deferred in #1333. Black & White is a **documented deliberate pass**: its design is the standard variants under a strict neutral palette.

## 🤖 For agents

Two mechanisms, chosen by whether the component has a `variant` dimension (documented in `packages/crouton-themes/CLAUDE.md` → *Component coverage mechanics*):

1. **Named variants** (tabs / checkbox / radioGroup / alert / selectMenu, + select/textarea for the originals): marker classes per slot + the shared subtractive replacer + scalar `defaultVariants` entries in `themes/configs/themeConfigs.ts` (scalars-only rule unchanged). Tabs hide the sliding indicator — active state lives on `[data-state=active]` triggers. Alert color compounds are per-theme (the stock ones key on standard variants).
2. **Ambient theme-scoped CSS** (switch / dialogs / toast / pagination — no variant hook): scoped to both activation paths (`[data-theme=x]` + `.theme-x`). Key DOM discoveries: toast root is `li[data-slot="base"]` (not `root`); pagination buttons carry explicit outline/solid variants so only ambient CSS reaches them (`nav[data-slot=root] button`, active `[data-selected]`).

Playground `/crouton` extended into the acceptance matrix (radio cards, checkboxes, selectMenu, alerts, slideover, toast triggers) and the playground app is now wrapped in `<UApp>` so toasts render.

## 🧪 How to test

1. `pnpm --filter crouton-themes-playground dev` → http://localhost:3031/crouton
2. Flip all 12 themes with the switcher: nothing on the page renders stock (tabs/radios/checkboxes/alerts/pagination all restyle; the table stays calm by design).
3. Open the edit modal, the detail slideover, and both toast triggers per theme — chrome follows the theme.
4. Verified this session in the playground browser under all 12 themes; `pnpm typecheck` green; no console errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)