### PR TITLE
fix(crouton-pages,crouton-sales): app conformance — editor chrome theme-reachable (#1394)

### DIFF
--- a/packages/crouton-pages/app/components/Blocks/Properties/ButtonRowEditor.vue
+++ b/packages/crouton-pages/app/components/Blocks/Properties/ButtonRowEditor.vue
@@ -279,7 +279,7 @@ function removeFile(index: number) {
               size="xs"
               @update:model-value="updateButton(index, 'external', $event)"
             />
-            <span class="text-xs text-neutral-500">{{ t('pages.blocks.buttonRow.openInNewTab') }}</span>
+            <span class="text-xs text-muted">{{ t('pages.blocks.buttonRow.openInNewTab') }}</span>
           </div>
         </template>
       </template>
@@ -287,9 +287,9 @@ function removeFile(index: number) {
       <!-- Download mode: File upload -->
       <template v-else>
         <!-- File preview -->
-        <div v-if="btn.file" class="flex items-center gap-2 rounded-md border border-default p-2 bg-neutral-50 dark:bg-neutral-900">
+        <div v-if="btn.file" class="flex items-center gap-2 rounded-md border border-default p-2 bg-muted">
           <UIcon name="i-lucide-file" class="size-4 text-primary shrink-0" />
-          <span class="text-xs text-neutral-600 dark:text-neutral-400 truncate flex-1">
+          <span class="text-xs text-toned truncate flex-1">
             {{ btn.fileName || btn.file.split('/').pop() }}
           </span>
           <UButton
@@ -304,13 +304,13 @@ function removeFile(index: number) {
         <!-- Upload zone -->
         <label
           v-else
-          class="flex flex-col items-center justify-center h-16 rounded-md border-2 border-dashed border-default bg-neutral-50 dark:bg-neutral-900 cursor-pointer hover:border-primary/50 transition-colors"
+          class="flex flex-col items-center justify-center h-16 rounded-md border-2 border-dashed border-default bg-muted cursor-pointer hover:border-primary/50 transition-colors"
         >
           <UIcon
             :name="uploadingIndex === index ? 'i-lucide-loader-2' : 'i-lucide-upload'"
-            :class="['size-4 text-neutral-400', { 'animate-spin': uploadingIndex === index }]"
+            :class="['size-4 text-dimmed', { 'animate-spin': uploadingIndex === index }]"
           />
-          <span class="text-[10px] text-neutral-500 mt-1">
+          <span class="text-[10px] text-muted mt-1">
             {{ uploadingIndex === index ? t('pages.blocks.media.uploading') : t('pages.blocks.media.clickToUpload') }}
           </span>
           <input

--- a/packages/crouton-pages/app/components/Blocks/Properties/FileEditor.vue
+++ b/packages/crouton-pages/app/components/Blocks/Properties/FileEditor.vue
@@ -78,9 +78,9 @@ async function handleFileUpload(event: Event) {
   <div class="space-y-3">
     <!-- File Preview -->
     <div v-if="hasFile && mode === 'preview'" class="space-y-2">
-      <div class="flex items-center gap-3 rounded-lg border border-default p-3 bg-neutral-50 dark:bg-neutral-900">
+      <div class="flex items-center gap-3 rounded-lg border border-default p-3 bg-muted">
         <UIcon name="i-lucide-file" class="size-5 text-primary shrink-0" />
-        <span class="text-sm text-neutral-700 dark:text-neutral-300 truncate flex-1">
+        <span class="text-sm text-default truncate flex-1">
           {{ displayName }}
         </span>
         <div class="flex gap-1 shrink-0">
@@ -105,11 +105,11 @@ async function handleFileUpload(event: Event) {
     <!-- Upload Mode -->
     <div v-if="mode === 'upload'" class="space-y-2">
       <label
-        class="flex flex-col items-center justify-center h-24 rounded-lg border-2 border-dashed border-default bg-neutral-50 dark:bg-neutral-900 cursor-pointer hover:border-primary/50 transition-colors"
+        class="flex flex-col items-center justify-center h-24 rounded-lg border-2 border-dashed border-default bg-muted cursor-pointer hover:border-primary/50 transition-colors"
       >
-        <UIcon v-if="!isUploading" name="i-lucide-upload" class="size-6 text-neutral-400 mb-1" />
-        <UIcon v-else name="i-lucide-loader-2" class="size-6 text-neutral-400 mb-1 animate-spin" />
-        <span class="text-xs text-neutral-500">
+        <UIcon v-if="!isUploading" name="i-lucide-upload" class="size-6 text-dimmed mb-1" />
+        <UIcon v-else name="i-lucide-loader-2" class="size-6 text-dimmed mb-1 animate-spin" />
+        <span class="text-xs text-muted">
           {{ isUploading ? t('pages.blocks.media.uploading') : t('pages.blocks.file.clickToUpload') }}
         </span>
         <input

--- a/packages/crouton-pages/app/components/Blocks/Properties/ImageEditor.vue
+++ b/packages/crouton-pages/app/components/Blocks/Properties/ImageEditor.vue
@@ -202,10 +202,10 @@ async function handleAssetSelected(asset: Record<string, any>) {
 
     <!-- No Image State — Browse tab shown first if available -->
     <div v-if="!hasImage && mode === 'preview'" class="flex flex-col gap-2">
-      <div class="flex items-center justify-center h-32 rounded-lg border-2 border-dashed border-default bg-neutral-50 dark:bg-neutral-900">
+      <div class="flex items-center justify-center h-32 rounded-lg border-2 border-dashed border-default bg-muted">
         <div class="text-center">
-          <UIcon name="i-lucide-image" class="size-8 text-neutral-400 mb-2" />
-          <p class="text-sm text-neutral-500">
+          <UIcon name="i-lucide-image" class="size-8 text-dimmed mb-2" />
+          <p class="text-sm text-muted">
             {{ t('pages.blocks.image.noImage') }}
           </p>
         </div>

--- a/packages/crouton-pages/app/components/Blocks/Properties/LogosEditor.vue
+++ b/packages/crouton-pages/app/components/Blocks/Properties/LogosEditor.vue
@@ -324,10 +324,10 @@ function getImageMode(index: number): string {
 
           <!-- No Image: action buttons -->
           <div v-if="!item.value && getImageMode(index) === 'preview'" class="flex flex-col gap-2">
-            <div class="flex items-center justify-center h-16 rounded-lg border-2 border-dashed border-default bg-neutral-50 dark:bg-neutral-900">
+            <div class="flex items-center justify-center h-16 rounded-lg border-2 border-dashed border-default bg-muted">
               <div class="text-center">
-                <UIcon name="i-lucide-image" class="size-5 text-neutral-400" />
-                <p class="text-xs text-neutral-500">{{ t('pages.blocks.logos.noImage') }}</p>
+                <UIcon name="i-lucide-image" class="size-5 text-dimmed" />
+                <p class="text-xs text-muted">{{ t('pages.blocks.logos.noImage') }}</p>
               </div>
             </div>
             <div class="flex gap-1">

--- a/packages/crouton-pages/app/components/Blocks/Properties/VideoEditor.vue
+++ b/packages/crouton-pages/app/components/Blocks/Properties/VideoEditor.vue
@@ -172,10 +172,10 @@ function handleAssetSelected(asset: Record<string, any>) {
 
     <!-- No Video State — Browse tab shown first if available -->
     <div v-if="!hasVideo && mode === 'preview'" class="flex flex-col gap-2">
-      <div class="flex items-center justify-center h-32 rounded-lg border-2 border-dashed border-default bg-neutral-50 dark:bg-neutral-900">
+      <div class="flex items-center justify-center h-32 rounded-lg border-2 border-dashed border-default bg-muted">
         <div class="text-center">
-          <UIcon name="i-lucide-video" class="size-8 text-neutral-400 mb-2" />
-          <p class="text-sm text-neutral-500">
+          <UIcon name="i-lucide-video" class="size-8 text-dimmed mb-2" />
+          <p class="text-sm text-muted">
             {{ t('pages.blocks.video.noVideoSet') }}
           </p>
         </div>
@@ -310,15 +310,15 @@ function handleAssetSelected(asset: Record<string, any>) {
     <div v-if="mode === 'upload'" class="space-y-2">
       <button
         type="button"
-        class="flex h-32 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-default bg-neutral-50 hover:bg-neutral-100 dark:bg-neutral-800 dark:hover:bg-neutral-900 transition-colors"
+        class="flex h-32 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-default bg-muted hover:bg-elevated transition-colors"
         :disabled="uploading"
         @click="openFilePicker()"
       >
         <UIcon
           :name="uploading ? 'i-lucide-loader-2' : 'i-lucide-upload'"
-          :class="['size-6 text-neutral-400', { 'animate-spin': uploading }]"
+          :class="['size-6 text-dimmed', { 'animate-spin': uploading }]"
         />
-        <span class="text-sm text-neutral-500">
+        <span class="text-sm text-muted">
           {{ uploading ? t('pages.blocks.media.uploading') : t('pages.blocks.video.clickToSelect') }}
         </span>
       </button>

--- a/packages/crouton-pages/app/components/Editor/BlockPropertyPanel.vue
+++ b/packages/crouton-pages/app/components/Editor/BlockPropertyPanel.vue
@@ -167,17 +167,19 @@ t
 
     <!-- Live Block Preview -->
     <div class="border-b border-default">
-      <button
-        class="w-full flex items-center justify-between px-4 py-2.5 text-sm font-medium hover:bg-muted/30 transition-colors"
-        type="button"
+      <UButton
+        color="neutral"
+        variant="ghost"
+        block
+        class="justify-between rounded-none px-4 py-2.5"
+        :trailing-icon="showPreview ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
         @click="showPreview = !showPreview"
       >
-        <span class="flex items-center gap-2 text-muted">
+        <span class="flex items-center gap-2 text-muted text-sm font-medium">
           <UIcon name="i-lucide-eye" class="size-3.5" />
           {{ t('pages.editor.livePreview') }}
         </span>
-        <UIcon :name="showPreview ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3.5 text-muted" />
-      </button>
+      </UButton>
       <div v-if="showPreview" class="relative overflow-hidden bg-muted/10" style="height: 200px;">
         <div style="transform: scale(0.33); transform-origin: top center; width: 303%; margin-left: -101.5%; pointer-events: none;">
           <CroutonPagesBlockContent :content="previewDoc as any" class="p-4" />

--- a/packages/crouton-pages/app/pages/[team]/[locale]/[...slug].vue
+++ b/packages/crouton-pages/app/pages/[team]/[locale]/[...slug].vue
@@ -355,13 +355,15 @@ useHead({
         leave-from-class="opacity-100 scale-100"
         leave-to-class="opacity-0 scale-90"
       >
-        <button
+        <UButton
           v-if="isAdmin && !isEditing && page?.id"
-          class="fixed bottom-6 right-6 z-40 flex items-center justify-center size-12 rounded-full bg-muted/80 backdrop-blur-sm text-muted-foreground border border-default shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-200 cursor-pointer"
+          icon="i-lucide-pencil"
+          color="neutral"
+          variant="soft"
+          :aria-label="t('pages.admin.editPage', 'Edit Page')"
+          class="fixed bottom-6 right-6 z-40 size-12 justify-center rounded-full backdrop-blur-sm shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-200"
           @click="startEditing"
-        >
-          <UIcon name="i-lucide-pencil" class="size-5" />
-        </button>
+        />
       </Transition>
     </ClientOnly>
   </div>

--- a/packages/crouton-sales/app/components/Settings/PrintPreviewModal.vue
+++ b/packages/crouton-sales/app/components/Settings/PrintPreviewModal.vue
@@ -41,7 +41,10 @@
           </div>
         </UCard>
 
-        <!-- Receipt Preview -->
+        <!-- Receipt Preview — deliberately NOT themed (#1394): this mocks the
+             physical thermal paper the printer spits out, so it keeps literal
+             paper white / ink gray regardless of app theme (chrome-vs-data
+             rule: the modal chrome themes, the paper mock doesn't). -->
         <UCard class="bg-gray-50 dark:bg-gray-900">
           <div class="flex justify-center">
             <div


### PR DESCRIPTION
Closes #1394

## 👤 For humans

The `/frontend-review` sweep over crouton-sales + crouton-pages (WS3 of epic #1392). crouton-sales came back **clean** — its POS chrome is proper Nuxt UI on semantic tokens (the kassa pill lives in crouton-pages' Nav, also token-driven, and is reached by the #1390 ambient token tuning). crouton-pages had the real offenders: hardcoded grays in the block property editors and two raw-HTML buttons. Fixed; themes now reach all of it.

## 🤖 For agents

**Fixed (crouton-pages):**
- 5 block property editors (Image/Video/ButtonRow/File/Logos): `bg-neutral-50 dark:bg-neutral-900` → `bg-muted`, `text-neutral-400/500/600/700` → `text-dimmed/muted/toned/default` — the empty-state/upload-zone colors themes literally could not recolor.
- `BlockPropertyPanel.vue` live-preview toggle: raw `<button>` → `UButton` ghost.
- Public route floating edit FAB: raw `<button>` with the **invalid `text-muted-foreground` class** (a shadcn-ism that doesn't exist in Nuxt UI 4) → `UButton` icon soft, with `aria-label`.

**Deliberate passes (documented):**
- `PrintPreviewModal.vue` (sales) keeps literal paper white/gray — it mocks the physical thermal printout (chrome-vs-data rule; comment added in code).
- `PageTypePicker`/`LayoutPicker` radio cards + upload drop zones stay custom widgets: they're fully semantic-token-driven with correct ARIA (radiogroup/radio, focus-visible), so themes reach them via tokens; forcing `URadioGroup`/`UButton` onto their layouts would be regression risk for zero theme gain.

## 🧪 How to test

1. `pnpm --filter fanfare dev` (:3007), log in as an admin.
2. Pagina's workspace → edit a page → insert a Video block → double-click it: the property panel's "Live voorbeeld" toggle and the "Geen video ingesteld" empty state follow the app palette (previously fixed gray).
3. Open a public page while logged in as admin: the floating edit pencil (bottom-right) is a Nuxt UI button — themed, focus ring, aria-label.
4. Verified this session in fanfare dev (screenshots of the block panel + FAB); `pnpm typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)