### PR TITLE
feat(crouton-themes,crouton-admin): every theme dual-scheme (#1395)

### DIFF
--- a/packages/crouton-admin/app/composables/useTeamTheme.ts
+++ b/packages/crouton-admin/app/composables/useTeamTheme.ts
@@ -173,9 +173,12 @@ export function applyThemeSettings(settings: TeamThemeSettings, colorMode?: { pr
     }
     else {
       updateAppConfig({ ui: entry.ui as any })
-      // Pin the scheme the theme was designed for (#1387).
+      // The theme's designed scheme is a DEFAULT, not a lock (#1395 relaxed
+      // the #1387 pin): applied only while the visitor has no explicit
+      // preference ('system'). Themes carry designed counterpart palettes
+      // for both schemes, so an explicit light/dark choice always wins.
       const scheme = THEME_PRESET_REGISTRY[preset as ThemePresetName]?.colorMode
-      if (scheme && colorMode) {
+      if (scheme && colorMode && colorMode.preference === 'system') {
         colorMode.preference = scheme
       }
     }

--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -525,6 +525,37 @@ Two mechanisms, chosen by whether the component has a `variant` dimension:
    Toasts require the app to be wrapped in `<UApp>` (hosts the Toaster) — the
    playground got this in #1393.
 
+## Dual scheme (#1395) — every theme works in light AND dark
+
+Every theme ships a **designed counterpart palette** for the scheme it wasn't
+drawn in (never an auto-inversion): brutalist/mtv/riso go ink-flipped with
+their accents intact, braun/ko/kr11 become their real-world black-unit
+hardware, gameboy gets the backlit mod, eink a night-reading page, terminal
+paper-mode, blueprint pencil-on-white. minimal is the negative; blackandwhite
+was adaptive already.
+
+Mechanics (uniform across themes):
+
+1. **Palette flip**: theme custom properties are re-declared under the
+   colorMode class on `<html>` — `.dark { --<p>-…: … }` for light-default
+   themes, `.light { … }` for terminal/blueprint. Vars are theme-namespaced,
+   so the blocks don't need `[data-theme]` scoping.
+2. **Text-on-fill constants**: fills that stay the same in both schemes
+   (shock yellow, neon pink, the orange dot, colored pads) get their own
+   `--<p>-on-*` / `--<p>-accent-ink` constants so the text on them does NOT
+   flip with ink/paper. This is the one audit that matters when adding a
+   scheme: every `color:` that sits on a constant fill must use a constant.
+3. **Semantic counterpart block**: each theme's #1390 `--ui-*` block gets a
+   scheme-scoped sibling (`[data-theme="x"].dark body, .dark body.theme-x`)
+   tuned to the counterpart paper.
+4. **No literal surface colors**: `#fff`-style literals were replaced by
+   `--<p>-surface` vars so raised surfaces flip too.
+
+**The scheme pin is a DEFAULT now (#1395, was a lock in #1387):**
+`ThemeConfig.colorMode` is applied only while the user's preference is
+`'system'` — an explicit light/dark choice (the nav toggle) always wins, in
+both `useThemeSwitcher.setTheme` and crouton-admin's `applyThemeSettings`.
+
 ## Nuxt UI Theming Pattern
 
 The key insight for Nuxt UI 4 theming:

--- a/packages/crouton-themes/blueprint/assets/css/main.css
+++ b/packages/crouton-themes/blueprint/assets/css/main.css
@@ -10,6 +10,8 @@
   --bp-line-dim: #7fa3c4;
   --bp-accent: #ffd66b;   /* the surveyor's pencil mark */
   --bp-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  /* Text on the pencil accent — constant across schemes (#1395). */
+  --bp-on-accent: #0d2c4d;
 }
 
 /* ============================================
@@ -321,7 +323,7 @@ body.theme-blueprint {
 }
 
 .bp-tabs-trigger[data-state="active"] {
-  color: var(--bp-blue-deep);
+  color: var(--bp-on-accent);
   background-color: var(--bp-accent);
   border-color: var(--bp-line);
 }
@@ -348,7 +350,7 @@ body.theme-blueprint {
 
 .bp-check-indicator {
   background-color: var(--bp-accent);
-  color: var(--bp-blue-deep);
+  color: var(--bp-on-accent);
 }
 
 .bp-radio-indicator {
@@ -478,6 +480,37 @@ body.theme-blueprint {
 [data-theme="blueprint"] nav[data-slot="root"] button[data-selected],
 .theme-blueprint nav[data-slot="root"] button[data-selected] {
   background-color: var(--bp-accent);
-  color: var(--bp-blue-deep);
+  color: var(--bp-on-accent);
   border-color: var(--bp-accent);
+}
+
+/* ============================================
+   DUAL SCHEME (#1395) — pencil-on-white, DESIGNED not inverted: blue
+   linework on white drafting paper, the pencil mark goes graphite-gold.
+   Activated by the colorMode class on <html>.
+   ============================================ */
+
+.light {
+  --bp-blue: #f4f7fa;
+  --bp-blue-deep: #e9eef5;
+  --bp-line: #16406e;
+  --bp-line-dim: #6787a8;
+  --bp-accent: #b58900;
+}
+
+/* Semantic tokens for the white sheet (counterpart of the #1390 block). */
+[data-theme="blueprint"].light body,
+.light body.theme-blueprint {
+  --ui-text-dimmed: #7d94ab;
+  --ui-text-muted: #5b7a99;
+  --ui-text-toned: #2e567f;
+  --ui-text: #16406e;
+  --ui-text-highlighted: #0d2c4d;
+  --ui-bg: #f4f7fa;
+  --ui-bg-muted: #edf1f7;
+  --ui-bg-elevated: #e9eef5;
+  --ui-bg-accented: #dde5ef;
+  --ui-border: #b5c6d8;
+  --ui-border-muted: #cbd8e5;
+  --ui-border-accented: #16406e;
 }

--- a/packages/crouton-themes/braun/assets/css/main.css
+++ b/packages/crouton-themes/braun/assets/css/main.css
@@ -524,3 +524,45 @@ body.theme-braun {
   color: var(--braun-cream-raised);
   border-color: var(--braun-charcoal);
 }
+
+/* ============================================
+   DUAL SCHEME (#1395) — the black-unit counterpart, DESIGNED not inverted:
+   charcoal chassis, backlit light legends, the one orange unchanged.
+   Activated by the colorMode class on <html>.
+   ============================================ */
+
+.dark {
+  --braun-cream: #23211e;
+  --braun-cream-raised: #2b2926;
+  --braun-charcoal: #e8e4dc;
+  --braun-hairline: #3d3a36;
+  --braun-text: #d5d0c7;
+  --braun-label: #918c83;
+  --braun-red: #d96a52;
+  --braun-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25);
+  --braun-shadow-pressed: inset 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.dark .braun-alert--warning {
+  background-color: #322a20;
+}
+
+.dark .braun-alert--error {
+  background-color: #33231f;
+}
+
+/* Semantic tokens for the charcoal chassis (counterpart of the #1390 block). */
+[data-theme="braun"].dark body,
+.dark body.theme-braun {
+  --ui-text-dimmed: #7d786f;
+  --ui-text-muted: #918c83;
+  --ui-text-toned: #b8b2a8;
+  --ui-text: #d5d0c7;
+  --ui-text-highlighted: #f0ece4;
+  --ui-bg-muted: #26241f;
+  --ui-bg-elevated: #2b2926;
+  --ui-bg-accented: #34312d;
+  --ui-border: #3d3a36;
+  --ui-border-muted: #33302c;
+  --ui-border-accented: #55514b;
+}

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -12,6 +12,11 @@
   --brutalist-ink: #0a0a0a;     /* near-black ink */
   --brutalist-accent: #ffd800;  /* shock yellow */
   --brutalist-danger: #ff3b30;  /* alarm red */
+  /* Text-on-fill constants (#1395): the accent/danger fills stay the same in
+     both schemes, so the text on them must NOT flip with ink/paper. */
+  --brutalist-accent-ink: #0a0a0a;
+  --brutalist-danger-ink: #fdfbf5;
+  --brutalist-paper-raised: #ffffff;
   --brutalist-border: 3px;
   --brutalist-shadow: 4px 4px 0 var(--brutalist-ink);
   --brutalist-shadow-hover: 6px 6px 0 var(--brutalist-ink);
@@ -54,6 +59,11 @@
   transition: none;
 }
 
+[data-theme="brutalist"] button[role="switch"][data-state="checked"] > span,
+.theme-brutalist button[role="switch"][data-state="checked"] > span {
+  background-color: var(--brutalist-accent-ink);
+}
+
 /* ============================================
    SOLID BUTTONS — flat block + hard shadow
    ============================================ */
@@ -81,6 +91,7 @@
 
 .brutalist-btn--primary {
   background-color: var(--brutalist-accent);
+  color: var(--brutalist-accent-ink);
 }
 
 .brutalist-btn--neutral {
@@ -90,7 +101,7 @@
 
 .brutalist-btn--error {
   background-color: var(--brutalist-danger);
-  color: var(--brutalist-paper);
+  color: var(--brutalist-danger-ink);
 }
 
 /* ============================================
@@ -110,11 +121,12 @@
 
 .brutalist-outline:hover {
   background-color: var(--brutalist-accent);
+  color: var(--brutalist-accent-ink);
 }
 
 .brutalist-outline--error:hover {
   background-color: var(--brutalist-danger);
-  color: var(--brutalist-paper);
+  color: var(--brutalist-danger-ink);
 }
 
 /* ============================================
@@ -123,7 +135,7 @@
 
 .brutalist-soft {
   background-color: var(--brutalist-accent);
-  color: var(--brutalist-ink);
+  color: var(--brutalist-accent-ink);
   border: none;
   box-shadow: none;
   font-weight: 800;
@@ -138,7 +150,7 @@
 
 .brutalist-soft--error {
   background-color: var(--brutalist-danger);
-  color: var(--brutalist-paper);
+  color: var(--brutalist-danger-ink);
 }
 
 /* ============================================
@@ -188,6 +200,7 @@
 
 .brutalist-link:hover {
   background-size: 100% 100%;
+  color: var(--brutalist-accent-ink);
 }
 
 .brutalist-link--error {
@@ -195,7 +208,7 @@
 }
 
 .brutalist-link--error:hover {
-  color: var(--brutalist-paper);
+  color: var(--brutalist-danger-ink);
 }
 
 /* ============================================
@@ -226,7 +239,7 @@
   outline: none;
   transform: translate(-2px, -2px);
   box-shadow: var(--brutalist-shadow-hover);
-  background-color: #fff;
+  background-color: var(--brutalist-paper-raised);
 }
 
 .brutalist-input-base:disabled {
@@ -249,6 +262,7 @@
 
 .brutalist-card-header {
   background-color: var(--brutalist-accent);
+  color: var(--brutalist-accent-ink);
   border-bottom: var(--brutalist-border) solid var(--brutalist-ink);
   font-weight: 800;
   text-transform: uppercase;
@@ -280,7 +294,7 @@
 
 .brutalist-badge {
   background-color: var(--brutalist-accent);
-  color: var(--brutalist-ink);
+  color: var(--brutalist-accent-ink);
   border: 2px solid var(--brutalist-ink);
   border-radius: 0;
   box-shadow: 2px 2px 0 var(--brutalist-ink);
@@ -320,6 +334,7 @@
 .brutalist-tabs-trigger[data-state="active"] {
   background-color: var(--brutalist-accent);
   border-color: var(--brutalist-ink);
+  color: var(--brutalist-accent-ink);
 }
 
 .brutalist-tabs-indicator {
@@ -341,7 +356,7 @@
 
 .brutalist-check-indicator {
   background-color: var(--brutalist-accent);
-  color: var(--brutalist-ink);
+  color: var(--brutalist-accent-ink);
 }
 
 .brutalist-radio-indicator {
@@ -349,7 +364,7 @@
 }
 
 .brutalist-radio-indicator::after {
-  background-color: var(--brutalist-ink);
+  background-color: var(--brutalist-accent-ink);
   border-radius: 0;
   width: 50%;
   height: 50%;
@@ -378,11 +393,12 @@
 
 .brutalist-alert--primary {
   background-color: var(--brutalist-accent);
+  color: var(--brutalist-accent-ink);
 }
 
 .brutalist-alert--error {
   background-color: var(--brutalist-danger);
-  color: var(--brutalist-paper);
+  color: var(--brutalist-danger-ink);
 }
 
 .brutalist-alert--neutral {
@@ -475,4 +491,34 @@ body.theme-brutalist {
   --ui-border: #0a0a0a;
   --ui-border-muted: #d9d5c9;
   --ui-border-accented: #0a0a0a;
+}
+
+/* ============================================
+   DUAL SCHEME (#1395) — the dark counterpart, DESIGNED not inverted:
+   white ink on near-black paper, the shock yellow stays, shadows go
+   white (a dark brutalist poster). Activated by the colorMode class
+   on <html>; the scheme pin relaxed to a default in useThemeSwitcher.
+   ============================================ */
+
+.dark {
+  --brutalist-paper: #161514;
+  --brutalist-ink: #f4f1e8;
+  --brutalist-danger: #ff5247;
+  --brutalist-paper-raised: #201f1d;
+}
+
+/* Semantic tokens for the dark paper (counterpart of the #1390 block). */
+[data-theme="brutalist"].dark body,
+.dark body.theme-brutalist {
+  --ui-text-dimmed: #8f8a7f;
+  --ui-text-muted: #a8a296;
+  --ui-text-toned: #d8d2c5;
+  --ui-text: #f4f1e8;
+  --ui-text-highlighted: #ffffff;
+  --ui-bg-muted: #1d1c1a;
+  --ui-bg-elevated: #21201d;
+  --ui-bg-accented: #2b2926;
+  --ui-border: #f4f1e8;
+  --ui-border-muted: #3c3a36;
+  --ui-border-accented: #f4f1e8;
 }

--- a/packages/crouton-themes/eink/assets/css/main.css
+++ b/packages/crouton-themes/eink/assets/css/main.css
@@ -437,3 +437,33 @@ body.theme-eink {
   color: var(--eink-paper);
   border-color: var(--eink-ink);
 }
+
+/* ============================================
+   DUAL SCHEME (#1395) — night reading mode, DESIGNED not inverted:
+   soft light ink on matte near-black (an e-reader at night; still
+   zero motion, hairlines stay hairlines). Activated by the colorMode
+   class on <html>.
+   ============================================ */
+
+.dark {
+  --eink-paper: #161616;
+  --eink-ink: #d8d8d2;
+  --eink-gray: #8a8a85;
+  --eink-hairline: #383836;
+}
+
+/* Semantic tokens for the night page (counterpart of the #1390 block). */
+[data-theme="eink"].dark body,
+.dark body.theme-eink {
+  --ui-text-dimmed: #6e6e69;
+  --ui-text-muted: #8a8a85;
+  --ui-text-toned: #b4b4ae;
+  --ui-text: #d8d8d2;
+  --ui-text-highlighted: #efefe9;
+  --ui-bg-muted: #1c1c1b;
+  --ui-bg-elevated: #202020;
+  --ui-bg-accented: #292928;
+  --ui-border: #383836;
+  --ui-border-muted: #2a2a29;
+  --ui-border-accented: #d8d8d2;
+}

--- a/packages/crouton-themes/gameboy/assets/css/main.css
+++ b/packages/crouton-themes/gameboy/assets/css/main.css
@@ -479,3 +479,32 @@ body.theme-gameboy {
   background-color: var(--gb-0);
   color: var(--gb-3);
 }
+
+/* ============================================
+   DUAL SCHEME (#1395) — the backlit-mod counterpart: same 4-shade
+   constraint, screen goes deep olive-black, ink goes lit green.
+   Activated by the colorMode class on <html>.
+   ============================================ */
+
+.dark {
+  --gb-0: #9fc814;   /* lit ink */
+  --gb-1: #6f9410;   /* mid glow */
+  --gb-2: #1e3d1e;   /* active fills, dark */
+  --gb-3: #0c1f0c;   /* the unlit screen */
+}
+
+/* Semantic tokens for the dark screen (counterpart of the base block). */
+[data-theme="gameboy"].dark body,
+.dark body.theme-gameboy {
+  --ui-text-dimmed: #567a2a;
+  --ui-text-muted: #6f9410;
+  --ui-text-toned: #8ab312;
+  --ui-text: #9fc814;
+  --ui-text-highlighted: #c2e63a;
+  --ui-bg-muted: #102810;
+  --ui-bg-elevated: #123012;
+  --ui-bg-accented: #1e3d1e;
+  --ui-border: #6f9410;
+  --ui-border-muted: #2c4f2c;
+  --ui-border-accented: #9fc814;
+}

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -1075,3 +1075,37 @@ body.theme-ko {
   color: var(--ko-accent-orange);
   box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.4);
 }
+
+/* ============================================
+   DUAL SCHEME (#1395) — the black-unit counterpart (the dark TE
+   hardware), DESIGNED not inverted: charcoal chassis, light silkscreen,
+   the displays were already dark and stay identical. Activated by the
+   colorMode class on <html>.
+   ============================================ */
+
+.dark {
+  --ko-surface-light: #2c2b29;      /* chassis goes charcoal */
+  --ko-surface-mid: #232221;
+  --ko-surface-dark: #3c3a38;
+  --ko-surface-recess: #121212;
+  --ko-text-dark: #d9d6d2;          /* silkscreen legends go light */
+  --ko-text-label: #8f8d8a;
+  --ko-highlight-light: #45433f;    /* the chassis edge highlight, dimmed */
+  --ko-highlight-dark: #1d1c1b;
+}
+
+/* Semantic tokens for the charcoal chassis (counterpart of the base block). */
+[data-theme="ko"].dark body,
+.dark body.theme-ko {
+  --ui-text-dimmed: #78756f;
+  --ui-text-muted: #8f8d8a;
+  --ui-text-toned: #b8b5b0;
+  --ui-text: #d9d6d2;
+  --ui-text-highlighted: #f2f2f2;
+  --ui-bg-muted: #262523;
+  --ui-bg-elevated: #2c2b29;
+  --ui-bg-accented: #363431;
+  --ui-border: #45433f;
+  --ui-border-muted: #383633;
+  --ui-border-accented: #5a5751;
+}

--- a/packages/crouton-themes/kr11/assets/css/main.css
+++ b/packages/crouton-themes/kr11/assets/css/main.css
@@ -59,6 +59,9 @@
   /* === Spacing & Sizing === */
   --kr-pad-radius: 8px;
   --kr-button-radius: 6px;
+  /* Text on the colored pads (mint/yellow/coral stay light in both schemes,
+     so the label on them must not flip) — #1395. */
+  --kr-on-pad: #3d3d3d;
   --kr-display-radius: 4px;
   --kr-card-radius: 12px;
 
@@ -128,7 +131,7 @@
 /* Coral Pink Pad (Pad 1 style) */
 .kr-pad.kr-pad--coral {
   background-color: var(--kr-pad-coral);
-  color: var(--kr-text-dark);
+  color: var(--kr-on-pad);
   /* Pad 1 on the device: pale salmon face, CORAL keyline. */
   border-color: var(--kr-pad-coral-rim);
 }
@@ -140,7 +143,7 @@
 /* Golden Yellow Pad (Fill buttons) */
 .kr-pad.kr-pad--gold {
   background-color: var(--kr-pad-gold);
-  color: var(--kr-text-dark);
+  color: var(--kr-on-pad);
 }
 
 .kr-pad.kr-pad--gold:hover {
@@ -150,7 +153,7 @@
 /* Mint Green Pad (Play button) */
 .kr-pad.kr-pad--mint {
   background-color: var(--kr-pad-mint);
-  color: var(--kr-text-dark);
+  color: var(--kr-on-pad);
 }
 
 .kr-pad.kr-pad--mint:hover {
@@ -754,7 +757,7 @@ body.theme-kr11 {
 
 .kr-check-indicator {
   background-color: var(--kr-pad-mint-pressed);
-  color: var(--kr-text-dark);
+  color: var(--kr-on-pad);
   border-radius: 3px;
 }
 
@@ -793,15 +796,18 @@ body.theme-kr11 {
 
 .kr-alert--primary {
   background-color: var(--kr-pad-mint);
+  color: var(--kr-on-pad);
 }
 
 .kr-alert--warning {
   background-color: var(--kr-led-yellow);
+  color: var(--kr-on-pad);
 }
 
 .kr-alert--error {
   background-color: var(--kr-pad-coral);
   border-color: var(--kr-pad-coral-rim);
+  color: var(--kr-on-pad);
 }
 
 .kr-alert--neutral {
@@ -877,4 +883,38 @@ body.theme-kr11 {
   color: var(--kr-display-red);
   border-color: var(--kr-display-bg);
   text-shadow: 0 0 6px var(--kr-display-red-glow);
+}
+
+/* ============================================
+   DUAL SCHEME (#1395) — the dark-unit counterpart (a Volca on a night
+   stage), DESIGNED not inverted: graphite chassis, dark pads with light
+   legends, the red LED display and the colored pads stay themselves.
+   Activated by the colorMode class on <html>.
+   ============================================ */
+
+.dark {
+  --kr-chassis: #26262a;
+  --kr-chassis-light: #2d2d31;
+  --kr-chassis-shadow: #1c1c1f;
+  --kr-chassis-dark: #3a3a3f;
+  --kr-pad-cream: #35353b;
+  --kr-pad-cream-pressed: #2c2c31;
+  --kr-pad-keyline: #55555c;
+  --kr-text-dark: #e2e2e6;
+}
+
+/* Semantic tokens for the graphite chassis (counterpart of the #1390 block). */
+[data-theme="kr11"].dark body,
+.dark body.theme-kr11 {
+  --ui-text-dimmed: #77777d;
+  --ui-text-muted: #8f8f95;
+  --ui-text-toned: #bcbcc2;
+  --ui-text: #e2e2e6;
+  --ui-text-highlighted: #f5f5f8;
+  --ui-bg-muted: #232327;
+  --ui-bg-elevated: #2d2d31;
+  --ui-bg-accented: #37373c;
+  --ui-border: #3a3a3f;
+  --ui-border-muted: #303034;
+  --ui-border-accented: #55555c;
 }

--- a/packages/crouton-themes/minimal/assets/css/main.css
+++ b/packages/crouton-themes/minimal/assets/css/main.css
@@ -631,3 +631,24 @@
   color: var(--minimal-white);
   border-color: var(--minimal-black);
 }
+
+/* ============================================
+   DUAL SCHEME (#1395) — the negative, DESIGNED for the same geometry:
+   white lines on black, grays re-stepped for the dark page. Activated
+   by the colorMode class on <html>.
+   ============================================ */
+
+.dark {
+  --minimal-white: #121212;
+  --minimal-black: #f2f2f2;
+  --minimal-gray-50: #171717;
+  --minimal-gray-100: #1f1f1f;
+  --minimal-gray-200: #292929;
+  --minimal-gray-300: #404040;
+  --minimal-gray-400: #737373;
+  --minimal-gray-500: #a3a3a3;
+  --minimal-gray-600: #c4c4c4;
+  --minimal-gray-700: #d9d9d9;
+  --minimal-gray-800: #e8e8e8;
+  --minimal-gray-900: #f5f5f5;
+}

--- a/packages/crouton-themes/mtv/assets/css/main.css
+++ b/packages/crouton-themes/mtv/assets/css/main.css
@@ -17,6 +17,11 @@
   --mtv-purple: #7b2ff7;
   --mtv-border: 2px;
   --mtv-snap: 90ms;
+  /* Raised surface + text-on-fill constants (#1395): the neon fills stay the
+     same in both schemes, so text on them must NOT flip with ink/paper. */
+  --mtv-surface: #ffffff;
+  --mtv-on-neon: #17131f;   /* on yellow / cyan */
+  --mtv-on-pink: #f6f2ea;   /* on pink / purple */
 }
 
 /* ============================================
@@ -34,7 +39,7 @@
 
 .mtv-btn {
   background-color: var(--mtv-yellow);
-  color: var(--mtv-ink);
+  color: var(--mtv-on-neon);
   border: var(--mtv-border) solid var(--mtv-ink);
   box-shadow: 4px 4px 0 var(--mtv-purple);
   font-weight: 800;
@@ -55,7 +60,7 @@
 
 .mtv-btn--pink {
   background-color: var(--mtv-pink);
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
   box-shadow: 4px 4px 0 var(--mtv-cyan);
 }
 
@@ -83,7 +88,7 @@
 
 .mtv-btn--cyan {
   background-color: var(--mtv-cyan);
-  color: var(--mtv-ink);
+  color: var(--mtv-on-neon);
   box-shadow: 4px 4px 0 var(--mtv-pink);
 }
 
@@ -113,15 +118,17 @@
 .mtv-outline:hover {
   transform: rotate(-1deg);
   background-color: var(--mtv-yellow);
+  color: var(--mtv-on-neon);
 }
 
 .mtv-outline--pink:hover {
   background-color: var(--mtv-pink);
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
 }
 
 .mtv-outline--cyan:hover {
   background-color: var(--mtv-cyan);
+  color: var(--mtv-on-neon);
 }
 
 /* ============================================
@@ -130,7 +137,7 @@
 
 .mtv-soft {
   background-color: var(--mtv-yellow);
-  color: var(--mtv-ink);
+  color: var(--mtv-on-neon);
   border: none;
   box-shadow: none;
   font-weight: 800;
@@ -146,7 +153,7 @@
 
 .mtv-soft--purple {
   background-color: var(--mtv-purple);
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
 }
 
 .mtv-soft--cyan {
@@ -170,7 +177,7 @@
 
 .mtv-ghost:hover {
   background-color: var(--mtv-ink);
-  color: var(--mtv-yellow);
+  color: var(--mtv-paper);
 }
 
 .mtv-ghost--cyan:hover {
@@ -197,7 +204,7 @@
 
 .mtv-link:hover {
   background-size: 100% 100%;
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
 }
 
 .mtv-link--cyan {
@@ -205,7 +212,7 @@
 }
 
 .mtv-link--cyan:hover {
-  color: var(--mtv-ink);
+  color: var(--mtv-on-neon);
 }
 
 .mtv-link--yellow {
@@ -213,7 +220,7 @@
 }
 
 .mtv-link--yellow:hover {
-  color: var(--mtv-ink);
+  color: var(--mtv-on-neon);
 }
 
 /* ============================================
@@ -225,7 +232,7 @@
 }
 
 .mtv-input-base {
-  background-color: #fff;
+  background-color: var(--mtv-surface);
   color: var(--mtv-ink);
   border: var(--mtv-border) solid var(--mtv-ink);
   border-radius: 0;
@@ -256,7 +263,7 @@
    ============================================ */
 
 .mtv-card {
-  background-color: #fff;
+  background-color: var(--mtv-surface);
   border: var(--mtv-border) solid var(--mtv-ink);
   border-radius: 0;
   box-shadow: 8px 8px 0 var(--mtv-pink);
@@ -265,6 +272,7 @@
 
 .mtv-card-header {
   background-color: var(--mtv-cyan);
+  color: var(--mtv-on-neon);
   border-bottom: var(--mtv-border) solid var(--mtv-ink);
   font-weight: 800;
   text-transform: uppercase;
@@ -305,7 +313,7 @@
 
 .mtv-badge {
   background-color: var(--mtv-yellow);
-  color: var(--mtv-ink);
+  color: var(--mtv-on-neon);
   border: 2px solid var(--mtv-ink);
   border-radius: 0;
   box-shadow: 2px 2px 0 var(--mtv-purple);
@@ -323,7 +331,7 @@
 .theme-mtv button[role="switch"] {
   border-radius: 0;
   border: var(--mtv-border) solid var(--mtv-ink);
-  background-color: #fff;
+  background-color: var(--mtv-surface);
   box-shadow: 2px 2px 0 var(--mtv-purple);
   transition: background-color var(--mtv-snap) ease-out;
 }
@@ -368,11 +376,12 @@
 .mtv-tabs-trigger:hover {
   border-color: var(--mtv-ink);
   background-color: var(--mtv-yellow);
+  color: var(--mtv-on-neon);
 }
 
 .mtv-tabs-trigger[data-state="active"] {
   background-color: var(--mtv-pink);
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
   border-color: var(--mtv-ink);
   box-shadow: 3px -3px 0 var(--mtv-cyan);
 }
@@ -387,7 +396,7 @@
 
 .mtv-check-box,
 .mtv-radio-box {
-  background-color: #fff;
+  background-color: var(--mtv-surface);
   border: 2px solid var(--mtv-ink);
   border-radius: 0;
   box-shadow: 2px 2px 0 var(--mtv-purple);
@@ -395,7 +404,7 @@
 
 .mtv-check-indicator {
   background-color: var(--mtv-pink);
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
 }
 
 .mtv-radio-indicator {
@@ -403,7 +412,7 @@
 }
 
 .mtv-radio-indicator::after {
-  background-color: var(--mtv-paper);
+  background-color: var(--mtv-on-pink);
   border-radius: 0;
   width: 50%;
   height: 50%;
@@ -432,17 +441,19 @@
 
 .mtv-alert--primary {
   background-color: var(--mtv-pink);
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
   box-shadow: 4px 4px 0 var(--mtv-cyan);
 }
 
 .mtv-alert--warning {
   background-color: var(--mtv-yellow);
+  color: var(--mtv-on-neon);
   box-shadow: 4px 4px 0 var(--mtv-pink);
 }
 
 .mtv-alert--error {
   background-color: var(--mtv-cyan);
+  color: var(--mtv-on-neon);
   box-shadow: 4px 4px 0 var(--mtv-pink);
 }
 
@@ -498,7 +509,7 @@
 /* Pagination: track numbers; the current one is on air. */
 [data-theme="mtv"] nav[data-slot="root"] button,
 .theme-mtv nav[data-slot="root"] button {
-  background-color: #fff;
+  background-color: var(--mtv-surface);
   color: var(--mtv-ink);
   border: 2px solid var(--mtv-ink);
   border-radius: 0;
@@ -515,7 +526,7 @@
 [data-theme="mtv"] nav[data-slot="root"] button[data-selected],
 .theme-mtv nav[data-slot="root"] button[data-selected] {
   background-color: var(--mtv-pink);
-  color: var(--mtv-paper);
+  color: var(--mtv-on-pink);
   box-shadow: 2px 2px 0 var(--mtv-cyan);
 }
 
@@ -556,4 +567,32 @@ body.theme-mtv {
   --ui-border: #d9d2c8;
   --ui-border-muted: #e4ded4;
   --ui-border-accented: #17131f;
+}
+
+/* ============================================
+   DUAL SCHEME (#1395) — neon on black, DESIGNED not inverted: the day-glo
+   fills stay, the paper goes club-dark. Activated by the colorMode class
+   on <html>; the scheme pin relaxed to a default in useThemeSwitcher.
+   ============================================ */
+
+.dark {
+  --mtv-paper: #17131f;
+  --mtv-ink: #f6f2ea;
+  --mtv-surface: #221c2e;
+}
+
+/* Semantic tokens for the dark paper (counterpart of the #1390 block). */
+[data-theme="mtv"].dark body,
+.dark body.theme-mtv {
+  --ui-text-dimmed: #857c8f;
+  --ui-text-muted: #9d94a8;
+  --ui-text-toned: #cfc7d8;
+  --ui-text: #f6f2ea;
+  --ui-text-highlighted: #ffffff;
+  --ui-bg-muted: #1d1826;
+  --ui-bg-elevated: #221c2e;
+  --ui-bg-accented: #2c2439;
+  --ui-border: #453a54;
+  --ui-border-muted: #322a3e;
+  --ui-border-accented: #f6f2ea;
 }

--- a/packages/crouton-themes/riso/assets/css/main.css
+++ b/packages/crouton-themes/riso/assets/css/main.css
@@ -10,6 +10,9 @@
   --riso-teal: #00887a;
   --riso-pink-soft: rgba(255, 72, 176, 0.18);
   --riso-teal-soft: rgba(0, 136, 122, 0.16);
+  /* Raised print stock + text-on-fluoro constant (#1395). */
+  --riso-surface: #fffdf6;
+  --riso-on-pink: #fff8f0;
   /* Grain: tiny SVG turbulence tile, self-contained (CSP-safe data URI). */
   --riso-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");
 }
@@ -62,7 +65,7 @@
 /* Overprint alert: both inks at once. */
 .riso-btn--alert {
   background-color: var(--riso-pink);
-  color: var(--riso-paper);
+  color: var(--riso-on-pink);
   background-image: var(--riso-grain), linear-gradient(var(--riso-teal-soft), var(--riso-teal-soft));
 }
 
@@ -175,7 +178,7 @@
 }
 
 .riso-input-base {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   color: var(--riso-ink);
   border: 2px solid var(--riso-ink);
   border-radius: 2px;
@@ -204,7 +207,7 @@
    ============================================ */
 
 .riso-card {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   background-image: var(--riso-grain);
   border: 2px solid var(--riso-ink);
   border-radius: 2px;
@@ -257,7 +260,7 @@
 [data-theme="riso"] button[role="switch"],
 .theme-riso button[role="switch"] {
   border: 2px solid var(--riso-ink);
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   box-shadow: 2px 2px 0 var(--riso-teal-soft);
   transition: background-color 100ms ease;
 }
@@ -334,7 +337,7 @@ body.theme-riso {
 
 .riso-check-box,
 .riso-radio-box {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   border: 2px solid var(--riso-ink);
   border-radius: 2px;
   box-shadow: 2px 2px 0 var(--riso-pink-soft);
@@ -342,11 +345,11 @@ body.theme-riso {
 
 .riso-check-indicator {
   background-color: var(--riso-pink);
-  color: var(--riso-paper);
+  color: var(--riso-on-pink);
 }
 
 .riso-radio-indicator {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
 }
 
 .riso-radio-indicator::after {
@@ -364,7 +367,7 @@ body.theme-riso {
    ============================================ */
 
 .riso-alert {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   background-image: var(--riso-grain);
   color: var(--riso-ink);
   border: 2px solid var(--riso-ink);
@@ -386,7 +389,7 @@ body.theme-riso {
 
 .riso-alert--error {
   background-color: var(--riso-pink);
-  color: var(--riso-paper);
+  color: var(--riso-on-pink);
   box-shadow: 5px 5px 0 var(--riso-teal-soft);
 }
 
@@ -401,7 +404,7 @@ body.theme-riso {
 
 [data-theme="riso"] [role="dialog"][data-slot="content"],
 .theme-riso [role="dialog"][data-slot="content"] {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   background-image: var(--riso-grain);
   border: 2px solid var(--riso-ink);
   border-radius: 2px;
@@ -421,7 +424,7 @@ body.theme-riso {
 
 [data-theme="riso"] li[data-slot="base"],
 .theme-riso li[data-slot="base"] {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   background-image: var(--riso-grain);
   border: 2px solid var(--riso-ink);
   border-radius: 2px;
@@ -436,7 +439,7 @@ body.theme-riso {
 
 [data-theme="riso"] nav[data-slot="root"] button,
 .theme-riso nav[data-slot="root"] button {
-  background-color: #fffdf6;
+  background-color: var(--riso-surface);
   color: var(--riso-ink);
   border: 2px solid var(--riso-ink);
   border-radius: 2px;
@@ -453,6 +456,37 @@ body.theme-riso {
 [data-theme="riso"] nav[data-slot="root"] button[data-selected],
 .theme-riso nav[data-slot="root"] button[data-selected] {
   background-color: var(--riso-pink);
-  color: var(--riso-paper);
+  color: var(--riso-on-pink);
   box-shadow: 2px 2px 0 var(--riso-teal-soft);
+}
+
+/* ============================================
+   DUAL SCHEME (#1395) — fluoro on black card, DESIGNED not inverted:
+   the pink/teal passes stay fluoro, the stock goes black (a night-mode
+   riso zine). Activated by the colorMode class on <html>.
+   ============================================ */
+
+.dark {
+  --riso-paper: #1b1815;
+  --riso-ink: #f0ebe0;
+  --riso-surface: #262220;
+  --riso-pink-soft: rgba(255, 72, 176, 0.24);
+  --riso-teal-soft: rgba(0, 176, 158, 0.22);
+  --riso-teal: #17b09e;
+}
+
+/* Semantic tokens for the black card (counterpart of the #1390 block). */
+[data-theme="riso"].dark body,
+.dark body.theme-riso {
+  --ui-text-dimmed: #8f887b;
+  --ui-text-muted: #a69e8f;
+  --ui-text-toned: #cfc7b8;
+  --ui-text: #f0ebe0;
+  --ui-text-highlighted: #fff8ec;
+  --ui-bg-muted: #221e1b;
+  --ui-bg-elevated: #262220;
+  --ui-bg-accented: #302b27;
+  --ui-border: #45403a;
+  --ui-border-muted: #332f2a;
+  --ui-border-accented: #f0ebe0;
 }

--- a/packages/crouton-themes/terminal/assets/css/main.css
+++ b/packages/crouton-themes/terminal/assets/css/main.css
@@ -550,3 +550,43 @@ body.theme-terminal {
   border-color: var(--term-phosphor);
   box-shadow: var(--term-glow);
 }
+
+/* ============================================
+   DUAL SCHEME (#1395) — paper mode, DESIGNED not inverted: dark green ink
+   on warm terminal-paper (a DEC printout), glow off, scanlines off.
+   Activated by the colorMode class on <html>.
+   ============================================ */
+
+.light {
+  --term-bg: #f2f2ea;
+  --term-bg-raised: #e8e8de;
+  --term-phosphor: #157a36;
+  --term-phosphor-dim: #56795f;
+  --term-phosphor-soft: #2e4a38;
+  --term-amber: #96690a;
+  --term-glow: 0 0 0 rgba(0, 0, 0, 0);
+  --term-glow-amber: 0 0 0 rgba(0, 0, 0, 0);
+}
+
+/* No CRT texture on paper. */
+.light body.theme-terminal::after,
+[data-theme="terminal"].light body::after {
+  display: none;
+}
+
+/* Semantic tokens for the paper (counterpart of the #1390 block). */
+[data-theme="terminal"].light body,
+.light body.theme-terminal {
+  --ui-text-dimmed: #6d7d6f;
+  --ui-text-muted: #56695a;
+  --ui-text-toned: #3a4f40;
+  --ui-text: #24352a;
+  --ui-text-highlighted: #14231a;
+  --ui-bg: #f2f2ea;
+  --ui-bg-muted: #eaeae0;
+  --ui-bg-elevated: #e8e8de;
+  --ui-bg-accented: #dededf;
+  --ui-border: #b9c4ba;
+  --ui-border-muted: #ccd4cc;
+  --ui-border-accented: #157a36;
+}

--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -17,9 +17,11 @@ export interface ThemeConfig {
   /** Default base variant for this theme (solid, outline, ghost, etc.) */
   defaultVariant: BaseVariant
   /**
-   * The color scheme this theme is designed for. Applying the theme pins the
-   * app's color mode to it (#1387 — a light-paper theme under dark-mode text
-   * tokens washes out). Omit for themes that adapt to both (blackandwhite).
+   * The color scheme this theme was DESIGNED in — its default. Applying the
+   * theme sets the color mode to it only while the user has no explicit
+   * preference (#1395 relaxed the #1387 pin: every theme now ships a designed
+   * counterpart palette for the other scheme, so an explicit light/dark
+   * choice always wins). Omit for themes that adapt to both (blackandwhite).
    */
   colorMode?: 'light' | 'dark'
 }
@@ -189,10 +191,13 @@ export function useThemeSwitcher() {
       })
     }
 
-    // Pin the scheme the theme was designed for (#1387); adaptive themes
-    // (blackandwhite, default) leave the user's preference untouched.
+    // The theme's designed scheme is a DEFAULT, not a lock (#1395 relaxed the
+    // #1387 pin): applied only while the user has no explicit preference
+    // ('system'). Every theme now carries a designed counterpart palette for
+    // the other scheme, so an explicit light/dark choice always wins; adaptive
+    // themes (blackandwhite, default) never touch the preference at all.
     const scheme = AVAILABLE_THEMES.find(t => t.name === theme)?.colorMode
-    if (scheme) {
+    if (scheme && colorMode.preference === 'system') {
       colorMode.preference = scheme
     }
   }


### PR DESCRIPTION
Closes #1395

## 👤 For humans

The last workstream of epic #1392: **all 12 themes now work in both light and dark**, each with a **designed counterpart palette** (per the epic's decision: never an auto-inversion):

| Theme | Counterpart |
|---|---|
| Brutalist | white ink + white hard shadows on near-black paper |
| MTV | neon on club-black |
| Terminal | **paper mode** — dark green ink on printout paper, glow + scanlines off |
| Blueprint | **pencil-on-white** — navy linework on white drafting sheet |
| Braun / KO / KR-11 | their real-world black-unit hardware (charcoal chassis, backlit legends; displays/LEDs stay themselves) |
| Game Boy | the backlit mod (same 4-shade constraint, lit green on unlit screen) |
| Riso | fluoro pink/teal on black card |
| E-ink | night reading mode |
| Minimal | the negative |
| Black & White | already adaptive (no change) |

**The #1387 scheme pin is now a default, not a lock**: applying a theme only sets the color mode while you have no explicit preference — the dark-mode toggle has authority again under every theme.

## 🤖 For agents

Mechanics documented in `packages/crouton-themes/CLAUDE.md` → *Dual scheme*: (1) palette flip via theme-namespaced custom props re-declared under `.dark`/`.light`; (2) **text-on-fill constants** (`--<p>-accent-ink`, `--<p>-on-*`) for fills that stay constant across schemes — computed values identical in the base scheme, so no light regression; (3) scheme-scoped siblings of the #1390 semantic `--ui-*` blocks; (4) literal `#fff` surfaces → `--<p>-surface` vars. Pin relaxation in `useThemeSwitcher.setTheme` + crouton-admin `applyThemeSettings` (guard: `preference === 'system'`).

## 🧪 How to test

1. Playground `/crouton`: flip each theme, then toggle dark mode (or set `nuxt-color-mode` in localStorage) — every theme readable and intentional in both schemes.
2. Explicit-preference check: choose dark, then switch themes — your choice sticks (previously each theme apply forced its scheme).
3. kassa staging after merge: dark + Game Boy renders the backlit DMG palette.
4. Verified this session in the playground browser: all 12 themes in their counterpart scheme + a light-mode regression spot-check; `pnpm typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)