### PR TITLE
fix(root): fanfare watches crouton-themes + crouton-admin (#1402)

### DIFF
--- a/apps/fanfare/deploy.config.json
+++ b/apps/fanfare/deploy.config.json
@@ -11,6 +11,8 @@
     "packages/crouton-charts/**",
     "packages/crouton-pages/**",
     "packages/crouton-sales/**",
+    "packages/crouton-themes/**",
+    "packages/crouton-admin/**",
     "pnpm-lock.yaml"
   ]
 }


### PR DESCRIPTION
Closes #1402

## 👤 For humans
Kassa ships every crouton theme (#1383) and applies presets via crouton-admin, but its deploy config never watched those packages — so the #1395 dual-scheme merge didn't redeploy kassa staging. Two watchPaths entries fix it.

## 🧪 How to test
Next `packages/crouton-themes/**`-only merge to main → deploy-apps `detect` lists fanfare → kassa.pmcp.dev redeploys. (For right now, I manually dispatched a fanfare staging deploy so #1392 verification isn't blocked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)