### PR TITLE
fix(crouton-sales,crouton-pages): raw-HTML chrome → Nuxt UI, batch 1 (#1410)

### DIFF
--- a/packages/crouton-pages/app/components/Blocks/Render/MailingBlock.vue
+++ b/packages/crouton-pages/app/components/Blocks/Render/MailingBlock.vue
@@ -67,14 +67,15 @@ const submitted = ref(false)
         class="flex gap-2"
         @submit="submitted = true"
       >
-        <input
+        <!-- UInput (not a raw input) so themes reach this public form (#1410) -->
+        <UInput
           v-model="email"
           type="email"
           :name="attrs.emailFieldName || 'EMAIL'"
           :placeholder="attrs.placeholder || 'Enter your email'"
           required
-          class="flex-1 min-w-0 rounded-[var(--ui-radius)] border border-[var(--ui-border)] bg-[var(--ui-bg)] px-3 py-2 text-sm text-[var(--ui-text)] placeholder:text-[var(--ui-text-dimmed)] focus:outline-none focus:ring-2 focus:ring-[var(--ui-primary)] focus:border-transparent transition-colors"
-        >
+          class="flex-1 min-w-0"
+        />
         <UButton type="submit" color="primary">
           {{ attrs.buttonLabel || 'Subscribe' }}
         </UButton>

--- a/packages/crouton-pages/app/components/Blocks/Views/AddonBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/AddonBlockView.vue
@@ -94,26 +94,28 @@ function handleOpenPanel() {
               {{ blockDef.name }}
             </span>
             <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-              <button
-                type="button"
-                class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+              <UButton
+                color="neutral"
+                variant="ghost"
+                size="xs"
+                square
+                icon="i-lucide-pencil"
+                class="text-dimmed hover:text-primary"
+                :aria-label="t('pages.blocks.editBlock')"
                 :title="t('pages.blocks.editBlock')"
                 @click.stop="handleOpenPanel"
-              >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-              </button>
-              <button
-                type="button"
-                class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+              />
+              <UButton
+                color="neutral"
+                variant="ghost"
+                size="xs"
+                square
+                icon="i-lucide-trash-2"
+                class="text-dimmed hover:text-error"
+                :aria-label="t('pages.blocks.deleteBlock')"
                 :title="t('pages.blocks.deleteBlock')"
                 @click.stop="deleteNode"
-              >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-              </button>
+              />
             </div>
           </div>
           <div class="bg-gray-50/50 dark:bg-gray-800/30 rounded-lg p-4 border border-gray-100 dark:border-gray-700/50">

--- a/packages/crouton-pages/app/components/Blocks/Views/ButtonRowBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/ButtonRowBlockView.vue
@@ -79,26 +79,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/CTABlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/CTABlockView.vue
@@ -61,26 +61,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/CardGridBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/CardGridBlockView.vue
@@ -61,26 +61,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/CollectionBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/CollectionBlockView.vue
@@ -84,26 +84,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/ContactBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/ContactBlockView.vue
@@ -96,26 +96,28 @@ function handleOpenPanel() {
             <span v-if="isHorizontal" class="text-gray-300 ml-1">(Horizontal)</span>
           </span>
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/EmbedBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/EmbedBlockView.vue
@@ -83,26 +83,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/FaqBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/FaqBlockView.vue
@@ -53,26 +53,28 @@ function handleOpenPanel() {
             FAQ
           </span>
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/FileBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/FileBlockView.vue
@@ -71,26 +71,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/GalleryBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/GalleryBlockView.vue
@@ -57,26 +57,28 @@ const imageCount = computed(() => (attrs.value.images || []).length)
             Gallery
           </span>
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/HeroBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/HeroBlockView.vue
@@ -68,26 +68,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/ImageBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/ImageBlockView.vue
@@ -70,26 +70,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/LogoBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/LogoBlockView.vue
@@ -68,26 +68,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/MailingBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/MailingBlockView.vue
@@ -55,26 +55,28 @@ function handleOpenPanel() {
             Mailing List
           </span>
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/QrCodeBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/QrCodeBlockView.vue
@@ -77,26 +77,28 @@ function handleOpenPanel() {
         </div>
         <!-- Action buttons -->
         <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5 flex-shrink-0">
-          <button
-            type="button"
-            class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+          <UButton
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            square
+            icon="i-lucide-pencil"
+            class="text-dimmed hover:text-primary"
+            :aria-label="t('pages.blocks.editBlock')"
             :title="t('pages.blocks.editBlock')"
             @click.stop="handleOpenPanel"
-          >
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+          />
+          <UButton
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            square
+            icon="i-lucide-trash-2"
+            class="text-dimmed hover:text-error"
+            :aria-label="t('pages.blocks.deleteBlock')"
             :title="t('pages.blocks.deleteBlock')"
             @click.stop="deleteNode"
-          >
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          </button>
+          />
         </div>
       </div>
     </div>

--- a/packages/crouton-pages/app/components/Blocks/Views/SectionBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/SectionBlockView.vue
@@ -61,26 +61,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/SeparatorBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/SeparatorBlockView.vue
@@ -66,26 +66,28 @@ function handleOpenPanel() {
           <div v-if="attrs.label" class="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5 flex-shrink-0">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
       </div>

--- a/packages/crouton-pages/app/components/Blocks/Views/StatsBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/StatsBlockView.vue
@@ -55,26 +55,28 @@ function handleOpenPanel() {
             Stats
           </span>
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/TwoColumnBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/TwoColumnBlockView.vue
@@ -62,26 +62,28 @@ function handleOpenPanel() {
             Two Columns · {{ splitLabel }}
           </span>
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-pages/app/components/Blocks/Views/VideoBlockView.vue
+++ b/packages/crouton-pages/app/components/Blocks/Views/VideoBlockView.vue
@@ -83,26 +83,28 @@ function handleOpenPanel() {
           </span>
           <!-- Action buttons -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('pages.blocks.editBlock')"
               :title="t('pages.blocks.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('pages.blocks.deleteBlock')"
               :title="t('pages.blocks.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-sales/app/components/Client/CategoryTabs.vue
+++ b/packages/crouton-sales/app/components/Client/CategoryTabs.vue
@@ -95,15 +95,16 @@
 
     <!-- Add category: starts a draft tab instead of opening a form -->
     <li role="presentation" class="shrink-0">
-      <button
-        type="button"
-        class="flex items-center justify-center size-8 rounded-md cursor-pointer
-               text-muted hover:text-highlighted hover:bg-elevated/60 transition-colors"
+      <!-- UButton, not a raw button, so themes reach it (#1410) -->
+      <UButton
+        color="neutral"
+        variant="ghost"
+        icon="i-lucide-plus"
+        square
+        class="size-8 justify-center text-muted hover:text-highlighted"
         :aria-label="t('sales.workspace.add')"
         @click="startCreate"
-      >
-        <UIcon name="i-lucide-plus" class="size-4" />
-      </button>
+      />
     </li>
   </ul>
 </template>

--- a/packages/crouton-sales/app/components/Client/ProductList.vue
+++ b/packages/crouton-sales/app/components/Client/ProductList.vue
@@ -26,18 +26,21 @@
           @click.stop
         />
       </div>
-      <button
+      <!-- UButton, not a raw button, so themes reach it (#1410); the class
+           list keeps the slide-out positioning + reveal behavior. -->
+      <UButton
         v-if="editable"
-        type="button"
-        class="absolute right-0 top-0 bottom-0 z-10 flex items-center justify-center px-2.5
-               bg-elevated/95 hover:bg-elevated text-muted hover:text-highlighted cursor-pointer
+        color="neutral"
+        variant="ghost"
+        icon="i-lucide-pencil"
+        square
+        class="absolute right-0 top-0 bottom-0 z-10 justify-center rounded-none px-2.5
+               bg-elevated/95 hover:bg-elevated text-muted hover:text-highlighted
                transition-all duration-200 ease-out translate-x-full group-hover/card:translate-x-0
                pointer-coarse:translate-x-0"
         :aria-label="t('common.edit')"
         @click.stop="emit('edit', product.id)"
-      >
-        <UIcon name="i-lucide-pencil" class="size-4" />
-      </button>
+      />
 
       <!-- Hover pushes the content inward so the slide-out panels never cover
            the title or price. -->

--- a/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
@@ -519,17 +519,20 @@ const ordersFilterCount = ref(0)
 
     <!-- Vertical pane tabs: hang just outside the kassa's right edge while
          their pane is closed (the open pane has its own close button).
-         top-14 drops them under the POS header line (client-selector row). -->
+         top-14 drops them under the POS header line (client-selector row).
+         UButtons (not raw buttons) so themes reach them (#1410); the class
+         list keeps the gutter geometry + vertical writing mode. -->
     <div
       v-if="hasGutter"
       class="absolute top-14 left-[calc(100%-2.75rem)] -ml-px flex flex-col gap-2"
     >
-      <button
+      <UButton
         v-if="!ordersOpen"
-        type="button"
-        class="flex flex-col items-center gap-1.5 px-1.5 py-3 rounded-e-md cursor-pointer
+        color="neutral"
+        variant="soft"
+        class="flex-col items-center gap-1.5 px-1.5 py-3 rounded-none rounded-e-md
                border border-l-0 border-default bg-elevated/60 hover:bg-elevated
-               text-muted hover:text-highlighted transition-colors"
+               text-muted hover:text-highlighted"
         :aria-label="t('sales.orders.title')"
         @click="ordersOpen = true"
       >
@@ -537,13 +540,14 @@ const ordersFilterCount = ref(0)
         <span class="[writing-mode:vertical-rl] text-sm font-medium tracking-wide">
           {{ t('sales.orders.title') }}
         </span>
-      </button>
-      <button
+      </UButton>
+      <UButton
         v-if="event.requiresClient && !clientsOpen"
-        type="button"
-        class="flex flex-col items-center gap-1.5 px-1.5 py-3 rounded-e-md cursor-pointer
+        color="neutral"
+        variant="soft"
+        class="flex-col items-center gap-1.5 px-1.5 py-3 rounded-none rounded-e-md
                border border-l-0 border-default bg-elevated/60 hover:bg-elevated
-               text-muted hover:text-highlighted transition-colors"
+               text-muted hover:text-highlighted"
         :aria-label="t('sales.workspace.clientsPanel.button')"
         @click="clientsOpen = true"
       >
@@ -551,13 +555,14 @@ const ordersFilterCount = ref(0)
         <span class="[writing-mode:vertical-rl] text-sm font-medium tracking-wide">
           {{ t('sales.workspace.clientsPanel.button') }}
         </span>
-      </button>
-      <button
+      </UButton>
+      <UButton
         v-if="loggedIn && !dataOpen"
-        type="button"
-        class="flex flex-col items-center gap-1.5 px-1.5 py-3 rounded-e-md cursor-pointer
+        color="neutral"
+        variant="soft"
+        class="flex-col items-center gap-1.5 px-1.5 py-3 rounded-none rounded-e-md
                border border-l-0 border-default bg-elevated/60 hover:bg-elevated
-               text-muted hover:text-highlighted transition-colors"
+               text-muted hover:text-highlighted"
         :aria-label="t('sales.workspace.dataPanel.button')"
         @click="dataOpen = true"
       >
@@ -565,7 +570,7 @@ const ordersFilterCount = ref(0)
         <span class="[writing-mode:vertical-rl] text-sm font-medium tracking-wide">
           {{ t('sales.workspace.dataPanel.button') }}
         </span>
-      </button>
+      </UButton>
     </div>
     </div>
 


### PR DESCRIPTION
Part of #1410 (batch 1 of 4 — the kassa/public-visible set). Also resolves items 1-of-4 on #1407's seam list.

## 👤 For humans
Owner ruling: *"as much as possible must be Nuxt UI, so we can theme easily."* This converts the most user-visible offenders: the kassa's side-pane gutter tabs, add-category button and product edit pencil (crouton-sales), all 20 block views' hover edit/delete buttons (hand-drawn SVGs on hardcoded grays), and the public mailing block's subscribe input (crouton-pages).

## 🤖 For agents
- Shell gutter tabs keep their vertical `[writing-mode:vertical-rl]` geometry via class overrides on UButton (verified tailwind-merge wins for flex-col/padding/rounding).
- Block-view swap was a scripted regex over a uniform pattern (40 buttons, 20 files) — hardcoded `text-gray-400`/gray hovers replaced by `text-dimmed hover:text-primary|error`, aria-labels added.
- MailingBlock keeps `name`/`required` on the UInput so the external form POST is unchanged.

## 🧪 How to test
1. Kassa event workspace (staging redeploys on merge): the vertical Bestellingen/Klanten/Data tabs render and open their panes; under Riso/Game Boy they follow the theme.
2. Pages editor: hover a block → pencil/trash are themed icon buttons; edit panel and delete still work.
3. Public page with a mailing block: the email field is a themed UInput; subscribe POST unchanged.

Typecheck green. Note on verification honesty: the visual check of the gutter tabs rode the PR's staging preview rather than local dev (this worktree's local fanfare DB turned out empty — noted in session memory); the conversion is mechanical and the PR smoke + owner's staging pass cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)