### PR TITLE
chore(root): record pi 0.80.6 in the pi-box manifest (#1409)

### DIFF
--- a/scripts/pi-box/pi-config.manifest.json
+++ b/scripts/pi-box/pi-config.manifest.json
@@ -1,8 +1,8 @@
 {
-  "$comment": "GitOps'd pi.dev box config (#1060). The mac-mini's pi setup as code: an opinionated installer pinned as the BASE, plus only OUR deltas + settings overrides on top — we do NOT re-vendor the installer's curated package list. Apply with `node scripts/pi-box/apply-pi-config.mjs` (--dry-run first). A base version bump is a deliberate, reviewed change here. Snapshot: 2026-07-07 from Maartens-Mac-mini.",
+  "$comment": "GitOps'd pi.dev box config (#1060). The mac-mini's pi setup as code: an opinionated installer pinned as the BASE, plus only OUR deltas + settings overrides on top — we do NOT re-vendor the installer's curated package list. Apply with `node scripts/pi-box/apply-pi-config.mjs` (--dry-run first). A base version bump is a deliberate, reviewed change here. Snapshot: 2026-07-11 from Maartens-Mac-mini.",
   "pi": {
     "package": "@earendil-works/pi-coding-agent",
-    "version": "0.80.3"
+    "version": "0.80.6"
   },
   "base": {
     "installer": "@robzolkos/lazypi",


### PR DESCRIPTION
Part of #1409 (epic #669).

## 👤 For humans

The mac-mini's pi CLI was upgraded 0.80.3 → 0.80.6 today — required because 0.80.3's baked model catalog predates GLM-5.2, which is now the box's first non-Anthropic provider (flat-rate GLM Coding Plan, verified working on #1409). This PR records that version in the GitOps'd box manifest so the repo and the box agree again (#1060 rule: box state is config-as-code).

## 🤖 For agents

- `scripts/pi-box/pi-config.manifest.json`: `pi.version` `0.80.3` → `0.80.6`; `$comment` snapshot date `2026-07-07` → `2026-07-11`. Nothing else (base installer + deltas unchanged).
- Note: `apply-pi-config.mjs` does NOT reconcile the pi CLI version — the `pi` block is a recorded snapshot only. The upgrade itself was done directly on the box.

## 🧪 How to test

1. On the mac-mini: `pi --version` → `0.80.6`.
2. In this diff: manifest `pi.version` matches, valid JSON (`node -e "JSON.parse(require('fs').readFileSync('scripts/pi-box/pi-config.manifest.json'))"`).
3. `node scripts/pi-box/apply-pi-config.mjs --dry-run` on the box still plans zero changes for base/add/remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
