### PR TITLE
feat(root): zai/GLM provider lane for the pi a11y sweep (#1409)

### DIFF
--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -41,16 +41,16 @@ on:
         type: choice
         options: ["off", "pi"]
       model:
-        description: "Model for pi (cheap by default — first quality/cost read). For provider=zai use e.g. glm-5.2."
+        description: "Model for pi. Default glm-5.2 (flat-rate GLM Coding Plan — beat the Haiku baseline on fidelity at $0 marginal, #1409). For provider=anthropic use e.g. claude-haiku-4-5-20251001."
         required: false
-        default: "claude-haiku-4-5-20251001"
+        default: "glm-5.2"
         type: string
       provider:
-        description: "pi provider. anthropic = funded PI_PROVIDER_KEY; zai = GLM Coding Plan via the runner box's pi auth store (#1409, self-hosted runner only)."
+        description: "pi provider. Default zai = GLM Coding Plan via the runner box's pi auth store (#1409, self-hosted runner only); anthropic = funded PI_PROVIDER_KEY (metered baseline lane)."
         required: false
-        default: "anthropic"
+        default: "zai"
         type: choice
-        options: ["anthropic", "zai"]
+        options: ["zai", "anthropic"]
 
 concurrency:
   group: a11y-daily-pidev
@@ -103,7 +103,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.PI_PROVIDER_KEY }}
           PI_MODEL: ${{ inputs.model }}
-          PI_PROVIDER: ${{ inputs.provider || 'anthropic' }}
+          PI_PROVIDER: ${{ inputs.provider || 'zai' }}
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent

--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -41,10 +41,16 @@ on:
         type: choice
         options: ["off", "pi"]
       model:
-        description: "Model for pi (cheap by default — first quality/cost read)."
+        description: "Model for pi (cheap by default — first quality/cost read). For provider=zai use e.g. glm-5.2."
         required: false
         default: "claude-haiku-4-5-20251001"
         type: string
+      provider:
+        description: "pi provider. anthropic = funded PI_PROVIDER_KEY; zai = GLM Coding Plan via the runner box's pi auth store (#1409, self-hosted runner only)."
+        required: false
+        default: "anthropic"
+        type: choice
+        options: ["anthropic", "zai"]
 
 concurrency:
   group: a11y-daily-pidev
@@ -84,10 +90,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # ── The agent: pi.dev, REPORTS-ONLY, scoped to the model key only ──────────────
-      # env carries ONLY the provider key — no GH_TOKEN/GITHUB_TOKEN. CI pins
-      # `--provider anthropic` with a FUNDED API key (PI_PROVIDER_KEY) — NOT a Claude
+      # env carries ONLY the provider key — no GH_TOKEN/GITHUB_TOKEN. Two provider lanes:
+      # `anthropic` (default) uses a FUNDED API key (PI_PROVIDER_KEY) — NOT a Claude
       # subscription (subscription OAuth must never back unattended CI — Anthropic terms;
       # the box's interactive `pi-claude-cli`/subscription path stays interactive-only).
+      # `zai` (#1409) uses the GLM Coding Plan via pi's auth store on the runner box —
+      # z.ai's plan officially whitelists pi, and the flat-rate key is model-scoped.
       # Invocation + skills confirmed on the mac-mini (#888): the `.pi/skills` symlink
       # bridge does NOT load — pi's discovery ignores it — so skills are passed via the
       # explicit `--skill .claude/skills` flag (our SKILL.md format is drop-in portable).
@@ -95,6 +103,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.PI_PROVIDER_KEY }}
           PI_MODEL: ${{ inputs.model }}
+          PI_PROVIDER: ${{ inputs.provider || 'anthropic' }}
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent
@@ -122,7 +131,7 @@ jobs:
           echo "exec=$LOG" >> "$GITHUB_OUTPUT"
           START=$(date +%s)
           # Confirmed on the mac-mini (#888): pin provider + load skills via --skill.
-          pi --print --provider anthropic --model "$PI_MODEL" --skill .claude/skills "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
+          pi --print --provider "$PI_PROVIDER" --model "$PI_MODEL" --skill .claude/skills "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
           RC=${PIPESTATUS[0]}
           END=$(date +%s)
           echo "wall=$((END-START))" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Part of #1409 (epic #669). Companion to #1412.

## 👤 For humans

The pi.dev a11y sweep (#867) could only run on a metered Anthropic key. This adds a second lane: dispatch it with `provider=zai, model=glm-5.2` and it runs on the flat-rate GLM Coding Plan just set up on the runner box — the first real-flow smoke for #1409, and a like-for-like eval datapoint against the existing Haiku baseline for #865 (same prompt, same report template, same standing issue for comparison).

**Update (2nd commit, owner-approved):** after the #1409 eval (GLM more faithful than the Haiku baseline at $0 marginal), the defaults now flip to `provider=zai`, `model=glm-5.2` — the flat-rate lane is the default; the metered `anthropic` lane stays available for baseline re-runs. Both lanes were proven green on this branch (runs 29158264842 / 29159192376).

## 🤖 For agents

- `.github/workflows/a11y-daily-pidev.yml` only:
  - new `workflow_dispatch` input `provider` (choice `anthropic` | `zai`, default `anthropic`)
  - pi invocation: `--provider anthropic` → `--provider "$PI_PROVIDER"` (env `PI_PROVIDER: ${{ inputs.provider || 'anthropic' }}`)
  - scoped-credential comment updated to document both lanes
- The `zai` lane holds **no new secrets** — pi resolves the plan credential from its auth store on the self-hosted runner box (set up + verified on #1409). It therefore requires `vars.AGENT_RUNNER` to point at the self-hosted runner; on `ubuntu-latest` the zai lane has no credential and the run fails cleanly.

## 🧪 How to test

1. Merge, then dispatch **a11y-daily-pidev** with `harness=pi`, `provider=zai`, `model=glm-5.2`.
2. Expect: the run completes, the report lands on the pi.dev standing a11y issue, and the run-metrics table shows model `glm-5.2`.
3. Dispatch again with defaults (`provider=anthropic`) — behaviour identical to before this PR (Haiku lane untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

