### PR TITLE
fix(crouton-core): shared chrome raw buttons -> UButton (#1410 batch 2)

### DIFF
--- a/packages/crouton-core/CLAUDE.md
+++ b/packages/crouton-core/CLAUDE.md
@@ -74,7 +74,7 @@ export default defineNuxtConfig({
 | `app/components/UsersAvatarUpload.vue` | Avatar upload with 1:1 circular crop |
 | `app/components/DropZone.vue` | Drag-and-drop file upload zone (VueUse) |
 | `app/components/QrCode.vue` | `CroutonQrCode` — renders any string (usually a URL) as an inline SVG QR code via `uqr` (zero-dep, SSR-safe). Props: `data`, `size?` (px). |
-| `app/components/DeleteButton.vue` | `CroutonDeleteButton` — two-step pill delete (click arms "sure?", click again emits `confirm`; mouseleave disarms). Props: `loading?`, `expanded?` (always show the label; collapsed mode is an icon pill that expands on hover — pointer-only, so forms/touch surfaces pass `expanded`). Parent performs the delete. `rounded-md`, `min-h-7`: stretches to match neighbors in a `flex items-stretch` row (sales form footers pair it with `CroutonFormActionButton class="flex-1"`). |
+| `app/components/DeleteButton.vue` | `CroutonDeleteButton` — two-step pill delete (click arms "sure?", click again emits `confirm`; mouseleave disarms). Props: `loading?`, `expanded?` (always show the label; collapsed mode is an icon pill that expands on hover — pointer-only, so forms/touch surfaces pass `expanded`). Parent performs the delete. A `UButton` (soft, neutral→error) so themes reach it (#1410); free height + `min-h-7`: stretches to match neighbors in a `flex items-stretch` row (sales form footers pair it with `CroutonFormActionButton class="flex-1"`). |
 | `server/api/upload-image.post.ts` | Authenticated file upload to blob storage |
 | `server/api/upload-image.delete.ts` | Authenticated file deletion from blob storage |
 | `server/routes/images/[pathname].get.ts` | Image serving with cache headers |

--- a/packages/crouton-core/app/components/ConfirmButton.vue
+++ b/packages/crouton-core/app/components/ConfirmButton.vue
@@ -75,25 +75,18 @@ watch(() => props.loading, (isLoading, wasLoading) => {
 </script>
 
 <template>
-  <button
-    type="button"
-    class="h-7 rounded-md flex items-center gap-1.5 justify-center shrink-0 transition-all cursor-pointer px-2.5 text-xs font-medium whitespace-nowrap"
-    :class="[
-      disabled && 'opacity-50 cursor-not-allowed',
-      confirming
-        ? 'bg-red-500/20 text-red-500'
-        : 'text-red-400/60 hover:bg-red-500/20 hover:text-red-500'
-    ]"
+  <!-- UButton (not raw) so themes reach it (#1410). Explicit error
+       ghost→soft: quiet destructive chrome that fills as it arms. -->
+  <UButton
+    color="error"
+    :variant="confirming ? 'soft' : 'ghost'"
+    size="sm"
+    :icon="confirming ? undefined : icon"
+    :loading="loading && confirming"
     :disabled="disabled"
+    class="shrink-0 whitespace-nowrap transition-all"
     @click.stop="handleClick"
   >
-    <UIcon v-if="loading && confirming" name="i-lucide-loader-2" class="size-3.5 animate-spin" />
-    <template v-else-if="confirming">
-      {{ confirmLabel }}
-    </template>
-    <template v-else>
-      <UIcon v-if="icon" :name="icon" class="size-3.5" />
-      {{ label }}
-    </template>
-  </button>
+    {{ confirming ? confirmLabel : label }}
+  </UButton>
 </template>

--- a/packages/crouton-core/app/components/DeleteButton.vue
+++ b/packages/crouton-core/app/components/DeleteButton.vue
@@ -39,29 +39,32 @@ function disarm() {
 </script>
 
 <template>
-  <!-- rounded-md + free height so it lines up with Nuxt UI buttons: in a
-       `flex items-stretch` row it matches the neighboring button's height -->
-  <button
-    type="button"
-    class="group/del relative min-h-7 rounded-md flex items-center justify-center flex-shrink-0 transition-all cursor-pointer"
+  <!-- UButton (not raw) so themes reach it (#1410). Explicit soft variant:
+       quiet destructive chrome — neutral while idle-collapsed, error once the
+       label shows. Free height (min-h-7, no fixed h) so it stretches to match
+       neighbors in a `flex items-stretch` row. -->
+  <UButton
+    :color="armed || loading || expanded ? 'error' : 'neutral'"
+    variant="soft"
+    class="group/del min-h-7 flex-shrink-0 justify-center transition-all"
     :class="[
       armed || loading
-        ? 'bg-red-500/20 text-red-500 px-3'
+        ? 'px-3 bg-error/20'
         : expanded
-          ? 'px-3 bg-red-500/10 text-red-400 hover:bg-red-500/20 hover:text-red-500'
-          : 'w-7 h-7 hover:!w-auto hover:!px-2.5 bg-gray-500/10 text-gray-400 hover:!bg-red-500/20 hover:!text-red-500'
+          ? 'px-3'
+          : 'w-7 h-7 p-0 hover:!w-auto hover:!px-2.5 text-muted hover:!bg-error/20 hover:!text-error'
     ]"
     @click.stop="handleClick"
     @mouseleave="disarm"
   >
-    <UIcon v-if="loading" name="i-lucide-loader-2" class="w-3.5 h-3.5 animate-spin" />
+    <UIcon v-if="loading" name="i-lucide-loader-2" class="size-3.5 animate-spin" />
     <span v-else-if="armed" class="text-sm font-medium whitespace-nowrap">{{ t('deleteConfirm.sure') }}</span>
     <template v-else-if="expanded">
       <span class="text-sm font-medium whitespace-nowrap">{{ t('common.delete') }}</span>
     </template>
     <template v-else>
-      <UIcon name="i-lucide-trash-2" class="w-3.5 h-3.5 group-hover/del:hidden" />
+      <UIcon name="i-lucide-trash-2" class="size-3.5 group-hover/del:hidden" />
       <span class="hidden group-hover/del:inline text-xs font-medium whitespace-nowrap">{{ t('common.delete') }}</span>
     </template>
-  </button>
+  </UButton>
 </template>

--- a/packages/crouton-core/app/components/FormColorPicker.vue
+++ b/packages/crouton-core/app/components/FormColorPicker.vue
@@ -94,7 +94,9 @@ const hasValue = computed(() => !!props.modelValue && props.modelValue !== '')
 
     <template #content>
       <div class="p-3 w-64">
-        <!-- Preset swatches -->
+        <!-- Preset swatches: deliberately a custom widget — a color-swatch
+             grid has no Nuxt UI equivalent; selection uses semantic primary
+             tokens so themes still reach it (#1410) -->
         <div class="grid grid-cols-8 gap-1.5">
           <button
             v-for="hex in presetColors"
@@ -109,15 +111,17 @@ const hasValue = computed(() => !!props.modelValue && props.modelValue !== '')
 
         <USeparator class="my-3" />
 
-        <!-- Custom toggle -->
-        <button
-          type="button"
-          class="flex items-center gap-2 text-sm text-muted hover:text-highlighted transition-colors w-full mb-2"
+        <!-- Custom toggle — UButton so themes reach it (#1410) -->
+        <UButton
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          :icon="showCustom ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'"
+          class="w-full justify-start mb-2 text-sm text-muted hover:text-highlighted"
           @click="showCustom = !showCustom"
         >
-          <UIcon :name="showCustom ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'" class="size-4" />
           Custom color
-        </button>
+        </UButton>
 
         <!-- Custom picker -->
         <div v-if="showCustom" class="mb-3">

--- a/packages/crouton-core/app/components/IconPicker.vue
+++ b/packages/crouton-core/app/components/IconPicker.vue
@@ -228,17 +228,20 @@ watch(open, (isOpen) => {
             v-else-if="icons.length"
             class="grid grid-cols-8 gap-1 max-h-[200px] overflow-y-auto"
           >
-            <button
+            <!-- UButton cells (not raw buttons) so themes reach them (#1410) -->
+            <UButton
               v-for="icon in icons"
               :key="icon"
-              type="button"
-              class="flex items-center justify-center size-8 rounded-md hover:bg-elevated transition-colors"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              square
+              :icon="toIconClass(icon)"
+              class="justify-center size-8 p-0"
               :class="{ 'bg-primary/10 ring-1 ring-primary': toIconClass(icon) === modelValue }"
               :title="icon"
               @click="selectIcon(icon)"
-            >
-              <UIcon :name="toIconClass(icon)" class="size-4" />
-            </button>
+            />
           </div>
 
           <!-- Empty state -->

--- a/packages/crouton-core/app/components/TreeNode.vue
+++ b/packages/crouton-core/app/components/TreeNode.vue
@@ -387,19 +387,23 @@ onBeforeUnmount(() => {
         />
       </div>
 
-      <!-- Child count / expand toggle -->
-      <button
+      <!-- Child count / expand toggle — UButton so themes reach it (#1410);
+           the rounded-full pill geometry + flash classes win via class merge -->
+      <UButton
         v-if="hasChildren"
-        class="shrink-0 flex items-center justify-center size-6 text-xs font-semibold tabular-nums rounded-full transition-colors duration-200"
+        color="neutral"
+        variant="soft"
+        square
+        class="shrink-0 justify-center size-6 p-0 text-xs font-semibold tabular-nums rounded-full transition-colors duration-200"
         :class="[
           isCountFlashing
-            ? 'count-pulse bg-primary text-primary-foreground'
-            : 'bg-elevated text-muted hover:bg-accented hover:text-default'
+            ? 'count-pulse bg-primary text-primary-foreground hover:bg-primary'
+            : 'text-muted hover:text-default'
         ]"
         @click.stop="treeDrag.toggle(item.id)"
       >
         {{ childCount }}
-      </button>
+      </UButton>
 
       <!-- Custom card content OR default -->
       <template v-if="cardComponent">


### PR DESCRIPTION
Part of #1410 (batch 2 of 4 — crouton-core shared chrome). Batch 1 was #1411.

## 👤 For humans
The shared two-step delete/confirm pills, the tree count pill, the color-picker toggle and the icon-picker grid cells hand-copied Nuxt UI button styling in raw HTML — invisible to themes. They're Nuxt UI buttons now, so every consuming app's forms and pickers follow the active theme.

## 🤖 For agents
- `DeleteButton.vue` — UButton soft, neutral→error; hover-expand icon-pill + `min-h-7` stretch kept via class overrides; arm/confirm logic unchanged.
- `ConfirmButton.vue` — UButton error ghost→soft as it arms; native `loading`/`disabled` props replace hand-rolled spinner/opacity.
- `TreeNode.vue` — count pill → UButton neutral soft (rounded-full + `count-pulse` flash kept).
- `FormColorPicker.vue` — toggle → UButton neutral ghost; swatch grid stays custom (commented why — no Nuxt UI equivalent).
- `IconPicker.vue` — grid cells → UButton neutral ghost sm square (`size-8`), selected keeps `bg-primary/10` + ring.
- Explicit soft/ghost variants (not variant-less): quiet chrome, same rationale as batch 1.

## 🧪 How to test
1. Fanfare (or any app) → event workspace → Instellingen: the "Verwijderen" pill is an error-soft UButton; first click arms to "zeker?", second deletes. Verified live on fanfare dev (event created + deleted through it).
2. Pages editor toolbar: "Verwijderen" is error ghost; first click arms to soft "Verwijderen?". Verified live.
3. Tree layout collections: child-count pill is a neutral-soft round UButton; icon picker / color picker popovers in pages block editors render UButton cells/toggle.
4. `pnpm typecheck` green on fanfare/triage/velo.