### PR TITLE
fix(crouton-cli): partial-locale translation PATCH — merge before invariant (#1414)

### DIFF
--- a/apps/fanfare/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts
+++ b/apps/fanfare/layers/pages/collections/pages/server/api/teams/[id]/pages-pages/[pageId].patch.ts
@@ -23,15 +23,12 @@ const bodySchema = z.object({
   translations: z.record(
     z.string(),
     z.object({
-      title: z.string().min(1, 'Title is required'),
-      slug: z.string().min(1, 'Slug is required'),
-      content: z.string().optional(),
-      seoTitle: z.string().optional(),
-      seoDescription: z.string().optional()
-    })
-  ).refine(
-    (translations) => translations.nl && translations.nl.title && translations.nl.slug,
-    { message: 'Translations for title, slug (nl) are required' }
+      title: z.string().min(1, 'Title is required').optional(),
+      slug: z.string().min(1, 'Slug is required').optional(),
+      content: z.string().nullish(),
+      seoTitle: z.string().nullish(),
+      seoDescription: z.string().nullish()
+    }).nullable()
   ),
   // Transient hint: which locale the translation patch targets (not a column)
   locale: z.string().optional()
@@ -51,18 +48,27 @@ export default defineEventHandler(async (event) => {
 
   const body = await readValidatedBody(event, bodySchema.parse)
 
-  // Handle translation updates properly
-  if (body.translations && body.locale) {
+  // Merge translations into the existing record (partial-locale PATCH, #1414):
+  // each sent locale patches per-field; a null locale entry deletes that
+  // locale; omitted locales and fields stay untouched. The default-locale
+  // invariant is enforced on the merged result, not the wire payload.
+  if (body.translations) {
     const [existing] = await getPagesPagesByIds(team.id, [pageId]) as any[]
-    if (existing) {
-      body.translations = {
-        ...existing.translations,
-        [body.locale]: {
-          ...existing.translations?.[body.locale],
-          ...body.translations[body.locale]
-        }
+    const merged: Record<string, any> = { ...(existing?.translations ?? {}) }
+    for (const [loc, patch] of Object.entries(body.translations)) {
+      if (patch === null) {
+        delete merged[loc]
+      } else {
+        merged[loc] = { ...merged[loc], ...patch }
       }
     }
+    if (!(merged.nl && merged.nl.title && merged.nl.slug)) {
+      throw createError({
+        status: 400,
+        statusText: 'Translations for title, slug (nl) are required'
+      })
+    }
+    body.translations = merged
   }
 
   // Only include fields that were actually sent in the request

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -445,16 +445,19 @@ async function createDatabaseTable(config: { name: string; layer: string; fields
 // mode 'client' (default): the form-facing schema the composable exports —
 // form state binds these fields to inputs, so non-required fields stay
 // `.optional()` (null only for json/date/meta.nullable, as before).
-// mode 'server': the wire-facing body schema the generated endpoints validate —
+// mode 'server': the wire-facing body schema the generated POST validates —
 // nullable columns round-trip null and `null` is how a client clears a field,
 // so every non-required field is `.nullish()` (#1403).
+// mode 'server-patch': the PATCH body — like 'server', plus partial-locale
+// translations (#1414): per-locale fields optional, null entry deletes a
+// locale, and the default-locale invariant moves post-merge into the handler.
 export function buildFieldsSchema(params: {
   fields: Field[]
   config: Record<string, any> | null
   hierarchy: HierarchyConfig
   cases: any
   layerCamelCase: string
-  mode?: 'client' | 'server'
+  mode?: 'client' | 'server' | 'server-patch'
 }): string {
   const { fields, config, hierarchy, cases, layerCamelCase, mode = 'client' } = params
   const translatableFieldNames = config?.translations?.collections?.[cases.plural] || []
@@ -491,7 +494,7 @@ export function buildFieldsSchema(params: {
         } else {
           return `${f.name}: ${baseZod}`
         }
-      } else if (mode === 'server') {
+      } else if (mode !== 'client') {
         // Wire schema: non-required columns are nullable in the DB and
         // round-trip as null (a loaded record PATCHed back, or an explicit
         // null to clear the field) — so every non-required field must accept
@@ -507,7 +510,7 @@ export function buildFieldsSchema(params: {
     })
   const translatableFieldsSchema = fields
     .filter(f => translatableFieldNames.includes(f.name))
-    .map(f => `${f.name}: ${f.zod}${mode === 'server' ? '.nullish()' : '.optional()'}`)
+    .map(f => `${f.name}: ${f.zod}${mode === 'client' ? '.optional()' : '.nullish()'}`)
   let allFieldsSchema = [...regularFieldsSchema, ...translatableFieldsSchema].join(',\n  ')
   if (hierarchy?.enabled) {
     const hierarchySchemaField = `parentId: z.string().nullable().optional()`
@@ -516,17 +519,25 @@ export function buildFieldsSchema(params: {
   if (translatableFieldNames.length > 0) {
     const translatableFields = fields.filter(f => translatableFieldNames.includes(f.name))
     const requiredTranslatableFields = translatableFields.filter(f => f.meta?.required)
+    // PATCH wire shape (#1414): per-locale required fields are
+    // present ⇒ non-empty, absent ⇒ untouched, never null; other per-locale
+    // fields are clearable (nullish). POST/client keep the strict shape — a
+    // new record must arrive complete.
+    const isPatch = mode === 'server-patch'
     const translationsFieldSchema = translatableFields.map((f) => {
       if (f.meta?.required) {
-        return `      ${f.name}: z.string().min(1, '${f.name.charAt(0).toUpperCase() + f.name.slice(1)} is required')`
+        return `      ${f.name}: z.string().min(1, '${f.name.charAt(0).toUpperCase() + f.name.slice(1)} is required')${isPatch ? '.optional()' : ''}`
       } else {
-        return `      ${f.name}: z.string().optional()`
+        return `      ${f.name}: z.string()${isPatch ? '.nullish()' : '.optional()'}`
       }
     }).join(',\n')
     // Validate the app's default locale (not a hardcoded 'en') — single-language
     // apps (e.g. defaultLocale: 'nl') must validate that locale, not English.
+    // On PATCH the invariant is enforced POST-MERGE in the generated handler
+    // (a partial payload legitimately omits the default locale), so no wire
+    // refine — and a null locale entry means "delete this locale".
     const defaultLocale = config?.defaultLocale || 'en'
-    const requiredFieldsCheck = requiredTranslatableFields.length > 0
+    const requiredFieldsCheck = requiredTranslatableFields.length > 0 && !isPatch
       ? `.refine(
     (translations) => translations.${defaultLocale} && ${requiredTranslatableFields.map(f => `translations.${defaultLocale}.${f.name}`).join(' && ')},
     { message: 'Translations for ${requiredTranslatableFields.map(f => f.name).join(', ')} (${defaultLocale}) are required' }
@@ -536,7 +547,7 @@ export function buildFieldsSchema(params: {
     z.string(),
     z.object({
 ${translationsFieldSchema}
-    })
+    })${isPatch ? '.nullable()' : ''}
   )${requiredFieldsCheck}`
   }
   return allFieldsSchema
@@ -646,10 +657,12 @@ function buildGeneratorData(params: {
     .join('')
 
   const fieldsSchema = buildFieldsSchema({ fields, config, hierarchy, cases, layerCamelCase })
-  // Wire-facing variant for the generated endpoints: accepts null on every
+  // Wire-facing variants for the generated endpoints: accept null on every
   // non-required field (#1403). Kept separate from the client/form schema so
-  // FormData never widens to null.
+  // FormData never widens to null. The PATCH variant additionally allows
+  // partial-locale translations (#1414).
   const serverFieldsSchema = buildFieldsSchema({ fields, config, hierarchy, cases, layerCamelCase, mode: 'server' })
+  const patchFieldsSchema = buildFieldsSchema({ fields, config, hierarchy, cases, layerCamelCase, mode: 'server-patch' })
 
   const fieldsDefault = buildFieldsDefault({ fields, config, hierarchy, cases })
 
@@ -676,6 +689,7 @@ function buildGeneratorData(params: {
     fields,
     fieldsSchema,
     serverFieldsSchema,
+    patchFieldsSchema,
     repeaterItemSchemasCode,
     fieldsDefault,
     fieldsColumns,

--- a/packages/crouton-cli/lib/generators/api-endpoints.ts
+++ b/packages/crouton-cli/lib/generators/api-endpoints.ts
@@ -216,6 +216,22 @@ export function generatePatchEndpoint(data: Record<string, any>, config: Record<
   // locally so the server validation doesn't reference an undefined symbol.
   const itemSchemasPrefix = data.repeaterItemSchemasCode ? `${data.repeaterItemSchemasCode}\n\n` : ''
 
+  // Post-merge default-locale invariant (#1414): the wire schema allows
+  // partial-locale payloads, so "the default locale keeps its required
+  // fields" is checked on the merged RESULT, mirroring the POST refine.
+  const translatableNames: string[] = Array.isArray(hasTranslations) ? hasTranslations : []
+  const requiredTranslatable = fields.filter((f: any) => translatableNames.includes(f.name) && f.meta?.required)
+  const defaultLocale = config?.defaultLocale || 'en'
+  const mergedInvariant = requiredTranslatable.length > 0
+    ? `
+    if (!(merged.${defaultLocale} && ${requiredTranslatable.map((f: any) => `merged.${defaultLocale}.${f.name}`).join(' && ')})) {
+      throw createError({
+        status: 400,
+        statusText: 'Translations for ${requiredTranslatable.map((f: any) => f.name).join(', ')} (${defaultLocale}) are required'
+      })
+    }`
+    : ''
+
   return `// Team-based endpoint - requires @fyit/crouton-auth package
 // The resolveTeamAndCheckMembership utility handles team resolution and auth
 ${imports}
@@ -223,7 +239,7 @@ import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/t
 import { z } from 'zod'
 
 ${itemSchemasPrefix}const bodySchema = z.object({
-  ${bodyFieldsSchemaOf(data)}${hasTranslations ? ',\n  // Transient hint: which locale the translation patch targets (not a column)\n  locale: z.string().optional()' : ''}
+  ${data.patchFieldsSchema ?? bodyFieldsSchemaOf(data)}${hasTranslations ? ',\n  // Transient hint: which locale the translation patch targets (not a column)\n  locale: z.string().optional()' : ''}
 }).partial().strip()
 
 export default defineEventHandler(async (event) => {
@@ -241,18 +257,21 @@ export default defineEventHandler(async (event) => {
   const body = await readValidatedBody(event, bodySchema.parse)${hasTranslations
     ? `
 
-  // Handle translation updates properly
-  if (body.translations && body.locale) {
+  // Merge translations into the existing record (partial-locale PATCH, #1414):
+  // each sent locale patches per-field; a null locale entry deletes that
+  // locale; omitted locales and fields stay untouched. The default-locale
+  // invariant is enforced on the merged result, not the wire payload.
+  if (body.translations) {
     const [existing] = await get${prefixedPascalCasePlural}ByIds(team.id, [${camelCase}Id]) as any[]
-    if (existing) {
-      body.translations = {
-        ...existing.translations,
-        [body.locale]: {
-          ...existing.translations?.[body.locale],
-          ...body.translations[body.locale]
-        }
+    const merged: Record<string, any> = { ...(existing?.translations ?? {}) }
+    for (const [loc, patch] of Object.entries(body.translations)) {
+      if (patch === null) {
+        delete merged[loc]
+      } else {
+        merged[loc] = { ...merged[loc], ...patch }
       }
-    }
+    }${mergedInvariant}
+    body.translations = merged
   }`
     : ''}
 

--- a/packages/crouton-cli/tests/unit/generators/api-endpoints.test.ts
+++ b/packages/crouton-cli/tests/unit/generators/api-endpoints.test.ts
@@ -119,11 +119,26 @@ describe('API Endpoint Generators', () => {
       expect(result).toContain('updates[key] = value')
     })
 
-    it('includes translation merge logic when configured', () => {
+    it('includes translation merge logic when configured (#1414: unconditional, per-locale)', () => {
       const result = generatePatchEndpoint(apiEndpointData, translationsConfig as AnyConfig)
-      expect(result).toContain('body.translations')
-      expect(result).toContain('existing.translations')
+      expect(result).toContain('if (body.translations) {')
+      expect(result).toContain('...(existing?.translations ?? {})')
       expect(result).toContain('getShopProductsByIds')
+      // null locale entry = delete that locale
+      expect(result).toContain('if (patch === null)')
+      expect(result).toContain('delete merged[loc]')
+      // per-field merge for sent locales
+      expect(result).toContain('merged[loc] = { ...merged[loc], ...patch }')
+    })
+
+    it('enforces the default-locale invariant post-merge, not on the wire (#1414)', () => {
+      const result = generatePatchEndpoint(apiEndpointData, translationsConfig as AnyConfig)
+      // the invariant guards the merged result
+      expect(result).toContain('merged.en && merged.en.name')
+      expect(result).toContain("'Translations for name (en) are required'")
+      // and the PATCH wire schema carries no refine
+      const schemaSection = result.slice(0, result.indexOf('defineEventHandler'))
+      expect(schemaSection).not.toContain('.refine(')
     })
   })
 

--- a/packages/crouton-cli/tests/unit/generators/fields-schema.test.ts
+++ b/packages/crouton-cli/tests/unit/generators/fields-schema.test.ts
@@ -150,6 +150,48 @@ describe('buildFieldsSchema client mode (default) — FormData never widens to n
   })
 })
 
+describe('buildFieldsSchema server-patch mode — partial-locale translations (#1414)', () => {
+  const config = { defaultLocale: 'nl', translations: { collections: { products: ['title', 'slug', 'content'] } } }
+  const fieldsT = [
+    field('title', 'string', { required: true }),
+    field('slug', 'string', { required: true }),
+    field('content', 'text'),
+    field('layout', 'string')
+  ]
+  const schema = () => compilePatchSchema(build(fieldsT, config, 'server-patch'))
+
+  it('accepts a partial-locale patch (one field of one locale, no default locale sent)', () => {
+    const parsed = schema().parse({ translations: { fr: { content: 'bonjour' } } })
+    expect(parsed.translations).toEqual({ fr: { content: 'bonjour' } })
+  })
+
+  it('per-locale required fields: absent is fine, empty and null are rejected', () => {
+    expect(() => schema().parse({ translations: { nl: { title: '' } } })).toThrow()
+    expect(() => schema().parse({ translations: { nl: { title: null } } })).toThrow()
+    expect(schema().parse({ translations: { nl: { title: 'ok' } } }).translations.nl.title).toBe('ok')
+  })
+
+  it('a null locale entry is accepted (delete-locale semantics)', () => {
+    expect(schema().parse({ translations: { fr: null } }).translations.fr).toBeNull()
+  })
+
+  it('carries no wire refine — the default-locale invariant is enforced post-merge, not here', () => {
+    const out = build(fieldsT, config, 'server-patch')
+    expect(out).not.toContain('.refine(')
+  })
+
+  it('non-translations fields behave like server mode (nullish)', () => {
+    const out = build(fieldsT, config, 'server-patch')
+    expect(out).toContain('layout: z.string().nullish()')
+  })
+
+  it('server (POST) mode keeps the strict per-locale shape and refine', () => {
+    const out = build(fieldsT, config, 'server')
+    expect(out).toContain(".min(1, 'Title is required')")
+    expect(out).toContain('.refine(')
+  })
+})
+
 describe('buildFieldsTypes — read interface stays narrow (#1403)', () => {
   function buildTypes(fields: any[], config: Record<string, any> | null = null) {
     return buildFieldsTypes({ fields, config, hierarchy: { enabled: false } as any, cases })


### PR DESCRIPTION
Closes #1414

## 👤 For humans

Follow-up of #1403. PATCHing a single locale's translation (e.g. just `fr.content`) always 400'd: the wire schema required `title`+`slug` on every sent locale and the default locale in every payload — rejecting the request before the handler's merge logic (designed for exactly this) could run. The fix moves the invariant to where it belongs: the wire accepts partial payloads, the handler merges per-locale/per-field into the existing record, and "the default locale keeps its title+slug" is enforced on the **merged result**. A `null` locale entry now explicitly deletes that locale (consistent with #1403's null-clears-a-field convention). POST stays strict — new records must arrive complete.

## 🧪 How to test

On fanfare (team `test1`), against a page with nl translations:
1. `PATCH …/pages-pages/<id>` body `{"translations":{"fr":{"content":"bonjour"}}}` → **before**: 400 "Translations for title, slug (nl) are required"; **after**: 200, `fr.content` set, `nl` untouched.
2. `{"translations":{"nl":{"title":""}}}` → 400 (post-merge invariant holds).
3. `{"translations":{"fr":null}}` → 200, fr locale removed.
4. A full Editor save (all locales, all fields) stores the same result as before (merge of complete entries ≡ replace).

## 🤖 For agents

- `buildFieldsSchema` mode `'server-patch'`: per-locale required → `.min(1).optional()`, others `.nullish()`, entry `.nullable()`, no wire refine. Wired via `data.patchFieldsSchema` into `generatePatchEndpoint` only.
- PATCH template: unconditional merge (null deletes, spread patches) + post-merge default-locale invariant; `body.locale` hint accepted but redundant.
- fanfare handler hand-aligned to the new emitted shape (velo/triage run pre-zod handlers; next regen picks it up).
- Behavior change to note: translations merge by default — locale deletion is explicit (`null`), no longer implicit via omission. Workspace Editor has no locale-removal path (verified), so no client change needed.
- Verified: 315 CLI tests green; with-pages fixture regenerated with the new generator emits the designed schema and typechecks; fanfare typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
