### PR TITLE
fix(crouton-cli): generated forms normalize DB nulls to field defaults (#1415)

### DIFF
--- a/packages/crouton-cli/lib/generators/form-component.ts
+++ b/packages/crouton-cli/lib/generators/form-component.ts
@@ -818,6 +818,17 @@ const initialValues = props.action === 'update' && props.activeItem?.id
   ? { ...defaultValue, ...props.activeItem }
   : { ...defaultValue${hasHierarchy ? ', ...hierarchyDefaults' : ''} }${dateInitCode}
 
+// DB nulls are wire/storage values, not form values (#1415): fall back to the
+// field default so the strict form schema never sees null on an untouched
+// field. No-op when the default itself is null (dates, dependent fields).
+const initialRecord = initialValues as Record<string, unknown>
+const defaultRecord = defaultValue as Record<string, unknown>
+for (const key of Object.keys(defaultRecord)) {
+  if (initialRecord[key] === null && defaultRecord[key] !== null) {
+    initialRecord[key] = defaultRecord[key]
+  }
+}
+
 // Draft state: seeded from defaults (required fields may start null/empty until
 // the user fills them; the zod schema validates on submit), so cast the initial
 // values to the validated shape.

--- a/packages/crouton-cli/tests/unit/generators/__snapshots__/form-component.test.ts.snap
+++ b/packages/crouton-cli/tests/unit/generators/__snapshots__/form-component.test.ts.snap
@@ -136,6 +136,17 @@ if (props.action === 'update' && props.activeItem?.id) {
   }
 }
 
+// DB nulls are wire/storage values, not form values (#1415): fall back to the
+// field default so the strict form schema never sees null on an untouched
+// field. No-op when the default itself is null (dates, dependent fields).
+const initialRecord = initialValues as Record<string, unknown>
+const defaultRecord = defaultValue as Record<string, unknown>
+for (const key of Object.keys(defaultRecord)) {
+  if (initialRecord[key] === null && defaultRecord[key] !== null) {
+    initialRecord[key] = defaultRecord[key]
+  }
+}
+
 // Draft state: seeded from defaults (required fields may start null/empty until
 // the user fills them; the zod schema validates on submit), so cast the initial
 // values to the validated shape.
@@ -263,6 +274,17 @@ const { close, loading } = useCrouton()
 const initialValues = props.action === 'update' && props.activeItem?.id
   ? { ...defaultValue, ...props.activeItem }
   : { ...defaultValue }
+
+// DB nulls are wire/storage values, not form values (#1415): fall back to the
+// field default so the strict form schema never sees null on an untouched
+// field. No-op when the default itself is null (dates, dependent fields).
+const initialRecord = initialValues as Record<string, unknown>
+const defaultRecord = defaultValue as Record<string, unknown>
+for (const key of Object.keys(defaultRecord)) {
+  if (initialRecord[key] === null && defaultRecord[key] !== null) {
+    initialRecord[key] = defaultRecord[key]
+  }
+}
 
 // Draft state: seeded from defaults (required fields may start null/empty until
 // the user fills them; the zod schema validates on submit), so cast the initial

--- a/packages/crouton-cli/tests/unit/generators/form-component.test.ts
+++ b/packages/crouton-cli/tests/unit/generators/form-component.test.ts
@@ -52,6 +52,19 @@ describe('generateFormComponent', () => {
     expect(result).toContain('import useShopProducts from')
   })
 
+  it('normalizes DB nulls to field defaults on init (#1415)', () => {
+    // Nullable columns round-trip null (#1403); a raw { ...defaultValue,
+    // ...activeItem } spread would let null overwrite the form default,
+    // making FormData a runtime lie and tripping the strict client schema
+    // on submit for fields the user never touched. The emitted form must
+    // fall back to the field default for null values — generically, so
+    // fields whose default IS null (dates, dependent fields) are a no-op.
+    const result = generateFormComponent(formComponentData, minimalConfig)
+    expect(result).toContain('...defaultValue, ...props.activeItem')
+    expect(result).toContain('if (initialRecord[key] === null && defaultRecord[key] !== null)')
+    expect(result).toContain('initialRecord[key] = defaultRecord[key]')
+  })
+
   describe('field type rendering', () => {
     it('renders string fields with UInput', () => {
       const result = generateFormComponent(formComponentData, minimalConfig)


### PR DESCRIPTION
Closes #1415

## 👤 For humans

Follow-up of #1403. Generated `_Form.vue` components initialize state with `{ ...defaultValue, ...activeItem }` — so a record whose optional column is `NULL` puts `null` into form state, overriding the `''` default. That makes the `FormData` type a runtime lie, and submitting can trip the strict client schema ("expected string, received null") on a field the user never touched. Latent today (generated forms mostly write `''`, not `NULL`), but #1403 made `null` a first-class wire value, so the surface grows. Generated forms now normalize: any `null` in initial state falls back to the field's default, generically — fields whose default is legitimately `null` (dates, dependent fields) are untouched.

This completes the #1403 loop: **server** accepts null (wire) → **DB** stores null → **form boundary** normalizes null → **client schema stays strict**, as an enforced invariant.

## 🧪 How to test

1. Insert a row with a NULL optional text column in any generated collection (e.g. `UPDATE sales_events SET description = NULL …`).
2. Open its edit form in an app regenerated with this CLI. **Before**: state holds `null`; submit can fail validation on the untouched field. **After**: the field shows its empty default and submit passes.

## 🤖 For agents

- `form-component.ts`: normalization loop after the initialValues spread + date init, via `Record<string, unknown>` views (plain `initialValues[key]` string-indexing fails `nuxt typecheck` with TS7053 — caught by regenerating the with-sales fixture).
- Deliberately NOT: widening the client schema to nullish (that's the exact regression the #1403 e2e failures caught) or a second record-tolerant schema (no consumer).
- Existing apps pick this up at next regen — no mass alignment.
- Verified: 309 CLI tests green; regenerated `with-sales` fixture typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
