### PR TITLE
fix(crouton-auth,crouton-admin): auth + admin chrome raw buttons -> UButton (#1410 batch 3)

### DIFF
--- a/packages/crouton-admin/app/components/Admin/Dashboard.vue
+++ b/packages/crouton-admin/app/components/Admin/Dashboard.vue
@@ -131,33 +131,36 @@ function handleQuickAction(path: string) {
       <h3 class="mb-4 text-lg font-medium text-gray-900 dark:text-white">
         {{ t('superAdmin.quickActions.title') }}
       </h3>
+      <!-- Quick-action cards — UButton on semantic tokens (not raw buttons on
+           hardcoded grays) so themes reach them (#1410) -->
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <button
+        <UButton
           v-for="action in quickActions"
           :key="action.path"
-          type="button"
-          class="group flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 text-left transition-colors hover:border-primary-500 hover:bg-primary-50 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-primary-400 dark:hover:bg-primary-950"
+          color="neutral"
+          variant="outline"
+          class="group w-full justify-start gap-4 p-4 text-left transition-colors hover:ring-primary hover:bg-primary/5"
           @click="handleQuickAction(action.path)"
         >
-          <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-600 group-hover:bg-primary-100 group-hover:text-primary-600 dark:bg-gray-800 dark:text-gray-400 dark:group-hover:bg-primary-900 dark:group-hover:text-primary-400">
+          <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-elevated text-muted group-hover:bg-primary/10 group-hover:text-primary">
             <UIcon
               :name="action.icon"
               class="size-5"
             />
           </div>
           <div>
-            <p class="font-medium text-gray-900 dark:text-white">
+            <p class="font-medium text-highlighted">
               {{ action.label }}
             </p>
-            <p class="text-sm text-gray-500 dark:text-gray-400">
+            <p class="text-sm text-muted">
               {{ action.description }}
             </p>
           </div>
           <UIcon
             name="i-lucide-chevron-right"
-            class="ml-auto size-5 text-gray-400 group-hover:text-primary-500"
+            class="ml-auto size-5 text-dimmed group-hover:text-primary"
           />
-        </button>
+        </UButton>
       </div>
     </div>
   </div>

--- a/packages/crouton-admin/app/components/TeamColorSwatchPicker.vue
+++ b/packages/crouton-admin/app/components/TeamColorSwatchPicker.vue
@@ -5,6 +5,10 @@
  * A grid of color swatches for selecting primary/neutral colors.
  * Tailwind color names are mapped to their 500 shade for display.
  *
+ * Deliberately a custom widget (#1410): a color-swatch grid has no Nuxt UI
+ * equivalent — each cell's background IS the data, so themes shouldn't
+ * restyle it. Chrome around it uses semantic tokens.
+ *
  * @example
  * ```vue
  * <TeamColorSwatchPicker

--- a/packages/crouton-admin/app/components/TeamRadiusPicker.vue
+++ b/packages/crouton-admin/app/components/TeamRadiusPicker.vue
@@ -4,6 +4,10 @@
  *
  * A button group for selecting border radius values with visual preview.
  *
+ * Deliberately a custom widget (#1410): each option previews its own literal
+ * radius — a themed UButton would repaint the previews with the theme's
+ * radius and destroy the comparison. Chrome uses semantic tokens.
+ *
  * @example
  * ```vue
  * <TeamRadiusPicker v-model="radius" />

--- a/packages/crouton-admin/app/components/TeamThemeSettings.vue
+++ b/packages/crouton-admin/app/components/TeamThemeSettings.vue
@@ -175,16 +175,19 @@ const presetEntries = computed(() =>
           <!-- Preset Picker (vertical) -->
           <div class="space-y-2">
             <label class="text-sm font-medium text-default">{{ $t('themeSettings.preset') }}</label>
+            <!-- Preset cards — UButton (not raw buttons) so themes reach the
+                 theme picker itself (#1410); selection ring wins via class merge -->
             <div class="flex flex-col gap-2">
-              <button
+              <UButton
                 v-for="[key, preset] in presetEntries"
                 :key="key"
-                type="button"
+                color="neutral"
+                variant="outline"
                 :disabled="!isAdmin || isSaving"
-                class="relative flex items-center gap-3 p-3 rounded-lg border text-left transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="relative w-full justify-start gap-3 p-3 text-left transition-colors"
                 :class="(localTheme.preset === key) || (key === 'custom' && !localTheme.preset)
-                  ? 'border-primary bg-primary/5'
-                  : 'border-muted hover:border-default hover:bg-elevated/50'"
+                  ? 'ring-primary bg-primary/5'
+                  : 'hover:bg-elevated/50'"
                 @click="selectPreset(key)"
               >
                 <div class="flex shrink-0 gap-1">
@@ -210,7 +213,7 @@ const presetEntries = computed(() =>
                   name="i-lucide-check-circle"
                   class="size-4 text-primary shrink-0"
                 />
-              </button>
+              </UButton>
             </div>
           </div>
 

--- a/packages/crouton-admin/app/pages/admin/[team]/team/email-templates.vue
+++ b/packages/crouton-admin/app/pages/admin/[team]/team/email-templates.vue
@@ -214,16 +214,16 @@ onMounted(loadSettings)
       <div class="flex flex-col lg:flex-row gap-6">
         <!-- Email type selector (sidebar) -->
         <div class="lg:w-56 shrink-0">
+          <!-- Type nav — UButton (not raw buttons) so themes reach it (#1410) -->
           <nav class="flex lg:flex-col gap-1">
-            <button
+            <UButton
               v-for="type in emailTypes"
               :key="type.key"
-              class="flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left w-full transition-colors"
-              :class="[
-                activeType === type.key
-                  ? 'bg-primary/10 text-primary font-medium'
-                  : 'text-muted hover:bg-elevated hover:text-default'
-              ]"
+              :color="activeType === type.key ? 'primary' : 'neutral'"
+              :variant="activeType === type.key ? 'soft' : 'ghost'"
+              size="md"
+              class="w-full justify-start gap-2 text-left"
+              :class="activeType === type.key ? '' : 'text-muted hover:text-default'"
               @click="activeType = type.key"
             >
               <UIcon :name="type.icon" class="size-4 shrink-0" />
@@ -232,7 +232,7 @@ onMounted(loadSettings)
                 v-if="hasOverrides(type.key)"
                 class="size-1.5 rounded-full bg-primary ml-auto shrink-0"
               />
-            </button>
+            </UButton>
           </nav>
         </div>
 

--- a/packages/crouton-auth/app/components/Auth/RouteModal.vue
+++ b/packages/crouton-auth/app/components/Auth/RouteModal.vue
@@ -386,13 +386,14 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
                 </template>
                 <template v-else>
                   {{ t('auth.dontHaveAccount') }}
-                  <button
-                    type="button"
-                    class="text-primary font-medium hover:text-primary/80"
+                  <UButton
+                    variant="link"
+                    size="md"
+                    class="p-0"
                     @click="authModal.setMode('register')"
                   >
                     {{ t('auth.signUp') }}
-                  </button>
+                  </UButton>
                 </template>
               </template>
 
@@ -400,14 +401,15 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
                 v-if="!showMagicLink && hasPassword"
                 #password-hint
               >
-                <button
-                  type="button"
-                  class="text-primary font-medium hover:text-primary/80"
+                <UButton
+                  variant="link"
+                  size="md"
+                  class="p-0"
                   tabindex="-1"
                   @click="authModal.setMode('forgot-password')"
                 >
                   {{ t('auth.forgotPassword') }}
-                </button>
+                </UButton>
               </template>
 
               <template
@@ -425,13 +427,14 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
                 v-if="hasMagicLink && hasPassword"
                 #footer
               >
-                <button
-                  type="button"
-                  class="text-sm text-primary font-medium hover:text-primary/80"
+                <UButton
+                  variant="link"
+                  size="md"
+                  class="p-0"
                   @click="showMagicLink = !showMagicLink; formError = null"
                 >
                   {{ showMagicLink ? t('auth.signInWithPassword') : t('auth.signInWithMagicLink') }}
-                </button>
+                </UButton>
               </template>
             </UAuthForm>
 
@@ -452,13 +455,14 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
                 </h2>
                 <p class="mt-2 text-muted">
                   {{ t('auth.dontHaveAccount') }}
-                  <button
-                    type="button"
-                    class="text-primary font-medium hover:text-primary/80"
+                  <UButton
+                    variant="link"
+                    size="md"
+                    class="p-0"
                     @click="authModal.setMode('register')"
                   >
                     {{ t('auth.signUp') }}
-                  </button>
+                  </UButton>
                 </p>
               </div>
               <div class="space-y-3">
@@ -501,13 +505,14 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
           >
             <template #description>
               {{ t('auth.alreadyHaveAccount') }}
-              <button
-                type="button"
-                class="text-primary font-medium hover:text-primary/80"
+              <UButton
+                variant="link"
+                size="md"
+                class="p-0"
                 @click="authModal.setMode('login')"
               >
                 {{ t('auth.signIn') }}
-              </button>
+              </UButton>
             </template>
 
             <template
@@ -556,13 +561,14 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
               </h2>
               <p class="mt-2 text-muted">
                 {{ t('auth.alreadyHaveAccount') }}
-                <button
-                  type="button"
-                  class="text-primary font-medium hover:text-primary/80"
+                <UButton
+                  variant="link"
+                  size="md"
+                  class="p-0"
                   @click="authModal.setMode('login')"
                 >
                   {{ t('auth.signIn') }}
-                </button>
+                </UButton>
               </p>
             </div>
             <div class="space-y-3">
@@ -643,13 +649,14 @@ async function onForgotPasswordSubmit(event: FormSubmitEvent<{ email: string }>)
             </template>
 
             <template #footer>
-              <button
-                type="button"
-                class="text-primary font-medium hover:text-primary/80"
+              <UButton
+                variant="link"
+                size="md"
+                class="p-0"
                 @click="authModal.setMode('login')"
               >
                 {{ t('auth.backToSignIn') }}
-              </button>
+              </UButton>
             </template>
           </UAuthForm>
         </div>

--- a/packages/crouton-auth/app/components/Auth/TwoFactorForm.vue
+++ b/packages/crouton-auth/app/components/Auth/TwoFactorForm.vue
@@ -153,15 +153,16 @@ function toggleMode() {
         {{ t('auth.verify') }}
       </UButton>
 
-      <!-- Toggle Mode -->
+      <!-- Toggle Mode — UButton so themes reach it (#1410) -->
       <div class="text-center">
-        <button
-          type="button"
-          class="text-sm font-medium text-primary hover:text-primary/80"
+        <UButton
+          variant="link"
+          size="md"
+          class="p-0"
           @click="toggleMode"
         >
           {{ mode === 'totp' ? $t('auth.twoFactor.useBackupCode') : $t('auth.twoFactor.useAuthenticatorApp') }}
-        </button>
+        </UButton>
       </div>
     </UForm>
   </div>


### PR DESCRIPTION
Part of #1410 (batch 3 of 4 — crouton-auth + crouton-admin). Batch 1 was #1411, batch 2 is #1416.

## 👤 For humans
The auth modal's inline links ("Sign up", "Forgot password?", magic-link/2FA toggles), the theme-preset picker, the super-admin quick actions and the email-template type nav were raw HTML buttons — invisible to themes. All Nuxt UI now. The color-swatch and radius pickers deliberately stay custom (their pixels are the data), with in-file comments saying why.

## 🤖 For agents
- `Auth/RouteModal.vue` (×7) + `Auth/TwoFactorForm.vue` toggle → `UButton variant="link" size="md" class="p-0"` (inline sentence flow kept).
- `TeamThemeSettings.vue` preset cards → UButton neutral outline; selected = `ring-primary bg-primary/5` via class merge.
- `Admin/Dashboard.vue` quick actions → UButton neutral outline, hardcoded grays → semantic tokens.
- `email-templates.vue` type nav → UButton primary-soft active / neutral-ghost inactive.
- `TeamColorSwatchPicker.vue` / `TeamRadiusPicker.vue`: acceptable-custom, commented.
- Known behavior delta: the autofocused auth link shows Nuxt UI's focus outline on load (raw button showed nothing); clears on blur — correct a11y.

## 🧪 How to test
1. Log out → `/auth/login`: "Registreren" and "Wachtwoord vergeten?" render as primary links in the app's theme; switch modes via them. Verified on fanfare dev.
2. `/admin/<team>/team/look-and-feel`: preset list = outline cards, selected has primary ring + tint + check. Verified.
3. `/admin/<team>/team/email-templates`: type nav = soft primary active / ghost inactive. Verified.
4. `/super-admin` dashboard quick actions: outline cards, primary hover (was hardcoded gray).
5. `pnpm typecheck` green on fanfare/triage/velo.