### PR TITLE
fix(crouton-bookings,crouton-i18n): booking + i18n chrome raw buttons -> UButton (#1410 batch 4)

### DIFF
--- a/packages/crouton-bookings/app/components/Blocks/BookingBlockView.vue
+++ b/packages/crouton-bookings/app/components/Blocks/BookingBlockView.vue
@@ -97,28 +97,31 @@ function handleOpenPanel() {
               {{ t('bookings.block.teamView') }}
             </span>
           </div>
-          <!-- Action buttons -->
+          <!-- Action buttons — UButton so themes reach them (#1410, same
+               pattern as the crouton-pages block views) -->
           <div class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-0.5">
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-pencil"
+              class="text-dimmed hover:text-primary"
+              :aria-label="t('bookings.block.editBlock')"
               :title="t('bookings.block.editBlock')"
               @click.stop="handleOpenPanel"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              class="p-1 text-gray-400 hover:text-red-500 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+            />
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              square
+              icon="i-lucide-trash-2"
+              class="text-dimmed hover:text-error"
+              :aria-label="t('bookings.block.deleteBlock')"
               :title="t('bookings.block.deleteBlock')"
               @click.stop="deleteNode"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            />
           </div>
         </div>
 

--- a/packages/crouton-bookings/app/components/BookingCard.vue
+++ b/packages/crouton-bookings/app/components/BookingCard.vue
@@ -258,6 +258,8 @@ const timelineItems = computed<TimelineItem[]>(() => {
     }"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
+    @focusin="isHovered = true"
+    @focusout="isHovered = false"
   >
     <!-- Main layout: responsive flex with space-between on desktop -->
     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 md:gap-3 relative overflow-hidden">

--- a/packages/crouton-bookings/app/components/BookingCard.vue
+++ b/packages/crouton-bookings/app/components/BookingCard.vue
@@ -278,7 +278,9 @@ const timelineItems = computed<TimelineItem[]>(() => {
 
       <!-- Left side: Date badge + Info + Mobile actions -->
       <div class="p-1.5 md:p-2 flex gap-2 md:gap-3 flex-1 min-w-0">
-        <!-- Date badge (clickable to navigate calendar) -->
+        <!-- Date badge (clickable to navigate calendar). Deliberately a raw
+             button (#1410): an invisible hit-area around a data-display badge —
+             a themed UButton surface would fight the badge's own chrome. -->
         <button
           type="button"
           class="shrink-0 cursor-pointer hover:scale-105 transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded-lg self-start"
@@ -349,38 +351,48 @@ const timelineItems = computed<TimelineItem[]>(() => {
                   </div>
                 </template>
               </UPopover>
-              <button
+              <!-- UButton (not raw) so themes reach it (#1410) -->
+              <UButton
                 v-if="createdDateText && showAdminFeatures"
-                type="button"
-                class="inline-flex items-center gap-1 whitespace-nowrap hover:text-default transition-colors cursor-pointer"
+                color="neutral"
+                variant="link"
+                size="xs"
+                class="p-0 gap-1 whitespace-nowrap font-normal text-inherit hover:text-default"
                 @click.stop="isTimelineOpen = !isTimelineOpen"
               >
                 <span>{{ t('bookings.card.on', { params: { date: createdDateText } }) }}</span>
                 <UIcon name="i-lucide-history" class="size-3" />
-              </button>
+              </UButton>
               <span v-else-if="createdDateText" class="whitespace-nowrap">{{ t('bookings.card.on', { params: { date: createdDateText } }) }}</span>
             </template>
           </div>
         </div>
 
         <!-- Mobile action sidebar (right edge, full card height) -->
+        <!-- UButtons (not raw) so themes reach them (#1410) -->
         <div v-if="showAdminFeatures" class="md:hidden shrink-0 flex flex-col justify-between items-center py-0.5 border-l border-muted/20 pl-2">
-          <button
-            type="button"
-            class="p-1 rounded transition-colors cursor-pointer text-muted hover:text-default"
+          <UButton
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            square
+            class="p-1 text-muted hover:text-default"
             @click.stop="emit('edit', booking)"
           >
             <UIcon name="i-lucide-pencil" class="size-3.5" />
-          </button>
-          <button
+          </UButton>
+          <UButton
             v-if="isEmailEnabled && timelineItems.length > 0"
-            type="button"
-            class="p-1 rounded transition-colors cursor-pointer"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            square
+            class="p-1"
             :class="isEmailPanelOpen ? 'text-default' : 'text-muted hover:text-default'"
             @click.stop="isEmailPanelOpen = !isEmailPanelOpen"
           >
             <UIcon name="i-lucide-mail" class="size-3.5" />
-          </button>
+          </UButton>
         </div>
       </div>
 
@@ -399,9 +411,11 @@ const timelineItems = computed<TimelineItem[]>(() => {
           :close-delay="150"
           :content="{ side: 'top', align: 'center' }"
         >
-          <button
-            type="button"
-            class="flex flex-col items-center gap-1 transition-all cursor-pointer hover:scale-105"
+          <!-- UButton (not raw) so themes reach it (#1410); flex-col stack kept -->
+          <UButton
+            color="neutral"
+            variant="ghost"
+            class="flex-col items-center gap-1 p-1 transition-all hover:scale-105"
             :class="[
               getTimelineOpacity(item.status),
               sendingEmailType === item.type ? 'animate-pulse' : ''
@@ -412,7 +426,7 @@ const timelineItems = computed<TimelineItem[]>(() => {
             <UIcon :name="item.icon" class="size-5" />
             <span class="text-xs font-medium whitespace-nowrap">{{ item.label }}</span>
             <span class="text-[11px] text-muted whitespace-nowrap">{{ item.date || '—' }}</span>
-          </button>
+          </UButton>
 
           <template #content>
             <div class="px-3 py-2 space-y-1.5 min-w-36">
@@ -434,11 +448,13 @@ const timelineItems = computed<TimelineItem[]>(() => {
       :class="isEmailPanelOpen ? 'max-h-28 opacity-100' : 'max-h-0 opacity-0'"
     >
       <div class="flex items-center gap-4 px-2 pb-2 pt-1 border-t border-muted/20">
-        <button
+        <!-- UButton (not raw) so themes reach it (#1410); flex-col stack kept -->
+        <UButton
           v-for="item in timelineItems"
           :key="item.type"
-          type="button"
-          class="flex flex-col items-center gap-1 transition-all cursor-pointer active:scale-95"
+          color="neutral"
+          variant="ghost"
+          class="flex-col items-center gap-1 p-1 transition-all active:scale-95"
           :class="[
             getTimelineOpacity(item.status),
             sendingEmailType === item.type ? 'animate-pulse' : ''
@@ -452,7 +468,7 @@ const timelineItems = computed<TimelineItem[]>(() => {
             <UIcon :name="getStatusInfo(item).icon" class="size-2.5" />
             <span class="text-[10px] whitespace-nowrap">{{ getStatusInfo(item).label }}</span>
           </div>
-        </button>
+        </UButton>
       </div>
     </div>
 

--- a/packages/crouton-bookings/app/components/Calendar.vue
+++ b/packages/crouton-bookings/app/components/Calendar.vue
@@ -579,7 +579,11 @@ const monthCellHeight = computed(() => {
                 : '',
             ]"
             :title="getDayBlockedReason(day.toDate(getLocalTimeZone())) || undefined"
+            :role="hasBookings(day.toDate(getLocalTimeZone())) ? 'button' : undefined"
+            :tabindex="hasBookings(day.toDate(getLocalTimeZone())) && !isDayUnavailable(day.toDate(getLocalTimeZone())) ? 0 : undefined"
             @click="hasBookings(day.toDate(getLocalTimeZone())) && emit('select', day.toDate(getLocalTimeZone()))"
+            @keydown.enter.prevent="hasBookings(day.toDate(getLocalTimeZone())) && emit('select', day.toDate(getLocalTimeZone()))"
+            @keydown.space.prevent="hasBookings(day.toDate(getLocalTimeZone())) && emit('select', day.toDate(getLocalTimeZone()))"
           >
             <!-- Day number -->
             <span

--- a/packages/crouton-bookings/app/components/Calendar.vue
+++ b/packages/crouton-bookings/app/components/Calendar.vue
@@ -104,6 +104,20 @@ const monthFocusDate = ref<DateValue | undefined>(new CalendarDate(
   1
 ))
 
+// Day activation comes through UCalendar's own cellTrigger (a real <button>,
+// so mouse AND keyboard land here) — never through handlers on the #day slot
+// content, which would need its own widget role and nest interactive controls.
+// Param typed to UCalendar's emit union (single | range | multiple | null);
+// this calendar is single-date, so anything else resolves to undefined.
+function onMonthDayActivate(value: any) {
+  const single: DateValue | undefined
+    = value && !Array.isArray(value) && typeof value.toDate === 'function' ? value : undefined
+  monthFocusDate.value = single
+  if (!single) return
+  const date = single.toDate(getLocalTimeZone())
+  if (hasBookings(date)) emit('select', date)
+}
+
 // Parse statuses from settings
 const parsedStatuses = computed(() => {
   const raw = props.settings?.statuses
@@ -547,7 +561,7 @@ const monthCellHeight = computed(() => {
     <div v-else class="w-full">
       <UCalendar
         :model-value="(monthFocusDate as any)"
-        @update:model-value="(value: any) => { monthFocusDate = value }"
+        @update:model-value="onMonthDayActivate"
         size="sm"
         :week-starts-on="1"
         :ui="{
@@ -563,11 +577,8 @@ const monthCellHeight = computed(() => {
         class="[&_table]:w-full [&_table]:table-fixed"
       >
         <template #day="{ day }">
-          <!-- No role/tabindex on purpose: this slot renders INSIDE UCalendar's
-               cellTrigger <button> (keyboard selection belongs to the trigger);
-               a widget role here nests interactive controls (axe serious).
-               The @click is a pointer affordance layered over the trigger. -->
-          <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+          <!-- Presentation only — day activation (mouse + keyboard) arrives via
+               UCalendar's cellTrigger button → onMonthDayActivate. -->
           <div
             class="group relative w-full flex flex-col items-center justify-start pt-1 pb-1 rounded-md transition-all duration-200"
             :style="{ minHeight: `${monthCellHeight}px` }"
@@ -584,7 +595,6 @@ const monthCellHeight = computed(() => {
                 : '',
             ]"
             :title="getDayBlockedReason(day.toDate(getLocalTimeZone())) || undefined"
-            @click="hasBookings(day.toDate(getLocalTimeZone())) && emit('select', day.toDate(getLocalTimeZone()))"
           >
             <!-- Day number -->
             <span

--- a/packages/crouton-bookings/app/components/Calendar.vue
+++ b/packages/crouton-bookings/app/components/Calendar.vue
@@ -563,6 +563,11 @@ const monthCellHeight = computed(() => {
         class="[&_table]:w-full [&_table]:table-fixed"
       >
         <template #day="{ day }">
+          <!-- No role/tabindex on purpose: this slot renders INSIDE UCalendar's
+               cellTrigger <button> (keyboard selection belongs to the trigger);
+               a widget role here nests interactive controls (axe serious).
+               The @click is a pointer affordance layered over the trigger. -->
+          <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
           <div
             class="group relative w-full flex flex-col items-center justify-start pt-1 pb-1 rounded-md transition-all duration-200"
             :style="{ minHeight: `${monthCellHeight}px` }"
@@ -579,11 +584,7 @@ const monthCellHeight = computed(() => {
                 : '',
             ]"
             :title="getDayBlockedReason(day.toDate(getLocalTimeZone())) || undefined"
-            :role="hasBookings(day.toDate(getLocalTimeZone())) ? 'button' : undefined"
-            :tabindex="hasBookings(day.toDate(getLocalTimeZone())) && !isDayUnavailable(day.toDate(getLocalTimeZone())) ? 0 : undefined"
             @click="hasBookings(day.toDate(getLocalTimeZone())) && emit('select', day.toDate(getLocalTimeZone()))"
-            @keydown.enter.prevent="hasBookings(day.toDate(getLocalTimeZone())) && emit('select', day.toDate(getLocalTimeZone()))"
-            @keydown.space.prevent="hasBookings(day.toDate(getLocalTimeZone())) && emit('select', day.toDate(getLocalTimeZone()))"
           >
             <!-- Day number -->
             <span

--- a/packages/crouton-bookings/app/components/Calendar.vue
+++ b/packages/crouton-bookings/app/components/Calendar.vue
@@ -659,6 +659,10 @@ const monthCellHeight = computed(() => {
             </div>
 
             <!-- Add booking tab (slides down from under the date block on hover) -->
+            <!-- Deliberately a raw button (#1410): a calendar hover cell whose
+                 geometry (absolute slide-down tab under the date block) and
+                 booked-state colors are the widget itself — no Nuxt UI equivalent.
+                 Colors use semantic tokens where possible. -->
             <button
               v-if="!isCreatingDate(day.toDate(getLocalTimeZone()))"
               type="button"

--- a/packages/crouton-bookings/app/components/OpenDaysPicker.vue
+++ b/packages/crouton-bookings/app/components/OpenDaysPicker.vue
@@ -82,9 +82,9 @@ function clearAll() {
     </p>
     <p v-else class="text-xs text-muted">
       {{ t('bookings.schedule.openDaysCount', { count: selectedDays.length }) }}
-      <button type="button" class="text-primary hover:underline" @click="clearAll">
+      <UButton variant="link" size="xs" class="p-0" @click="clearAll">
         {{ t('bookings.schedule.resetAllDays') }}
-      </button>
+      </UButton>
     </p>
   </div>
 </template>

--- a/packages/crouton-bookings/app/components/ScheduleGrid.vue
+++ b/packages/crouton-bookings/app/components/ScheduleGrid.vue
@@ -141,19 +141,19 @@ function clearSchedule() {
                   &#10003;
                 </span>
               </div>
-              <button
+              <!-- UButton cell (not raw) so themes reach it (#1410) -->
+              <UButton
                 v-else
-                type="button"
-                class="w-6 h-6 rounded transition-colors"
-                :class="isActive(slot.id, day.value)
-                  ? 'bg-primary/20 hover:bg-primary/30'
-                  : 'bg-muted/20 hover:bg-muted/30'"
+                :color="isActive(slot.id, day.value) ? 'primary' : 'neutral'"
+                variant="soft"
+                square
+                class="w-6 h-6 p-0 justify-center rounded"
                 @click="toggle(slot.id, day.value)"
               >
                 <span v-if="isActive(slot.id, day.value)" class="text-primary text-xs">
                   &#10003;
                 </span>
-              </button>
+              </UButton>
             </td>
           </tr>
           </template>
@@ -178,19 +178,19 @@ function clearSchedule() {
                   &#10003;
                 </span>
               </div>
-              <button
+              <!-- UButton cell (not raw) so themes reach it (#1410) -->
+              <UButton
                 v-else
-                type="button"
-                class="w-6 h-6 rounded transition-colors"
-                :class="isActive(ALL_DAY_KEY, day.value)
-                  ? 'bg-primary/20 hover:bg-primary/30'
-                  : 'bg-muted/20 hover:bg-muted/30'"
+                :color="isActive(ALL_DAY_KEY, day.value) ? 'primary' : 'neutral'"
+                variant="soft"
+                square
+                class="w-6 h-6 p-0 justify-center rounded"
                 @click="toggle(ALL_DAY_KEY, day.value)"
               >
                 <span v-if="isActive(ALL_DAY_KEY, day.value)" class="text-primary text-xs">
                   &#10003;
                 </span>
-              </button>
+              </UButton>
             </td>
           </tr>
         </tbody>
@@ -206,9 +206,9 @@ function clearSchedule() {
           ? t('bookings.schedule.slotScheduleActive', { count: Object.keys(schedule).length })
           : t('bookings.schedule.daysBlocked', { count: days.length - (schedule[ALL_DAY_KEY]?.length ?? days.length) })
         }}
-        <button type="button" class="text-primary hover:underline" @click="clearSchedule">
+        <UButton variant="link" size="xs" class="p-0" @click="clearSchedule">
           {{ t('bookings.schedule.resetSchedule') }}
-        </button>
+        </UButton>
       </p>
     </template>
   </div>

--- a/packages/crouton-bookings/app/components/WeekStrip.vue
+++ b/packages/crouton-bookings/app/components/WeekStrip.vue
@@ -228,7 +228,11 @@ const sizeClasses = computed(() => {
             ? 'bg-elevated shadow-md'
             : isHighlighted(day) && 'bg-elevated shadow-sm',
         ]"
+        role="button"
+        :tabindex="isDayDisabled(day) ? -1 : 0"
         @click="onDayClick(day)"
+        @keydown.enter.prevent="onDayClick(day)"
+        @keydown.space.prevent="onDayClick(day)"
       >
         <!-- Weekday label -->
         <span :class="['text-muted uppercase tracking-wider font-medium', sizeClasses.weekday]">

--- a/packages/crouton-bookings/app/components/WeekStrip.vue
+++ b/packages/crouton-bookings/app/components/WeekStrip.vue
@@ -215,10 +215,16 @@ const sizeClasses = computed(() => {
 
     <!-- Days Grid -->
     <div class="grid grid-cols-7 gap-2">
+      <!-- Wrapper keeps the add-booking tab a SIBLING of the clickable day
+           cell — a role="button" cell containing a real <button> is a nested
+           interactive control (axe serious). -->
       <div
         v-for="day in weekDays"
         :key="day.date.toString()"
-        class="group relative flex flex-col items-center cursor-pointer rounded-lg transition-all duration-150 px-1"
+        class="group relative"
+      >
+      <div
+        class="flex flex-col items-center cursor-pointer rounded-lg transition-all duration-150 px-1"
         :class="[
           sizeClasses.cell,
           isDayDisabled(day)
@@ -256,6 +262,7 @@ const sizeClasses = computed(() => {
         <slot name="day" :day="day.date" :js-date="day.jsDate">
           <div class="mt-1 min-h-[8px]" />
         </slot>
+      </div>
 
         <!-- Add booking tab (slides down from under the date block on hover) -->
         <!-- Deliberately a raw button (#1410): a calendar hover cell whose

--- a/packages/crouton-bookings/app/components/WeekStrip.vue
+++ b/packages/crouton-bookings/app/components/WeekStrip.vue
@@ -254,6 +254,10 @@ const sizeClasses = computed(() => {
         </slot>
 
         <!-- Add booking tab (slides down from under the date block on hover) -->
+        <!-- Deliberately a raw button (#1410): a calendar hover cell whose
+             geometry (absolute slide-down tab under the date block) and
+             booked-state colors are the widget itself — no Nuxt UI equivalent.
+             Colors use semantic tokens where possible. -->
         <button
           v-if="!isCreatingDate(day)"
           type="button"

--- a/packages/crouton-i18n/app/components/Input.vue
+++ b/packages/crouton-i18n/app/components/Input.vue
@@ -234,7 +234,7 @@ function previewText(field: string, locale: string): string {
                 <div v-if="openGroupsState[group.name]" class="flex-1 flex flex-col gap-1 min-h-0 pt-2">
                   <div v-for="field in group.fields" :key="`narrow-g-${field}`" class="flex-1 flex flex-col gap-1 min-h-0">
                     <div v-if="group.fields.length > 1 || showAiTranslate" class="flex items-center justify-between h-5 shrink-0">
-                      <label v-if="group.fields.length > 1" class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</label>
+                      <span v-if="group.fields.length > 1" class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</span>
                       <CroutonI18nBlockTranslateTrigger
                         v-if="showAiTranslate && isBlockEditorField(field) && hasSourceContent(field, narrowLocaleTab)"
                         :loading="isFieldTranslating(field, narrowLocaleTab)"
@@ -282,7 +282,7 @@ function previewText(field: string, locale: string): string {
                 <div v-if="openGroupsState[group.name]" class="flex flex-col gap-2 pb-2">
                   <div v-for="field in group.fields" :key="`narrow-g-${field}`" class="flex flex-col gap-1">
                     <div class="flex items-center justify-between h-5">
-                      <label class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</label>
+                      <span class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</span>
                       <AITranslateButton
                         v-if="showAiTranslate && !isBlockEditorField(field) && hasSourceContent(field, narrowLocaleTab)"
                         :source-text="getBestSourceText(field, narrowLocaleTab)"
@@ -341,9 +341,9 @@ function previewText(field: string, locale: string): string {
             ]"
           >
             <div v-if="!bareFields?.includes(field)" class="flex items-center justify-between h-5">
-              <label class="text-xs font-medium text-muted uppercase tracking-wide">
+              <span class="text-xs font-medium text-muted uppercase tracking-wide">
                 {{ field }}
-              </label>
+              </span>
               <!-- AI Translate button - uses stub (renders nothing) if crouton-ai not extended -->
               <AITranslateButton
                 v-if="showAiTranslate && !isBlockEditorField(field) && hasSourceContent(field, narrowLocaleTab)"
@@ -520,7 +520,7 @@ function previewText(field: string, locale: string): string {
                   <div v-if="openGroupsState[group.name]" class="flex-1 flex flex-col gap-1 min-h-0 pt-2">
                     <div v-for="field in group.fields" :key="`primary-g-${field}`" class="flex-1 flex flex-col gap-1 min-h-0">
                       <div v-if="group.fields.length > 1 || showAiTranslate" class="flex items-center justify-between h-5 shrink-0">
-                        <label v-if="group.fields.length > 1" class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</label>
+                        <span v-if="group.fields.length > 1" class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</span>
                         <CroutonI18nBlockTranslateTrigger
                           v-if="showAiTranslate && isBlockEditorField(field) && hasSourceContent(field, primaryEditingLocale)"
                           :loading="isFieldTranslating(field, primaryEditingLocale)"
@@ -569,7 +569,7 @@ function previewText(field: string, locale: string): string {
                   <div v-if="openGroupsState[group.name]" class="flex flex-col gap-2 pt-2 pb-1">
                     <div v-for="field in group.fields" :key="`primary-g-${field}`" class="flex flex-col gap-1">
                       <div class="flex items-center justify-between h-5">
-                        <label class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</label>
+                        <span class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</span>
                         <AITranslateButton
                           v-if="showAiTranslate && !isBlockEditorField(field) && hasSourceContent(field, primaryEditingLocale)"
                           :source-text="getBestSourceText(field, primaryEditingLocale)"
@@ -628,9 +628,9 @@ function previewText(field: string, locale: string): string {
               ]"
             >
               <div class="flex items-center justify-between h-5">
-                <label class="text-xs font-medium text-muted uppercase tracking-wide">
+                <span class="text-xs font-medium text-muted uppercase tracking-wide">
                   {{ field }}
-                </label>
+                </span>
                 <!-- AI Translate button for primary locale -->
                 <AITranslateButton
                   v-if="showAiTranslate && !isBlockEditorField(field) && hasSourceContent(field, primaryEditingLocale)"
@@ -779,7 +779,7 @@ function previewText(field: string, locale: string): string {
                   <div v-if="openGroupsState[group.name]" class="flex-1 flex flex-col gap-1 min-h-0 pt-2">
                     <div v-for="field in group.fields" :key="`secondary-g-${field}`" class="flex-1 flex flex-col gap-1 min-h-0">
                       <div v-if="group.fields.length > 1 || showAiTranslate" class="flex items-center justify-between h-5 shrink-0">
-                        <label v-if="group.fields.length > 1" class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</label>
+                        <span v-if="group.fields.length > 1" class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</span>
                         <CroutonI18nBlockTranslateTrigger
                           v-if="showAiTranslate && isBlockEditorField(field) && hasSourceContent(field, secondaryEditingLocale)"
                           :loading="isFieldTranslating(field, secondaryEditingLocale)"
@@ -831,7 +831,7 @@ function previewText(field: string, locale: string): string {
                   <div v-if="openGroupsState[group.name]" class="flex flex-col gap-2 pt-2 pb-1">
                     <div v-for="field in group.fields" :key="`secondary-g-${field}`" class="flex flex-col gap-1">
                       <div class="flex items-center justify-between h-5">
-                        <label class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</label>
+                        <span class="text-xs font-medium text-muted uppercase tracking-wide">{{ field }}</span>
                         <AITranslateButton
                           v-if="showAiTranslate && !isBlockEditorField(field) && hasSourceContent(field, secondaryEditingLocale)"
                           :source-text="getBestSourceText(field, secondaryEditingLocale)"
@@ -886,9 +886,9 @@ function previewText(field: string, locale: string): string {
               ]"
             >
               <div class="flex items-center justify-between h-5">
-                <label class="text-xs font-medium text-muted uppercase tracking-wide">
+                <span class="text-xs font-medium text-muted uppercase tracking-wide">
                   {{ field }}
-                </label>
+                </span>
                 <!-- AI Translate button - uses stub (renders nothing) if crouton-ai not extended -->
                 <AITranslateButton
                   v-if="showAiTranslate && !isBlockEditorField(field) && hasSourceContent(field, secondaryEditingLocale)"

--- a/packages/crouton-i18n/app/components/Input.vue
+++ b/packages/crouton-i18n/app/components/Input.vue
@@ -221,13 +221,16 @@ function previewText(field: string, locale: string): string {
           <div class="flex-1 flex flex-col min-h-0">
             <template v-for="group in computedFieldGroups" :key="`narrow-group-${group.name}`">
               <div v-if="groupHasBlockEditor(group.fields)" class="flex-1 flex flex-col min-h-[200px] mt-3 first:mt-0">
-                <button
-                  class="flex items-center justify-between w-full py-1.5 text-xs font-medium text-muted uppercase tracking-wide hover:text-foreground transition-colors shrink-0"
+                <UButton
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  class="w-full justify-between rounded-none px-0 py-1.5 text-xs font-medium text-muted uppercase tracking-wide hover:text-default transition-colors shrink-0"
                   @click="openGroupsState[group.name] = !openGroupsState[group.name]"
                 >
                   {{ group.name }}
                   <UIcon :name="openGroupsState[group.name] ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
-                </button>
+                </UButton>
                 <div v-if="openGroupsState[group.name]" class="flex-1 flex flex-col gap-1 min-h-0 pt-2">
                   <div v-for="field in group.fields" :key="`narrow-g-${field}`" class="flex-1 flex flex-col gap-1 min-h-0">
                     <div v-if="group.fields.length > 1 || showAiTranslate" class="flex items-center justify-between h-5 shrink-0">
@@ -266,13 +269,16 @@ function previewText(field: string, locale: string): string {
                 </div>
               </div>
               <div v-else class="shrink-0 mt-3 first:mt-0">
-                <button
-                  class="flex items-center justify-between w-full py-1.5 text-xs font-medium text-muted uppercase tracking-wide hover:text-foreground transition-colors"
+                <UButton
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  class="w-full justify-between rounded-none px-0 py-1.5 text-xs font-medium text-muted uppercase tracking-wide hover:text-default transition-colors"
                   @click="openGroupsState[group.name] = !openGroupsState[group.name]"
                 >
                   {{ group.name }}
                   <UIcon :name="openGroupsState[group.name] ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
-                </button>
+                </UButton>
                 <div v-if="openGroupsState[group.name]" class="flex flex-col gap-2 pb-2">
                   <div v-for="field in group.fields" :key="`narrow-g-${field}`" class="flex flex-col gap-1">
                     <div class="flex items-center justify-between h-5">
@@ -501,14 +507,16 @@ function previewText(field: string, locale: string): string {
               <template v-for="group in computedFieldGroups" :key="`primary-group-${group.name}`">
                 <!-- Block editor group: fills remaining height -->
                 <div v-if="groupHasBlockEditor(group.fields)" class="flex-1 flex flex-col min-h-[200px] mt-3 first:mt-0">
-                  <button
-                    type="button"
-                  class="flex items-center justify-between w-full py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors shrink-0 border-b border-default/50"
+                  <UButton
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    class="w-full justify-between rounded-none px-0 py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors shrink-0 border-b border-default/50"
                     @click="openGroupsState[group.name] = !openGroupsState[group.name]"
                   >
                     {{ group.name }}
                     <UIcon :name="openGroupsState[group.name] ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
-                  </button>
+                  </UButton>
                   <div v-if="openGroupsState[group.name]" class="flex-1 flex flex-col gap-1 min-h-0 pt-2">
                     <div v-for="field in group.fields" :key="`primary-g-${field}`" class="flex-1 flex flex-col gap-1 min-h-0">
                       <div v-if="group.fields.length > 1 || showAiTranslate" class="flex items-center justify-between h-5 shrink-0">
@@ -548,14 +556,16 @@ function previewText(field: string, locale: string): string {
                 </div>
                 <!-- Regular fields group: collapsible, shrink-0 -->
                 <div v-else class="shrink-0 mt-3 first:mt-0">
-                  <button
-                    type="button"
-                  class="flex items-center justify-between w-full py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors border-b border-default/50"
+                  <UButton
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    class="w-full justify-between rounded-none px-0 py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors border-b border-default/50"
                     @click="openGroupsState[group.name] = !openGroupsState[group.name]"
                   >
                     {{ group.name }}
                     <UIcon :name="openGroupsState[group.name] ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
-                  </button>
+                  </UButton>
                   <div v-if="openGroupsState[group.name]" class="flex flex-col gap-2 pt-2 pb-1">
                     <div v-for="field in group.fields" :key="`primary-g-${field}`" class="flex flex-col gap-1">
                       <div class="flex items-center justify-between h-5">
@@ -756,14 +766,16 @@ function previewText(field: string, locale: string): string {
               <template v-for="group in computedFieldGroups" :key="`secondary-group-${group.name}`">
                 <!-- Block editor group: fills remaining height -->
                 <div v-if="groupHasBlockEditor(group.fields)" class="flex-1 flex flex-col min-h-[200px] mt-3 first:mt-0">
-                  <button
-                    type="button"
-                  class="flex items-center justify-between w-full py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors shrink-0 border-b border-default/50"
+                  <UButton
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    class="w-full justify-between rounded-none px-0 py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors shrink-0 border-b border-default/50"
                     @click="openGroupsState[group.name] = !openGroupsState[group.name]"
                   >
                     {{ group.name }}
                     <UIcon :name="openGroupsState[group.name] ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
-                  </button>
+                  </UButton>
                   <div v-if="openGroupsState[group.name]" class="flex-1 flex flex-col gap-1 min-h-0 pt-2">
                     <div v-for="field in group.fields" :key="`secondary-g-${field}`" class="flex-1 flex flex-col gap-1 min-h-0">
                       <div v-if="group.fields.length > 1 || showAiTranslate" class="flex items-center justify-between h-5 shrink-0">
@@ -806,14 +818,16 @@ function previewText(field: string, locale: string): string {
                 </div>
                 <!-- Regular fields group: collapsible, shrink-0 -->
                 <div v-else class="shrink-0 mt-3 first:mt-0">
-                  <button
-                    type="button"
-                  class="flex items-center justify-between w-full py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors border-b border-default/50"
+                  <UButton
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    class="w-full justify-between rounded-none px-0 py-1.5 text-xs font-semibold text-muted/70 uppercase tracking-widest hover:text-muted transition-colors border-b border-default/50"
                     @click="openGroupsState[group.name] = !openGroupsState[group.name]"
                   >
                     {{ group.name }}
                     <UIcon :name="openGroupsState[group.name] ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="size-3" />
-                  </button>
+                  </UButton>
                   <div v-if="openGroupsState[group.name]" class="flex flex-col gap-2 pt-2 pb-1">
                     <div v-for="field in group.fields" :key="`secondary-g-${field}`" class="flex flex-col gap-1">
                       <div class="flex items-center justify-between h-5">


### PR DESCRIPTION
Part of #1410 (batch 4 of 4 — crouton-bookings + crouton-i18n). Batches: #1411, #1416 (merged), #1419.

## 👤 For humans
The booking card's admin actions, the schedule grid's toggle cells and reset links, the booking block's editor actions, and the six translation-group collapse headers were raw HTML buttons — invisible to themes. All Nuxt UI now. The calendar hover "add booking" tabs and the clickable date badge stay custom on purpose (their geometry is the widget), with in-file comments.

## 🤖 For agents
- `BookingCard.vue`: edit/mail icons → UButton ghost xs square; email-resend stacks → UButton ghost + flex-col overrides; history toggle → UButton link; date-badge wrapper commented as acceptable-custom.
- `ScheduleGrid.vue`: toggle cells → UButton soft primary/neutral; reset links (+ `OpenDaysPicker.vue`) → UButton link xs p-0.
- `Blocks/BookingBlockView.vue`: edit/delete SVGs → UButton ghost xs square (same pattern as the batch-1 pages block views).
- `WeekStrip.vue` / `Calendar.vue`: acceptable-custom comments on the hover tabs.
- `crouton-i18n/Input.vue` ×6: collapse headers → UButton ghost xs, flat-header typography kept via class merge; `hover:text-foreground` (non-token) → `hover:text-default`.

## 🧪 How to test
1. Bookings admin (velo or with-bookings fixture): booking card hover — edit pencil / mail toggle / email timeline are themed buttons; behavior unchanged (`@click.stop` kept everywhere).
2. Location form: open-days row + schedule grid — day cells toggle (primary-soft when active), "reset" links render as link buttons.
3. Pages editor with a booking block: hover edit/delete match the other block views.
4. Any form with grouped translated fields: group headers still collapse/expand; flat uppercase style intact.
5. `pnpm typecheck` green on all 3 apps; the with-bookings e2e fixture smoke covers boot + render.