### PR TITLE
fix(crouton-sales,crouton-pages): remaining #1407 seams — stepper, block shells, toolbar pills

### DIFF
--- a/packages/crouton-pages/app/components/Workspace/Editor.vue
+++ b/packages/crouton-pages/app/components/Workspace/Editor.vue
@@ -1206,14 +1206,17 @@ defineExpose({ state })
 
           <!-- SEO & social — one quiet disclosure (root og/robots + per-locale seo text) -->
           <div v-if="!isCollectionPage" class="mt-3 shrink-0 border-t border-default pt-2">
-            <button
-              type="button"
-              class="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted hover:text-default transition-colors"
+            <!-- UButton (not raw) so themes reach it (#1410) -->
+            <UButton
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              class="gap-1 px-0 font-semibold uppercase tracking-wide text-muted hover:text-default"
               @click="showSeoMeta = !showSeoMeta"
             >
               <UIcon :name="showSeoMeta ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'" class="size-3.5" />
               {{ t('pages.editor.seoSocial', 'SEO & social') }}
-            </button>
+            </UButton>
             <div v-if="showSeoMeta" class="mt-2 flex flex-col gap-2">
               <UFormField :label="t('pages.fields.seoTitle', 'SEO title')" name="seoTitle">
                 <UInput v-model="seoTitle" size="sm" class="w-full" :placeholder="t('pages.editor.seoTitlePlaceholder', 'Defaults to the page title')" />

--- a/packages/crouton-pages/app/components/Workspace/Sidebar.vue
+++ b/packages/crouton-pages/app/components/Workspace/Sidebar.vue
@@ -281,10 +281,12 @@ defineExpose({
         size="sm"
         class="flex-1"
       />
+      <!-- Toggle pills (#1407): the ACTIVE state is variant-less so the
+           theme's defaultVariants reach it; inactive stays quiet ghost. -->
       <UButton
         size="xs"
-        :color="showDrafts ? 'primary' : 'neutral'"
-        :variant="showDrafts ? 'subtle' : 'ghost'"
+        :color="showDrafts ? undefined : 'neutral'"
+        :variant="showDrafts ? undefined : 'ghost'"
         icon="i-lucide-file-pen-line"
         @click="showDrafts = !showDrafts"
       >
@@ -292,8 +294,8 @@ defineExpose({
       </UButton>
       <UButton
         size="xs"
-        :color="reorderMode.isActive.value ? 'primary' : 'neutral'"
-        :variant="reorderMode.isActive.value ? 'subtle' : 'ghost'"
+        :color="reorderMode.isActive.value ? undefined : 'neutral'"
+        :variant="reorderMode.isActive.value ? undefined : 'ghost'"
         icon="i-lucide-arrow-up-down"
         :disabled="pending"
         aria-label="Reorder pages"

--- a/packages/crouton-sales/app/components/Blocks/ClientsRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/ClientsRender.vue
@@ -28,25 +28,25 @@ const eventSlug = computed(() => props.attrs.eventSlug || '')
 <template>
   <div class="sales-clients-block">
     <!-- Editor didn't pick an event -->
-    <div
+    <UAlert
       v-if="!eventSlug"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-users" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.block.noEventPicked') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-users"
+      :title="t('sales.block.noEventPicked')"
+    />
 
     <!-- Team-members-only tool. -->
-    <div
+    <UAlert
       v-else-if="!loggedIn"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-lock" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.blocks.salesClients.ui.teamOnly') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-lock"
+      :title="t('sales.blocks.salesClients.ui.teamOnly')"
+    />
 
     <!-- Signed-in team member → the open client tabs (recurring-client events). -->
-    <div v-else class="rounded-3xl bg-default p-6">
+    <UCard>
       <Suspense>
         <SalesBlocksEventResolver
           v-slot="{ event }"
@@ -54,18 +54,18 @@ const eventSlug = computed(() => props.attrs.eventSlug || '')
           :not-found-label="t('sales.blocks.salesClients.ui.eventNotFound')"
         >
           <SalesEventWorkspaceClientsPanel v-if="event.requiresClient" :event="event" />
-          <div
+          <UAlert
             v-else
-            class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-          >
-            <UIcon name="i-lucide-user-x" class="w-6 h-6 mx-auto mb-2 text-muted" />
-            {{ t('sales.blocks.salesClients.ui.notRecurring') }}
-          </div>
+            color="neutral"
+            variant="soft"
+            icon="i-lucide-user-x"
+            :title="t('sales.blocks.salesClients.ui.notRecurring')"
+          />
         </SalesBlocksEventResolver>
         <template #fallback>
           <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
         </template>
       </Suspense>
-    </div>
+    </UCard>
   </div>
 </template>

--- a/packages/crouton-sales/app/components/Blocks/EventResolver.vue
+++ b/packages/crouton-sales/app/components/Blocks/EventResolver.vue
@@ -27,11 +27,11 @@ const event = computed(() =>
 
 <template>
   <slot v-if="event" :event="event" />
-  <div
+  <UAlert
     v-else
-    class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-  >
-    <UIcon name="i-lucide-calendar-x" class="w-6 h-6 mx-auto mb-2 text-muted" />
-    {{ notFoundLabel }}
-  </div>
+    color="neutral"
+    variant="soft"
+    icon="i-lucide-calendar-x"
+    :title="notFoundLabel"
+  />
 </template>

--- a/packages/crouton-sales/app/components/Blocks/EventWorkspaceRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/EventWorkspaceRender.vue
@@ -76,32 +76,32 @@ function openPane(pane: 'orders' | 'clients' | 'data' | 'settings') {
 <template>
   <div class="event-workspace-block">
     <!-- Editor didn't pick an event -->
-    <div
+    <UAlert
       v-if="!eventSlug"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-store" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.block.noEventPicked') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-store"
+      :title="t('sales.block.noEventPicked')"
+    />
 
     <!-- Wide-screen team member → the full workspace inline (event fixed, no
-         switcher). No border: the shell frames its own kassa; p-6 stays so the
-         block keeps the exact same width as the previously bordered version. -->
-    <div v-else-if="showInlineShell" class="rounded-3xl bg-default p-6">
+         switcher). Variant-less UCard (#1407): the theme's card chrome frames
+         the block instead of a hardcoded rounded-3xl shell. -->
+    <UCard v-else-if="showInlineShell">
       <Suspense>
         <SalesEventWorkspaceShell :event-slug="eventSlug" :show-switcher="false" />
         <template #fallback>
           <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
         </template>
       </Suspense>
-    </div>
+    </UCard>
 
     <!-- Otherwise → "Open kassa" launcher + fullscreen modal. Two cases: a
          member on a narrow screen (modal hosts the full workspace shell), or an
          anonymous volunteer (modal hosts the POS panel). The session indicator
          + logout live in the page nav's auth pill, not here. -->
     <template v-else>
-      <div class="rounded-3xl border border-default bg-default p-8 flex flex-col items-center gap-5 text-center">
+      <UCard :ui="{ body: 'flex flex-col items-center gap-5 text-center' }">
         <p class="text-sm text-muted">{{ t('sales.block.openKassaHint') }}</p>
         <UButton size="xl" block class="max-w-md" @click="kassaOpen = true">
           {{ loggedIn ? t('sales.block.openKassa') : t('sales.block.makeOrder') }}
@@ -116,7 +116,7 @@ function openPane(pane: 'orders' | 'clients' | 'data' | 'settings') {
           class="max-w-md"
           @open="openPane($event)"
         />
-      </div>
+      </UCard>
 
       <!-- Pane deep-entry: just the pane, in its own fullscreen surface —
            the kassa is never mounted behind it. -->

--- a/packages/crouton-sales/app/components/Blocks/KitchenDisplayRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/KitchenDisplayRender.vue
@@ -130,25 +130,25 @@ function ago(iso: string) {
 <template>
   <div class="kitchen-display-block">
     <!-- Editor didn't pick an event -->
-    <div
+    <UAlert
       v-if="!eventSlug"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-monitor" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.block.noEventPicked') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-monitor"
+      :title="t('sales.block.noEventPicked')"
+    />
 
     <!-- Picked event no longer resolves (deleted / stale slug) -->
-    <div
+    <UAlert
       v-else-if="eventNotFound"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-monitor-x" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.blocks.kitchenDisplay.ui.eventNotFound') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-monitor-x"
+      :title="t('sales.blocks.kitchenDisplay.ui.eventNotFound')"
+    />
 
     <!-- The board — theme-driven via Nuxt UI semantic tokens (follows dark mode) -->
-    <div v-else class="rounded-3xl overflow-hidden bg-default ring ring-default p-5">
+    <UCard>
       <header class="flex items-center justify-between mb-5">
         <div class="flex items-center gap-3">
           <UIcon name="i-lucide-chef-hat" class="size-6 text-primary" />
@@ -211,7 +211,7 @@ function ago(iso: string) {
           />
         </div>
       </TransitionGroup>
-    </div>
+    </UCard>
   </div>
 </template>
 

--- a/packages/crouton-sales/app/components/Blocks/LiveDashboardRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/LiveDashboardRender.vue
@@ -34,25 +34,25 @@ const teamParam = computed(() => String(route.params.team || ''))
 <template>
   <div class="sales-live-dashboard-block">
     <!-- Editor didn't pick an event -->
-    <div
+    <UAlert
       v-if="!eventSlug"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-layout-dashboard" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.block.noEventPicked') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-layout-dashboard"
+      :title="t('sales.block.noEventPicked')"
+    />
 
     <!-- Team-members-only: anonymous visitors don't see mirrored data. -->
-    <div
+    <UAlert
       v-else-if="!loggedIn"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-lock" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.blocks.liveDashboard.ui.teamOnly') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-lock"
+      :title="t('sales.blocks.liveDashboard.ui.teamOnly')"
+    />
 
     <!-- Signed-in team member → the live dashboard. -->
-    <div v-else class="rounded-3xl bg-default p-6 space-y-6">
+    <UCard :ui="{ body: 'space-y-6' }">
       <Suspense>
         <SalesBlocksEventResolver
           v-slot="{ event }"
@@ -83,6 +83,6 @@ const teamParam = computed(() => String(route.params.team || ''))
           <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
         </template>
       </Suspense>
-    </div>
+    </UCard>
   </div>
 </template>

--- a/packages/crouton-sales/app/components/Blocks/OrdersRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/OrdersRender.vue
@@ -27,25 +27,25 @@ const eventSlug = computed(() => props.attrs.eventSlug || '')
 <template>
   <div class="sales-orders-block">
     <!-- Editor didn't pick an event -->
-    <div
+    <UAlert
       v-if="!eventSlug"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-receipt" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.block.noEventPicked') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-receipt"
+      :title="t('sales.block.noEventPicked')"
+    />
 
     <!-- Team-members-only tool: anonymous visitors don't see orders. -->
-    <div
+    <UAlert
       v-else-if="!loggedIn"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-lock" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.blocks.salesOrders.ui.teamOnly') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-lock"
+      :title="t('sales.blocks.salesOrders.ui.teamOnly')"
+    />
 
     <!-- Signed-in team member → the live orders list. -->
-    <div v-else class="rounded-3xl bg-default p-6">
+    <UCard>
       <Suspense>
         <SalesBlocksEventResolver
           v-slot="{ event }"
@@ -58,6 +58,6 @@ const eventSlug = computed(() => props.attrs.eventSlug || '')
           <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
         </template>
       </Suspense>
-    </div>
+    </UCard>
   </div>
 </template>

--- a/packages/crouton-sales/app/components/Blocks/PrintBridgeRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/PrintBridgeRender.vue
@@ -150,25 +150,25 @@ onUnmounted(() => {
 <template>
   <div class="print-bridge-block">
     <!-- Editor didn't pick an event -->
-    <div
+    <UAlert
       v-if="!eventSlug"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-printer" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.block.noEventPicked') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-printer"
+      :title="t('sales.block.noEventPicked')"
+    />
 
     <!-- Picked event no longer resolves -->
-    <div
+    <UAlert
       v-else-if="eventNotFound"
-      class="bg-muted/80 rounded-3xl border border-dashed border-default p-6 text-center text-sm text-muted"
-    >
-      <UIcon name="i-lucide-printer" class="w-6 h-6 mx-auto mb-2 text-muted" />
-      {{ t('sales.blocks.printBridge.ui.eventNotFound') }}
-    </div>
+      color="neutral"
+      variant="soft"
+      icon="i-lucide-printer"
+      :title="t('sales.blocks.printBridge.ui.eventNotFound')"
+    />
 
     <!-- The bridge -->
-    <div v-else class="rounded-3xl overflow-hidden bg-elevated/60 border border-default p-5">
+    <UCard>
       <header class="flex items-center justify-between mb-4">
         <div class="flex items-center gap-2">
           <UIcon name="i-lucide-printer" class="size-5 text-primary" />
@@ -225,7 +225,7 @@ onUnmounted(() => {
           </UButton>
         </div>
       </TransitionGroup>
-    </div>
+    </UCard>
   </div>
 </template>
 

--- a/packages/crouton-sales/app/components/Client/Cart.vue
+++ b/packages/crouton-sales/app/components/Client/Cart.vue
@@ -29,25 +29,29 @@
             :remark="entry.item.remarks"
           >
             <template #actions>
-              <!-- md: +/− are the most-tapped controls during an order — keep
-                   them thumb-sized on touch devices. -->
-              <UButton
-                icon="i-lucide-minus"
-                size="md"
-                color="neutral"
-                variant="soft"
-                square
-                @click="$emit('updateQuantity', entry.index, entry.item.quantity - 1)"
-              />
-              <span :key="entry.item.quantity" class="w-6 text-center text-sm animate-pop">{{ entry.item.quantity }}</span>
-              <UButton
-                icon="i-lucide-plus"
-                size="md"
-                color="neutral"
-                variant="soft"
-                square
-                @click="$emit('updateQuantity', entry.index, entry.item.quantity + 1)"
-              />
+              <!-- One grouped stepper (#1407): UFieldGroup joins −/qty/+ so
+                   themes style it as a single control. md: +/− are the
+                   most-tapped controls during an order — keep them thumb-sized
+                   on touch devices. -->
+              <UFieldGroup size="md">
+                <UButton
+                  icon="i-lucide-minus"
+                  color="neutral"
+                  variant="soft"
+                  square
+                  @click="$emit('updateQuantity', entry.index, entry.item.quantity - 1)"
+                />
+                <UBadge color="neutral" variant="soft" class="w-8 justify-center text-sm tabular-nums">
+                  <span :key="entry.item.quantity" class="animate-pop">{{ entry.item.quantity }}</span>
+                </UBadge>
+                <UButton
+                  icon="i-lucide-plus"
+                  color="neutral"
+                  variant="soft"
+                  square
+                  @click="$emit('updateQuantity', entry.index, entry.item.quantity + 1)"
+                />
+              </UFieldGroup>
             </template>
           </SalesClientOrderLineItem>
         </div>


### PR DESCRIPTION
Closes the remaining items (2, 3, 4) of the #1407 seam list from the owner's kassa/pages verification screenshots. Item 1 (cart warning UAlerts) landed with #1405.

## 👤 For humans
- The cart's +/− quantity buttons are now one grouped stepper control (UFieldGroup) themes style as a unit.
- The CMS block shells (kassa, orders, clients, live dashboard, KDS, print bridge) no longer draw hardcoded rounded-3xl corners — they're variant-less UCards, so sharp-chrome themes (riso, brutalist) finally reach them. The dashed "sign in / no event" placeholders are UAlerts.
- The pages sidebar's Concepten/reorder pills now follow the theme in their active state (they pinned stock variants before).

## 🤖 For agents
- `Client/Cart.vue`: −/qty/+ → `UFieldGroup(md)` [UButton soft · UBadge soft · UButton soft], `animate-pop` kept.
- `Blocks/*Render.vue` (+`EventResolver.vue`): content shells → variant-less `UCard`; 13 dashed placeholder divs → `UAlert` neutral soft (icon + title).
- `Workspace/Sidebar.vue`: toggle pills pass `undefined` color/variant when active (theme defaultVariants wins, #1304); inactive stays neutral ghost. `Workspace/Editor.vue`: SEO & social disclosure → UButton ghost.

## 🧪 How to test
1. Kassa (kassa.pmpc.dev after merge, or fanfare dev): add a product to the cart — the stepper is one joined − 1 + control; tapping updates qty + the Bestel total. Verified live on fanfare dev.
2. A CMS page with the kassa block under riso/brutalist: the block frame follows the theme's card chrome (no more giant round corners around sharp content).
3. Pages workspace: Concepten pill active = the theme's default button look; inactive = quiet ghost. Verified live.
4. `pnpm typecheck` green on all 3 apps.