### PR TITLE
Sales design tweaks + block-panel persistence fix

### DIFF
--- a/packages/crouton-editor/app/components/Blocks.vue
+++ b/packages/crouton-editor/app/components/Blocks.vue
@@ -264,6 +264,19 @@ function handleEditorCreate(event: { editor: Editor }) {
   emit('create', event)
 }
 
+// UEditor declares no `create`/`update` events (only update:modelValue), and
+// its internal useEditor options clobber a consumer-passed onCreate/onUpdate —
+// so @create above never fires. Capture the instance from UEditor's exposed
+// `editor` ref instead; the :key remount (collab extensions loading) swaps the
+// template ref, so this also re-captures the recreated editor.
+const ueditorRef = ref<{ editor?: Editor | null } | null>(null)
+watch(() => ueditorRef.value?.editor, (ed) => {
+  if (ed && ed !== editorInstance.value) {
+    handleEditorCreate({ editor: ed })
+    ed.on('update', () => handleEditorUpdate({ editor: ed }))
+  }
+})
+
 // Track selection changes to find selected block
 function handleEditorUpdate(event: { editor: Editor }) {
   const editor = event.editor
@@ -496,6 +509,7 @@ defineExpose({
     <!-- In collab mode, content syncs via Yjs, not v-model -->
     <!-- Key forces recreation when collab extensions load -->
     <UEditor
+      ref="ueditorRef"
       v-slot="{ editor, handlers }"
       :key="editorKey"
       v-model="(content as any)"

--- a/packages/crouton-editor/app/components/Blocks.vue
+++ b/packages/crouton-editor/app/components/Blocks.vue
@@ -269,11 +269,15 @@ function handleEditorCreate(event: { editor: Editor }) {
 // so @create above never fires. Capture the instance from UEditor's exposed
 // `editor` ref instead; the :key remount (collab extensions loading) swaps the
 // template ref, so this also re-captures the recreated editor.
-const ueditorRef = ref<{ editor?: Editor | null } | null>(null)
+const ueditorRef = ref<{ editor?: unknown } | null>(null)
 watch(() => ueditorRef.value?.editor, (ed) => {
-  if (ed && ed !== editorInstance.value) {
-    handleEditorCreate({ editor: ed })
-    ed.on('update', () => handleEditorUpdate({ editor: ed }))
+  // UEditor's exposed editor comes from @nuxt/ui's own tiptap type tree, which
+  // vue-tsc treats as structurally different from our @tiptap/vue-3 Editor —
+  // it's the same runtime object, so cast across the duplicate type identity.
+  const editor = ed as Editor | undefined
+  if (editor && editor !== editorInstance.value) {
+    handleEditorCreate({ editor })
+    editor.on('update', () => handleEditorUpdate({ editor }))
   }
 })
 

--- a/packages/crouton-editor/app/components/Simple.vue
+++ b/packages/crouton-editor/app/components/Simple.vue
@@ -202,6 +202,14 @@ async function handleImageUpload() {
   input.click()
 }
 
+// UEditor declares no `create` event (only update:modelValue) and its internal
+// useEditor options clobber a consumer-passed onCreate — @create below never
+// fires. Capture the instance from UEditor's exposed `editor` ref instead.
+const ueditorRef = ref<{ editor?: Editor | null } | null>(null)
+watch(() => ueditorRef.value?.editor, (ed) => {
+  if (ed && ed !== editorInstance.value) handleEditorCreate({ editor: ed })
+})
+
 // Handle paste/drop image upload
 function handleEditorCreate(event: { editor: Editor }) {
   editorInstance.value = event.editor
@@ -288,6 +296,7 @@ const bubbleToolbarItems: EditorToolbarItem[][] = [
 
 <template>
   <UEditor
+    ref="ueditorRef"
     v-slot="{ editor }"
     v-model="model"
     :content-type="contentType"

--- a/packages/crouton-editor/app/components/Simple.vue
+++ b/packages/crouton-editor/app/components/Simple.vue
@@ -205,9 +205,12 @@ async function handleImageUpload() {
 // UEditor declares no `create` event (only update:modelValue) and its internal
 // useEditor options clobber a consumer-passed onCreate — @create below never
 // fires. Capture the instance from UEditor's exposed `editor` ref instead.
-const ueditorRef = ref<{ editor?: Editor | null } | null>(null)
+const ueditorRef = ref<{ editor?: unknown } | null>(null)
 watch(() => ueditorRef.value?.editor, (ed) => {
-  if (ed && ed !== editorInstance.value) handleEditorCreate({ editor: ed })
+  // Same runtime object as our @tiptap/vue-3 Editor — cast across @nuxt/ui's
+  // duplicate tiptap type identity (vue-tsc sees them as different types).
+  const editor = ed as Editor | undefined
+  if (editor && editor !== editorInstance.value) handleEditorCreate({ editor })
 })
 
 // Handle paste/drop image upload

--- a/packages/crouton-pages/app/components/Blocks/Properties/ButtonRowEditor.vue
+++ b/packages/crouton-pages/app/components/Blocks/Properties/ButtonRowEditor.vue
@@ -194,7 +194,7 @@ function removeFile(index: number) {
 
       <!-- Mode toggle: Link / Download -->
       <div class="flex items-center gap-2">
-        <UButtonGroup size="xs" class="w-full">
+        <UFieldGroup size="xs" class="w-full">
           <UButton
             :color="!btn.download ? 'primary' : 'neutral'"
             :variant="!btn.download ? 'solid' : 'outline'"
@@ -211,7 +211,7 @@ function removeFile(index: number) {
             class="flex-1"
             @click="toggleDownloadMode(index, true)"
           />
-        </UButtonGroup>
+        </UFieldGroup>
       </div>
 
       <!-- Label -->
@@ -225,7 +225,7 @@ function removeFile(index: number) {
       <!-- Link mode: page picker or custom URL -->
       <template v-if="!btn.download">
         <!-- Sub-toggle: link to a CMS page vs a custom URL -->
-        <UButtonGroup size="xs" class="w-full">
+        <UFieldGroup size="xs" class="w-full">
           <UButton
             :color="linkMode(btn) === 'page' ? 'primary' : 'neutral'"
             :variant="linkMode(btn) === 'page' ? 'solid' : 'outline'"
@@ -242,7 +242,7 @@ function removeFile(index: number) {
             class="flex-1"
             @click="setLinkMode(index, 'url')"
           />
-        </UButtonGroup>
+        </UFieldGroup>
 
         <!-- Page mode: pick a page from the CMS -->
         <USelectMenu

--- a/packages/crouton-pages/app/components/Blocks/Properties/LogosEditor.vue
+++ b/packages/crouton-pages/app/components/Blocks/Properties/LogosEditor.vue
@@ -248,7 +248,7 @@ function getImageMode(index: number): string {
               class="drag-handle size-4 text-muted cursor-grab active:cursor-grabbing"
             />
             <!-- Type toggle buttons -->
-            <UButtonGroup size="xs">
+            <UFieldGroup size="xs">
               <UButton
                 :color="isIcon(item) ? 'primary' : 'neutral'"
                 :variant="isIcon(item) ? 'solid' : 'ghost'"
@@ -263,7 +263,7 @@ function getImageMode(index: number): string {
                 :label="t('pages.blocks.logos.typeImage')"
                 @click="!isIcon(item) ? undefined : switchItemType(index, 'image')"
               />
-            </UButtonGroup>
+            </UFieldGroup>
           </div>
 
           <!-- Delete -->

--- a/packages/crouton-sales/app/components/Blocks/ProductMatrixRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/ProductMatrixRender.vue
@@ -159,7 +159,7 @@ function downloadCsv() {
     <div class="flex items-center justify-between gap-2">
       <h3 v-if="attrs.title" class="min-w-0 truncate text-base @sm:text-lg font-semibold">{{ attrs.title }}</h3>
       <div class="ms-auto flex shrink-0 items-center gap-3">
-        <UButtonGroup size="sm">
+        <UFieldGroup size="sm">
           <UButton
             :color="measure === 'units' ? 'primary' : 'neutral'"
             :variant="measure === 'units' ? 'solid' : 'outline'"
@@ -178,7 +178,7 @@ function downloadCsv() {
           >
             <span class="hidden @sm:inline">{{ t('sales.block.revenue') }}</span>
           </UButton>
-        </UButtonGroup>
+        </UFieldGroup>
         <UButton
           size="sm"
           color="neutral"

--- a/packages/crouton-sales/app/components/Client/ProductList.vue
+++ b/packages/crouton-sales/app/components/Client/ProductList.vue
@@ -7,7 +7,7 @@
       v-for="product in orderedProducts"
       :key="product.id"
       variant="soft"
-      class="cursor-pointer group/card relative overflow-hidden"
+      class="cursor-pointer group/card relative overflow-hidden transition-colors duration-150 hover:bg-elevated"
       :class="product.isActive === false ? 'opacity-60' : ''"
       :ui="{ body: 'px-3 py-2 sm:px-3 sm:py-2' }"
       @click="handleProductClick(product)"
@@ -71,6 +71,7 @@
             size="md"
             square
             :icon="activeProductId === product.id ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+            class="group-hover/card:bg-accented/50 hover:bg-accented"
             @click.stop="toggleProduct(product)"
           />
           <UButton
@@ -79,7 +80,7 @@
             color="primary"
             size="md"
             square
-            class="active:scale-90 transition-transform"
+            class="active:scale-90 transition-[transform,background-color] group-hover/card:bg-primary/10 hover:bg-primary/20"
             @click.stop="addProduct(product)"
           >
             <UIcon


### PR DESCRIPTION
## 👤 For humans

Three small-but-real improvements from an interactive design session on the kassa:

1. **POS product rows get hover states** — the whole row is clickable, now it looks like it: card lifts, the + tints. Desktop only.
2. **Units/revenue toggle is a real segmented control again** — it was wrapped in `UButtonGroup`, which no longer exists in Nuxt UI v4 (renamed `UFieldGroup`), so the buttons rendered loose. Two crouton-pages property editors had the same dead wrapper.
3. **Block property panel changes actually persist now** — every "Klaar" in the pages block panel was silently discarded because `UEditor` never emits `@create` in Nuxt UI v4 (and clobbers a passed `onCreate`), so the editor wrapper never captured its TipTap instance. This also silently broke image paste-upload and AI translation in the simple editor. Verified end-to-end: panel change → Klaar → Opslaan → row in `pages_pages` carries the new attr.

## 🤖 For agents

- `crouton-sales/app/components/Client/ProductList.vue` — hover classes only (card `hover:bg-elevated`, + button `group-hover/card:bg-primary/10` / `hover:bg-primary/20`, chevron accented equivalents)
- `UButtonGroup` → `UFieldGroup`: `crouton-sales/.../Blocks/ProductMatrixRender.vue`, `crouton-pages/.../Blocks/Properties/{LogosEditor,ButtonRowEditor}.vue` — no other usages remain
- `crouton-editor/app/components/{Blocks,Simple}.vue` — capture instance via template ref on UEditor + watch of its exposed `editor`; Blocks re-wires update via `editor.on('update')`; `:key` collab remount re-captures. `@create`/`@update` bindings kept for forward compat.
- `pnpm typecheck` green across velo/triage/fanfare after each change set.

## 🧪 How to test

1. **Hover**: open the kassa (e.g. `/admin/<team>/sales/events/<event>`) on desktop; sweep the product list — rows elevate, + tints; on touch nothing changed.
2. **Toggle**: open the Data pane (or a `salesProductMatrixBlock`); the #/💳 pair renders as one joined control.
3. **Panel persistence**: Pagina's workspace → page with a block → Blok bewerken → change Blokgrootte → Klaar → reopen (value still there) → Opslaan → reload (still there).

Closes #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)