### PR TITLE
chore(root): record the zai/glm-5.2 routes in the routing registry (#1421)

### DIFF
--- a/.claude/routing.json
+++ b/.claude/routing.json
@@ -3,8 +3,8 @@
 
   "_tiers": "Each tier maps to a concrete model per harness. out_per_mtok is the Claude baseline output price ($/Mtok) — the cost lever; pi's cheaper/local equivalents are measured for real by the #865 eval loop, not assumed here. pi_local = the local (~$0) option on the Mac mini (informational; the generator reads `pi`).",
   "tiers": {
-    "small":  { "claude": "haiku",  "pi": "deepseek-v3.2", "pi_local": "ollama:qwen2.5-coder:7b", "out_per_mtok": 5,  "note": "reports / triage / decompose — no code written" },
-    "medium": { "claude": "sonnet", "pi": "deepseek-v3.2", "out_per_mtok": 15, "note": "most work" },
+    "small":  { "claude": "haiku",  "pi": "zai/glm-5.2", "pi_local": "ollama:qwen2.5-coder:7b", "out_per_mtok": 5,  "note": "reports / triage / decompose — no code written. pi tier MEASURED (#1409: beat the Haiku baseline on report fidelity at $0 marginal, flat GLM Coding Plan)" },
+    "medium": { "claude": "sonnet", "pi": "zai/glm-5.2", "out_per_mtok": 15, "note": "most work. pi tier MEASURED (#1421: autonomous code-writing eval — correct house-style PR, artifact-gate PASS, no #1019 stall, $0 marginal)" },
     "large":  { "claude": "opus",   "pi": "claude-opus-4-8", "out_per_mtok": 75, "note": "hard build / synthesis — quality-sensitive" }
   },
 
@@ -22,7 +22,8 @@
 
   "_overrides": "Per-flow exceptions that pin an exact model regardless of tier. This is where a one-off flow declares itself VISIBLY instead of burying the decision in a branch.",
   "overrides": [
-    { "flow": "prototype-example", "model": "claude-opus-4-8", "why": "exploratory prototype flow — quality over cost (replace with your real flow)" }
+    { "flow": "a11y-daily-pidev", "model": "zai/glm-5.2", "why": "#1409 eval: matched engine ground truth (153/152), beat the metered Haiku baseline (+28% overcount, $0.347/run) at $0 marginal on the flat GLM Coding Plan. Workflow default since #1413." },
+    { "flow": "decompose-on-issue-pidev", "model": "zai/glm-5.2", "why": "#1421 eval: autonomous code-writing run produced a correct house-style PR (#1434), artifact-gate PASS, no #1019 stall, $0 marginal. Owner-approved flip 2026-07-11; metered anthropic/sonnet lane stays selectable as baseline. Subscription auth never backs unattended CI — the zai flat plan is vendor-permitted for pi (officially whitelisted)." }
   ],
 
   "_known_gaps": "The top-level workflow loop (claude.yml, decompose-on-issue.yml, resume-on-comment, fix-ci-on-failure, a11y[-daily], frontend-review, red-team[-daily], gate-smoke, loop-station-advisor) is now PINNED to claude-sonnet-5 via `--model` in each step's claude_args (#1158, closing the earlier UNPINNED gap that let the action default to the older claude-sonnet-4-6). `--model` sets only the MAIN loop; Task-spawned sub-agents still resolve their own frontmatter model (task-worker = opus). OPEN: whether a sub-agent's `model: sonnet` frontmatter alias also resolves to sonnet-4-6 in the pinned action SHA — verify against a post-merge run's modelUsage and, if so, pin the full id in frontmatter too."

--- a/writeups/architecture/routing-registry.md
+++ b/writeups/architecture/routing-registry.md
@@ -6,8 +6,8 @@ The single view of **what runs on what model**. Source of truth: `.claude/routin
 demotion. `$out/Mtok` is the Claude baseline output price — the cost lever.
 
 ## Tiers
-- **small** — Claude `claude-haiku-4-5` · pi `deepseek-v3.2` · ~$5/Mtok out — reports / triage / decompose — no code written
-- **medium** — Claude `claude-sonnet-5` · pi `deepseek-v3.2` · ~$15/Mtok out — most work
+- **small** — Claude `claude-haiku-4-5` · pi `zai/glm-5.2` · ~$5/Mtok out — reports / triage / decompose — no code written. pi tier MEASURED (#1409: beat the Haiku baseline on report fidelity at $0 marginal, flat GLM Coding Plan)
+- **medium** — Claude `claude-sonnet-5` · pi `zai/glm-5.2` · ~$15/Mtok out — most work. pi tier MEASURED (#1421: autonomous code-writing eval — correct house-style PR, artifact-gate PASS, no #1019 stall, $0 marginal)
 - **large** — Claude `claude-opus-4-8` · pi `claude-opus-4-8` · ~$75/Mtok out — hard build / synthesis — quality-sensitive
 
 Default tier: **medium**
@@ -16,14 +16,15 @@ Default tier: **medium**
 | Agent / flow | Current tier | Claude model | pi / local | $out/Mtok | Proposed | Why |
 |---|---|---|---|---|---|---|
 | `task-worker` | large | claude-opus-4-8 | claude-opus-4-8 | $75 | — | writes code → PR; quality-sensitive — hold on Claude until #865 proves a cheaper model |
-| `task-orchestrator` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | — | reads epic → workstreams; no code written. Moved opus→Sonnet 5 on an N=4 decompose A/B (Sonnet 5 matched/beat Opus 4.8 on 3 of 4 real epics, ~5× cheaper, fewer NEEDS-SPLIT recursion rounds). Refines #824: the strong-but-cheaper model is a peer planner, not the blunt one that decision guarded against. |
-| `task-decomposer` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | — | LEAF test + split issues; no code written. Moved opus→Sonnet 5 with the orchestrator on the same N=4 A/B evidence. Refines #824. |
-| `red-team` | medium | claude-sonnet-5 | deepseek-v3.2 | $15 | — | security analysis, reports only — opus was overkill; moved to Sonnet 5 (no code written, daily deep sweep is the cost). Free win per #823/#824. |
-| `a11y` | small | claude-haiku-4-5 | deepseek-v3.2 | $5 | — | template review, reports only — Sonnet→Haiku (#1272/#823); reversible if the #865 scoreboard shows missed axe findings |
-| `frontend-review` | small | claude-haiku-4-5 | deepseek-v3.2 | $5 | — | convention review, reports only — Sonnet→Haiku (#1272/#823); reversible if it stops catching v3 names |
+| `task-orchestrator` | medium | claude-sonnet-5 | zai/glm-5.2 | $15 | — | reads epic → workstreams; no code written. Moved opus→Sonnet 5 on an N=4 decompose A/B (Sonnet 5 matched/beat Opus 4.8 on 3 of 4 real epics, ~5× cheaper, fewer NEEDS-SPLIT recursion rounds). Refines #824: the strong-but-cheaper model is a peer planner, not the blunt one that decision guarded against. |
+| `task-decomposer` | medium | claude-sonnet-5 | zai/glm-5.2 | $15 | — | LEAF test + split issues; no code written. Moved opus→Sonnet 5 with the orchestrator on the same N=4 A/B evidence. Refines #824. |
+| `red-team` | medium | claude-sonnet-5 | zai/glm-5.2 | $15 | — | security analysis, reports only — opus was overkill; moved to Sonnet 5 (no code written, daily deep sweep is the cost). Free win per #823/#824. |
+| `a11y` | small | claude-haiku-4-5 | zai/glm-5.2 | $5 | — | template review, reports only — Sonnet→Haiku (#1272/#823); reversible if the #865 scoreboard shows missed axe findings |
+| `frontend-review` | small | claude-haiku-4-5 | zai/glm-5.2 | $5 | — | convention review, reports only — Sonnet→Haiku (#1272/#823); reversible if it stops catching v3 names |
 
 ## Overrides (per-flow exact-model pins)
-- **prototype-example** → `claude-opus-4-8` — exploratory prototype flow — quality over cost (replace with your real flow)
+- **a11y-daily-pidev** → `zai/glm-5.2` — #1409 eval: matched engine ground truth (153/152), beat the metered Haiku baseline (+28% overcount, $0.347/run) at $0 marginal on the flat GLM Coding Plan. Workflow default since #1413.
+- **decompose-on-issue-pidev** → `zai/glm-5.2` — #1421 eval: autonomous code-writing run produced a correct house-style PR (#1434), artifact-gate PASS, no #1019 stall, $0 marginal. Owner-approved flip 2026-07-11; metered anthropic/sonnet lane stays selectable as baseline. Subscription auth never backs unattended CI — the zai flat plan is vendor-permitted for pi (officially whitelisted).
 
 ## Known gaps
 The top-level workflow loop (claude.yml, decompose-on-issue.yml, fix-ci, daily sweeps)


### PR DESCRIPTION
Part of #1421 (epic #669, WS6a registry #864).

## 👤 For humans

Records what is now true after the two GLM evals: the pi harness's small + medium tiers are **measured** at `zai/glm-5.2` (no longer assumed deepseek), and both live pi flows get explicit override pins with their evidence. The registry doc is regenerated; `gen-routing.mjs --check` is green.

## 🤖 For agents

- `.claude/routing.json`: `tiers.small.pi` + `tiers.medium.pi` → `zai/glm-5.2` (eval refs in notes); `overrides` placeholder replaced with `a11y-daily-pidev` + `decompose-on-issue-pidev` pins (evidence: #1409, #1421). Claude tiers/routes untouched.
- `writeups/architecture/routing-registry.md`: regenerated.

## 🧪 How to test

`node scripts/gen-routing.mjs --check` → green. Registry doc shows the two override rows with the zai/glm-5.2 model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
