### PR TITLE
feat(root): add pi-claude-bridge to the pi-box manifest (#1439)

### DIFF
--- a/scripts/pi-box/pi-config.manifest.json
+++ b/scripts/pi-box/pi-config.manifest.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "GitOps'd pi.dev box config (#1060). The mac-mini's pi setup as code: an opinionated installer pinned as the BASE, plus only OUR deltas + settings overrides on top — we do NOT re-vendor the installer's curated package list. Apply with `node scripts/pi-box/apply-pi-config.mjs` (--dry-run first). A base version bump is a deliberate, reviewed change here. Snapshot: 2026-07-11 from Maartens-Mac-mini.",
+  "$comment": "GitOps'd pi.dev box config (#1060). The mac-mini's pi setup as code: an opinionated installer pinned as the BASE, plus only OUR deltas + settings overrides on top — we do NOT re-vendor the installer's curated package list. Apply with `node scripts/pi-box/apply-pi-config.mjs` (--dry-run first). A base version bump is a deliberate, reviewed change here. Snapshot: 2026-07-11 from Maartens-Mac-mini. NB pi-claude-bridge (#1439) = the Claude-Max-subscription seat for INTERACTIVE/attended pi sessions ONLY (claude-bridge/* models + /ask-claude); it is deliberately NOT wired into subagents.agentOverrides — the CI runner shares this box+user, and a global override would let unattended CI burn subscription quota (ToS line). CI stays on zai/glm-5.2 + the metered key.",
   "pi": {
     "package": "@earendil-works/pi-coding-agent",
     "version": "0.80.6"
@@ -10,6 +10,7 @@
     "note": "Opinionated one-shot installer; lays down the 24-package curated baseline. Run via `npx @robzolkos/lazypi@<version>`. It overwrites ~/.pi/agent/settings.json (backing up the old), so our `add` + `settings` are re-layered AFTER it."
   },
   "add": [
+    "npm:pi-claude-bridge@0.6.2",
     "npm:pi-otel@0.1.0",
     "npm:@jademind/pi-telemetry@0.1.4",
     "git:github.com/supabitapp/supaterm-skills@5b17a56f0caf9ba9932ba624face75a81a1af560"


### PR DESCRIPTION
Part of #1439 (epic #669).

## 👤 For humans

Adds **pi-claude-bridge** to the mini's GitOps'd pi config: attended pi sessions get `claude-bridge/*` models (Opus 4.8, Sonnet 5, Fable 5) running on the existing **Claude Max subscription** — the official-CLI-subprocess pattern whose billing Anthropic formalized 2026-06-15 — plus the `/ask-claude` delegation tool. This is the reviewer seat of the routing intent: GLM does the work, Opus judges, at $0 marginal on both.

**Design decision (logged on #1439):** the bridge is deliberately **NOT** wired into `subagents.agentOverrides`. The CI runner runs as the same user on this box; a global reviewer→bridge override would let *unattended CI* burn subscription quota — the hard ToS line. Bridge use is explicit and interactive only (`/model claude-bridge/…` or `/ask-claude`). For the same reason no GLM overrides are set either: CI's session `--model` already governs, and a global override would contaminate the metered baseline lane.

Merging this PR **applies to the box automatically** (`pi-box-apply.yml` fires on manifest merges).

## 🤖 For agents

- `scripts/pi-box/pi-config.manifest.json`: `add[]` += `npm:pi-claude-bridge@0.6.2`; `$comment` documents the interactive-only rule. No settings changes.
- Post-merge human step (owner): one-time `claude` `/login` on the mini as `maarten` (browser OAuth → Max sub) — the bridge fails with "Not logged in" until then (verified: box has claude CLI 2.1.198, unauthenticated).

## 🧪 How to test

1. Merge → `pi-box-apply.yml` runs on the mini → `pi list` shows pi-claude-bridge.
2. On the mini (interactive, after `claude` login): `pi --list-models | grep claude-bridge` shows the models; `/ask-claude` is available in a session.
3. A bridge call ticks Claude Max usage, not the metered API console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
