### PR TITLE
chore(root): pi pipeline timeout headroom + poc label registry (#1459)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -144,6 +144,12 @@
 - name: "poc:notes"
   color: "fef2c0"
   description: "POC: pocs/notes"
+- name: "poc:snippets"
+  color: "fef2c0"
+  description: "POC: pocs/snippets"
+- name: "poc:pins"
+  color: "fef2c0"
+  description: "POC: pocs/pins"
 
 # ── Sandboxes (sandboxes/*) — throwaway, human-eyeball test apps (delete-after) ──
 # (none currently — minimal-theme-demo retired in #1306, superseded by

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -91,7 +91,7 @@ jobs:
       (vars.AGENT_HARNESS == 'pi' && github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'delegate') ||
       (vars.AGENT_HARNESS == 'pi' && github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate'))
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     # No `id-token` — pi uses a provider key, not OIDC. The write scopes are for the
     # Harness App token minted below, which pi uses to push/PR/comment.
     permissions:


### PR DESCRIPTION
Closes #1459 (epic #669 follow-up).

## 👤 For humans

Two pieces of drift from the GLM eval day, one commit each: the pi code-writing job gets timeout headroom (30→45 min — the #1421 run finished all real work then got marked `cancelled` during the post-run cache-save), and `poc:snippets`/`poc:pins` join the label registry (`poc:snippets` was minted ad-hoc for the eval leaf).

## 🧪 How to test

1. Next successful pi code-writing run reads `success`, not `cancelled`.
2. Post-merge label sync: `poc:pins` exists, housekeeping stops flagging both dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
