### PR TITLE
Workspace: settings pane + chrome-less kassa + bottom-left nav

### DIFF
--- a/packages/crouton-pages/app/components/Nav.vue
+++ b/packages/crouton-pages/app/components/Nav.vue
@@ -170,6 +170,12 @@ const adminDropdownItems = computed<DropdownMenuItem[][]>(() => {
 
 // Shared pill styles
 const pillClass = 'flex items-center gap-1 bg-muted/80 backdrop-blur-sm rounded-full border border-default shadow-lg shadow-neutral-950/5'
+
+// Full-screen pages (kassa and friends) own the whole viewport top — the
+// pills dock to the bottom-left corner there instead of reserving a top
+// strip. Same 'pageLayout' state the route publishes and the layout reads.
+const pageLayout = useState<'default' | 'full-height' | 'full-screen'>('pageLayout', () => 'default')
+const dockBottom = computed(() => pageLayout.value === 'full-screen')
 </script>
 
 <template>
@@ -177,7 +183,12 @@ const pillClass = 'flex items-center gap-1 bg-muted/80 backdrop-blur-sm rounded-
        line right under it (in portrait Safari the webview already starts
        below the status bar — env(safe-area-inset-top) is 0 there; the max()
        keeps it clear of the notch in standalone/PWA mode). -->
-  <div class="fixed top-[max(0.25rem,env(safe-area-inset-top))] sm:top-6 inset-x-0 z-50 px-4 sm:px-6 pointer-events-none [&>*]:pointer-events-auto">
+  <div
+    class="fixed z-50 pointer-events-none [&>*]:pointer-events-auto"
+    :class="dockBottom
+      ? 'bottom-[max(1rem,env(safe-area-inset-bottom))] left-4 sm:left-6'
+      : 'top-[max(0.25rem,env(safe-area-inset-top))] sm:top-6 inset-x-0 px-4 sm:px-6'"
+  >
     <!-- Loading state -->
     <template v-if="isLoading">
       <div class="relative flex items-center justify-center">
@@ -195,7 +206,7 @@ const pillClass = 'flex items-center gap-1 bg-muted/80 backdrop-blur-sm rounded-
     </template>
 
     <!-- Desktop layout -->
-    <div v-else-if="isDesktop" class="relative flex items-center" :class="showPageNav ? 'justify-center' : 'justify-end'">
+    <div v-else-if="isDesktop" class="relative flex items-center" :class="dockBottom ? 'gap-2' : (showPageNav ? 'justify-center' : 'justify-end')">
       <!-- Center pill: Page navigation (hidden when ≤1 page) -->
       <div v-if="showPageNav" :class="[pillClass, 'px-4']">
         <UNavigationMenu
@@ -211,7 +222,7 @@ const pillClass = 'flex items-center gap-1 bg-muted/80 backdrop-blur-sm rounded-
       </div>
 
       <!-- Right pill: User menu + language + dark mode (pinned right) -->
-      <div :class="[pillClass, 'px-2 py-1', showPageNav && 'absolute right-0']">
+      <div :class="[pillClass, 'px-2 py-1', showPageNav && !dockBottom && 'absolute right-0']">
         <ClientOnly>
           <template v-if="showAuthControls">
             <!-- Authenticated: Avatar dropdown -->
@@ -354,7 +365,7 @@ const pillClass = 'flex items-center gap-1 bg-muted/80 backdrop-blur-sm rounded-
       </div>
 
       <!-- Right pill: auth controls (unless the page hides them) + language + dark mode -->
-      <div :class="[pillClass, 'px-2 py-1', showPageNav && 'absolute right-0']">
+      <div :class="[pillClass, 'px-2 py-1', showPageNav && !dockBottom && 'absolute right-0']">
         <ClientOnly>
           <template v-if="showAuthControls">
             <!-- Authenticated: Avatar dropdown -->

--- a/packages/crouton-pages/app/layouts/public.vue
+++ b/packages/crouton-pages/app/layouts/public.vue
@@ -125,7 +125,7 @@ function applyLayoutClasses() {
       break
     case 'full-screen':
       container.className = 'bg-background min-h-screen'
-      main.className = 'pt-16'
+      main.className = 'pt-0'
       break
     default:
       container.className = 'bg-background min-h-screen'
@@ -161,7 +161,7 @@ const mainClasses = computed(() => {
     case 'full-height':
       return `flex-1 overflow-hidden ${pt} px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto w-full`
     case 'full-screen':
-      return 'pt-16'
+      return 'pt-0'
     default:
       return `max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 ${pt} pb-8`
   }

--- a/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
@@ -2,25 +2,24 @@
 /**
  * Event Workspace shell (reusable)
  *
- * Kassa-first: resolves an event from its slug, then renders the header
- * (event switcher + actions) above the POS, which is the main surface. No
- * tabs — the two former tabs became header-driven panels:
+ * Kassa-first: resolves an event from its slug, then renders the POS as the
+ * main (and only chrome-less) surface — there is NO header row. Everything
+ * else is a pane toggled from the vertical tabs in the right gutter (which
+ * also hosts the compact icon-only event switcher at its top):
  *
- *  - "Instellingen" expands the settings (SettingsTab) inline under the header
- *  - "Bestellingen" toggles the orders list (OrdersTab) as a pane beside
- *    the POS's products/cart columns
- *  - "Klanten" (recurring-clients mode only) toggles the client end-receipts
- *    list (ClientsPanel) as another pane
- *  - "Data" (admin sessions only — PIN helpers never see it) toggles the
- *    event's sales numbers (DataPanel) as a third pane — any combination can
- *    be open at once, side by side
+ *  - "Bestellingen" — the orders list (OrdersTab)
+ *  - "Klanten" (recurring-clients mode only) — client end-receipts (ClientsPanel)
+ *  - "Data" (admin sessions only — PIN helpers never see it) — sales numbers
+ *  - "Instellingen" (admin sessions only) — the tabbed SettingsTab, same
+ *    sectioned design as the narrow slideover; Opslaan in the pane header
+ *
+ * Any combination can be open at once, side by side.
  *
  * Used in two places:
  *  - the admin page `/admin/[team]/sales/events/[slug]`
  *  - the `eventWorkspaceBlock` CMS block, for signed-in team members only
- *    (event fixed by the editor, so the switcher is hidden; the header stays
- *    so the settings/orders toggles are reachable). Anonymous visitors get
- *    <SalesPosPanel> from the block instead — never this shell.
+ *    (event fixed by the editor, so the switcher is hidden). Anonymous
+ *    visitors get <SalesPosPanel> from the block instead — never this shell.
  *
  * @see app/pages/admin/[team]/sales/events/[slug]/index.vue
  * @see app/components/Blocks/EventWorkspaceRender.vue
@@ -126,11 +125,7 @@ const unhookMutation = useNuxtApp().hook('crouton:mutation', (payload: any) => {
 })
 onUnmounted(unhookMutation)
 
-// Header-driven panels. Local state — not worth query params, and the CMS
-// block (showHeaderActions=false) never exposes the toggles.
-const settingsOpen = ref(false)
-
-// SettingsTab's save API — the Save button lives in our header row. Handed up
+// SettingsTab's save API — the Save button lives in the pane header. Handed up
 // via the child's `register` emit: a template ref binds before an async-setup
 // component's defineExpose attaches, so it would stay a bare public proxy and
 // the button would never enable (#1321).
@@ -148,12 +143,14 @@ const settingsSaving = computed(() => settingsTab.value?.saving.value ?? false)
 const ordersOpen = useLocalStorage('sales-workspace-orders-open', false, { initOnMounted: true })
 const clientsOpen = useLocalStorage('sales-workspace-clients-open', false, { initOnMounted: true })
 const dataOpen = useLocalStorage('sales-workspace-data-open', false, { initOnMounted: true })
+const settingsOpen = useLocalStorage('sales-workspace-settings-open', false, { initOnMounted: true })
 
 // The stored flags are global, but the clients pane only exists in
-// recurring-clients mode and the data pane only for admin sessions — gate
-// the persisted values per event/session.
+// recurring-clients mode and the data/settings panes only for admin sessions —
+// gate the persisted values per event/session.
 const clientsPaneOpen = computed(() => clientsOpen.value && !!event.value?.requiresClient)
 const dataPaneOpen = computed(() => dataOpen.value && loggedIn.value)
+const settingsPaneOpen = computed(() => settingsOpen.value && loggedIn.value && props.showHeaderActions)
 
 // Narrow screens can't host side-by-side panes — the splitter would squeeze
 // the kassa to nothing. Below lg the panes become slideovers instead, toggled
@@ -173,16 +170,9 @@ const dataSlideoverOpen = ref(false)
 
 onMounted(() => { hydrated.value = true })
 
-// Settings follow the same split: inline collapsible under the header on
-// desktop, but a slideover on narrow screens — the inline panel's nested
-// containers eat too much of a phone viewport. One toggle, two surfaces.
+// Settings follow the same split as the other panes: a splitter pane (tabbed
+// SettingsTab) on desktop, a slideover on narrow screens.
 const settingsSlideoverOpen = ref(false)
-const settingsToggled = computed(() => isNarrow.value ? settingsSlideoverOpen.value : settingsOpen.value)
-
-function toggleSettings() {
-  if (isNarrow.value) settingsSlideoverOpen.value = !settingsSlideoverOpen.value
-  else settingsOpen.value = !settingsOpen.value
-}
 
 // Kassa edit mode, lifted so the narrow tab strip can host the pencil (the
 // inline pencil in the kassa's category-tabs row is hidden on narrow via
@@ -197,6 +187,8 @@ const hasGutter = computed(() =>
     !ordersOpen.value
     || (!!event.value?.requiresClient && !clientsPaneOpen.value)
     || (loggedIn.value && !dataPaneOpen.value)
+    || (loggedIn.value && props.showHeaderActions && !settingsPaneOpen.value)
+    || (props.showHeader && props.showSwitcher)
   )
 )
 
@@ -215,105 +207,10 @@ const ordersFilterCount = ref(0)
   </div>
 
   <div v-else class="space-y-4">
-    <!-- Header + settings: one bordered container. The header row (event
-         switcher, settings toggle right beside it, Save on the right while
-         open) stays visible; the settings slide open underneath, inside the
-         same panel. Same right gutter as the kassa when a vertical tab hangs
-         there, so the container aligns with the kassa edge, not the gutter. -->
-    <!-- Desktop only — on narrow the strip below carries the switcher and
-         toggles, and the event name is already where you came from (events
-         list) plus the page title. -->
-    <div v-if="showHeader && !isNarrow" :class="hasGutter ? 'pe-11' : ''">
-      <div class="border border-default rounded-xl bg-elevated/20">
-        <div class="flex flex-wrap items-center gap-2 p-3 sm:p-4">
-          <USelectMenu
-            v-if="showSwitcher"
-            :model-value="event.id"
-            :items="eventOptions"
-            value-key="id"
-            :placeholder="t('sales.events.selectEvent')"
-            icon="i-lucide-ticket"
-            size="sm"
-            class="w-56"
-            :ui="{ base: 'font-semibold' }"
-            @update:model-value="switchEvent"
-          >
-            <!-- Create-from-dropdown, same pattern as CroutonFormReferenceSelect -->
-            <template #content-top>
-              <div class="p-1">
-                <UButton
-                  color="neutral"
-                  icon="i-lucide-plus"
-                  variant="soft"
-                  block
-                  @click="openCreateEvent"
-                >
-                  {{ t('reference.createNew', { label: t('sales.events.title') }) }}
-                </UButton>
-              </div>
-            </template>
-          </USelectMenu>
-          <h2 v-else class="font-semibold text-lg">{{ event.title }}</h2>
-          <!-- Desktop only — on narrow the toggle lives in the tab strip. -->
-          <UButton
-            v-if="showHeaderActions && !isNarrow"
-            icon="i-lucide-settings"
-            size="sm"
-            color="neutral"
-            :variant="settingsToggled ? 'solid' : 'outline'"
-            @click="toggleSettings"
-          >
-            {{ t('sales.events.settings') }}
-          </UButton>
-          <p v-if="event.eventType" class="text-muted text-sm ms-2">
-            {{ event.eventType }}
-          </p>
-          <!-- Panel-wide Save, hosted here so it shares the header line.
-               Drives the { save, dirty, saving } API SettingsTab registers. -->
-          <div v-if="settingsOpen && !isNarrow" class="ms-auto flex items-center gap-3">
-            <span v-if="settingsDirty" class="text-sm text-muted hidden sm:inline">
-              {{ t('sales.workspace.unsavedChanges') }}
-            </span>
-            <UButton
-              size="sm"
-              :loading="settingsSaving"
-              :disabled="!settingsDirty"
-              @click="settingsTab?.save()"
-            >
-              {{ t('sales.common.save') }}
-            </UButton>
-          </div>
-          <!-- Fullscreen-modal exit (closable) — the wide-viewport twin of the
-               strip's ✕, for a modal resized past the narrow breakpoint. -->
-          <UButton
-            v-if="closable"
-            icon="i-lucide-x"
-            size="sm"
-            color="neutral"
-            variant="ghost"
-            :class="settingsOpen ? '' : 'ms-auto'"
-            :aria-label="t('sales.common.close')"
-            @click="emit('close')"
-          />
-        </div>
-
-        <!-- Own Suspense — SettingsTab is an async-setup component. Desktop
-             only: narrow screens get the settings slideover below instead
-             (never both, so only one instance registers its save API). -->
-        <UCollapsible :open="settingsOpen && !isNarrow">
-          <template #content>
-            <div class="p-4 sm:p-6 pt-1">
-              <Suspense>
-                <SalesEventWorkspaceSettingsTab :event="event" hide-save-bar @register="settingsTab = $event" />
-                <template #fallback>
-                  <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
-                </template>
-              </Suspense>
-            </div>
-          </template>
-        </UCollapsible>
-      </div>
-    </div>
+    <!-- No desktop header row anymore: the event switcher moved into the
+         gutter, settings became a pane like orders/data, and the kassa is the
+         page — the event name lives in the switcher and the page you came
+         from. -->
 
     <!-- Narrow screens: the side panes can't fit beside the kassa, so they
          open as slideovers from this row. Styled as a segmented tab strip
@@ -393,7 +290,7 @@ const ordersFilterCount = ref(0)
         :variant="settingsSlideoverOpen ? 'solid' : 'ghost'"
         class="shrink-0 justify-center"
         :aria-label="t('sales.events.settings')"
-        @click="toggleSettings"
+        @click="settingsSlideoverOpen = true"
       />
       <!-- Kassa edit-mode pencil, lifted out of the category-tabs row on
            narrow screens (hide-edit-toggle on the POS below). -->
@@ -427,21 +324,25 @@ const ordersFilterCount = ref(0)
          kassa's right edge (reserved gutter via pe-11, so they never
          overflow the page). -->
     <div class="relative" :class="hasGutter ? 'pe-11' : ''">
-    <div class="flex border border-default rounded-xl overflow-clip bg-default h-[calc(100dvh-13rem)] min-h-[28rem]">
+    <!-- Height budget: the desktop header row is gone, so the kassa reclaims
+         its ~4.5rem (13rem → 8.5rem of surrounding chrome). -->
+    <div class="flex border border-default rounded-xl overflow-clip bg-default h-[calc(100dvh-8.5rem)] min-h-[28rem]">
       <SplitterGroup
         direction="horizontal"
         auto-save-id="sales-workspace-pos"
         class="flex flex-1 min-w-0"
       >
         <SplitterPanel id="pos" :order="1" :min-size="35" class="min-w-0">
-          <!-- No panel header: the workspace header above already names the
-               event (the standalone order page keeps it). -->
+          <!-- No panel header: the event is named by the gutter switcher (the
+               standalone order page keeps its own). closable: with no desktop
+               header row, the kassa's category row hosts the modal exit
+               everywhere except when the narrow strip already carries one. -->
           <SalesPosPanel
             :event-slug="event.slug"
             :team-param="teamParam"
             :show-header="false"
             :hide-edit-toggle="isNarrow && showStrip"
-            :closable="closable && isNarrow && !showStrip"
+            :closable="closable && !(isNarrow && showStrip)"
             v-model:edit-mode="kassaEditMode"
             @close="emit('close')"
           />
@@ -513,6 +414,40 @@ const ordersFilterCount = ref(0)
             </div>
           </SplitterPanel>
         </template>
+        <template v-if="settingsPaneOpen && !isNarrow">
+          <SplitterResizeHandle
+            class="w-1 shrink-0 bg-accented hover:bg-primary/60 data-[state=drag]:bg-primary transition-colors"
+          />
+          <!-- Settings pane hosts the tabbed (sectioned) SettingsTab — the
+               pane is never wide enough for the old 3-column layout, so the
+               narrow-mode design is the design. Opslaan lives in the pane
+               header, driven by the registered save API; the narrow slideover
+               is gated on isNarrow so only one instance ever registers. -->
+          <SplitterPanel id="settings" :order="5" :default-size="30" :min-size="20" class="min-w-0 flex flex-col">
+            <SalesEventWorkspacePaneHeader
+              icon="i-lucide-settings"
+              :title="t('sales.events.settings')"
+              @close="settingsOpen = false"
+            >
+              <UButton
+                size="xs"
+                :loading="settingsSaving"
+                :disabled="!settingsDirty"
+                @click="settingsTab?.save()"
+              >
+                {{ t('sales.common.save') }}
+              </UButton>
+            </SalesEventWorkspacePaneHeader>
+            <div class="flex-1 overflow-y-auto p-4 pt-3">
+              <Suspense>
+                <SalesEventWorkspaceSettingsTab :event="event" hide-save-bar tabbed @register="settingsTab = $event" />
+                <template #fallback>
+                  <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
+                </template>
+              </Suspense>
+            </div>
+          </SplitterPanel>
+        </template>
       </SplitterGroup>
 
     </div>
@@ -526,6 +461,41 @@ const ordersFilterCount = ref(0)
       v-if="hasGutter"
       class="absolute top-14 left-[calc(100%-2.75rem)] -ml-px flex flex-col gap-2"
     >
+      <!-- Compact event switcher (icon-only): the desktop header row is gone,
+           so switching/creating events lives at the top of the gutter — same
+           items + create-event #content-top as the narrow strip's switcher. -->
+      <USelectMenu
+        v-if="showHeader && showSwitcher"
+        :model-value="event.id"
+        :items="eventOptions"
+        value-key="id"
+        icon="i-lucide-ticket"
+        size="sm"
+        color="neutral"
+        variant="ghost"
+        class="shrink-0 justify-center rounded-none rounded-e-md border border-l-0 border-default
+               bg-elevated/60 hover:bg-elevated text-muted hover:text-highlighted py-3"
+        :ui="{ base: 'px-1.5', trailingIcon: 'hidden' }"
+        :aria-label="t('sales.events.selectEvent')"
+        @update:model-value="switchEvent"
+      >
+        <template #default>
+          <span class="sr-only">{{ event.title }}</span>
+        </template>
+        <template #content-top>
+          <div class="p-1">
+            <UButton
+              color="neutral"
+              icon="i-lucide-plus"
+              variant="soft"
+              block
+              @click="openCreateEvent"
+            >
+              {{ t('reference.createNew', { label: t('sales.events.title') }) }}
+            </UButton>
+          </div>
+        </template>
+      </USelectMenu>
       <UButton
         v-if="!ordersOpen"
         color="neutral"
@@ -569,6 +539,21 @@ const ordersFilterCount = ref(0)
         <UIcon name="i-lucide-chart-line" class="size-4 shrink-0" />
         <span class="[writing-mode:vertical-rl] text-sm font-medium tracking-wide">
           {{ t('sales.workspace.dataPanel.button') }}
+        </span>
+      </UButton>
+      <UButton
+        v-if="loggedIn && showHeaderActions && !settingsOpen"
+        color="neutral"
+        variant="soft"
+        class="flex-col items-center gap-1.5 px-1.5 py-3 rounded-none rounded-e-md
+               border border-l-0 border-default bg-elevated/60 hover:bg-elevated
+               text-muted hover:text-highlighted"
+        :aria-label="t('sales.events.settings')"
+        @click="settingsOpen = true"
+      >
+        <UIcon name="i-lucide-settings" class="size-4 shrink-0" />
+        <span class="[writing-mode:vertical-rl] text-sm font-medium tracking-wide">
+          {{ t('sales.events.settings') }}
         </span>
       </UButton>
     </div>


### PR DESCRIPTION
Reincarnation of #1442 — GitHub closed it (instead of retargeting) when its stacked base branch was deleted on #1432's merge. Same two commits, now against main; all checks were green on #1442.

## 👤 For humans

The kassa becomes the whole page:

1. **Instellingen is a pane** like Bestellingen/Data — gutter tab → resizable pane hosting the sectioned (mobile-design) settings, Opslaan in the pane header.
2. **No more desktop header row** — event title gone, the compact icon-only event switcher (incl. create-event) moved to the top of the gutter, kassa reclaims the ~4.5rem.
3. **Full-screen pages dock the floating nav bottom-left** — the top strip is released, so the kassa starts at the very top of the viewport. Normal pages keep the top pills.

## 🤖 For agents

- `crouton-sales/app/components/EventWorkspace/Shell.vue` — settingsOpen → persisted localStorage toggle; new `SplitterPanel id="settings"` (order 5) with `SettingsTab tabbed hide-save-bar` + registered save API; header block deleted; gutter: event switcher + settings tab; `hasGutter` extended; `closable` exit on the kassa category row for non-strip hosts; height `13rem → 8.5rem`. Narrow strip/slideovers unchanged.
- `crouton-pages/app/components/Nav.vue` — `dockBottom = pageLayout === 'full-screen'`: wrapper flips to bottom/left, right pills drop `absolute right-0`.
- `crouton-pages/app/layouts/public.vue` — full-screen `pt-16 → pt-0` (SSR string + applyLayoutClasses copy).

## 🧪 How to test

1. `/admin/<team>/sales/events/<slug>` desktop: no header; gutter = event icon + Bestellingen/Data/Instellingen. Open Instellingen → sectioned settings pane; edit → Opslaan enables; save persists; state survives reload.
2. Below 1024px: segmented strip + slideovers as before.
3. Public full-screen kassa page: content flush with the viewport top; avatar/gear/color-mode pill bottom-left; regular pages keep top pills.

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)