### PR TITLE
Kassa polish: cart pane surface + settings row wrapping

### DIFF
--- a/packages/crouton-sales/app/components/Client/Cart.vue
+++ b/packages/crouton-sales/app/components/Client/Cart.vue
@@ -2,7 +2,11 @@
   <!-- Footer stays compact (space-y-3, py-3) — in the mobile drawer every
        saved pixel goes to the scrollable line-item area above it. The total
        rides the order button; remark + staff share one row. -->
-  <UCard class="flex flex-col h-full" :ui="{ root: 'rounded-none', body: 'flex-1 overflow-y-auto px-3 sm:px-3', footer: 'space-y-3 px-3 sm:px-3 py-3 sm:py-3' }">
+  <!-- ring-0 + bg-transparent: the cart is a filled pane, not a floating
+       card — its container owns the edges and the background tint. The
+       default ring doubled every border it touched (input row above, pane
+       edge, module bottom). -->
+  <UCard class="flex flex-col h-full" :ui="{ root: 'rounded-none ring-0 bg-transparent', body: 'flex-1 overflow-y-auto px-3 sm:px-3', footer: 'space-y-3 px-3 sm:px-3 py-3 sm:py-3' }">
     <!-- Cart items -->
     <div v-if="items.length === 0" class="h-full flex flex-col items-center justify-center gap-3 text-muted">
       <UIcon name="i-lucide-shopping-cart" class="size-10 opacity-40" />

--- a/packages/crouton-sales/app/components/Client/OrderInterface.vue
+++ b/packages/crouton-sales/app/components/Client/OrderInterface.vue
@@ -92,8 +92,10 @@
           </div>
         </div>
 
-        <!-- Cart sidebar (wide panes only) -->
-        <div class="hidden @2xl:flex w-80 border-l border-default flex-col">
+        <!-- Cart sidebar (wide panes only). bg-elevated/40 tints the whole
+             order column (name row + cart) so it reads as its own surface in
+             every theme — semantic token, so themes restyle it for free. -->
+        <div class="hidden @2xl:flex w-80 border-l border-default flex-col bg-elevated/40">
           <!-- h-14 matches the category-tabs row so both bottom borders align.
                Every order needs a client indication on the ticket: reusable
                clients when the event requires them, otherwise a plain

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
@@ -461,51 +461,53 @@ function helperExpiry(value: string): string {
 
           <USeparator />
 
-          <!-- Client selection: switch row, trailing edge aligned with the label line. -->
-          <div class="flex items-start justify-between gap-3">
-            <div class="space-y-1">
+          <!-- Explained rows: label + action share the top line, the
+               description gets the full card width underneath — a side
+               column squeezes into one-word lines in the narrow settings
+               pane. -->
+          <div class="space-y-1">
+            <div class="flex items-center justify-between gap-3">
               <p class="text-sm font-medium leading-5">{{ t('sales.workspace.requiresClient') }}</p>
-              <p class="text-sm text-muted">{{ t('sales.workspace.requiresClientDesc') }}</p>
+              <USwitch
+                v-model="eventForm.requiresClient"
+                :aria-label="t('sales.workspace.requiresClient')"
+              />
             </div>
-            <USwitch
-              v-model="eventForm.requiresClient"
-              :aria-label="t('sales.workspace.requiresClient')"
-              class="mt-0.5"
-            />
+            <p class="text-sm text-muted">{{ t('sales.workspace.requiresClientDesc') }}</p>
           </div>
 
           <USeparator />
 
           <!-- Event-level actions as explained rows (moved out of the header). -->
-          <div class="flex items-start justify-between gap-3">
-            <div class="space-y-1">
+          <div class="space-y-1">
+            <div class="flex items-center justify-between gap-3">
               <p class="text-sm font-medium leading-5">{{ t('sales.workspace.duplicateEvent') }}</p>
-              <p class="text-sm text-muted">{{ t('sales.workspace.duplicateEventDesc') }}</p>
+              <UButton
+                size="xs"
+                variant="outline"
+                color="neutral"
+                icon="i-lucide-copy"
+                :loading="duplicating"
+                class="shrink-0"
+                @click="duplicateEvent"
+              >
+                {{ t('sales.events.duplicate') }}
+              </UButton>
             </div>
-            <UButton
-              size="xs"
-              variant="outline"
-              color="neutral"
-              icon="i-lucide-copy"
-              :loading="duplicating"
-              class="shrink-0 mt-0.5"
-              @click="duplicateEvent"
-            >
-              {{ t('sales.events.duplicate') }}
-            </UButton>
+            <p class="text-sm text-muted">{{ t('sales.workspace.duplicateEventDesc') }}</p>
           </div>
 
-          <div class="flex items-start justify-between gap-3">
-            <div class="space-y-1">
+          <div class="space-y-1">
+            <div class="flex items-center justify-between gap-3">
               <p class="text-sm font-medium leading-5">{{ t('sales.workspace.deleteEvent') }}</p>
-              <p class="text-sm text-muted">{{ t('sales.workspace.deleteEventDesc') }}</p>
+              <CroutonDeleteButton
+                expanded
+                class="shrink-0"
+                :loading="deletingEvent"
+                @confirm="deleteEvent"
+              />
             </div>
-            <CroutonDeleteButton
-              expanded
-              class="shrink-0 mt-0.5"
-              :loading="deletingEvent"
-              @confirm="deleteEvent"
-            />
+            <p class="text-sm text-muted">{{ t('sales.workspace.deleteEventDesc') }}</p>
           </div>
         </div>
       </UCard>


### PR DESCRIPTION
## 👤 For humans

Two paper cuts from the live design session:

1. **Cart pane gets its own surface, double lines gone** — the cart card's default ring doubled every border it touched (name-input row, pane edge, module bottom), glaring in ink-border themes. The card is now edge-less and transparent; the order column carries a subtle `bg-elevated/40` tint — semantic token, so every theme restyles it for free.
2. **Settings rows keep full-width descriptions** — the switch/duplicate/delete rows no longer squeeze their explanation text into a one-word column beside the action; label + action share the top line, description spans the card. Matters most in the new settings pane (#1462), already helps the narrow slideover.

Verified live on fanfare dev at wide + pane widths (screenshots in session).

## 🤖 For agents
- `Client/Cart.vue` — UCard ui root += `ring-0 bg-transparent`
- `Client/OrderInterface.vue` — cart sidebar column += `bg-elevated/40`
- `EventWorkspace/SettingsTab.vue` — explained rows restructured to stacked layout; no logic changes

## 🧪 How to test
1. Kassa wide: order column tinted, single borders around it (input row, pane edge, under Bestel)
2. Instellingen (pane or narrow slideover): Terugkerende klanten / dupliceren / verwijderen rows show full-width descriptions

Closes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
