### PR TITLE
Kassa: live Data pane + full-screen height fit

### DIFF
--- a/packages/crouton-sales/app/components/Blocks/EventWorkspaceRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/EventWorkspaceRender.vue
@@ -85,16 +85,15 @@ function openPane(pane: 'orders' | 'clients' | 'data' | 'settings') {
     />
 
     <!-- Wide-screen team member → the full workspace inline (event fixed, no
-         switcher). Variant-less UCard (#1407): the theme's card chrome frames
-         the block instead of a hardcoded rounded-3xl shell. -->
-    <UCard v-else-if="showInlineShell">
-      <Suspense>
-        <SalesEventWorkspaceShell :event-slug="eventSlug" :show-switcher="false" />
-        <template #fallback>
-          <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
-        </template>
-      </Suspense>
-    </UCard>
+         switcher). Bare — the shell's kassa module draws its own border, so a
+         card wrapper doubled the frame (card border + module border) and its
+         body padding ate kassa height. -->
+    <Suspense v-else-if="showInlineShell">
+      <SalesEventWorkspaceShell :event-slug="eventSlug" :show-switcher="false" />
+      <template #fallback>
+        <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
+      </template>
+    </Suspense>
 
     <!-- Otherwise → "Open kassa" launcher + fullscreen modal. Two cases: a
          member on a narrow screen (modal hosts the full workspace shell), or an

--- a/packages/crouton-sales/app/components/Blocks/ProductMatrixRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/ProductMatrixRender.vue
@@ -60,6 +60,16 @@ async function load() {
 onMounted(load)
 watch(() => props.attrs.eventScope, load)
 
+// Live beside the kassa (Data pane): checkout emits the salesOrders mutation
+// hook, so a fresh order re-pivots the table — otherwise it only loaded on
+// mount while the summary tiles above it poll. Harmless on public CMS pages
+// (no admin mutations fire there).
+const unhookMutation = useNuxtApp().hook('crouton:mutation', (payload: any) => {
+  if (payload.collection !== 'salesOrders') return
+  load()
+})
+onUnmounted(unhookMutation)
+
 function fmt(n: number) {
   return measure.value === 'revenue' ? n.toFixed(2) : String(Math.round(n))
 }

--- a/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
@@ -32,6 +32,15 @@ const hasCharts = computed(() => hasApp('charts'))
 // {teamId} in the apiPath itself; per-event scope goes as a query param.
 const revenueKind = SALES_CHART_KINDS['revenue-by-day']!
 const chartQuery = computed(() => ({ eventId: props.event.id }))
+
+// Checkout (right beside this pane) emits the salesOrders mutation hook —
+// remount the chart widget so it refetches; it has no refresh API of its own.
+// The matrix below handles the same hook internally.
+const chartRefreshKey = ref(0)
+const unhookMutation = useNuxtApp().hook('crouton:mutation', (payload: any) => {
+  if (payload.collection === 'salesOrders') chartRefreshKey.value++
+})
+onUnmounted(unhookMutation)
 </script>
 
 <template>
@@ -46,6 +55,7 @@ const chartQuery = computed(() => ({ eventId: props.event.id }))
     <!-- Revenue over time — only with the charts package installed -->
     <div v-if="hasCharts" class="rounded-2xl border border-default bg-elevated/40 p-4">
       <LazyCroutonChartsWidget
+        :key="chartRefreshKey"
         :api-path="revenueKind.apiPath"
         :type="revenueKind.type"
         :x-field="revenueKind.xField"

--- a/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
@@ -196,6 +196,22 @@ const hasGutter = computed(() =>
 // selects live in OrdersTab — state is lifted here, count feeds the chip.
 const ordersFiltersOpen = ref(false)
 const ordersFilterCount = ref(0)
+
+// Kassa height: fill the viewport from wherever the module actually starts —
+// hosts differ wildly (admin page with navbar, chrome-less full-screen CMS
+// page, fullscreen modal), so a hardcoded budget always wastes space in one
+// of them. Measured after mount (SSR falls back to the class budget below);
+// 1rem breathing room at the bottom.
+const kassaRef = ref<HTMLElement | null>(null)
+const kassaTop = ref<number | null>(null)
+function measureKassaTop() {
+  if (kassaRef.value) kassaTop.value = Math.max(0, Math.round(kassaRef.value.getBoundingClientRect().top))
+}
+onMounted(() => nextTick(measureKassaTop))
+useEventListener('resize', measureKassaTop)
+const kassaHeightStyle = computed(() =>
+  kassaTop.value === null ? undefined : { height: `calc(100dvh - ${kassaTop.value}px - 1rem)` }
+)
 </script>
 
 <template>
@@ -324,9 +340,14 @@ const ordersFilterCount = ref(0)
          kassa's right edge (reserved gutter via pe-11, so they never
          overflow the page). -->
     <div class="relative" :class="hasGutter ? 'pe-11' : ''">
-    <!-- Height budget: the desktop header row is gone, so the kassa reclaims
-         its ~4.5rem (13rem → 8.5rem of surrounding chrome). -->
-    <div class="flex border border-default rounded-xl overflow-clip bg-default h-[calc(100dvh-8.5rem)] min-h-[28rem]">
+    <!-- Height: measured to fill the viewport from the module's real top
+         (kassaHeightStyle); the class budget is only the SSR/first-paint
+         fallback before the measurement lands. -->
+    <div
+      ref="kassaRef"
+      class="flex border border-default rounded-xl overflow-clip bg-default h-[calc(100dvh-8.5rem)] min-h-[28rem]"
+      :style="kassaHeightStyle"
+    >
       <SplitterGroup
         direction="horizontal"
         auto-save-id="sales-workspace-pos"


### PR DESCRIPTION
## 👤 For humans

Two fixes you caught in the live kassa (rebased onto current `main`, so it sits cleanly on top of the talk-to-order work that landed meanwhile):

1. **Data pane went stale** — the product × day matrix and revenue chart only loaded once; placing an order beside them left the totals frozen while the summary tiles kept polling. They now refresh on the `salesOrders` mutation hook checkout already fires.
2. **Full-screen kassa didn't fill the page** — the inline workspace block sat inside a themed `UCard`, which doubled the frame (3px card border around the module's own 1px border in ink themes) and ate height; plus the height was a hardcoded budget that left a ~117px dead gap on chrome-less pages. The card is gone and the module now measures its own top and fills to 1rem above the viewport bottom, in every host.

Verified live on fanfare dev: admin route (top 112px) and public full-screen page (top 0), both filling to a 16px bottom gap with no page scroll.

## 🤖 For agents
- `Blocks/ProductMatrixRender.vue` — reload on `crouton:mutation` (salesOrders)
- `EventWorkspace/DataPanel.vue` — same hook bumps a `:key` on `LazyCroutonChartsWidget` (no refresh API)
- `Blocks/EventWorkspaceRender.vue` — inline member shell rendered bare (Suspense only; UCard removed)
- `EventWorkspace/Shell.vue` — kassa module height = `100dvh - measuredTop - 1rem` (getBoundingClientRect after mount + on resize); old class budget kept as SSR fallback

## 🧪 How to test
1. Data pane open → place an order in the kassa → matrix rows/totals + revenue chart update within a second
2. Full-screen kassa page → single border, fills to ~1rem above the bottom; admin route → same fill below the navbar, no page scroll

Closes #1466
Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)