### PR TITLE
feat(crouton-themes): second-tier coverage — calendar, slider, color picker (#1458)

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -525,6 +525,46 @@ Two mechanisms, chosen by whether the component has a `variant` dimension:
    Toasts require the app to be wrapped in `<UApp>` (hosts the Toaster) — the
    playground got this in #1393.
 
+## Second-tier coverage (#1458)
+
+The rarer components, themed **only where a real app consumes them** — a
+grep-confirmed consumer or a documented skip, never CSS on a component nothing
+uses. The split (verified 2026-07-11):
+
+- **Themed** — the three with real consumers, via the same two mechanics above:
+  - **UCalendar** (crouton-core `Calendar.vue`, crouton-bookings `Calendar.vue`)
+    — a **named variant** (`<p>-cal-{heading,head,cell}`) on the
+    `headingLabel`/`headCell`/`cellTrigger` slots (all three carry markers +
+    the replacer, because the `color` dimension fires on `headCell`/`cellTrigger`
+    regardless of variant, exactly like checkbox). The named variant suppresses
+    **all** of Nuxt UI's `data-selected`/`data-today` color compounds (they're
+    keyed to the STANDARD variants), so each theme supplies its own state CSS on
+    `.cal-cell[data-selected]`, `[data-today]:not([data-selected])`,
+    `[data-highlighted]` (keyboard), and `[data-outside-view]` (dimmed) — skip a
+    state and it renders invisible. Runtime scalar: `calendar.defaultVariants.variant`
+    in `themeConfigs.ts` (set in **every** config entry, incl. default + bw, so a
+    theme-switch never leaves a stale variant behind — the deepAssign rule).
+  - **USlider** (crouton-layout `LayoutBreakpointAuthor.vue`) and **UColorPicker**
+    (crouton-core `FormColorPicker.vue`) — **ambient CSS** (no `variant`
+    dimension). DOM hooks: slider anchors on **`[data-slider-impl]`** (unique to
+    USlider — the color picker also has a `track` slot, so an unqualified
+    `[data-slot="track"]` would hit both), slots `track`/`range`/`thumb`; recolor
+    the thumb ring via `--tw-ring-color`. Color picker is **chrome-only** (never
+    tint the color surfaces): frame `[data-slot="selector"]` +
+    `[data-color-picker-track]`, round-off `selectorThumb`/`trackThumb` (camelCase
+    in the DOM). Both scoped to BOTH activation paths like the #1393 ambient set.
+- **Documented skips** — no consumer anywhere in the repo, so stock (they still
+  adapt to the theme via the `#1390` semantic `--ui-*` tokens — verified not
+  broken, e.g. terminal's PIN boxes render as phosphor-bordered squares):
+  - **UPinInput** — the issue's real-use map guessed 2FA, but `TwoFactorForm.vue`
+    (and the POS helper-login) use a plain **`UInput`** for the code, not
+    `UPinInput`. No consumer → skip.
+  - **UInputTags**, **UCommandPalette** — zero consumers outside the playground
+    `/matrix` zoo.
+
+blackandwhite stays the deliberate stock pass here too (its calendar runtime is
+`solid`, no `bw-cal-*` variant).
+
 ## Dual scheme (#1395) — every theme works in light AND dark
 
 Every theme ships a **designed counterpart palette** for the scheme it wasn't

--- a/packages/crouton-themes/blueprint/app.config.ts
+++ b/packages/crouton-themes/blueprint/app.config.ts
@@ -220,6 +220,27 @@ export default defineAppConfig({
         { color: "error", variant: "blueprint", class: { root: "bp-alert--error" } },
         { color: "neutral", variant: "blueprint", class: { root: "bp-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          blueprint: {
+            headingLabel: "bp-cal-heading",
+            headCell: "bp-cal-head",
+            cellTrigger: "bp-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/blueprint/assets/css/main.css
+++ b/packages/crouton-themes/blueprint/assets/css/main.css
@@ -485,6 +485,104 @@ body.theme-blueprint {
 }
 
 /* ============================================
+   CALENDAR (#1458) — a dimension grid on the sheet: mono title block,
+   the drawn part for the selected day, the pencil-yellow callout for
+   today. Named variant (bp-cal-*); selected/today state is ours.
+   ============================================ */
+
+.bp-cal-heading {
+  font-family: var(--bp-mono);
+  color: var(--bp-line);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bp-cal-head {
+  font-family: var(--bp-mono);
+  color: var(--bp-line-dim);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.bp-cal-cell {
+  font-family: var(--bp-mono);
+  color: var(--bp-line);
+  border: 1px solid transparent;
+  border-radius: 0;
+  transition: background-color 120ms ease;
+}
+
+.bp-cal-cell:hover:not([data-selected]):not([data-disabled]),
+.bp-cal-cell[data-highlighted] {
+  background-color: rgba(220, 233, 245, 0.12);
+  border-color: var(--bp-line-dim);
+}
+
+.bp-cal-cell[data-selected] {
+  background-color: var(--bp-line);
+  color: var(--bp-blue-deep);
+}
+
+.bp-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--bp-accent);
+  color: var(--bp-accent);
+}
+
+.bp-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider (a dimension line with a callout) +
+   color picker. No variant hook; scoped to both activation paths.
+   Slider anchors on [data-slider-impl] (unique to USlider).
+   ============================================ */
+
+[data-theme="blueprint"] [data-slider-impl] [data-slot="track"],
+.theme-blueprint [data-slider-impl] [data-slot="track"] {
+  background-color: transparent;
+  border: 1px solid var(--bp-line-dim);
+  border-radius: 0;
+}
+
+[data-theme="blueprint"] [data-slider-impl] [data-slot="range"],
+.theme-blueprint [data-slider-impl] [data-slot="range"] {
+  background-color: var(--bp-line);
+  border-radius: 0;
+}
+
+[data-theme="blueprint"] [data-slider-impl] [data-slot="thumb"],
+.theme-blueprint [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--bp-blue-deep);
+  border-radius: 0;
+  --tw-ring-color: var(--bp-line);
+}
+
+[data-theme="blueprint"] [data-slot="picker"] [data-slot="selector"],
+.theme-blueprint [data-slot="picker"] [data-slot="selector"],
+[data-theme="blueprint"] [data-color-picker-track],
+.theme-blueprint [data-color-picker-track] {
+  border: 1px solid var(--bp-line);
+  outline: 1px solid var(--bp-line-dim);
+  outline-offset: 2px;
+  border-radius: 0;
+}
+
+[data-theme="blueprint"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-blueprint [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 0;
+}
+
+[data-theme="blueprint"] [data-slot="selectorThumb"],
+.theme-blueprint [data-slot="selectorThumb"],
+[data-theme="blueprint"] [data-slot="trackThumb"],
+.theme-blueprint [data-slot="trackThumb"] {
+  border-radius: 0;
+  --tw-ring-color: var(--bp-line);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — pencil-on-white, DESIGNED not inverted: blue
    linework on white drafting paper, the pencil mark goes graphite-gold.
    Activated by the colorMode class on <html>.

--- a/packages/crouton-themes/braun/app.config.ts
+++ b/packages/crouton-themes/braun/app.config.ts
@@ -227,6 +227,27 @@ export default defineAppConfig({
         { color: "error", variant: "braun", class: { root: "braun-alert--error" } },
         { color: "neutral", variant: "braun", class: { root: "braun-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          braun: {
+            headingLabel: "braun-cal-heading",
+            headCell: "braun-cal-head",
+            cellTrigger: "braun-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/braun/assets/css/main.css
+++ b/packages/crouton-themes/braun/assets/css/main.css
@@ -526,6 +526,111 @@ body.theme-braun {
 }
 
 /* ============================================
+   CALENDAR (#1458) — a desk-calendar page: hairlined, calm, the one
+   orange spent only on the selected day. Named variant (braun-cal-*);
+   selected/today state is ours to supply.
+   ============================================ */
+
+.braun-cal-heading {
+  font-family: inherit;
+  color: var(--braun-text);
+  letter-spacing: 0.02em;
+}
+
+.braun-cal-head {
+  color: var(--braun-label);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: var(--braun-radius);
+}
+
+.braun-cal-cell {
+  color: var(--braun-text);
+  border: 1px solid transparent;
+  border-radius: var(--braun-radius);
+  transition: background-color var(--braun-ease), box-shadow var(--braun-ease);
+}
+
+.braun-cal-cell:hover:not([data-selected]):not([data-disabled]),
+.braun-cal-cell[data-highlighted] {
+  background-color: var(--braun-cream-raised);
+  box-shadow: var(--braun-shadow);
+}
+
+.braun-cal-cell[data-selected] {
+  background-color: var(--braun-orange);
+  color: #fff;
+  box-shadow: var(--braun-shadow);
+}
+
+.braun-cal-cell[data-today]:not([data-selected]) {
+  position: relative;
+}
+
+.braun-cal-cell[data-today]:not([data-selected])::after {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background-color: var(--braun-orange);
+}
+
+.braun-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider (the hi-fi fader Braun is made for) +
+   color picker. No variant hook; scoped to both activation paths.
+   Slider anchors on [data-slider-impl] (unique to USlider).
+   ============================================ */
+
+[data-theme="braun"] [data-slider-impl] [data-slot="track"],
+.theme-braun [data-slider-impl] [data-slot="track"] {
+  background-color: var(--braun-cream-raised);
+  border: 1px solid var(--braun-hairline);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+  border-radius: 999px;
+}
+
+[data-theme="braun"] [data-slider-impl] [data-slot="range"],
+.theme-braun [data-slider-impl] [data-slot="range"] {
+  background-color: var(--braun-orange);
+}
+
+[data-theme="braun"] [data-slider-impl] [data-slot="thumb"],
+.theme-braun [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--braun-cream-raised);
+  box-shadow: var(--braun-shadow);
+  --tw-ring-color: var(--braun-hairline);
+}
+
+[data-theme="braun"] [data-slot="picker"] [data-slot="selector"],
+.theme-braun [data-slot="picker"] [data-slot="selector"],
+[data-theme="braun"] [data-color-picker-track],
+.theme-braun [data-color-picker-track] {
+  border: 1px solid var(--braun-hairline);
+  border-radius: var(--braun-radius);
+}
+
+[data-theme="braun"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-braun [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: var(--braun-radius);
+}
+
+[data-theme="braun"] [data-slot="selectorThumb"],
+.theme-braun [data-slot="selectorThumb"],
+[data-theme="braun"] [data-slot="trackThumb"],
+.theme-braun [data-slot="trackThumb"] {
+  --tw-ring-color: var(--braun-hairline);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — the black-unit counterpart, DESIGNED not inverted:
    charcoal chassis, backlit light legends, the one orange unchanged.
    Activated by the colorMode class on <html>.

--- a/packages/crouton-themes/brutalist/app.config.ts
+++ b/packages/crouton-themes/brutalist/app.config.ts
@@ -230,6 +230,27 @@ export default defineAppConfig({
         { color: 'error', variant: 'brutalist', class: { root: 'brutalist-alert--error' } },
         { color: 'neutral', variant: 'brutalist', class: { root: 'brutalist-alert--neutral' } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          brutalist: {
+            headingLabel: 'brutalist-cal-heading',
+            headCell: 'brutalist-cal-head',
+            cellTrigger: 'brutalist-cal-cell'
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -475,6 +475,108 @@
 }
 
 /* ============================================
+   CALENDAR (#1458) — a wall calendar, stamped.
+   Named variant (brutalist-cal-*); selected/today state is ours to
+   supply — the named variant never fires Nuxt UI's color compounds.
+   ============================================ */
+
+.brutalist-cal-heading {
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.brutalist-cal-head {
+  color: var(--brutalist-ink);
+  font-weight: 800;
+  text-transform: uppercase;
+  border-radius: 0;
+}
+
+.brutalist-cal-cell {
+  color: var(--brutalist-ink);
+  border: 2px solid transparent;
+  border-radius: 0;
+  transition: none;
+}
+
+.brutalist-cal-cell:hover:not([data-selected]):not([data-disabled]) {
+  background-color: var(--brutalist-accent);
+  color: var(--brutalist-accent-ink);
+}
+
+.brutalist-cal-cell[data-highlighted] {
+  background-color: var(--brutalist-accent);
+  color: var(--brutalist-accent-ink);
+}
+
+.brutalist-cal-cell[data-selected] {
+  background-color: var(--brutalist-ink);
+  color: var(--brutalist-paper);
+  box-shadow: 2px 2px 0 var(--brutalist-accent);
+}
+
+.brutalist-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--brutalist-ink);
+  font-weight: 800;
+}
+
+.brutalist-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker have no variant
+   dimension; scoped to both activation paths like the switch above.
+   Slider anchors on [data-slider-impl] (unique to USlider — the color
+   picker has a "track" slot too), picker on its own slot names.
+   ============================================ */
+
+/* Slider: a fader on the mixing desk. */
+[data-theme="brutalist"] [data-slider-impl] [data-slot="track"],
+.theme-brutalist [data-slider-impl] [data-slot="track"] {
+  background-color: var(--brutalist-paper);
+  border: 2px solid var(--brutalist-ink);
+  border-radius: 0;
+}
+
+[data-theme="brutalist"] [data-slider-impl] [data-slot="range"],
+.theme-brutalist [data-slider-impl] [data-slot="range"] {
+  background-color: var(--brutalist-accent);
+  border-radius: 0;
+}
+
+[data-theme="brutalist"] [data-slider-impl] [data-slot="thumb"],
+.theme-brutalist [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--brutalist-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--brutalist-accent);
+  --tw-ring-color: var(--brutalist-ink);
+}
+
+/* Color picker: swatches are stamps too. */
+[data-theme="brutalist"] [data-slot="picker"] [data-slot="selector"],
+.theme-brutalist [data-slot="picker"] [data-slot="selector"],
+[data-theme="brutalist"] [data-color-picker-track],
+.theme-brutalist [data-color-picker-track] {
+  border: 2px solid var(--brutalist-ink);
+  border-radius: 0;
+}
+
+[data-theme="brutalist"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-brutalist [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 0;
+}
+
+[data-theme="brutalist"] [data-slot="selectorThumb"],
+.theme-brutalist [data-slot="selectorThumb"],
+[data-theme="brutalist"] [data-slot="trackThumb"],
+.theme-brutalist [data-slot="trackThumb"] {
+  border-radius: 0;
+  --tw-ring-color: var(--brutalist-ink);
+}
+
+/* ============================================
    SEMANTIC TOKENS (#1390) — tuned to the paper.
    ============================================ */
 

--- a/packages/crouton-themes/eink/app.config.ts
+++ b/packages/crouton-themes/eink/app.config.ts
@@ -220,6 +220,27 @@ export default defineAppConfig({
         { color: "error", variant: "eink", class: { root: "eink-alert--error" } },
         { color: "neutral", variant: "eink", class: { root: "eink-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          eink: {
+            headingLabel: "eink-cal-heading",
+            headCell: "eink-cal-head",
+            cellTrigger: "eink-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/eink/assets/css/main.css
+++ b/packages/crouton-themes/eink/assets/css/main.css
@@ -439,6 +439,101 @@ body.theme-eink {
 }
 
 /* ============================================
+   CALENDAR (#1458) — an almanac page: small-caps heads, a double-rule
+   frame for today, solid ink for the selected day. Named variant
+   (eink-cal-*); selected/today state is ours to supply. Zero motion.
+   ============================================ */
+
+.eink-cal-heading {
+  font-family: var(--eink-serif);
+  color: var(--eink-ink);
+  font-variant: small-caps;
+  letter-spacing: 0.03em;
+}
+
+.eink-cal-head {
+  color: var(--eink-gray);
+  font-variant: small-caps;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+}
+
+.eink-cal-cell {
+  color: var(--eink-ink);
+  border: 1px solid transparent;
+  border-radius: 0;
+  transition: none;
+}
+
+.eink-cal-cell:hover:not([data-selected]):not([data-disabled]),
+.eink-cal-cell[data-highlighted] {
+  background-color: var(--eink-hairline);
+}
+
+.eink-cal-cell[data-selected] {
+  background-color: var(--eink-ink);
+  color: var(--eink-paper);
+}
+
+.eink-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--eink-ink);
+  outline: 1px solid var(--eink-ink);
+  outline-offset: 2px;
+}
+
+.eink-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker. No variant hook;
+   scoped to both activation paths. Slider anchors on [data-slider-impl]
+   (unique to USlider). Ink line-work, zero motion.
+   ============================================ */
+
+[data-theme="eink"] [data-slider-impl] [data-slot="track"],
+.theme-eink [data-slider-impl] [data-slot="track"] {
+  background-color: var(--eink-paper);
+  border: 1px solid var(--eink-ink);
+  border-radius: 0;
+}
+
+[data-theme="eink"] [data-slider-impl] [data-slot="range"],
+.theme-eink [data-slider-impl] [data-slot="range"] {
+  background-color: var(--eink-ink);
+  border-radius: 0;
+}
+
+[data-theme="eink"] [data-slider-impl] [data-slot="thumb"],
+.theme-eink [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--eink-ink);
+  border-radius: 0;
+  transition: none;
+  --tw-ring-color: var(--eink-paper);
+}
+
+[data-theme="eink"] [data-slot="picker"] [data-slot="selector"],
+.theme-eink [data-slot="picker"] [data-slot="selector"],
+[data-theme="eink"] [data-color-picker-track],
+.theme-eink [data-color-picker-track] {
+  border: 1px solid var(--eink-ink);
+  border-radius: 0;
+}
+
+[data-theme="eink"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-eink [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 0;
+}
+
+[data-theme="eink"] [data-slot="selectorThumb"],
+.theme-eink [data-slot="selectorThumb"],
+[data-theme="eink"] [data-slot="trackThumb"],
+.theme-eink [data-slot="trackThumb"] {
+  border-radius: 0;
+  --tw-ring-color: var(--eink-ink);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — night reading mode, DESIGNED not inverted:
    soft light ink on matte near-black (an e-reader at night; still
    zero motion, hairlines stay hairlines). Activated by the colorMode

--- a/packages/crouton-themes/gameboy/app.config.ts
+++ b/packages/crouton-themes/gameboy/app.config.ts
@@ -228,6 +228,27 @@ export default defineAppConfig({
         { color: "error", variant: "gameboy", class: { root: "gb-alert--error" } },
         { color: "neutral", variant: "gameboy", class: { root: "gb-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          gameboy: {
+            headingLabel: 'gb-cal-heading',
+            headCell: 'gb-cal-head',
+            cellTrigger: 'gb-cal-cell'
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/gameboy/assets/css/main.css
+++ b/packages/crouton-themes/gameboy/assets/css/main.css
@@ -481,6 +481,97 @@ body.theme-gameboy {
 }
 
 /* ============================================
+   CALENDAR (#1458) — an RPG menu grid, 4 shades only, states via
+   inversion never hue. Named variant (gb-cal-*); selected/today state
+   is ours to supply. No glide — the DMG doesn't animate.
+   ============================================ */
+
+.gb-cal-heading {
+  color: var(--gb-0);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.gb-cal-head {
+  color: var(--gb-1);
+  text-transform: uppercase;
+  border-radius: 0;
+}
+
+.gb-cal-cell {
+  color: var(--gb-0);
+  border: 2px solid transparent;
+  border-radius: 0;
+  transition: none;
+}
+
+.gb-cal-cell:hover:not([data-selected]):not([data-disabled]),
+.gb-cal-cell[data-highlighted] {
+  background-color: var(--gb-2);
+  color: var(--gb-0);
+}
+
+.gb-cal-cell[data-selected] {
+  background-color: var(--gb-0);
+  color: var(--gb-3);
+}
+
+.gb-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--gb-0);
+}
+
+.gb-cal-cell[data-outside-view] {
+  color: var(--gb-1);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider (a DMG volume slider) + color picker.
+   No variant hook; scoped to both activation paths. Slider anchors on
+   [data-slider-impl] (unique to USlider). 4 shades only.
+   ============================================ */
+
+[data-theme="gameboy"] [data-slider-impl] [data-slot="track"],
+.theme-gameboy [data-slider-impl] [data-slot="track"] {
+  background-color: var(--gb-2);
+  border: 2px solid var(--gb-0);
+  border-radius: 0;
+}
+
+[data-theme="gameboy"] [data-slider-impl] [data-slot="range"],
+.theme-gameboy [data-slider-impl] [data-slot="range"] {
+  background-color: var(--gb-0);
+  border-radius: 0;
+}
+
+[data-theme="gameboy"] [data-slider-impl] [data-slot="thumb"],
+.theme-gameboy [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--gb-3);
+  border-radius: 0;
+  --tw-ring-color: var(--gb-0);
+}
+
+[data-theme="gameboy"] [data-slot="picker"] [data-slot="selector"],
+.theme-gameboy [data-slot="picker"] [data-slot="selector"],
+[data-theme="gameboy"] [data-color-picker-track],
+.theme-gameboy [data-color-picker-track] {
+  border: 2px solid var(--gb-0);
+  border-radius: 0;
+}
+
+[data-theme="gameboy"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-gameboy [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 0;
+}
+
+[data-theme="gameboy"] [data-slot="selectorThumb"],
+.theme-gameboy [data-slot="selectorThumb"],
+[data-theme="gameboy"] [data-slot="trackThumb"],
+.theme-gameboy [data-slot="trackThumb"] {
+  border-radius: 0;
+  --tw-ring-color: var(--gb-0);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — the backlit-mod counterpart: same 4-shade
    constraint, screen goes deep olive-black, ink goes lit green.
    Activated by the colorMode class on <html>.

--- a/packages/crouton-themes/ko/app.config.ts
+++ b/packages/crouton-themes/ko/app.config.ts
@@ -257,6 +257,27 @@ export default defineAppConfig({
         { color: "error", variant: "ko", class: { root: "ko-alert--error" } },
         { color: "neutral", variant: "ko", class: { root: "ko-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          ko: {
+            headingLabel: "ko-cal-heading",
+            headCell: "ko-cal-head",
+            cellTrigger: "ko-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -1077,6 +1077,126 @@ body.theme-ko {
 }
 
 /* ============================================
+   CALENDAR (#1458) — a date pad on the chassis: silkscreen weekday
+   labels, key-like day cells, the selected day lights up on the LCD.
+   Named variant (ko-cal-*); selected/today state is ours to supply —
+   the named variant never fires Nuxt UI's color compounds.
+   ============================================ */
+
+.ko-cal-heading {
+  font-family: 'ko-tech', monospace;
+  color: var(--ko-text-dark);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.ko-cal-head {
+  font-family: 'ko-tech', monospace;
+  font-size: 0.7rem;
+  color: var(--ko-text-label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border-radius: 4px;
+}
+
+.ko-cal-cell {
+  font-family: 'ko-tech', monospace;
+  color: var(--ko-text-dark);
+  border-radius: 4px;
+  transition: background-color 100ms ease, color 100ms ease;
+}
+
+.ko-cal-cell:hover:not([data-selected]):not([data-disabled]) {
+  background-color: var(--ko-highlight-dark);
+}
+
+.ko-cal-cell[data-highlighted] {
+  background-color: var(--ko-highlight-dark);
+}
+
+/* Selected day: on the display — orange-on-panel, pressed in. */
+.ko-cal-cell[data-selected] {
+  background-color: var(--ko-surface-panel);
+  color: var(--ko-accent-orange);
+  box-shadow: inset 1px 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+/* Today: an LED under the key, lit but not engaged. */
+.ko-cal-cell[data-today]:not([data-selected]) {
+  position: relative;
+}
+
+.ko-cal-cell[data-today]:not([data-selected])::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--ko-accent-orange);
+  box-shadow: 0 0 4px var(--ko-highlight-orange);
+}
+
+.ko-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker have no variant
+   dimension; scoped to both activation paths like the switch above.
+   Slider anchors on [data-slider-impl] (unique to USlider — the color
+   picker has a "track" slot too), picker on its own slot names.
+   ============================================ */
+
+/* Slider: a fader — recessed slot, orange level, chassis-key cap. */
+[data-theme="ko"] [data-slider-impl] [data-slot="track"],
+.theme-ko [data-slider-impl] [data-slot="track"] {
+  background-color: var(--ko-surface-mid);
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: 4px;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="ko"] [data-slider-impl] [data-slot="range"],
+.theme-ko [data-slider-impl] [data-slot="range"] {
+  background-color: var(--ko-accent-orange);
+  border-radius: 4px;
+}
+
+[data-theme="ko"] [data-slider-impl] [data-slot="thumb"],
+.theme-ko [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--ko-surface-light);
+  border-radius: 4px;
+  box-shadow: inset 0 1px 0 var(--ko-highlight-light), 0 1px 2px rgba(0, 0, 0, 0.25);
+  --tw-ring-color: var(--ko-surface-recess);
+}
+
+/* Color picker: frame the color surfaces like display panels —
+   dark bezel border only, never tint the colors themselves. */
+[data-theme="ko"] [data-slot="picker"] [data-slot="selector"],
+.theme-ko [data-slot="picker"] [data-slot="selector"],
+[data-theme="ko"] [data-color-picker-track],
+.theme-ko [data-color-picker-track] {
+  border: 1px solid var(--ko-surface-recess);
+  border-radius: var(--ko-button-radius);
+}
+
+[data-theme="ko"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-ko [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: calc(var(--ko-button-radius) - 1px);
+}
+
+[data-theme="ko"] [data-slot="selectorThumb"],
+.theme-ko [data-slot="selectorThumb"],
+[data-theme="ko"] [data-slot="trackThumb"],
+.theme-ko [data-slot="trackThumb"] {
+  border-radius: 9999px;
+  --tw-ring-color: var(--ko-surface-panel);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — the black-unit counterpart (the dark TE
    hardware), DESIGNED not inverted: charcoal chassis, light silkscreen,
    the displays were already dark and stay identical. Activated by the

--- a/packages/crouton-themes/kr11/app.config.ts
+++ b/packages/crouton-themes/kr11/app.config.ts
@@ -229,6 +229,27 @@ export default defineAppConfig({
         { color: "error", variant: "kr11", class: { root: "kr-alert--error" } },
         { color: "neutral", variant: "kr11", class: { root: "kr-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          kr11: {
+            headingLabel: "kr-cal-heading",
+            headCell: "kr-cal-head",
+            cellTrigger: "kr-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/kr11/assets/css/main.css
+++ b/packages/crouton-themes/kr11/assets/css/main.css
@@ -886,6 +886,127 @@ body.theme-kr11 {
 }
 
 /* ============================================
+   CALENDAR (#1458) — a month of pads on the chassis.
+   Named variant (kr-cal-*); selected/today state is ours to supply —
+   the named variant never fires Nuxt UI's color compounds.
+   ============================================ */
+
+.kr-cal-heading {
+  font-family: var(--kr-font);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--kr-text-dark);
+}
+
+.kr-cal-head {
+  font-family: var(--kr-font);
+  font-size: 0.625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--kr-text-medium);
+  border-radius: var(--kr-button-radius);
+}
+
+.kr-cal-cell {
+  font-family: var(--kr-font);
+  color: var(--kr-text-dark);
+  border: 1px solid transparent;
+  border-radius: var(--kr-pad-radius);
+  transition: all var(--kr-transition-fast);
+}
+
+/* Hover / keyboard focus: the day rises as a cream pad. */
+.kr-cal-cell:hover:not([data-selected]):not([data-disabled]) {
+  background-color: var(--kr-pad-cream);
+  border-color: var(--kr-pad-keyline);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.kr-cal-cell[data-highlighted] {
+  background-color: var(--kr-pad-cream);
+  border-color: var(--kr-pad-keyline);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+/* Selected: the pressed mint play-key. Mint stays mint in both schemes,
+   so the legend uses the constant pad ink (#1395). */
+.kr-cal-cell[data-selected] {
+  background-color: var(--kr-pad-mint-pressed);
+  color: var(--kr-on-pad);
+  border-color: var(--kr-pad-keyline);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.12);
+  font-weight: 600;
+}
+
+/* Today: the red LED is lit on that pad. */
+.kr-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--kr-display-red);
+  box-shadow: 0 0 5px var(--kr-display-red-glow);
+  font-weight: 600;
+}
+
+.kr-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker have no variant
+   dimension; scoped to both activation paths like the switch above.
+   Slider anchors on [data-slider-impl] (unique to USlider — the color
+   picker has a "track" slot too), picker on its own slot names.
+   ============================================ */
+
+/* Slider: a volume fader — recessed groove, mint level, cream cap. */
+[data-theme="kr11"] [data-slider-impl] [data-slot="track"],
+.theme-kr11 [data-slider-impl] [data-slot="track"] {
+  background-color: var(--kr-chassis-dark);
+  border-radius: var(--kr-display-radius);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+[data-theme="kr11"] [data-slider-impl] [data-slot="range"],
+.theme-kr11 [data-slider-impl] [data-slot="range"] {
+  background-color: var(--kr-pad-mint);
+  border-radius: var(--kr-display-radius);
+}
+
+[data-theme="kr11"] [data-slider-impl] [data-slot="thumb"],
+.theme-kr11 [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--kr-pad-cream);
+  border-radius: var(--kr-button-radius);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  --tw-ring-color: var(--kr-pad-keyline);
+}
+
+/* Color picker: chrome only — keyline frames, knob-round thumbs;
+   never tint the color surfaces themselves. */
+[data-theme="kr11"] [data-slot="picker"] [data-slot="selector"],
+.theme-kr11 [data-slot="picker"] [data-slot="selector"],
+[data-theme="kr11"] [data-color-picker-track],
+.theme-kr11 [data-color-picker-track] {
+  border: 1px solid var(--kr-pad-keyline);
+  border-radius: var(--kr-button-radius);
+}
+
+[data-theme="kr11"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-kr11 [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: var(--kr-button-radius);
+}
+
+[data-theme="kr11"] [data-slot="selectorThumb"],
+.theme-kr11 [data-slot="selectorThumb"],
+[data-theme="kr11"] [data-slot="trackThumb"],
+.theme-kr11 [data-slot="trackThumb"] {
+  border-radius: 9999px;
+  --tw-ring-color: var(--kr-text-dark);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — the dark-unit counterpart (a Volca on a night
    stage), DESIGNED not inverted: graphite chassis, dark pads with light
    legends, the red LED display and the colored pads stay themselves.

--- a/packages/crouton-themes/minimal/app.config.ts
+++ b/packages/crouton-themes/minimal/app.config.ts
@@ -214,6 +214,27 @@ export default defineAppConfig({
         { color: "error", variant: "minimal", class: { root: "minimal-alert--error" } },
         { color: "neutral", variant: "minimal", class: { root: "minimal-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          minimal: {
+            headingLabel: "minimal-cal-heading",
+            headCell: "minimal-cal-head",
+            cellTrigger: "minimal-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/minimal/assets/css/main.css
+++ b/packages/crouton-themes/minimal/assets/css/main.css
@@ -633,6 +633,98 @@
 }
 
 /* ============================================
+   CALENDAR (#1458) — pure geometry, square cells, inversion for the
+   selected day. Named variant (minimal-cal-*); selected/today state is
+   ours to supply.
+   ============================================ */
+
+.minimal-cal-heading {
+  color: var(--minimal-black);
+  font-weight: 600;
+}
+
+.minimal-cal-head {
+  color: var(--minimal-muted);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  border-radius: 0;
+}
+
+.minimal-cal-cell {
+  color: var(--minimal-black);
+  border: 1px solid transparent;
+  border-radius: 0;
+  transition: var(--minimal-transition);
+}
+
+.minimal-cal-cell:hover:not([data-selected]):not([data-disabled]),
+.minimal-cal-cell[data-highlighted] {
+  border-color: var(--minimal-black);
+}
+
+.minimal-cal-cell[data-selected] {
+  background-color: var(--minimal-black);
+  color: var(--minimal-white);
+}
+
+.minimal-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--minimal-black);
+  border-width: var(--minimal-border-width-thick);
+}
+
+.minimal-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker. No variant hook;
+   scoped to both activation paths. Slider anchors on [data-slider-impl]
+   (unique to USlider). Thin black lines, square, no shadow.
+   ============================================ */
+
+[data-theme="minimal"] [data-slider-impl] [data-slot="track"],
+.theme-minimal [data-slider-impl] [data-slot="track"] {
+  background-color: var(--minimal-white);
+  border: 1px solid var(--minimal-black);
+  border-radius: 0;
+}
+
+[data-theme="minimal"] [data-slider-impl] [data-slot="range"],
+.theme-minimal [data-slider-impl] [data-slot="range"] {
+  background-color: var(--minimal-black);
+  border-radius: 0;
+}
+
+[data-theme="minimal"] [data-slider-impl] [data-slot="thumb"],
+.theme-minimal [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--minimal-black);
+  border-radius: 0;
+  --tw-ring-color: var(--minimal-white);
+}
+
+[data-theme="minimal"] [data-slot="picker"] [data-slot="selector"],
+.theme-minimal [data-slot="picker"] [data-slot="selector"],
+[data-theme="minimal"] [data-color-picker-track],
+.theme-minimal [data-color-picker-track] {
+  border: 1px solid var(--minimal-black);
+  border-radius: 0;
+}
+
+[data-theme="minimal"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-minimal [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 0;
+}
+
+[data-theme="minimal"] [data-slot="selectorThumb"],
+.theme-minimal [data-slot="selectorThumb"],
+[data-theme="minimal"] [data-slot="trackThumb"],
+.theme-minimal [data-slot="trackThumb"] {
+  border-radius: 0;
+  --tw-ring-color: var(--minimal-black);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — the negative, DESIGNED for the same geometry:
    white lines on black, grays re-stepped for the dark page. Activated
    by the colorMode class on <html>.

--- a/packages/crouton-themes/mtv/app.config.ts
+++ b/packages/crouton-themes/mtv/app.config.ts
@@ -228,6 +228,27 @@ export default defineAppConfig({
         { color: 'error', variant: 'mtv', class: { root: 'mtv-alert--error' } },
         { color: 'neutral', variant: 'mtv', class: { root: 'mtv-alert--neutral' } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          mtv: {
+            headingLabel: 'mtv-cal-heading',
+            headCell: 'mtv-cal-head',
+            cellTrigger: 'mtv-cal-cell'
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/mtv/assets/css/main.css
+++ b/packages/crouton-themes/mtv/assets/css/main.css
@@ -570,6 +570,118 @@ body.theme-mtv {
 }
 
 /* ============================================
+   CALENDAR (#1458) — the program grid; today is circled in ink,
+   the selected day is a day-glo sticker slammed on the page.
+   Named variant (mtv-cal-*); selected/today state is ours to supply —
+   the named variant never fires Nuxt UI's color compounds. A grid is
+   dense, so per-cell effects stay restrained (no tilt): the loud move
+   is reserved for [data-selected].
+   ============================================ */
+
+.mtv-cal-heading {
+  color: var(--mtv-ink);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mtv-cal-head {
+  color: var(--mtv-ink);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 0;
+}
+
+.mtv-cal-cell {
+  color: var(--mtv-ink);
+  border: var(--mtv-border) solid transparent;
+  border-radius: 0;
+  font-weight: 600;
+  transition: background-color var(--mtv-snap) ease-out, box-shadow var(--mtv-snap) ease-out;
+}
+
+.mtv-cal-cell:hover:not([data-selected]):not([data-disabled]) {
+  background-color: var(--mtv-yellow);
+  color: var(--mtv-on-neon);
+}
+
+.mtv-cal-cell[data-highlighted] {
+  background-color: var(--mtv-yellow);
+  color: var(--mtv-on-neon);
+}
+
+.mtv-cal-cell[data-selected] {
+  background-color: var(--mtv-pink);
+  color: var(--mtv-on-pink);
+  border-color: var(--mtv-ink);
+  box-shadow: 2px 2px 0 var(--mtv-cyan);
+  font-weight: 800;
+}
+
+.mtv-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--mtv-ink);
+  font-weight: 800;
+}
+
+.mtv-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker have no variant
+   dimension; scoped to both activation paths like the switch above.
+   Slider anchors on [data-slider-impl] (unique to USlider — the color
+   picker has a "track" slot too), picker on its own slot names.
+   Picker: chrome only — never tint the color surfaces themselves.
+   ============================================ */
+
+/* Slider: a fader on the video desk — cyan signal, pink cap. */
+[data-theme="mtv"] [data-slider-impl] [data-slot="track"],
+.theme-mtv [data-slider-impl] [data-slot="track"] {
+  background-color: var(--mtv-surface);
+  border: var(--mtv-border) solid var(--mtv-ink);
+  border-radius: 0;
+}
+
+[data-theme="mtv"] [data-slider-impl] [data-slot="range"],
+.theme-mtv [data-slider-impl] [data-slot="range"] {
+  background-color: var(--mtv-cyan);
+  border-radius: 0;
+}
+
+[data-theme="mtv"] [data-slider-impl] [data-slot="thumb"],
+.theme-mtv [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--mtv-pink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--mtv-cyan);
+  --tw-ring-color: var(--mtv-ink);
+}
+
+/* Color picker: an ink frame with a pink drop shadow — a taped-up swatch. */
+[data-theme="mtv"] [data-slot="picker"] [data-slot="selector"],
+.theme-mtv [data-slot="picker"] [data-slot="selector"],
+[data-theme="mtv"] [data-color-picker-track],
+.theme-mtv [data-color-picker-track] {
+  border: var(--mtv-border) solid var(--mtv-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--mtv-pink);
+}
+
+[data-theme="mtv"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-mtv [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 0;
+}
+
+[data-theme="mtv"] [data-slot="selectorThumb"],
+.theme-mtv [data-slot="selectorThumb"],
+[data-theme="mtv"] [data-slot="trackThumb"],
+.theme-mtv [data-slot="trackThumb"] {
+  border-radius: 0;
+  --tw-ring-color: var(--mtv-ink);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — neon on black, DESIGNED not inverted: the day-glo
    fills stay, the paper goes club-dark. Activated by the colorMode class
    on <html>; the scheme pin relaxed to a default in useThemeSwitcher.

--- a/packages/crouton-themes/riso/app.config.ts
+++ b/packages/crouton-themes/riso/app.config.ts
@@ -220,6 +220,27 @@ export default defineAppConfig({
         { color: "error", variant: "riso", class: { root: "riso-alert--error" } },
         { color: "neutral", variant: "riso", class: { root: "riso-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          riso: {
+            headingLabel: "riso-cal-heading",
+            headCell: "riso-cal-head",
+            cellTrigger: "riso-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/riso/assets/css/main.css
+++ b/packages/crouton-themes/riso/assets/css/main.css
@@ -461,6 +461,97 @@ body.theme-riso {
 }
 
 /* ============================================
+   CALENDAR (#1458) — a printed almanac grid: teal weekday heads, the
+   pink-with-teal-misregistration block for the selected day. Named
+   variant (riso-cal-*); selected/today state is ours to supply.
+   ============================================ */
+
+.riso-cal-heading {
+  color: var(--riso-ink);
+  letter-spacing: 0.02em;
+}
+
+.riso-cal-head {
+  color: var(--riso-teal);
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+}
+
+.riso-cal-cell {
+  color: var(--riso-ink);
+  border: 1px solid transparent;
+  border-radius: 2px;
+  transition: background-color 120ms ease;
+}
+
+.riso-cal-cell:hover:not([data-selected]):not([data-disabled]),
+.riso-cal-cell[data-highlighted] {
+  background-color: var(--riso-pink-soft);
+  background-image: var(--riso-grain);
+}
+
+.riso-cal-cell[data-selected] {
+  background-color: var(--riso-pink);
+  color: var(--riso-on-pink);
+  box-shadow: 2px 2px 0 var(--riso-teal-soft);
+}
+
+.riso-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--riso-teal);
+  box-shadow: 1.5px 1.5px 0 var(--riso-teal-soft);
+}
+
+.riso-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker. No variant hook;
+   scoped to both activation paths. Slider anchors on [data-slider-impl]
+   (unique to USlider). Pink ink pass with teal misregistration.
+   ============================================ */
+
+[data-theme="riso"] [data-slider-impl] [data-slot="track"],
+.theme-riso [data-slider-impl] [data-slot="track"] {
+  background-color: var(--riso-surface);
+  border: 1px solid var(--riso-ink);
+  border-radius: 999px;
+}
+
+[data-theme="riso"] [data-slider-impl] [data-slot="range"],
+.theme-riso [data-slider-impl] [data-slot="range"] {
+  background-color: var(--riso-pink);
+}
+
+[data-theme="riso"] [data-slider-impl] [data-slot="thumb"],
+.theme-riso [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--riso-pink);
+  box-shadow: 2px 2px 0 var(--riso-teal-soft);
+  --tw-ring-color: var(--riso-ink);
+}
+
+[data-theme="riso"] [data-slot="picker"] [data-slot="selector"],
+.theme-riso [data-slot="picker"] [data-slot="selector"],
+[data-theme="riso"] [data-color-picker-track],
+.theme-riso [data-color-picker-track] {
+  border: 1px solid var(--riso-ink);
+  border-radius: 2px;
+}
+
+[data-theme="riso"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-riso [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 2px;
+}
+
+[data-theme="riso"] [data-slot="selectorThumb"],
+.theme-riso [data-slot="selectorThumb"],
+[data-theme="riso"] [data-slot="trackThumb"],
+.theme-riso [data-slot="trackThumb"] {
+  --tw-ring-color: var(--riso-ink);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — fluoro on black card, DESIGNED not inverted:
    the pink/teal passes stay fluoro, the stock goes black (a night-mode
    riso zine). Activated by the colorMode class on <html>.

--- a/packages/crouton-themes/terminal/app.config.ts
+++ b/packages/crouton-themes/terminal/app.config.ts
@@ -227,6 +227,27 @@ export default defineAppConfig({
         { color: "error", variant: "terminal", class: { root: "term-alert--error" } },
         { color: "neutral", variant: "terminal", class: { root: "term-alert--neutral" } }
       ]
+    },
+
+    // #1458 second-tier coverage. Calendar: the color dimension fires on
+    // headCell/cellTrigger regardless of variant (like checkbox), so both
+    // carry markers + the replacer; selected/today state lives entirely in
+    // the theme CSS via [data-selected]/[data-today].
+    calendar: {
+      slots: {
+        headCell: subtractThemeDefaults,
+        cellTrigger: subtractThemeDefaults,
+        headingLabel: subtractThemeDefaults
+      },
+      variants: {
+        variant: {
+          terminal: {
+            headingLabel: "term-cal-heading",
+            headCell: "term-cal-head",
+            cellTrigger: "term-cal-cell"
+          }
+        }
+      }
     }
   }
 })

--- a/packages/crouton-themes/terminal/assets/css/main.css
+++ b/packages/crouton-themes/terminal/assets/css/main.css
@@ -552,6 +552,111 @@ body.theme-terminal {
 }
 
 /* ============================================
+   CALENDAR (#1458) — cal(1) on the tube.
+   Named variant (term-cal-*); selected/today state is ours to supply —
+   the named variant never fires Nuxt UI's color compounds.
+   ============================================ */
+
+.term-cal-heading {
+  font-family: var(--term-font);
+  color: var(--term-phosphor);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-shadow: var(--term-glow);
+}
+
+.term-cal-head {
+  font-family: var(--term-font);
+  color: var(--term-phosphor-dim);
+  text-transform: uppercase;
+  border-radius: 0;
+}
+
+.term-cal-cell {
+  font-family: var(--term-font);
+  color: var(--term-phosphor-soft);
+  border: 1px solid transparent;
+  border-radius: 0;
+  transition: none;
+}
+
+.term-cal-cell:hover:not([data-selected]):not([data-disabled]),
+.term-cal-cell[data-highlighted] {
+  color: var(--term-phosphor);
+  background-color: rgba(51, 255, 102, 0.12);
+  text-shadow: var(--term-glow);
+}
+
+.term-cal-cell[data-selected] {
+  background-color: var(--term-phosphor);
+  color: var(--term-bg);
+  box-shadow: var(--term-glow);
+  text-shadow: none;
+}
+
+.term-cal-cell[data-today]:not([data-selected]) {
+  border-color: var(--term-phosphor);
+  color: var(--term-phosphor);
+  text-shadow: var(--term-glow);
+}
+
+.term-cal-cell[data-outside-view] {
+  color: var(--ui-text-dimmed);
+}
+
+/* ============================================
+   AMBIENT CHROME (#1458) — slider + color picker have no variant
+   dimension; scoped to both activation paths like the switch above.
+   Slider anchors on [data-slider-impl] (unique to USlider — the color
+   picker has a "track" slot too), picker on its own slot names.
+   ============================================ */
+
+/* Slider: a signal level fader. */
+[data-theme="terminal"] [data-slider-impl] [data-slot="track"],
+.theme-terminal [data-slider-impl] [data-slot="track"] {
+  background-color: var(--term-bg-raised);
+  border: 1px solid var(--term-phosphor-dim);
+  border-radius: 0;
+}
+
+[data-theme="terminal"] [data-slider-impl] [data-slot="range"],
+.theme-terminal [data-slider-impl] [data-slot="range"] {
+  background-color: var(--term-phosphor);
+  box-shadow: var(--term-glow);
+  border-radius: 0;
+}
+
+[data-theme="terminal"] [data-slider-impl] [data-slot="thumb"],
+.theme-terminal [data-slider-impl] [data-slot="thumb"] {
+  background-color: var(--term-bg);
+  border-radius: 0;
+  box-shadow: var(--term-glow);
+  --tw-ring-color: var(--term-phosphor);
+}
+
+/* Color picker: a framed scope readout. */
+[data-theme="terminal"] [data-slot="picker"] [data-slot="selector"],
+.theme-terminal [data-slot="picker"] [data-slot="selector"],
+[data-theme="terminal"] [data-color-picker-track],
+.theme-terminal [data-color-picker-track] {
+  border: 1px solid var(--term-phosphor-dim);
+  border-radius: 0;
+}
+
+[data-theme="terminal"] [data-slot="picker"] [data-slot="selectorBackground"],
+.theme-terminal [data-slot="picker"] [data-slot="selectorBackground"] {
+  border-radius: 0;
+}
+
+[data-theme="terminal"] [data-slot="selectorThumb"],
+.theme-terminal [data-slot="selectorThumb"],
+[data-theme="terminal"] [data-slot="trackThumb"],
+.theme-terminal [data-slot="trackThumb"] {
+  border-radius: 0;
+  --tw-ring-color: var(--term-phosphor);
+}
+
+/* ============================================
    DUAL SCHEME (#1395) — paper mode, DESIGNED not inverted: dark green ink
    on warm terminal-paper (a DEC printout), glow off, scanlines off.
    Activated by the colorMode class on <html>.

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -14,9 +14,10 @@
 // useThemeSwitcher().getVariant('outline') to follow the active theme.
 //
 // Components WITHOUT a `variant` dimension (USwitch, UModal, USlideover,
-// UToast, UPagination) are themed AMBIENTLY instead — theme-scoped CSS in each
-// theme's main.css covering both activation paths ([data-theme="x"] from app
-// presets, .theme-x body class from useThemeSwitcher). See #1307/#1393.
+// UToast, UPagination, USlider, UColorPicker) are themed AMBIENTLY instead —
+// theme-scoped CSS in each theme's main.css covering both activation paths
+// ([data-theme="x"] from app presets, .theme-x body class from
+// useThemeSwitcher). See #1307/#1393/#1458.
 
 import type { ThemeName } from '../composables/useThemeSwitcher'
 
@@ -36,6 +37,7 @@ export interface ThemeUIConfig {
   checkbox?: { defaultVariants?: { variant?: string } }
   radioGroup?: { defaultVariants?: { variant?: string } }
   alert?: { defaultVariants?: { variant?: string } }
+  calendar?: { defaultVariants?: { variant?: string } }
 }
 
 // Every config sets EVERY key the swap owns, so switching A → B never leaves
@@ -60,6 +62,7 @@ const namedVariantConfig = (
   checkbox: { defaultVariants: { variant } },
   radioGroup: { defaultVariants: { variant } },
   alert: { defaultVariants: { variant } },
+  calendar: { defaultVariants: { variant } },
   ...overrides
 })
 
@@ -79,7 +82,8 @@ const defaultConfig: ThemeUIConfig = {
   tabs: { defaultVariants: { variant: 'pill' } },
   checkbox: { defaultVariants: { variant: 'list' } },
   radioGroup: { defaultVariants: { variant: 'list' } },
-  alert: { defaultVariants: { variant: 'solid' } }
+  alert: { defaultVariants: { variant: 'solid' } },
+  calendar: { defaultVariants: { variant: 'solid' } }
 }
 
 // KO — named variants registered by ko/app.config.ts (variant="ko" etc.)
@@ -114,7 +118,8 @@ const blackandwhiteConfig: ThemeUIConfig = {
   tabs: { defaultVariants: { variant: 'pill' } },
   checkbox: { defaultVariants: { variant: 'list' } },
   radioGroup: { defaultVariants: { variant: 'list' } },
-  alert: { defaultVariants: { variant: 'subtle' } }
+  alert: { defaultVariants: { variant: 'subtle' } },
+  calendar: { defaultVariants: { variant: 'solid' } }
 }
 
 // Brutalist — named variants registered by brutalist/app.config.ts


### PR DESCRIPTION
Closes #1458

## 👤 For humans
Themes 2.1 (#1393) covered the first tier of Nuxt UI components. This closes the second tier — but **only for the components real apps actually use**. I grepped every candidate first:

| Component | Real consumer? | Result |
|---|---|---|
| **UCalendar** | ✅ crouton-bookings `Calendar.vue`, crouton-core `Calendar.vue` | **themed** |
| **UColorPicker** | ✅ crouton-core `FormColorPicker.vue` | **themed** |
| **USlider** | ✅ crouton-layout `LayoutBreakpointAuthor.vue` | **themed** |
| **UPinInput** | ❌ 2FA form uses a plain `UInput`, not `UPinInput` | documented skip |
| **UInputTags** | ❌ only the `/matrix` zoo | documented skip |
| **UCommandPalette** | ❌ only the `/matrix` zoo | documented skip |

> ⚠️ The issue's real-use map guessed `UPinInput → 2FA`, but `TwoFactorForm.vue` (and the POS helper-login) render the code with a plain `UInput`. So UPinInput has no consumer and gets a documented skip, not CSS. The three skipped components still adapt to each theme via the `#1390` semantic tokens (verified not broken — e.g. terminal's PIN boxes render as phosphor-bordered squares).

All 11 non-blackandwhite themes now theme calendar / slider / color picker in **both** light and dark. blackandwhite stays the deliberate stock pass.

## 🤖 For agents
- **UCalendar** — named variant `<p>-cal-{heading,head,cell}` on the `headingLabel`/`headCell`/`cellTrigger` slots (markers + `subtractThemeDefaults`; the `color` dim fires on head/cell like checkbox). The named variant suppresses Nuxt UI's `data-selected`/`data-today` color compounds, so each theme supplies its own state CSS (`[data-selected]`, `[data-today]:not([data-selected])`, `[data-highlighted]`, `[data-outside-view]`). Runtime scalar `calendar.defaultVariants.variant` added to **every** `themeConfigs.ts` entry (incl. default + bw=`solid`) so a theme-switch never leaves a stale variant (the deepAssign rule).
- **USlider / UColorPicker** — ambient CSS (no `variant` dim), scoped to both `[data-theme="x"]` and `.theme-x`. Slider anchors `[data-slider-impl]` (unique vs the picker's own `track` slot). Picker is chrome-only (color surfaces untouched); DOM slot names are camelCase (`selectorThumb`).
- No `!important`, `focus-visible` never stripped, dual-scheme falls out of the existing `--<p>-*` var flips.

## 🧪 How to test
1. `pnpm --filter crouton-themes-playground dev` → http://localhost:3031/matrix
2. Flip through all 12 themes (ThemeSwitcher) × light/dark. For each: the **Calendar** (Data display), **Slider** + **ColorPicker** (Form controls) follow the theme — no stock chrome. Click a day to see the themed `data-selected` state; today's date shows the themed `data-today` marker.
3. The three skipped components (PIN, Tags, CommandPalette) render stock-but-theme-adapted (semantic tokens), not broken.
4. Real surface: crouton-bookings' month calendar uses the same `UCalendar` primitive, so it inherits the theming.

Verified: `pnpm --filter crouton-themes-playground typecheck` ✓ and `pnpm --filter fanfare typecheck` ✓ (both exit 0). Playground screenshots captured for all 12 themes × 2 schemes + selected-state across 8 themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)