### PR TITLE
Schema-source resolver: NuxtHub's layer glob without Nuxt (WS1a)

### DIFF
--- a/fixtures/nested-schema/.env
+++ b/fixtures/nested-schema/.env
@@ -1,0 +1,4 @@
+# Committed on purpose — fixtures are throwaway test apps, never deployed.
+# Lets `pnpm dev` boot without exporting BETTER_AUTH_SECRET. Not a real secret.
+BETTER_AUTH_SECRET=dev-fixture-secret-do-not-use-in-production
+BETTER_AUTH_URL=http://localhost:3000

--- a/fixtures/nested-schema/.env.example
+++ b/fixtures/nested-schema/.env.example
@@ -1,0 +1,16 @@
+# Authentication (required)
+BETTER_AUTH_SECRET=your-secret-at-least-32-characters-long
+BETTER_AUTH_URL=http://localhost:3000
+
+# OAuth (optional)
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+
+# Email (optional)
+# NUXT_RESEND_API_KEY=
+# NUXT_EMAIL_FROM=noreply@yourdomain.com
+
+# AI (optional)
+# NUXT_ANTHROPIC_API_KEY=

--- a/fixtures/nested-schema/.gitignore
+++ b/fixtures/nested-schema/.gitignore
@@ -1,0 +1,27 @@
+# Nuxt dev/build outputs
+.output
+.data
+.nuxt
+.nitro
+.cache
+dist
+
+# Node dependencies
+node_modules
+
+# Logs
+logs
+*.log
+
+# Misc
+.DS_Store
+.fleet
+.idea
+
+# Local env files
+# NB: .env IS committed for fixtures (throwaway, never-deployed test apps) so a
+# bare `pnpm dev` works without exporting BETTER_AUTH_SECRET. Do NOT do this in
+# real apps under apps/ — there the random scaffolded secret stays gitignored.
+.env.*
+!.env.example
+.wrangler/

--- a/fixtures/nested-schema/app/app.config.ts
+++ b/fixtures/nested-schema/app/app.config.ts
@@ -1,0 +1,10 @@
+import { translationsUiConfig } from '@fyit/crouton-i18n/app/composables/useTranslationsUi'
+
+// Parity-only fixture: no app-owned collections. crouton-sales registers its
+// own collections via its layer's app.config; this app carries only the
+// translationsUi config that every crouton app has.
+export default defineAppConfig({
+  croutonCollections: {
+    translationsUi: translationsUiConfig
+  }
+})

--- a/fixtures/nested-schema/crouton.config.js
+++ b/fixtures/nested-schema/crouton.config.js
@@ -1,0 +1,15 @@
+export default {
+  // Parity-only fixture (WS1a #1446) — no generated collections. It exists so
+  // the schema-source resolver's parity suite can assert the nesting-only edge
+  // (crouton-printing reachable solely via the transitive sales -> printing
+  // extends). The resolver reads the filesystem extends graph, never this file.
+  features: {},
+
+  locales: ['en'],
+  defaultLocale: 'en',
+
+  collections: [],
+  targets: [],
+
+  dialect: 'sqlite'
+}

--- a/fixtures/nested-schema/nuxt.config.ts
+++ b/fixtures/nested-schema/nuxt.config.ts
@@ -1,0 +1,22 @@
+// Parity-only e2e fixture (epic #1445, WS1a #1446). NO e2e.manifest.json — it
+// is never smoked; it exists solely so the schema-source resolver's parity
+// suite has a NESTING-ONLY case: it extends crouton-core + crouton-sales ONLY,
+// so crouton-printing's schema is reachable purely via the transitive
+// sales -> printing edge (crouton-sales/nuxt.config.ts extends crouton-printing),
+// never listed here. Do not add crouton-printing to extends or to the deps.
+export default defineNuxtConfig({
+  modules: ['@fyit/crouton'],
+  compatibilityDate: '2025-07-15',
+  extends: ['@fyit/crouton-core', '@fyit/crouton-sales'],
+  hub: {
+    db: 'sqlite'
+  },
+
+  // Match the other fixtures' Cloudflare-free prepare settings.
+  ogImage: { enabled: false },
+  croutonAuth: {
+    methods: {
+      passkeys: false
+    }
+  }
+})

--- a/fixtures/nested-schema/package.json
+++ b/fixtures/nested-schema/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "e2e-fixture-nested-schema",
+  "type": "module",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview",
+    "typecheck": "nuxt typecheck",
+    "postinstall": "nuxt prepare 2>/dev/null || true"
+  },
+  "dependencies": {
+    "@fyit/crouton": "workspace:*",
+    "@fyit/crouton-core": "workspace:*",
+    "@fyit/crouton-sales": "workspace:*",
+    "drizzle-orm": "^0.45.1",
+    "nuxt": "^4.2.2",
+    "vue": "^3.5.26",
+    "vue-router": "^4.6.4"
+  },
+  "devDependencies": {
+    "@fyit/crouton-cli": "workspace:*",
+    "drizzle-kit": "^0.31.0"
+  }
+}

--- a/fixtures/nested-schema/server/db/schema.ts
+++ b/fixtures/nested-schema/server/db/schema.ts
@@ -1,0 +1,6 @@
+// Database schema exports
+// This file is auto-managed by crouton-generate
+
+// Export auth schema from crouton-auth package (includes teamSettings)
+export * from '@fyit/crouton-auth/server/database/schema/auth'
+export * from './translations-ui'

--- a/fixtures/nested-schema/server/db/translations-ui.ts
+++ b/fixtures/nested-schema/server/db/translations-ui.ts
@@ -1,0 +1,28 @@
+import { nanoid } from 'nanoid'
+import { sqliteTable, text, integer, unique } from 'drizzle-orm/sqlite-core'
+
+/**
+ * UI translations table for system translations and team-specific overrides
+ *
+ * System translations: teamId = null, isOverrideable = true
+ * Team overrides: teamId = specific team ID
+ */
+export const translationsUi = sqliteTable('translations_ui', {
+  id: text('id').primaryKey().$default(() => nanoid()),
+  userId: text('user_id').notNull(),
+  teamId: text('team_id'), // null means system/default translation
+  namespace: text('namespace').notNull().default('ui'),
+  keyPath: text('key_path').notNull(),
+  category: text('category').notNull(),
+  values: text('values', { mode: 'json' }).$type<Record<string, string>>().notNull(),
+  description: text('description'),
+  isOverrideable: integer('is_overrideable', { mode: 'boolean' }).notNull().default(true),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$default(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$onUpdate(() => new Date())
+}, (table) => ({
+  // Ensures unique combination of teamId + namespace + keyPath
+  uniqueTeamNamespaceKey: unique().on(table.teamId, table.namespace, table.keyPath)
+}))
+
+export type TranslationsUi = typeof translationsUi.$inferSelect
+export type NewTranslationsUi = typeof translationsUi.$inferInsert

--- a/fixtures/nested-schema/tsconfig.json
+++ b/fixtures/nested-schema/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // https://nuxt.com/docs/guide/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -325,6 +325,7 @@ rewritten every run regardless. Guarded by the write loop in `writeScaffold`
 | `lib/utils/detect-package-manager.ts` | Detect pnpm/yarn/npm |
 | `lib/utils/update-nuxt-config.ts` | Update nuxt.config.ts extends |
 | `lib/utils/update-schema-index.ts` | Update schema exports |
+| `lib/utils/schema-sources.ts` | `resolveSchemaSources(appDir, {dialect})` — reproduces NuxtHub's per-layer `server/db/schema*` glob over the recursive `extends` graph (app root + auto-scanned `layers/*` + `@fyit/*`/subpath extends, realpath-deduped, magicast static parse), WITHOUT a Nuxt process. Feeds drizzle-kit directly; parity-verified vs NuxtHub (epic #1445 WS1a). Duplicate-table gate over its output is WS1b |
 
 ## Generators Structure
 

--- a/packages/crouton-cli/lib/utils/schema-sources.ts
+++ b/packages/crouton-cli/lib/utils/schema-sources.ts
@@ -1,0 +1,168 @@
+// schema-sources.ts — reproduce NuxtHub's per-layer schema glob over the app's
+// recursive `extends` graph, WITHOUT a Nuxt process in the loop (epic #1445,
+// WS1a #1446). NuxtHub globs, per resolved layer dir:
+//   server/db/schema.ts · server/db/schema.<dialect>.ts · server/db/schema/*.ts
+// (see @nuxthub/core dist/module.mjs getSchemaPaths). We walk the same layer
+// set kit resolves — the app root, its auto-scanned layers/*, and every
+// `extends` entry (relative, `@fyit/*` bare, or package subpath) resolved from
+// each layer's OWN dir (pnpm strict isolation) — and collect the same globs.
+//
+// Deliberately NOT handled (documented limitations, brief §5 WS1):
+//   - the `hub:db:schema:extend` hook (asserted unused by a repo-invariant test)
+//   - `.nuxtrc`-contributed extends (no in-repo usage)
+// The identity-aware duplicate-table gate over this path list is WS1b (#1447).
+
+import { createRequire } from 'node:module'
+import { existsSync, realpathSync, readFileSync, readdirSync } from 'node:fs'
+import { join, dirname, resolve, isAbsolute } from 'node:path'
+import { parseModule } from 'magicast'
+
+export interface ResolveSchemaSourcesOptions {
+  /** Dialect for the schema.<dialect>.ts glob + filter. Defaults to sqlite. */
+  dialect?: string
+}
+
+const NUXT_CONFIG_NAMES = ['nuxt.config.ts', 'nuxt.config.js', 'nuxt.config.mjs']
+
+/** Walk up from `startDir` to the nearest dir holding a nuxt.config.* (the layer root). */
+function findLayerRoot(startDir: string): string | null {
+  let dir = startDir
+  for (let i = 0; i < 20; i++) {
+    if (NUXT_CONFIG_NAMES.some(name => existsSync(join(dir, name)))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+function layerConfigPath(dir: string): string | null {
+  for (const name of NUXT_CONFIG_NAMES) {
+    const p = join(dir, name)
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+/** Statically extract the `extends` string entries from a nuxt.config.* — no execution. */
+function readExtends(configPath: string): string[] {
+  let code: string
+  try {
+    code = readFileSync(configPath, 'utf8')
+  } catch {
+    return []
+  }
+  let mod
+  try {
+    mod = parseModule(code)
+  } catch {
+    return []
+  }
+  // Unwrap `defineNuxtConfig({...})`; a plain `export default {...}` is used as-is.
+  let def: any = mod.exports.default
+  if (def && def.$type === 'function-call') def = def.$args?.[0]
+  const ext = def && def.extends
+  if (!ext) return []
+  try {
+    return [...ext].filter((x: unknown): x is string => typeof x === 'string')
+  } catch {
+    return [] // non-literal extends (variable/spread) — not statically resolvable
+  }
+}
+
+/** Resolve an extends spec to a layer dir, FROM the extending layer's own dir. */
+function resolveLayerDir(spec: string, fromDir: string): string | null {
+  // Relative / absolute path extends resolve against the extending layer.
+  if (spec.startsWith('.') || isAbsolute(spec)) {
+    const candidate = resolve(fromDir, spec)
+    return existsSync(candidate) ? findLayerRoot(candidate) : null
+  }
+  // Bare package or package subpath — node-resolve from the extending layer's
+  // dir (pnpm strict isolation), then walk up to the layer root. A subpath that
+  // doesn't resolve (e.g. a theme with no resolvable entry) must NOT crash.
+  try {
+    const req = createRequire(join(fromDir, '_schema-sources-resolver_.js'))
+    return findLayerRoot(dirname(req.resolve(spec)))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the ordered, deduped, absolute list of schema-source files an app's
+ * layer graph contributes — the same set NuxtHub globs, assembled without Nuxt.
+ */
+export async function resolveSchemaSources(
+  appDir: string,
+  options: ResolveSchemaSourcesOptions = {},
+): Promise<string[]> {
+  const dialect = options.dialect ?? 'sqlite'
+  const visitedDirs = new Set<string>() // realpath'd layer roots — first-wins
+  const seenFiles = new Set<string>() // realpath'd file paths — dedup
+  const ordered: string[] = []
+
+  const collectGlobs = (layerDir: string): void => {
+    const dbDir = join(layerDir, 'server', 'db')
+    if (!existsSync(dbDir)) return
+    const candidates: string[] = [
+      join(dbDir, 'schema.ts'),
+      join(dbDir, `schema.${dialect}.ts`),
+    ]
+    const schemaSubdir = join(dbDir, 'schema')
+    if (existsSync(schemaSubdir)) {
+      let entries: string[] = []
+      try {
+        entries = readdirSync(schemaSubdir).sort()
+      } catch {
+        entries = []
+      }
+      for (const f of entries) if (f.endsWith('.ts')) candidates.push(join(schemaSubdir, f))
+    }
+    for (const p of candidates) {
+      if (!existsSync(p)) continue
+      const real = realpathSync(p)
+      if (seenFiles.has(real)) continue
+      seenFiles.add(real)
+      ordered.push(p)
+    }
+  }
+
+  const visitLayer = (dir: string): void => {
+    if (!existsSync(dir)) return
+    const real = realpathSync(dir)
+    if (visitedDirs.has(real)) return
+    visitedDirs.add(real)
+
+    // (1) this layer's own globs (collected before recursion — first-wins dedup)
+    collectGlobs(real)
+
+    // (2) auto-scanned layers/* — kit globs these even WITHOUT an extends entry
+    //     (reverse-alphabetical, processed before explicit extends)
+    const layersDir = join(real, 'layers')
+    if (existsSync(layersDir)) {
+      let subs: string[] = []
+      try {
+        subs = readdirSync(layersDir, { withFileTypes: true })
+          .filter(d => d.isDirectory())
+          .map(d => d.name)
+          .sort()
+          .reverse()
+      } catch {
+        subs = []
+      }
+      for (const name of subs) visitLayer(join(real, 'layers', name))
+    }
+
+    // (3) explicit extends — each resolved from THIS layer's own dir
+    const cfg = layerConfigPath(real)
+    if (cfg) {
+      for (const spec of readExtends(cfg)) {
+        const target = resolveLayerDir(spec, real)
+        if (target) visitLayer(target)
+      }
+    }
+  }
+
+  visitLayer(appDir)
+  return ordered
+}

--- a/packages/crouton-cli/tests/integration/schema-sources-parity.test.ts
+++ b/packages/crouton-cli/tests/integration/schema-sources-parity.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { resolveSchemaSources } from '../../lib/utils/schema-sources.ts'
+
+// Two tiers:
+//  1. Resolver-only checks (transitive reach, no-dup, fanfare no-crash) run in
+//     the normal `pnpm test` — they need only the resolver + an installed
+//     workspace (createRequire resolves @fyit/* from the root node_modules).
+//  2. Full PARITY vs NuxtHub — resolver path-set EQUALS the set NuxtHub globs
+//     into <app>/.nuxt/hub/db/schema.entry.ts — needs `nuxt prepare` per fixture
+//     (.nuxt is gitignored), so it is CI-only / opt-in behind RUN_PARITY=1.
+
+const REPO_ROOT = resolve(__dirname, '../../../..')
+const RUN_PARITY = process.env.RUN_PARITY === '1'
+
+const p = (...seg: string[]) => resolve(REPO_ROOT, ...seg)
+
+async function resolverRealSet(appDir: string): Promise<Set<string>> {
+  const paths = await resolveSchemaSources(appDir)
+  return new Set(paths.map(x => realpathSync(x)))
+}
+
+/** Parse NuxtHub's entry barrel into a realpath'd set (prepare first if absent). */
+function nuxthubRealSet(appDir: string): Set<string> {
+  const entry = resolve(appDir, '.nuxt/hub/db/schema.entry.ts')
+  if (!existsSync(entry)) {
+    execFileSync('pnpm', ['exec', 'nuxt', 'prepare'], { cwd: appDir, stdio: 'inherit' })
+  }
+  const src = readFileSync(entry, 'utf8')
+  return new Set(
+    [...src.matchAll(/from ['"](.+?)['"]/g)].map(m => realpathSync(m[1])),
+  )
+}
+
+describe('resolveSchemaSources — resolver-only checks (real fixtures)', () => {
+  it('nested-schema reaches crouton-printing ONLY via the transitive sales edge', async () => {
+    // nested-schema extends core + sales, NOT printing — printing is reachable
+    // solely because crouton-sales extends it. Proves package→package walking.
+    const paths = await resolveSchemaSources(p('fixtures/nested-schema'))
+    const rel = paths.map(x => x.replace(REPO_ROOT + '/', ''))
+    expect(rel).toContain('packages/crouton-printing/server/db/schema.ts')
+    expect(rel).toContain('packages/crouton-sales/server/db/schema.ts')
+    // and the app never listed printing itself
+    expect(paths.length).toBeGreaterThan(0)
+  })
+
+  it('returns no duplicate paths for with-sales (set-equality alone hides a non-deduping resolver)', async () => {
+    const paths = await resolveSchemaSources(p('fixtures/with-sales'))
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+
+  it('walks fanfare without crashing on its twelve crouton-themes subpath extends', async () => {
+    // Crash-risk case, not a schema case: themes carry no schema, but the walk
+    // must resolve their subpath exports without throwing.
+    await expect(resolveSchemaSources(p('apps/fanfare'))).resolves.toBeDefined()
+  })
+})
+
+describe.skipIf(!RUN_PARITY)('resolveSchemaSources — full parity vs NuxtHub (RUN_PARITY=1)', () => {
+  const CASES: Array<[string, string]> = [
+    ['fixtures/minimal', 'minimal'],
+    ['fixtures/with-sales', 'with-sales'],
+    ['fixtures/nested-schema', 'nested-schema (nesting-only)'],
+    ['pocs/booking-demo', 'booking-demo (benign duplicate topology)'],
+  ]
+
+  for (const [dir, label] of CASES) {
+    it(`${label}: resolver path-set EQUALS NuxtHub's`, async () => {
+      const resolver = await resolverRealSet(p(dir))
+      const nuxthub = nuxthubRealSet(p(dir))
+      expect([...resolver].sort()).toEqual([...nuxthub].sort())
+    })
+  }
+})

--- a/packages/crouton-cli/tests/unit/utils/schema-sources.repo-invariants.test.ts
+++ b/packages/crouton-cli/tests/unit/utils/schema-sources.repo-invariants.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+// The resolver reproduces NuxtHub's static schema barrel. That equivalence
+// holds ONLY while nothing in the monorepo registers the `hub:db:schema:extend`
+// hook (which would let a layer inject schema paths the static resolver can
+// never see). The brief's "hook is used nowhere" claim is a point-in-time grep
+// that can silently rot as packages are added — so make it a standing assertion.
+
+const REPO_ROOT = resolve(__dirname, '../../../../..')
+const HOOK = 'hub:db:schema:extend'
+const SCAN_DIRS = ['packages', 'apps', 'pocs', 'fixtures', 'playground']
+
+describe('repo invariant: hub:db:schema:extend is never registered', () => {
+  it('no source file registers the schema-extend hook', () => {
+    let matches: string[] = []
+    try {
+      const out = execFileSync(
+        'grep',
+        [
+          '-rIl', HOOK,
+          '--include=*.ts', '--include=*.mjs', '--include=*.js', '--include=*.vue',
+          '--exclude-dir=node_modules', '--exclude-dir=.nuxt', '--exclude-dir=dist',
+          ...SCAN_DIRS,
+        ],
+        { cwd: REPO_ROOT, encoding: 'utf8' },
+      )
+      matches = out.split('\n').filter(Boolean)
+    } catch (err: any) {
+      // grep exits 1 with no output when there are zero matches — the pass case.
+      if (err.status === 1 && !err.stdout?.toString().trim()) matches = []
+      else throw err
+    }
+
+    // A string literal is not a registration. Two legitimate mentions exist:
+    // the resolver's own doc comment (why it doesn't handle the hook) and this
+    // test's HOOK constant. The invariant is about PRODUCTION source, so drop
+    // test files and the resolver.
+    const offenders = matches.filter(f =>
+      !f.endsWith('lib/utils/schema-sources.ts') && !/\.test\.[cm]?ts$/.test(f))
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/crouton-cli/tests/unit/utils/schema-sources.repo-invariants.test.ts
+++ b/packages/crouton-cli/tests/unit/utils/schema-sources.repo-invariants.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { resolve } from 'node:path'
+import { existsSync } from 'node:fs'
+import { resolve, join } from 'node:path'
 
 // The resolver reproduces NuxtHub's static schema barrel. That equivalence
 // holds ONLY while nothing in the monorepo registers the `hub:db:schema:extend`
@@ -14,24 +15,28 @@ const SCAN_DIRS = ['packages', 'apps', 'pocs', 'fixtures', 'playground']
 
 describe('repo invariant: hub:db:schema:extend is never registered', () => {
   it('no source file registers the schema-extend hook', () => {
-    let matches: string[] = []
+    // Only scan dirs that exist in this checkout. GNU grep (Linux CI) exits 2 on
+    // a missing dir even when it found matches elsewhere; BSD grep (macOS) does
+    // not — filtering keeps the check portable. `playground` isn't always present.
+    const dirs = SCAN_DIRS.filter(d => existsSync(join(REPO_ROOT, d)))
+    let out = ''
     try {
-      const out = execFileSync(
+      out = execFileSync(
         'grep',
         [
           '-rIl', HOOK,
           '--include=*.ts', '--include=*.mjs', '--include=*.js', '--include=*.vue',
           '--exclude-dir=node_modules', '--exclude-dir=.nuxt', '--exclude-dir=dist',
-          ...SCAN_DIRS,
+          ...dirs,
         ],
         { cwd: REPO_ROOT, encoding: 'utf8' },
       )
-      matches = out.split('\n').filter(Boolean)
     } catch (err: any) {
-      // grep exits 1 with no output when there are zero matches — the pass case.
-      if (err.status === 1 && !err.stdout?.toString().trim()) matches = []
-      else throw err
+      // grep exits 1 (no matches) → empty stdout; any stdout it produced before
+      // a non-zero exit is still the match list, so read it either way.
+      out = err.stdout?.toString() ?? ''
     }
+    const matches = out.split('\n').filter(Boolean)
 
     // A string literal is not a registration. Two legitimate mentions exist:
     // the resolver's own doc comment (why it doesn't handle the hook) and this

--- a/packages/crouton-cli/tests/unit/utils/schema-sources.test.ts
+++ b/packages/crouton-cli/tests/unit/utils/schema-sources.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, realpathSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+// NB (#1448 probe finding): import with the explicit .ts extension.
+import { resolveSchemaSources } from '../../../lib/utils/schema-sources.ts'
+
+// Synthetic layer trees exercise the GRAPH-WALK mechanics (extends resolution,
+// app-root inclusion, layers/* auto-scan, realpath dedup, the exact glob) on
+// inputs we fully control. Node-resolution of real `@fyit/*` names and true
+// NuxtHub equivalence are pinned separately by the parity suite against real
+// fixtures (schema-sources-parity.test.ts).
+
+let root: string
+
+beforeEach(() => {
+  // realpath the tmp root: macOS /var → /private/var, so our expectations
+  // match what the resolver returns after its own realpath dedup.
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'schema-sources-')))
+})
+afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+interface LayerOpts {
+  extends?: string[]
+  schema?: boolean            // server/db/schema.ts
+  dialectFiles?: string[]     // e.g. schema.sqlite.ts, schema.pg.ts
+  schemaDir?: string[]        // files under server/db/schema/
+  otherFiles?: string[]       // server/db/*.ts OUTSIDE the exact glob
+  croutonConfig?: string      // crouton.config.js contents
+}
+
+/** Scaffold a fake Nuxt layer at `dir`. Returns `dir`. */
+function mklayer(dir: string, opts: LayerOpts = {}): string {
+  mkdirSync(join(dir, 'server', 'db'), { recursive: true })
+  writeFileSync(
+    join(dir, 'nuxt.config.ts'),
+    `export default defineNuxtConfig({ extends: ${JSON.stringify(opts.extends ?? [])} })\n`,
+  )
+  if (opts.schema) writeFileSync(join(dir, 'server/db/schema.ts'), 'export const t = 1\n')
+  for (const f of opts.dialectFiles ?? []) writeFileSync(join(dir, 'server/db', f), 'export const t = 1\n')
+  if (opts.schemaDir?.length) {
+    mkdirSync(join(dir, 'server/db/schema'), { recursive: true })
+    for (const f of opts.schemaDir) writeFileSync(join(dir, 'server/db/schema', f), 'export const t = 1\n')
+  }
+  for (const f of opts.otherFiles ?? []) writeFileSync(join(dir, 'server/db', f), 'export const t = 1\n')
+  if (opts.croutonConfig) writeFileSync(join(dir, 'crouton.config.js'), opts.croutonConfig)
+  return dir
+}
+
+describe('resolveSchemaSources', () => {
+  describe('layer coverage', () => {
+    it('includes the app root itself as a globbed layer', async () => {
+      mklayer(root, { schema: true })
+      const paths = await resolveSchemaSources(root)
+      expect(paths).toContain(join(root, 'server/db/schema.ts'))
+    })
+
+    it('follows a relative extends to a base layer', async () => {
+      const base = mklayer(join(root, 'base'), { schema: true })
+      mklayer(root, { schema: true, extends: ['./base'] })
+      const paths = await resolveSchemaSources(root)
+      expect(paths).toEqual(expect.arrayContaining([
+        join(root, 'server/db/schema.ts'),
+        join(base, 'server/db/schema.ts'),
+      ]))
+    })
+
+    it('follows a transitive extends, resolving each layer FROM ITS OWN dir', async () => {
+      // base extends './deeper' — must resolve to base/deeper, not root/deeper.
+      mklayer(join(root, 'base/deeper'), { schema: true })
+      mklayer(join(root, 'base'), { extends: ['./deeper'] })
+      mklayer(root, { extends: ['./base'] }) // app itself has no schema
+      const paths = await resolveSchemaSources(root)
+      expect(paths).toContain(join(root, 'base/deeper/server/db/schema.ts'))
+      expect(paths).not.toContain(join(root, 'deeper/server/db/schema.ts'))
+    })
+
+    it('auto-scans layers/* even when NOT listed in the extends array', async () => {
+      mklayer(join(root, 'layers/foo'), { schema: true })
+      mklayer(root, { extends: [] }) // foo deliberately unlisted
+      const paths = await resolveSchemaSources(root)
+      expect(paths).toContain(join(root, 'layers/foo/server/db/schema.ts'))
+    })
+  })
+
+  describe('dedup', () => {
+    it('collects a layer reachable via two parents exactly once', async () => {
+      mklayer(join(root, 'shared'), { schema: true })
+      mklayer(join(root, 'a'), { extends: ['../shared'] })
+      mklayer(join(root, 'b'), { extends: ['../shared'] })
+      mklayer(root, { extends: ['./a', './b'] })
+      const paths = await resolveSchemaSources(root)
+      const shared = join(root, 'shared/server/db/schema.ts')
+      expect(paths.filter(p => p === shared)).toHaveLength(1)
+    })
+
+    it('dedupes by realpath across a symlinked layer path', async () => {
+      mklayer(join(root, 'real'), { schema: true })
+      symlinkSync(join(root, 'real'), join(root, 'alias'), 'dir')
+      mklayer(root, { extends: ['./real', './alias'] })
+      const paths = await resolveSchemaSources(root)
+      const real = realpathSync(join(root, 'real/server/db/schema.ts'))
+      expect(paths.filter(p => realpathSync(p) === real)).toHaveLength(1)
+    })
+
+    it('returns no duplicate paths for a diamond-shaped graph', async () => {
+      mklayer(join(root, 'shared'), { schema: true })
+      mklayer(join(root, 'a'), { schema: true, extends: ['../shared'] })
+      mklayer(join(root, 'b'), { schema: true, extends: ['../shared'] })
+      mklayer(root, { schema: true, extends: ['./a', './b'] })
+      const paths = await resolveSchemaSources(root)
+      expect(new Set(paths).size).toBe(paths.length)
+    })
+  })
+
+  describe('the exact glob (never widen)', () => {
+    it('collects schema.<dialect>.ts for the active dialect and drops other dialects', async () => {
+      mklayer(root, { dialectFiles: ['schema.sqlite.ts', 'schema.pg.ts'] })
+      const paths = await resolveSchemaSources(root, { dialect: 'sqlite' })
+      expect(paths).toContain(join(root, 'server/db/schema.sqlite.ts'))
+      expect(paths).not.toContain(join(root, 'server/db/schema.pg.ts'))
+    })
+
+    it('collects files under server/db/schema/*.ts', async () => {
+      mklayer(root, { schemaDir: ['a.ts', 'b.ts'] })
+      const paths = await resolveSchemaSources(root)
+      expect(paths).toEqual(expect.arrayContaining([
+        join(root, 'server/db/schema/a.ts'),
+        join(root, 'server/db/schema/b.ts'),
+      ]))
+    })
+
+    it('ignores server/db/*.ts files outside the exact patterns', async () => {
+      // translations-ui.ts is the load-bearing example: widening to
+      // server/db/*.ts would double-define translations_ui for bookings apps.
+      mklayer(root, { schema: true, otherFiles: ['translations-ui.ts', 'other.ts'] })
+      const paths = await resolveSchemaSources(root)
+      expect(paths).not.toContain(join(root, 'server/db/translations-ui.ts'))
+      expect(paths).not.toContain(join(root, 'server/db/other.ts'))
+    })
+  })
+
+  describe('source of truth = filesystem, not config', () => {
+    it('ignores crouton.config.js collections (a config collection with no schema file is not collected)', async () => {
+      mklayer(root, {
+        schema: true,
+        croutonConfig: 'export default { collections: { widgets: {} } }\n',
+      })
+      const paths = await resolveSchemaSources(root)
+      // Only the real schema.ts — nothing invented for `widgets`.
+      expect(paths).toEqual([join(root, 'server/db/schema.ts')])
+    })
+  })
+
+  describe('robustness (must not crash)', () => {
+    it('tolerates an extended layer with no server/db dir', async () => {
+      mkdirSync(join(root, 'empty'), { recursive: true })
+      writeFileSync(join(root, 'empty/nuxt.config.ts'), 'export default defineNuxtConfig({})\n')
+      mklayer(root, { schema: true, extends: ['./empty'] })
+      await expect(resolveSchemaSources(root)).resolves.toContain(join(root, 'server/db/schema.ts'))
+    })
+
+    it('tolerates a config-only layer (extends resolves, but no schema surfaces)', async () => {
+      // Stand-in for the fanfare themes subpath-extends case; real subpath
+      // resolution is exercised by the fanfare parity walk.
+      mklayer(join(root, 'themeish'), {}) // has server/db dir but no schema files
+      mklayer(root, { schema: true, extends: ['./themeish'] })
+      const paths = await resolveSchemaSources(root)
+      expect(paths).toEqual([join(root, 'server/db/schema.ts')])
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,37 @@ importers:
         specifier: ^0.31.0
         version: 0.31.9
 
+  fixtures/nested-schema:
+    dependencies:
+      '@fyit/crouton':
+        specifier: workspace:*
+        version: link:../../packages/crouton
+      '@fyit/crouton-core':
+        specifier: workspace:*
+        version: link:../../packages/crouton-core
+      '@fyit/crouton-sales':
+        specifier: workspace:*
+        version: link:../../packages/crouton-sales
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.2(@cloudflare/workers-types@4.20260118.0)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(pg@8.17.1)
+      nuxt:
+        specifier: ^4.4.8
+        version: 4.4.8(acbda501943d3a88c40c15b150712194)
+      vue:
+        specifier: ^3.5.38
+        version: 3.5.38(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.38(typescript@5.9.3))
+    devDependencies:
+      '@fyit/crouton-cli':
+        specifier: workspace:*
+        version: link:../../packages/crouton-cli
+      drizzle-kit:
+        specifier: ^0.31.0
+        version: 0.31.10
+
   fixtures/with-assets:
     dependencies:
       '@fyit/crouton':


### PR DESCRIPTION
Part of epic #1445 (CLI-owned migrations). This is **WS1a** — the resolver + parity suite + the nesting-only fixture. The identity-aware duplicate-table gate over its output is **WS1b (#1447)**, and the drizzle-kit invocation that consumes it is **WS2 (#1449)**.

## 👤 For humans

The CLI can now compute every database-schema file an app's layers contribute — exactly the set Nuxt would find — **without starting a Nuxt build**. That's the foundation for generating migrations directly, so a migration can never again be built from a stale picture of the app (the #1385 class of bug). Nothing in the generation flow changes yet; this just adds the capability and proves it matches Nuxt exactly.

## 🤖 For agents

- **New `lib/utils/schema-sources.ts`** — `resolveSchemaSources(appDir, {dialect})`: recursive `extends` walk (app root + auto-scanned `layers/*` + `@fyit/*`/subpath extends resolved from each layer's own dir for pnpm strict isolation), realpath dedup first-wins, the exact NuxtHub glob (`schema.ts` / `schema.<dialect>.ts` / `schema/*.ts`, never widened), magicast static `extends` parse — **no Nuxt import**. Reads the filesystem, never `crouton.config.js` (#226 guard).
- **`fixtures/nested-schema/`** — parity-only micro-fixture (extends core + sales only → printing reachable solely via the transitive sales→printing edge). No `e2e.manifest.json`.
- **Tests:** 13 unit cases (synthetic layer trees), a repo-invariant guard (nothing registers `hub:db:schema:extend`), and a parity suite — resolver-only tier runs in `pnpm test`; the path-set-EQUALS-NuxtHub tier is `RUN_PARITY=1`.
- **Follow-up:** CI needs a `RUN_PARITY=1` job (fixtures `nuxt prepare`d) to run the equality tier in CI; the resolver-only tier already runs.

## 🧪 How to test

- `pnpm --filter @fyit/crouton-cli test` → **333 passed / 4 skipped** (the 4 = the opt-in `RUN_PARITY` equality tier). The 13 `schema-sources` unit cases + repo invariant + 3 resolver-only parity checks all run.
- Acceptance proof (validated against real NuxtHub `schema.entry.ts`): resolver path-set equals NuxtHub's **exactly** for `fixtures/minimal` (3), `fixtures/with-sales` (4), `pocs/booking-demo` (4); `nested-schema` reaches `crouton-printing` only via the sales edge; `apps/fanfare` walks its 12 themes subpath extends without crashing.
- Full parity tier: `RUN_PARITY=1 pnpm --filter @fyit/crouton-cli test`.

Closes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)