### PR TITLE
Full-screen pages: uniform inset instead of edge-to-edge

### DIFF
--- a/packages/crouton-pages/app/layouts/public.vue
+++ b/packages/crouton-pages/app/layouts/public.vue
@@ -125,7 +125,10 @@ function applyLayoutClasses() {
       break
     case 'full-screen':
       container.className = 'bg-background min-h-screen'
-      main.className = 'pt-0'
+      // Uniform inset so a full-bleed module (kassa) breathes on every side
+      // instead of touching the viewport edges. The kassa measures its own
+      // top and fills to ~1rem above the bottom, so this gives symmetric gaps.
+      main.className = 'p-3 sm:p-4'
       break
     default:
       container.className = 'bg-background min-h-screen'
@@ -161,7 +164,7 @@ const mainClasses = computed(() => {
     case 'full-height':
       return `flex-1 overflow-hidden ${pt} px-4 sm:px-6 lg:px-8 max-w-3xl mx-auto w-full`
     case 'full-screen':
-      return 'pt-0'
+      return 'p-3 sm:p-4'
     default:
       return `max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 ${pt} pb-8`
   }


### PR DESCRIPTION
## 👤 For humans

Follow-up to #1467 — you flagged the full-screen kassa as too snug against the edges. It now floats with a ~16px margin on all four sides (top/left/right/bottom) instead of touching the viewport. Verified live on fanfare dev: 16px top/left/bottom, right edge tabs at 16px too.

## 🤖 For agents
- `layouts/public.vue`: full-screen `main` `pt-0` → `p-3 sm:p-4` (both the `applyLayoutClasses` DOM copy and the SSR `mainClasses` computed). The Shell's measured height (`100dvh - top - 1rem`) yields a matching bottom gap → symmetric inset.

## 🧪 How to test
Open a full-screen kassa page: the module has ~16px margin on every side, no longer flush with the viewport edges.

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)