### PR TITLE
feat(crouton-sales): use UPinInput for the volunteer PIN, fixed 4-digit (#1480)

### DIFF
--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
@@ -172,6 +172,13 @@ const eventDirty = computed(() =>
   || eventForm.value.helperPin !== (props.event.helperPin || '')
 )
 
+// UPinInput binds an array (one digit per cell); keep the joined string on
+// eventForm.helperPin so the dirty-check + save keep working. Fixed 4 digits (#1480).
+const helperPinCells = computed<number[]>({
+  get: () => (eventForm.value.helperPin || '').split('').map(Number),
+  set: cells => { eventForm.value.helperPin = cells.join('') }
+})
+
 const receiptDirty = computed(() =>
   receiptForm.value.special_instructions_title !== receiptSaved.value.special_instructions_title
   || receiptForm.value.staff_order_header !== receiptSaved.value.staff_order_header
@@ -611,13 +618,12 @@ function helperExpiry(value: string): string {
         </template>
 
         <UFormField :label="t('sales.workspace.helperPin')">
-          <UInput
-            v-model="eventForm.helperPin"
-            type="text"
-            :placeholder="t('sales.helperLogin.enterPin')"
+          <UPinInput
+            v-model="helperPinCells"
+            :length="4"
+            type="number"
             size="sm"
-            :ui="{ base: 'font-mono' }"
-            class="w-full"
+            :aria-label="t('sales.workspace.helperPin')"
           />
         </UFormField>
 

--- a/packages/crouton-sales/app/components/Pos/Panel.vue
+++ b/packages/crouton-sales/app/components/Pos/Panel.vue
@@ -99,6 +99,12 @@ const sessionMatchesEvent = computed(() =>
 
 // Login form state (helper PIN fallback)
 const formState = reactive({ helperName: '', pin: '' })
+// UPinInput binds an array (one digit per cell); keep the joined string as the
+// source of truth so onLoginSubmit / login() stay unchanged. Fixed 4 digits (#1480).
+const pinCells = computed<number[]>({
+  get: () => formState.pin.split('').map(Number),
+  set: cells => { formState.pin = cells.join('') }
+})
 const loginError = ref('')
 const submitting = ref(false)
 
@@ -286,15 +292,13 @@ onUnmounted(unhookMutation)
             />
           </UFormField>
           <UFormField :label="t('sales.helperLogin.pin')" name="pin">
-            <UInput
-              v-model="formState.pin"
-              type="password"
-              :placeholder="t('sales.helperLogin.enterPin')"
+            <UPinInput
+              v-model="pinCells"
+              :length="4"
+              type="number"
+              mask
               size="lg"
-              class="w-full"
-              :ui="{ base: 'font-mono text-center tracking-widest' }"
-              inputmode="numeric"
-              pattern="[0-9]*"
+              :aria-label="t('sales.helperLogin.pin')"
             />
           </UFormField>
           <UButton


### PR DESCRIPTION
Closes #1480

## 👤 For humans
Both helper-PIN surfaces become real 4-cell PIN inputs instead of text fields styled to look like one:
- **Volunteer login** (`Pos/Panel.vue`) — masked 4-cell numeric PinInput.
- **Admin event-PIN field** (`SettingsTab.vue`, event Settings → Helpers) — unmasked 4-cell numeric PinInput (the admin sets their own PIN, so they see it).

Both ends are now fixed to **4 numeric digits**, so an admin can't set a PIN a volunteer can't type. Owner decisions this session: length **4**, and **lock both** ends. Greenfield — no existing PINs to migrate; the seed PIN (`1234`) already fits.

## 🤖 For agents
- `UPinInput` v-model is an **array**, so each site uses a `computed<number[]>` proxy that splits/joins over the existing string PIN (source of truth unchanged): `pinCells` over `formState.pin` (volunteer), `helperPinCells` over `eventForm.helperPin` (admin). `onLoginSubmit`/`login()` and the admin dirty-check/save are untouched.
- `type="number"` → v-model is `number[]` (typecheck-confirmed). No server/schema change — `helperPin` stays a text column; redeem is still a trimmed string compare in crouton-auth.
- Side effect: `UPinInput` gains its **first real consumers** (it was a documented skip in #1458). Theming it across the 11 themes is now warranted — I'll open that follow-up.

## 🧪 How to test
1. **Admin**: open an event → Settings → Helpers. The PIN field is a 4-cell numeric PinInput. Set `1234`, Save (the "unsaved changes" hint + Save enable/disable still work).
2. **Volunteer**: open the event's kassa without a session → the login shows a name field + a masked 4-cell PinInput. Enter a name + `1234` → logs in and loads order data.
3. `pnpm --filter fanfare typecheck` — green (exit 0, 0 TS errors). ✓ verified.

## ⚠️ Review note — live surfaces not yet driven
Verified: typecheck green; the 4-cell PinInput render is already proven on the themes playground `/matrix`. **Not** yet driven end-to-end on a running fanfare (the volunteer login + admin settings both need a booted app with team/event context + auth, and this fresh worktree lacks the `.env`/seeded DB). The change is a component swap with a trivial array↔string proxy, but since it's a login surface I'd rather you eyeball it — happy to deploy a staging preview or boot it locally before merge. **Not auto-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)