### PR TITLE
feat(crouton-themes): theme UPinInput across the 11 themes (#1482)

### DIFF
--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -553,17 +553,23 @@ uses. The split (verified 2026-07-11):
     tint the color surfaces): frame `[data-slot="selector"]` +
     `[data-color-picker-track]`, round-off `selectorThumb`/`trackThumb` (camelCase
     in the DOM). Both scoped to BOTH activation paths like the #1393 ambient set.
+  - **UPinInput** (#1482 — crouton-sales volunteer login `Pos/Panel.vue` + admin
+    event-PIN `SettingsTab.vue`, themed once #1480 made it a real consumer) — a
+    **named variant** like `input`: it has a `variant` dimension + a `base` slot
+    per cell, so each theme registers `pinInput.variants.variant.<p>.base` pointing
+    at its existing `<p>-input-base` class (marker + replacer on `base`) — the
+    cells reuse the theme's input look for **zero new CSS**; the square geometry
+    comes from the size variant (no input-base class sets `width`, checked).
+    Runtime scalar `pinInput.defaultVariants.variant` in `themeConfigs.ts`.
 - **Documented skips** — no consumer anywhere in the repo, so stock (they still
-  adapt to the theme via the `#1390` semantic `--ui-*` tokens — verified not
-  broken, e.g. terminal's PIN boxes render as phosphor-bordered squares):
-  - **UPinInput** — the issue's real-use map guessed 2FA, but `TwoFactorForm.vue`
-    (and the POS helper-login) use a plain **`UInput`** for the code, not
-    `UPinInput`. No consumer → skip.
+  adapt to the theme via the `#1390` semantic `--ui-*` tokens):
   - **UInputTags**, **UCommandPalette** — zero consumers outside the playground
     `/matrix` zoo.
+  - (**UPinInput** was a skip here until #1480 gave it real consumers — the issue's
+    map guessed 2FA, but that form uses a plain `UInput`. Now themed, above.)
 
-blackandwhite stays the deliberate stock pass here too (its calendar runtime is
-`solid`, no `bw-cal-*` variant).
+blackandwhite stays the deliberate stock pass here too (calendar runtime `solid`,
+pinInput runtime `subtle` to match its stock inputs — no `bw-*` variants).
 
 ## Dual scheme (#1395) — every theme works in light AND dark
 

--- a/packages/crouton-themes/blueprint/app.config.ts
+++ b/packages/crouton-themes/blueprint/app.config.ts
@@ -241,6 +241,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { blueprint: { base: "bp-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/braun/app.config.ts
+++ b/packages/crouton-themes/braun/app.config.ts
@@ -248,6 +248,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { braun: { base: "braun-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/brutalist/app.config.ts
+++ b/packages/crouton-themes/brutalist/app.config.ts
@@ -251,6 +251,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { brutalist: { base: "brutalist-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/eink/app.config.ts
+++ b/packages/crouton-themes/eink/app.config.ts
@@ -241,6 +241,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { eink: { base: "eink-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/gameboy/app.config.ts
+++ b/packages/crouton-themes/gameboy/app.config.ts
@@ -249,6 +249,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { gameboy: { base: "gb-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/ko/app.config.ts
+++ b/packages/crouton-themes/ko/app.config.ts
@@ -278,6 +278,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { ko: { base: "ko-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/kr11/app.config.ts
+++ b/packages/crouton-themes/kr11/app.config.ts
@@ -250,6 +250,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { kr11: { base: "kr-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/minimal/app.config.ts
+++ b/packages/crouton-themes/minimal/app.config.ts
@@ -235,6 +235,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { minimal: { base: "minimal-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/mtv/app.config.ts
+++ b/packages/crouton-themes/mtv/app.config.ts
@@ -249,6 +249,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { mtv: { base: "mtv-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/riso/app.config.ts
+++ b/packages/crouton-themes/riso/app.config.ts
@@ -241,6 +241,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { riso: { base: "riso-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/terminal/app.config.ts
+++ b/packages/crouton-themes/terminal/app.config.ts
@@ -248,6 +248,13 @@ export default defineAppConfig({
           }
         }
       }
+    },
+
+    // #1482: UPinInput reuses this theme's input treatment on each cell
+    // (border/bg/focus); the size variant keeps the square geometry.
+    pinInput: {
+      slots: { base: subtractThemeDefaults },
+      variants: { variant: { terminal: { base: "term-input-base" } } }
     }
   }
 })

--- a/packages/crouton-themes/themes/configs/themeConfigs.ts
+++ b/packages/crouton-themes/themes/configs/themeConfigs.ts
@@ -38,6 +38,7 @@ export interface ThemeUIConfig {
   radioGroup?: { defaultVariants?: { variant?: string } }
   alert?: { defaultVariants?: { variant?: string } }
   calendar?: { defaultVariants?: { variant?: string } }
+  pinInput?: { defaultVariants?: { variant?: string } }
 }
 
 // Every config sets EVERY key the swap owns, so switching A → B never leaves
@@ -63,6 +64,7 @@ const namedVariantConfig = (
   radioGroup: { defaultVariants: { variant } },
   alert: { defaultVariants: { variant } },
   calendar: { defaultVariants: { variant } },
+  pinInput: { defaultVariants: { variant } },
   ...overrides
 })
 
@@ -83,7 +85,8 @@ const defaultConfig: ThemeUIConfig = {
   checkbox: { defaultVariants: { variant: 'list' } },
   radioGroup: { defaultVariants: { variant: 'list' } },
   alert: { defaultVariants: { variant: 'solid' } },
-  calendar: { defaultVariants: { variant: 'solid' } }
+  calendar: { defaultVariants: { variant: 'solid' } },
+  pinInput: { defaultVariants: { variant: 'outline' } }
 }
 
 // KO — named variants registered by ko/app.config.ts (variant="ko" etc.)
@@ -119,7 +122,8 @@ const blackandwhiteConfig: ThemeUIConfig = {
   checkbox: { defaultVariants: { variant: 'list' } },
   radioGroup: { defaultVariants: { variant: 'list' } },
   alert: { defaultVariants: { variant: 'subtle' } },
-  calendar: { defaultVariants: { variant: 'solid' } }
+  calendar: { defaultVariants: { variant: 'solid' } },
+  pinInput: { defaultVariants: { variant: 'subtle' } }
 }
 
 // Brutalist — named variants registered by brutalist/app.config.ts


### PR DESCRIPTION
Closes #1482

## 👤 For humans
Closes the loop from #1458: `UPinInput` was a documented skip there because nothing used it. #1480 gave it real consumers (the volunteer login + admin event-PIN field), so its cells now follow every theme (all 11 non-blackandwhite, both schemes) instead of stock chrome.

The nice part: **zero new CSS**. PinInput carries a `variant` dimension + a `base` slot per cell, so it's a named-variant component like `input` — each theme just points the pin cells at its **existing `<p>-input-base` class**. brutalist gets its shadowed black boxes, terminal its phosphor borders, ko its LCD panels, eink its underline cells, etc.

## 🤖 For agents
- Per theme: `pinInput.variants.variant.<p>.base = '<p>-input-base'` (marker + `subtractThemeDefaults` on the `base` slot). The square cell geometry comes from the size variant, not the named variant — none of the 11 input-base classes set `width` (checked), so reuse is safe.
- Runtime scalar `pinInput.defaultVariants.variant` in `themeConfigs.ts`, **every** entry (named → `<theme>`, default → `outline`, bw → `subtle` to match its stock inputs) — the deepAssign no-stale-variant rule.
- blackandwhite: deliberate stock pass (no `bw-*` pin variant), consistent with #1458/#1393.

## 🧪 How to test
Playground `/matrix` (Form controls → PIN) under all 12 themes × light/dark: the 4 cells follow the theme (border/bg/focus), no stock chrome. Real surface: the #1480 volunteer login + admin event-PIN field.

Verified: `pnpm --filter crouton-themes-playground typecheck` green (exit 0); `/matrix` PIN row screenshotted themed across all 11 themes × both schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)