### PR TITLE
fix(root): classify GLM plan-quota 429 as quota, not an SDK error (#1492)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -342,7 +342,18 @@ jobs:
               if (logFile && fs.existsSync(logFile)) {
                 const log = fs.readFileSync(logFile, 'utf8')
                 const tail = log.length > 600 ? log.slice(-600) : log
-                if (/credit balance is too low|insufficient.*(credit|balance|quota)|billing/i.test(log)) {
+                // GLM Coding Plan quota (z.ai) — checked FIRST: its 429 is distinct from an
+                // Anthropic billing failure and must not fall through to the generic SDK-error
+                // bucket (the #1451/#1492 misdiagnosis). z.ai emits `429 {"code":"1308",
+                // "message":"Usage limit reached for 5 hour. Your limit will reset at <ts>"}`.
+                const glmReset = (log.match(/reset at ([0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9:]+)/i) || [])[1]
+                if (/\b1308\b|usage limit reached/i.test(log)) {
+                  why = 'the GLM Coding Plan quota was reached mid-run'
+                    + (glmReset ? ` (the plan window resets at ${glmReset})` : ' (z.ai 5-hour / weekly window)')
+                  action = 'wait for that window to reset then re-dispatch on GLM (free), '
+                    + 'or escalate this one leaf to the metered `provider=anthropic` lane to unblock now — '
+                    + 'this is NOT a code/SDK bug, nothing is broken'
+                } else if (/credit balance is too low|insufficient.*(credit|balance|quota)|billing/i.test(log)) {
                   why = 'the Anthropic key (`PI_PROVIDER_KEY`) is out of credit'
                   action = 'top up the account, then re-dispatch' // NB: not "enable auto-reload" — owner declined it (#1327); the pi-key-canary workflow tracks key health
                 } else if (failed) {


### PR DESCRIPTION
Closes #1492 (epic #669).

## 👤 For humans

When GLM — now the default pipeline provider — hits its Coding Plan quota mid-run, the artifact-gate used to say *"fix the SDK/tooling error"* (misleading; nothing's broken). Now it names the real cause and the real fix: wait for the plan window to reset (surfaced from the run log when present) or escalate the leaf to the metered `anthropic` lane. First hit on #1451.

## 🤖 For agents

`decompose-on-issue-pidev.yml` artifact-gate classifier: a new **first** branch matches z.ai's `429` (`1308` / "Usage limit reached"), parses the reset timestamp from the log, and emits a quota-specific message. The Anthropic billing branch and the generic-error/underspecified branches are untouched (GLM quota is checked before them so it can't fall through).

## 🧪 How to test

Verified locally against the real #1451 log tail (`429 … "code":"1308" … "Usage limit reached … reset at 2026-07-12 04:30:37"`): classifier fires the quota branch, parses the reset ts, does **not** trigger the Anthropic billing branch. (Included as an inline node assertion in the PR discussion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
