### PR TITLE
Theme-aware chart colors from the primary (OKLCH, dep-free)

### DIFF
--- a/packages/crouton-charts/CLAUDE.md
+++ b/packages/crouton-charts/CLAUDE.md
@@ -9,6 +9,8 @@ Chart visualizations for Nuxt Crouton applications. Wraps `nuxt-charts` (free ba
 | File | Purpose |
 |------|---------|
 | `app/composables/useCollectionChart.ts` | Fetch + transform collection data for charting (auto-detects numeric fields) |
+| `app/composables/useChartPalette.ts` | **Theme-aware series colors** (#1483): resolves `--ui-primary` (an OKLCH string) at runtime and returns a reactive `colorAt(index, total)`. Client-only + reactive to dark-mode / theme swaps (MutationObserver on `<html>`); SSR falls back to the static palette. `var()` can't go in an SVG `fill`/`stop-color`, so the primary must be a resolved literal — Nuxt UI already stores it as OKLCH, which renders directly, so **no color library is needed** |
+| `app/utils/chart-constants.ts` | `CHART_COLOR_PALETTE` (static fallback) + `buildThemePalette(primary, count)` / `parseOklch` / `getChartColor(i, total, primary?)`. Palette derivation: 1 series → the primary; chromatic multi → series 0 = primary, rest sweep hue evenly at the same L/C; grayscale primary (chroma < 0.03, e.g. eink theme) → a lightness ramp so series stay distinct; no primary → the static 10-hue palette |
 | `app/components/Widget.vue` | `CroutonChartsWidget` - collection-driven chart component |
 | `nuxt.config.ts` | Layer config (extends crouton-core, registers nuxt-charts module) |
 | `crouton.manifest.ts` | Package manifest for the crouton registry |
@@ -87,7 +89,7 @@ useCollectionChart(collection, options)
   → $fetch(apiPath) for data
   → auto-detect numeric fields (if yFields not provided)
   → transform rows → [{ xField: value, yField1: num, yField2: num }]
-  → assign colors from palette [blue, emerald, amber, red, violet]
+  → assign colors via useChartPalette().colorAt (theme primary-derived, #1483)
   → return { chartData, categories, pending, error, refresh }
          ↓
 CroutonChartsWidget

--- a/packages/crouton-charts/app/components/Widget.vue
+++ b/packages/crouton-charts/app/components/Widget.vue
@@ -93,12 +93,15 @@ const donutData = computed(() => {
   return chartData.value.map((row: Record<string, unknown>) => Number(row[yField] ?? 0))
 })
 
+// DonutChart segment colors are theme-derived too (per segment, not per series).
+const { colorAt: donutColorAt } = useChartPalette()
+
 // DonutChart: categories keyed by X-field value (the segment labels), not Y-field name
 const donutCategories = computed(() =>
   Object.fromEntries(
     chartData.value.map((row: Record<string, unknown>, i: number) => {
       const label = String(row[xAxisKey.value] ?? `Item ${i}`)
-      return [label, { name: label, color: getChartColor(i, chartData.value.length) }]
+      return [label, { name: label, color: donutColorAt(i, chartData.value.length) }]
     })
   )
 )

--- a/packages/crouton-charts/app/composables/useChartPalette.ts
+++ b/packages/crouton-charts/app/composables/useChartPalette.ts
@@ -1,0 +1,52 @@
+import { getChartColor } from '../utils/chart-constants'
+
+/**
+ * Resolves the theme's primary color (as an OKLCH string) at runtime and hands
+ * back a reactive `colorAt(index, total)` for chart series colors.
+ *
+ * Why runtime + client-only: `var(--ui-primary)` does NOT resolve inside an SVG
+ * `fill`/`stop-color` presentation attribute, so the chart lib needs a literal
+ * color value. Nuxt UI 4 stores the primary as an OKLCH string (from
+ * `tailwindcss/colors`, Tailwind v4), so `getComputedStyle` reads it back
+ * verbatim and we feed it straight through — no color library, no conversion.
+ *
+ * `--ui-primary` (not `--ui-color-primary-500`) is the mode-correct alias:
+ * shade 500 in light, 400 in dark. We re-read on color-mode change and on any
+ * `<html>` class/style mutation (theme / Look-and-Feel swaps) so charts recolor
+ * live. SSR renders with `primary=null` → the static palette, then the client
+ * re-derives after mount (no hydration flash: same categories, only colors
+ * differ, which the chart lib applies reactively).
+ */
+export function useChartPalette() {
+  const primary = ref<string | null>(null)
+  const colorMode = useColorMode()
+
+  function readPrimary() {
+    if (!import.meta.client) return
+    const v = getComputedStyle(document.documentElement)
+      .getPropertyValue('--ui-primary')
+      .trim()
+    if (v && v !== primary.value) primary.value = v
+  }
+
+  let observer: MutationObserver | null = null
+  onMounted(() => {
+    readPrimary()
+    // Catch dark-mode class flips and runtime theme-var swaps (Look-and-Feel).
+    observer = new MutationObserver(() => readPrimary())
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style']
+    })
+  })
+  onUnmounted(() => observer?.disconnect())
+  // Belt-and-braces: color-mode toggles the .dark class, but the composable may
+  // outlive a class-only observe window during navigation.
+  watch(() => colorMode.value, () => nextTick(readPrimary))
+
+  function colorAt(index: number, total: number): string {
+    return getChartColor(index, total, primary.value)
+  }
+
+  return { primary, colorAt }
+}

--- a/packages/crouton-charts/app/composables/useCollectionChart.ts
+++ b/packages/crouton-charts/app/composables/useCollectionChart.ts
@@ -16,14 +16,15 @@ export interface UseCollectionChartOptions {
   query?: Record<string, string | number>
 }
 
-import { getChartColor } from '../utils/chart-constants'
-
 export function useCollectionChart(
   collectionKey: MaybeRef<string>,
   options?: MaybeRef<UseCollectionChartOptions>
 ) {
   const { getConfig } = useCollections()
   const { teamId } = useTeamContext()
+  // Theme-derived series colors (reactive to theme + dark mode); reads the
+  // categories computed below so a theme change recolors the chart live.
+  const { colorAt } = useChartPalette()
 
   const chartData = ref<Record<string, unknown>[]>([])
   const pending = ref(false)
@@ -127,7 +128,7 @@ export function useCollectionChart(
 
     return fields.map((field, index) => ({
       name: field,
-      color: getChartColor(index, fields.length)
+      color: colorAt(index, fields.length)
     }))
   })
 

--- a/packages/crouton-charts/app/utils/chart-constants.ts
+++ b/packages/crouton-charts/app/utils/chart-constants.ts
@@ -14,19 +14,78 @@ export const CHART_COLOR_PALETTE = [
   '#6366f1', // indigo
 ] as const
 
+/** Below this OKLCH chroma the primary is effectively grayscale (monochrome
+ *  themes, e.g. eink/black-and-white): hue-rotation can't make distinct
+ *  categorical colors, so we ramp lightness instead. */
+const ACHROMATIC_CHROMA = 0.03
+
+interface Oklch { l: number, c: number, h: number }
+
+/** Parse an `oklch(L C H)` / `oklch(L% C H [/ a])` string (the form Tailwind v4
+ *  / Nuxt UI emit, read back verbatim from getComputedStyle). L is normalised
+ *  to 0–1. Returns null for anything unparseable. */
+export function parseOklch(value: string | null | undefined): Oklch | null {
+  if (!value) return null
+  const m = /oklch\(\s*([\d.]+)(%?)\s+([\d.]+)\s+([\d.]+)/i.exec(value)
+  if (!m) return null
+  const l = m[2] === '%' ? Number(m[1]) / 100 : Number(m[1])
+  const c = Number(m[3])
+  const h = Number(m[4])
+  if ([l, c, h].some(n => Number.isNaN(n))) return null
+  return { l, c, h }
+}
+
+const oklchStr = (l: number, c: number, h: number) =>
+  `oklch(${+l.toFixed(4)} ${+c.toFixed(4)} ${+h.toFixed(2)})`
+
 /**
- * Color for series `index` of `total` series — guaranteed never to repeat.
+ * Build the ordered series palette for `count` series, derived from the theme
+ * `primary` (an OKLCH string, e.g. from `--ui-primary`). Dep-free: we stay in
+ * OKLCH the whole way, which renders directly in SVG fills.
  *
- * Uses the curated palette while it has enough distinct entries; once there
- * are more series than palette colors, switches to evenly-spaced HSL hues so
- * no two series ever share a color (e.g. 12 products → 12 distinct hues).
+ * - No primary (SSR / unparseable) → the static curated palette (unchanged
+ *   first-paint behaviour).
+ * - 1 series → the primary itself (themed, even if grayscale).
+ * - Chromatic primary → series 0 = primary; series i = primary's L & C with
+ *   hue stepped evenly around the wheel (distinct but on-theme).
+ * - Grayscale primary (chroma < ACHROMATIC_CHROMA) → a lightness ramp (still
+ *   monochrome, but the series stay distinguishable).
  */
-export function getChartColor(index: number, total: number): string {
+export function buildThemePalette(primary: string | null | undefined, count: number): string[] {
+  const n = Math.max(1, count)
+  const base = parseOklch(primary)
+  if (!base) return Array.from({ length: n }, (_, i) => staticColor(i, n))
+  if (n === 1) return [oklchStr(base.l, base.c, base.h)]
+
+  if (base.c < ACHROMATIC_CHROMA) {
+    // Even lightness ramp across a readable mid band (dark→light gray).
+    const lo = 0.4, hi = 0.78
+    return Array.from({ length: n }, (_, i) =>
+      oklchStr(lo + (hi - lo) * (i / (n - 1)), 0, 0))
+  }
+
+  // series 0 = primary; the rest sweep hue evenly from it.
+  return Array.from({ length: n }, (_, i) =>
+    oklchStr(base.l, base.c, (base.h + (i * 360) / n) % 360))
+}
+
+/** The original curated/HSL palette — the fallback when no theme primary is
+ *  available (SSR) and the base for grayscale themes' extra series. */
+function staticColor(index: number, total: number): string {
   if (total <= CHART_COLOR_PALETTE.length) {
     return CHART_COLOR_PALETTE[index % CHART_COLOR_PALETTE.length]!
   }
   const hue = Math.round((index * 360) / total)
   return `hsl(${hue} 65% 55%)`
+}
+
+/**
+ * Color for series `index` of `total` — theme-aware when a resolved `primary`
+ * OKLCH string is passed (see `useChartPalette`), else the static palette.
+ */
+export function getChartColor(index: number, total: number, primary?: string | null): string {
+  const pal = buildThemePalette(primary, total)
+  return pal[index % pal.length]!
 }
 
 /** Block attrs for chart editor blocks (used by both View and Render) */

--- a/packages/crouton-charts/test/chart-palette.test.ts
+++ b/packages/crouton-charts/test/chart-palette.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseOklch,
+  buildThemePalette,
+  getChartColor,
+  CHART_COLOR_PALETTE
+} from '../app/utils/chart-constants'
+
+const ORANGE = 'oklch(70.5% 0.213 47.604)' // Tailwind primary=orange, light
+const GRAY = 'oklch(55.6% 0 0)' // eink / black-and-white theme primary
+
+describe('parseOklch', () => {
+  it('parses a percentage lightness to 0–1', () => {
+    expect(parseOklch(ORANGE)).toEqual({ l: 0.705, c: 0.213, h: 47.604 })
+  })
+  it('parses a fractional lightness as-is', () => {
+    expect(parseOklch('oklch(0.62 0.19 260)')).toEqual({ l: 0.62, c: 0.19, h: 260 })
+  })
+  it('tolerates a trailing alpha', () => {
+    expect(parseOklch('oklch(0.62 0.19 260 / 0.5)')).toEqual({ l: 0.62, c: 0.19, h: 260 })
+  })
+  it('returns null for junk / missing', () => {
+    expect(parseOklch(null)).toBeNull()
+    expect(parseOklch('rgb(1,2,3)')).toBeNull()
+    expect(parseOklch('')).toBeNull()
+  })
+})
+
+describe('buildThemePalette', () => {
+  it('falls back to the static palette when no primary (SSR)', () => {
+    expect(buildThemePalette(null, 3)).toEqual([
+      CHART_COLOR_PALETTE[0], CHART_COLOR_PALETTE[1], CHART_COLOR_PALETTE[2]
+    ])
+  })
+
+  it('a single series is exactly the primary', () => {
+    expect(buildThemePalette(ORANGE, 1)).toEqual(['oklch(0.705 0.213 47.6)'])
+  })
+
+  it('single series stays the primary even when grayscale', () => {
+    expect(buildThemePalette(GRAY, 1)).toEqual(['oklch(0.556 0 0)'])
+  })
+
+  it('chromatic multi: series 0 is the primary, rest sweep hue at the same L/C', () => {
+    const pal = buildThemePalette(ORANGE, 4)
+    expect(pal).toHaveLength(4)
+    // series 0 == primary
+    expect(pal[0]).toBe('oklch(0.705 0.213 47.6)')
+    // all share L & C, only hue differs, evenly by 360/4 = 90°
+    const parsed = pal.map(c => parseOklch(c)!)
+    expect(parsed.every(p => p.l === 0.705 && p.c === 0.213)).toBe(true)
+    expect(parsed.map(p => Math.round(p.h))).toEqual([48, 138, 228, 318])
+    // no two series share a color
+    expect(new Set(pal).size).toBe(4)
+  })
+
+  it('grayscale multi: a lightness ramp (chroma 0, increasing L, all distinct)', () => {
+    const pal = buildThemePalette(GRAY, 4)
+    const parsed = pal.map(c => parseOklch(c)!)
+    expect(parsed.every(p => p.c === 0)).toBe(true)
+    // strictly increasing lightness → distinguishable
+    for (let i = 1; i < parsed.length; i++) {
+      expect(parsed[i]!.l).toBeGreaterThan(parsed[i - 1]!.l)
+    }
+    expect(new Set(pal).size).toBe(4)
+  })
+})
+
+describe('getChartColor', () => {
+  it('is theme-aware when a primary is passed', () => {
+    expect(getChartColor(0, 1, ORANGE)).toBe('oklch(0.705 0.213 47.6)')
+  })
+  it('is the static palette without a primary', () => {
+    expect(getChartColor(0, 5)).toBe(CHART_COLOR_PALETTE[0])
+  })
+})


### PR DESCRIPTION
## 👤 For humans

Charts now derive their colors from the active theme instead of a hardcoded blue palette. The sales revenue chart ("Omzet per dag") takes the theme primary — so it matches the top-product bars instead of clashing blue — and it recolors live when you switch theme or dark mode. **No new dependency.**

Verified live on fanfare: the revenue chart went from `#3b82f6` blue to the theme primary, and overriding `--ui-primary` recolored it instantly (proving the reactive path).

## 🤖 For agents

Ecosystem-check ([#1483](https://github.com/FriendlyInternet/nuxt-crouton/issues/1483)) concluded **dep-free**: Nuxt UI 4 stores the primary as an OKLCH string (`tailwindcss/colors`, already installed), `getComputedStyle` reads it back verbatim, and oklch renders directly in SVG `fill`/`stop-color` — so we never leave OKLCH and culori/chroma would be dead weight.

- `utils/chart-constants.ts` — `parseOklch`, `buildThemePalette(primary, count)`, `getChartColor(i, total, primary?)`. 1 series → primary; chromatic multi → series 0 = primary, rest sweep hue evenly at same L/C; grayscale primary (chroma < 0.03) → lightness ramp; no primary → static 10-hue palette (SSR fallback).
- `composables/useChartPalette.ts` — resolves `--ui-primary`, reactive to color-mode + a `<html>` MutationObserver (theme swaps).
- `useCollectionChart` + `Widget` donut consume `colorAt`.
- `test/chart-palette.test.ts` — 11 unit cases (all green).
- `pnpm typecheck` green across apps.

## 🧪 How to test
1. Data pane → "Omzet per dag" renders in the theme primary, not blue
2. Toggle dark mode / swap Look-and-Feel → the chart recolors
3. Monochrome (eink/b&w) theme → a multi-series chart shows a readable gray lightness ramp, not identical grays

Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)