### PR TITLE
Re-land WS3: default the dialect fallback to sqlite, not pg (#1450)

### DIFF
--- a/.changeset/fix-1450-pg-dialect-fallback.md
+++ b/.changeset/fix-1450-pg-dialect-fallback.md
@@ -1,0 +1,8 @@
+---
+"@fyit/crouton-cli": patch
+---
+
+`crouton config`: an explicit `dialect: null`/`''` in the config file no longer
+silently routes into the unexercised PostgreSQL path — the fallback is now sqlite
+(matching the c12 default that already covers an absent key). Centralized the
+fallback in `resolveDialect()` so it lives in one testable place. Fixes #1450.

--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -282,7 +282,7 @@ crouton db-pull --config ./custom-wrangler.jsonc
 | Option | Description |
 |--------|-------------|
 | `--fields-file <path>` | Schema JSON file |
-| `--dialect <pg\|sqlite>` | Database dialect (default: sqlite for the direct command; `crouton config` has no flag — it reads the config file's `dialect`, falling back to `pg` when omitted, so always set `dialect: 'sqlite'` explicitly) |
+| `--dialect <pg\|sqlite>` | Database dialect (default: sqlite for the direct command; `crouton config` has no flag — it reads the config file's `dialect`, falling back to `sqlite` when omitted or empty) |
 | `--hierarchy` | Enable tree structure |
 | `--seed` | Generate seed data file (drizzle-seed) |
 | `--count <number>` | Number of seed records (default: 25) |

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -1761,6 +1761,15 @@ async function autoMergeFeatureCollections(config: Record<string, any>, options:
   }
 }
 
+// Resolve the database dialect for a loaded config. An explicit 'sqlite'/'pg'
+// wins, but an absent / null / empty `dialect` falls back to **sqlite** — never
+// pg. pg is unexercised in the D1-only stack, and c12's `defaults.dialect` only
+// covers an *absent* key: an explicit `dialect: null`/`''` survives defu, so this
+// is the one source of truth for the fallback (#1450).
+export function resolveDialect(config: Record<string, any> | null | undefined): 'sqlite' | 'pg' {
+  return (config?.dialect as 'sqlite' | 'pg' | null | undefined) || 'sqlite'
+}
+
 // Generate one collection entry from the enhanced config format. Returns the
 // entry to track for the batch db:generate, or null when the collection has no
 // fields file.
@@ -1805,7 +1814,7 @@ async function generateConfigEntry(params: {
     layer,
     collection: collectionName,
     fields,
-    dialect: config.dialect || 'pg',
+    dialect: resolveDialect(config),
     autoRelations: config.flags?.autoRelations || false,
     dryRun: config.flags?.dryRun || false,
     noDb: true, // Skip individual db:generate
@@ -1888,7 +1897,7 @@ async function runSimpleConfigFormat(config: Record<string, any>, typeMapping: a
         layer: target.layer,
         collection,
         fields,
-        dialect: config.dialect || 'pg',
+        dialect: resolveDialect(config),
         autoRelations: config.flags?.autoRelations || false,
         dryRun: config.flags?.dryRun || false,
         noDb: true, // Skip individual db:generate

--- a/packages/crouton-cli/tests/unit/resolve-dialect.test.ts
+++ b/packages/crouton-cli/tests/unit/resolve-dialect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { resolveDialect } from '../../lib/generate-collection.ts'
+
+// #1450 — an explicit `dialect: null`/`''` survives c12's defu (the `defaults.dialect`
+// only fills an *absent* key) and used to hit `config.dialect || 'pg'`, silently
+// routing D1-only apps into the unexercised PostgreSQL path. The fallback is now
+// sqlite everywhere; these lock that in. The dialect→artifact mapping itself is
+// covered by generators/database-schema.test.ts.
+describe('resolveDialect', () => {
+  it('falls back to sqlite when dialect is explicitly null (the discriminating case)', () => {
+    // `null` is the value that survives defu and previously produced `'pg'`
+    expect(resolveDialect({ dialect: null })).toBe('sqlite')
+  })
+
+  it('falls back to sqlite when dialect is an empty string', () => {
+    expect(resolveDialect({ dialect: '' })).toBe('sqlite')
+  })
+
+  it('falls back to sqlite when the dialect key is absent (regression guard)', () => {
+    // an absent key is also filled by c12's defaults.dialect, but resolveDialect
+    // must agree even if that default is ever removed
+    expect(resolveDialect({})).toBe('sqlite')
+    expect(resolveDialect({ dialect: undefined })).toBe('sqlite')
+  })
+
+  it('falls back to sqlite when config itself is null/undefined', () => {
+    expect(resolveDialect(null)).toBe('sqlite')
+    expect(resolveDialect(undefined)).toBe('sqlite')
+  })
+
+  it('preserves an explicitly chosen dialect', () => {
+    expect(resolveDialect({ dialect: 'sqlite' })).toBe('sqlite')
+    expect(resolveDialect({ dialect: 'pg' })).toBe('pg')
+  })
+})


### PR DESCRIPTION
## 👤 For humans

Re-lands the WS3 fix that went missing from `main`. PR #1470 was merged and closed #1450, but its merge commit (`b0afd64b`) is **not on `main`** — the trunk was rewound after 18:58 in a way that dropped exactly that one PR (audited: it was the only casualty among today's merges). So the `dialect` fallback still routed an explicit `null`/`''` into the unexercised PostgreSQL path. This cherry-picks #1470's original commit onto current `main`, unchanged.

## 🤖 For agents

- Cherry-pick of `769617e39` (the sole non-merge commit of `chore/1450-remove-dead-pg-fallback`) onto current `origin/main`; CLAUDE.md auto-merged clean, no conflict with the WS1a doc row.
- Restores `resolveDialect(config)` (`config?.dialect || 'sqlite'`) at both call sites in `generate-collection.ts` + its unit test + the changeset.
- Incident: #1470 shows MERGED but is absent from `main`; full audit of PRs merged 2026-07-11 found #1470 the **only** dropped one.

## 🧪 How to test

`pnpm --filter @fyit/crouton-cli test tests/unit/resolve-dialect.test.ts` → 5 pass (`dialect: null`/`''`/absent → sqlite). Confirm `grep "config.dialect || 'pg'" packages/crouton-cli/lib/generate-collection.ts` returns nothing.

Closes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)