### PR TITLE
chore(root): warn on no-explicit-any so the -- reason convention is enforceable (#1490)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,8 +69,10 @@ export default createConfigForNuxt({
     rules: {
       // Allow console in CLI tools
       'no-console': 'off',
-      // Allow any type (common in utility packages, Nuxt UI does the same)
-      '@typescript-eslint/no-explicit-any': 'off',
+      // Warn on `any` so a deliberate use must carry an `eslint-disable ... -- <reason>`
+      // (a bare disable then shows as an unused directive) — the #1435 audit convention.
+      // `warn`, not `error`: it surfaces the signal without walling the existing backlog.
+      '@typescript-eslint/no-explicit-any': 'warn',
       // Allow dynamic delete (common in Vue reactive patterns)
       '@typescript-eslint/no-dynamic-delete': 'off',
       // Nuxt pages/layouts use file-based names (index.vue, login.vue, etc.)


### PR DESCRIPTION
## What & why

Flips `@typescript-eslint/no-explicit-any` from `off` → `warn` in the root `eslint.config.mjs`, the follow-up #1490 to the #1435 audit.

## 👤 For humans

The #1435 audit annotated every legitimate `any` disable in `packages/*` with a `-- reason` — but discovered the rule was switched **off** repo-wide, so a bare disable and a justified one were indistinguishable to the linter. This makes the convention enforceable: a deliberate `any` must sit behind a disable, and a bare disable now surfaces as an *unused directive*. `warn` (not `error`) is deliberate — the existing `any` backlog shows as warnings without walling any code.

## 🤖 For agents

- `eslint.config.mjs`: `'@typescript-eslint/no-explicit-any'` `'off'` → `'warn'`.
- CI does **not** run repo-wide `eslint .` (only typecheck jobs), so no gate flips red; this is editor/local signal + future enforceability.

## 🧪 How to test

`npx eslint packages/crouton-bookings/server/utils/email-service.ts packages/crouton-auth/server/lib/auth.ts packages/crouton-themes/themes/composables/useThemeSwitcher.ts` → the 9 justified disables report **0** `unused eslint-disable directive` warnings (each is now an active suppression). The pre-existing unguarded `any`s show as warnings, not errors.

Closes #1490
