### PR TITLE
fix(crouton-core,crouton-sales): edit forms reject a nullable column's null on submit

### DIFF
--- a/packages/crouton-core/CLAUDE.md
+++ b/packages/crouton-core/CLAUDE.md
@@ -59,6 +59,7 @@ export default defineNuxtConfig({
 | `app/components/Collection.vue` | Multi-layout display (table, list, grid, tree, kanban) |
 | `app/components/CollectionSkeleton.vue` | `CroutonCollectionSkeleton` — layout-aware shimmer (table/list/grid) used as the `<Suspense>` fallback in `CollectionViewer` so the viewer reveals the populated result at once instead of flashing a loader + filling in row-by-row |
 | `app/components/Form.vue` | Main CRUD form handler with nested modal support |
+| `app/utils/init-form-state.ts` | `initFormState(defaultValue, activeItem)` — builds an edit form's initial state, coercing a nullable column's loaded `null` back to the form default so it never reaches the narrow client schema and silently blocks submit (#1498; the hand-written form analog of the generator's #1415 coercion). Used by `RedirectsForm` + `crouton-sales`'s `useSalesCollectionForm`. |
 | `app/components/Detail.vue` | `CroutonDetail` — Generic detail view using display config and runtime field metadata |
 | `app/components/DefaultCard.vue` | `CroutonDefaultCard` — Display-aware card (title/image/badge from display config) |
 | `app/components/ItemCardMini.vue` | `CroutonItemCardMini` — Display-aware mini card for references and lists |

--- a/packages/crouton-core/app/components/RedirectsForm.vue
+++ b/packages/crouton-core/app/components/RedirectsForm.vue
@@ -98,11 +98,13 @@ const tabErrorCounts = computed(() => {
 const { create, update, deleteItems } = useCollectionMutation(collection)
 const { close, loading } = useCrouton()
 
+// initFormState coerces a nullable column's loaded null back to the form
+// default so it never reaches the narrow client schema and blocks submit (#1498).
 const initialValues = props.action === 'update' && props.activeItem?.id
-  ? { ...defaultValue, ...props.activeItem }
+  ? initFormState(defaultValue, props.activeItem)
   : { ...defaultValue }
 
-const state = ref<CroutonRedirectFormData & { id?: string | null }>(initialValues)
+const state = ref<CroutonRedirectFormData & { id?: string | null }>(initialValues as CroutonRedirectFormData & { id?: string | null })
 
 const handleSubmit = async () => {
   try {

--- a/packages/crouton-core/app/utils/__tests__/init-form-state.test.ts
+++ b/packages/crouton-core/app/utils/__tests__/init-form-state.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { initFormState } from '../init-form-state'
+
+// #1498 — a nullable DB column round-trips `null`; on the edit path the loaded
+// record spreads over the form defaults, so that `null` overrides the default
+// and reaches the deliberately-narrow client schema (`.optional()`, kept narrow
+// by #1403), which rejects it and silently blocks submit. initFormState coerces
+// a `null` back to the form default so state never carries it — no schema or
+// type widening.
+describe('initFormState', () => {
+  it('returns a fresh copy of the defaults when there is no active item (create)', () => {
+    const defaults = { title: '', options: [], isActive: false }
+    const state = initFormState(defaults, null)
+    expect(state).toEqual(defaults)
+    expect(state).not.toBe(defaults)
+    state.title = 'x'
+    expect(defaults.title).toBe('') // not mutated
+  })
+
+  it('coerces a nullable field\'s null back to its form default', () => {
+    const state = initFormState(
+      { title: '', description: '', options: [], requiresRemark: false },
+      { id: 'p1', title: 'Frisdrank', description: null, options: null, requiresRemark: null }
+    )
+    expect(state).toEqual({
+      id: 'p1',
+      title: 'Frisdrank',
+      description: '',
+      options: [],
+      requiresRemark: false
+    })
+  })
+
+  it('keeps real (non-null) values from the active item', () => {
+    const state = initFormState(
+      { title: '', price: 0, isActive: false },
+      { title: 'Cola', price: 2.5, isActive: true }
+    )
+    expect(state).toEqual({ title: 'Cola', price: 2.5, isActive: true })
+  })
+
+  it('passes system fields through untouched (they are not in defaultValue)', () => {
+    const state = initFormState(
+      { title: '' },
+      { id: 'p1', teamId: 't1', createdAt: '2026-01-01', title: 'X', ownerId: null }
+    )
+    // ownerId is not a form field → not coerced; system fields survive
+    expect(state).toMatchObject({ id: 'p1', teamId: 't1', createdAt: '2026-01-01', title: 'X', ownerId: null })
+  })
+
+  it('leaves undefined active values to fall back to the default', () => {
+    const state = initFormState({ title: 'def' }, { title: undefined })
+    expect(state.title).toBe('def')
+  })
+})

--- a/packages/crouton-core/app/utils/init-form-state.ts
+++ b/packages/crouton-core/app/utils/init-form-state.ts
@@ -1,0 +1,33 @@
+/**
+ * Build an edit form's initial state from the collection defaults + the record
+ * being edited (#1498).
+ *
+ * The naive `{ ...defaultValue, ...activeItem }` merge is subtly wrong on the
+ * edit path: a **nullable DB column round-trips `null`**, so the loaded record's
+ * `null` overrides the form default (`''` / `[]` / `false`) and reaches the
+ * generated **client** validation schema — which is `.optional()` (rejects
+ * `null`), the deliberately-narrow side kept by #1403 (widening it to
+ * `.nullish()` breaks typecheck across every generated form + package
+ * component). The result: `UForm` silently refuses to submit, and hidden
+ * fields show no error.
+ *
+ * The fix keeps `null` out of state without touching any schema or type: for a
+ * key that IS a form field (present in `defaultValue`), a `null`/`undefined`
+ * loaded value falls back to the default. System/audit fields (`id`, `teamId`,
+ * timestamps) aren't form fields — they pass through untouched, so the update
+ * still carries its `id`.
+ */
+export function initFormState(
+  defaultValue: Record<string, any>,
+  activeItem?: Record<string, any> | null
+): Record<string, any> {
+  const state: Record<string, any> = { ...defaultValue }
+  if (!activeItem) return state
+  for (const [key, value] of Object.entries(activeItem)) {
+    // A form field loaded as null/undefined keeps its default; everything else
+    // (real values, plus non-form system fields) is taken from the record.
+    if (value == null && key in defaultValue) continue
+    state[key] = value
+  }
+  return state
+}

--- a/packages/crouton-sales/app/composables/useSalesCollectionForm.ts
+++ b/packages/crouton-sales/app/composables/useSalesCollectionForm.ts
@@ -24,8 +24,10 @@ export function useSalesCollectionForm(
   const { close, loading } = useCrouton()
 
   // Merge activeItem for both create (preset eventId from the event workspace)
-  // and update (the full record being edited).
-  const initialValues = { ...options.defaultValue, ...(props.activeItem || {}) }
+  // and update (the full record being edited). initFormState coerces a nullable
+  // column's loaded null back to the form default, so it never reaches the
+  // narrow client schema and silently blocks submit (#1498).
+  const initialValues = initFormState(options.defaultValue, props.activeItem)
   const state = ref<Record<string, any> & { id?: string | null }>(initialValues)
 
   // Event is implied by the workspace — hide the selector when it's preset.


### PR DESCRIPTION
Closes #1498

## 👤 For humans

Editing a record whose optional fields are empty — e.g. a product with no Beschrijving/Opmerking (both `NULL` in the DB) — silently did nothing: the **Update** button wouldn't submit, and an empty Beschrijving showed **"Invalid input."** Now editing saves cleanly.

The cause: every edit form loads its state as `{ ...defaultValue, ...activeItem }`, so a **nullable column's `NULL`** overrides the form default (`''`/`[]`) and reaches the client validation schema — which is `.optional()` (rejects `null`). Hidden fields (a toggle off) show no inline error, so the form just refuses to submit with no feedback.

## 🤖 For agents

- **Not** by widening the client schema to `.nullish()` — that's the approach **#1403 tried and reverted** (its test asserts client stays `.optional()`; widening `z.infer` to `T | null` breaks typecheck across every generated form + package component). Instead, keep the `null` *out of state*.
- `crouton-core`: new `app/utils/init-form-state.ts` — `initFormState(defaultValue, activeItem)`: merge, but a **form-field** key (present in `defaultValue`) loaded as `null`/`undefined` keeps its default; **system fields** (`id`/`teamId`/audit — not in `defaultValue`) pass through untouched, so the update still carries its `id`. Auto-imported; unit-tested (5 cases).
- Adopted in `RedirectsForm.vue` + `crouton-sales`'s `useSalesCollectionForm.ts` (the Product/Printer/Category/Location edit forms). These are the **hand-written** forms that never inherited the generator's existing coercion.
- The generated `_Form.vue` template **already** does this (#1415, `form-component.ts` — the null→default loop); untouched. The **server** body schema stays `.nullish()` (#1403). This PR is the client-side follow-up #1403 explicitly deferred, done without any schema/type change.

## 🧪 How to test

1. On a products-having instance (staging after merge, or a seeded local): edit a product with no remark/options → change the name → **Update product** now saves and persists. An empty Beschrijving no longer shows "Invalid input."
2. Unit: `pnpm --filter @fyit/crouton-core test` → `init-form-state.test.ts` (5 cases: null→default, non-null kept, system fields passthrough, undefined→default, no-activeItem clone).

## Verification

- `initFormState` unit test green · crouton-core suite **701 pass** · fallow audit vs origin/main ✅ clean.
- **Adds 0 typecheck errors** — the exact gate #1403 tripped on. (`pnpm typecheck` shows one *pre-existing* error in `useVoiceOrder.ts`, a local VueUse `SpeechRecognitionErrorEvent` lib quirk that is **not** mine — it's on clean `main` and `main`'s CI is green, so CI won't hit it.)
- Live product-edit click-through wasn't reproducible in this worktree (its local DB has no seeded products); the fix mirrors the generator's shipped #1415 coercion, so confirmation is best on the instance that actually has products.

🤖 Generated with [Claude Code](https://claude.com/claude-code)