### PR TITLE
Identity-aware duplicate-table gate (WS1b)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -326,6 +326,7 @@ rewritten every run regardless. Guarded by the write loop in `writeScaffold`
 | `lib/utils/update-nuxt-config.ts` | Update nuxt.config.ts extends |
 | `lib/utils/update-schema-index.ts` | Update schema exports |
 | `lib/utils/schema-sources.ts` | `resolveSchemaSources(appDir, {dialect})` — reproduces NuxtHub's per-layer `server/db/schema*` glob over the recursive `extends` graph (app root + auto-scanned `layers/*` + `@fyit/*`/subpath extends, realpath-deduped, magicast static parse), WITHOUT a Nuxt process. Feeds drizzle-kit directly; parity-verified vs NuxtHub (epic #1445 WS1a). Duplicate-table gate over its output is WS1b |
+| `lib/utils/duplicate-tables.ts` | `findDuplicateTables(resolvedPaths)` — identity-aware gate over the resolver's output: jiti-imports each file through ONE instance, and fails only when a table name maps to ≥2 DISTINCT drizzle objects (benign same-object re-exports pass; catches distinct dups arriving via `export * from` that a regex misses). drizzle-kit otherwise silently last-wins. Epic #1445 WS1b |
 
 ## Generators Structure
 

--- a/packages/crouton-cli/lib/utils/duplicate-tables.ts
+++ b/packages/crouton-cli/lib/utils/duplicate-tables.ts
@@ -1,0 +1,61 @@
+// duplicate-tables.ts — the identity-aware duplicate-table gate over the WS1a
+// schema-source resolver's output (epic #1445, WS1b #1447).
+//
+// drizzle-kit does NOT error on two same-named tables across its schema list —
+// it silently last-wins, order-dependently. This makes that loud, but ONLY for
+// two GENUINELY DISTINCT definitions. The standard topology legitimately
+// re-exports the SAME auth tables via multiple bridges/barrels; loaded through a
+// SINGLE jiti instance those are the same object (its module cache returns one
+// object for a re-exported definition), so they are not a clash. The gate keys
+// on object IDENTITY, not the name alone — which also catches a distinct
+// duplicate arriving via `export * from` (a definition-regex scan would miss it,
+// since the re-exporting file has no `sqliteTable(` call).
+//
+// Reports at the RESOLVED-file level (which bridge/barrel), not the deep
+// definition site. Import errors propagate — the dist/loadability prerequisite
+// is the caller's failure contract (WS2), not silently swallowed here.
+
+import { createJiti } from 'jiti'
+import { isTable, getTableName } from 'drizzle-orm'
+
+export interface DuplicateTable {
+  /** The SQL table name that two or more distinct definitions share. */
+  table: string
+  /** The resolved files that contributed a definition of `table`. */
+  files: string[]
+}
+
+/**
+ * Find table names defined by two or more DISTINCT drizzle definitions across
+ * the resolved schema files. Same definition re-exported through several files
+ * is benign and not reported. Returns [] when the set is clean.
+ */
+export async function findDuplicateTables(resolvedPaths: string[]): Promise<DuplicateTable[]> {
+  // One jiti instance so a re-exported definition is the SAME object everywhere.
+  const jiti = createJiti(import.meta.url)
+
+  // name -> { the distinct table objects seen, the files that surfaced them }
+  const byName = new Map<string, { objects: Set<unknown>, files: Set<string> }>()
+
+  for (const path of resolvedPaths) {
+    const mod = (await jiti.import(path)) as Record<string, unknown>
+    for (const value of Object.values(mod)) {
+      if (!isTable(value)) continue
+      const name = getTableName(value)
+      let entry = byName.get(name)
+      if (!entry) {
+        entry = { objects: new Set(), files: new Set() }
+        byName.set(name, entry)
+      }
+      entry.objects.add(value)
+      entry.files.add(path)
+    }
+  }
+
+  const duplicates: DuplicateTable[] = []
+  for (const [table, { objects, files }] of byName) {
+    // A clash is >= 2 definitions of DISTINCT identity — not merely >= 2 files.
+    if (objects.size >= 2) duplicates.push({ table, files: [...files] })
+  }
+  return duplicates
+}

--- a/packages/crouton-cli/tests/unit/utils/duplicate-tables.test.ts
+++ b/packages/crouton-cli/tests/unit/utils/duplicate-tables.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+// NB: import with the explicit .ts extension (matches the package's test style).
+import { findDuplicateTables } from '../../../lib/utils/duplicate-tables.ts'
+
+// WS1b (#1447): the identity-aware duplicate-table gate over the WS1a resolver's
+// output. drizzle-kit silently last-wins on two same-named tables (order-dependent,
+// no warning); this makes that loud — BUT only for two DISTINCT definitions. The
+// standard topology legitimately re-exports the SAME auth tables via multiple
+// bridges/barrels (same object identity through one jiti cache) — those must pass.
+//
+// Empirically grounded (booking-demo): a benign `export * from` re-export yields
+// the SAME table object; two independent sqliteTable('x',…) calls yield DISTINCT
+// objects with the same name. The gate keys on object identity, not the name alone.
+//
+// Temp schema files live UNDER the package (not os.tmpdir()) so `drizzle-orm`
+// resolves via node walk-up when the gate jiti-imports them.
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(__dirname, '.tmp-dupgate-'))
+})
+afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+const DRIZZLE = "import { sqliteTable, text } from 'drizzle-orm/sqlite-core'"
+
+/** Write a schema file that DEFINES a table with the given SQL name. */
+function defineTable(file: string, exportName: string, sqlName: string): string {
+  const p = join(dir, file)
+  writeFileSync(p, `${DRIZZLE}\nexport const ${exportName} = sqliteTable('${sqlName}', { id: text('id').primaryKey() })\n`)
+  return p
+}
+
+/** Write a schema file that re-exports everything from another file (same objects). */
+function reExport(file: string, from: string): string {
+  const p = join(dir, file)
+  writeFileSync(p, `export * from './${from}'\n`)
+  return p
+}
+
+describe('findDuplicateTables', () => {
+  it('returns no duplicates for a clean set of distinctly-named tables', async () => {
+    const a = defineTable('a.ts', 'widgets', 'widgets')
+    const b = defineTable('b.ts', 'gadgets', 'gadgets')
+    expect(await findDuplicateTables([a, b])).toEqual([])
+  })
+
+  it('passes a benign re-export — the SAME table reached via two resolved files', async () => {
+    // Mirrors the auth topology: a shared definition re-exported by two bridges.
+    defineTable('base.ts', 'widgets', 'widgets')
+    const bridge = reExport('bridge.ts', 'base')
+    const barrel = reExport('barrel.ts', 'base')
+    // Both resolved files surface the SAME widgets object → not a conflict.
+    expect(await findDuplicateTables([bridge, barrel])).toEqual([])
+  })
+
+  it('flags two DISTINCT definitions that share a table name, naming both resolved files', async () => {
+    const a = defineTable('a.ts', 'widgetsA', 'widgets')
+    const b = defineTable('b.ts', 'widgetsB', 'widgets')
+    const dups = await findDuplicateTables([a, b])
+    expect(dups).toHaveLength(1)
+    expect(dups[0].table).toBe('widgets')
+    expect(dups[0].files.sort()).toEqual([a, b].sort())
+  })
+
+  it('catches a distinct duplicate that arrives via re-export (regex over the globbed file would miss it)', async () => {
+    // a.ts DEFINES widgets; b.ts RE-EXPORTS a *different* widgets from elsewhere.
+    // b.ts has no `sqliteTable(` call, so a definition-regex scan sees only one
+    // def and misses the clash — identity import-and-collect catches it.
+    const a = defineTable('a.ts', 'widgets', 'widgets')
+    defineTable('other.ts', 'widgetsOther', 'widgets')
+    const b = reExport('b.ts', 'other')
+    const dups = await findDuplicateTables([a, b])
+    expect(dups).toHaveLength(1)
+    expect(dups[0].table).toBe('widgets')
+    expect(dups[0].files.sort()).toEqual([a, b].sort())
+  })
+
+  it('does not flag a single file that defines two differently-named tables', async () => {
+    const p = join(dir, 'multi.ts')
+    writeFileSync(p, `${DRIZZLE}\nexport const a = sqliteTable('a', { id: text('id') })\nexport const b = sqliteTable('b', { id: text('id') })\n`)
+    expect(await findDuplicateTables([p])).toEqual([])
+  })
+
+  it('reports each clashing name once even when three distinct definitions collide', async () => {
+    const a = defineTable('a.ts', 'wa', 'widgets')
+    const b = defineTable('b.ts', 'wb', 'widgets')
+    const c = defineTable('c.ts', 'wc', 'widgets')
+    const dups = await findDuplicateTables([a, b, c])
+    expect(dups).toHaveLength(1)
+    expect(dups[0].table).toBe('widgets')
+    expect(dups[0].files.sort()).toEqual([a, b, c].sort())
+  })
+})
+
+describe('findDuplicateTables — real benign topology (acceptance)', () => {
+  it('booking-demo: auth tables reachable via the bookings bridge AND the app barrel do NOT clash', async () => {
+    const root = join(__dirname, '../../../../..')
+    const bridge = join(root, 'packages/crouton-bookings/server/db/schema.ts')
+    const barrel = join(root, 'pocs/booking-demo/server/db/schema.ts')
+    // Same auth bindings re-exported by both — must pass (proven: 16/16 same identity).
+    expect(await findDuplicateTables([bridge, barrel])).toEqual([])
+  })
+})


### PR DESCRIPTION
Part of epic #1445 (CLI-owned migrations). **WS1b** — the duplicate-table gate over WS1a's resolver output (#1446, already on main). WS2 (#1449) turns a non-empty result into a non-zero exit + recipe.

## 👤 For humans

When two different layers accidentally define a database table with the **same name**, drizzle-kit today silently keeps one of them at random (order-dependent, no warning). This turns that into a loud, named failure — while still allowing the normal, healthy case where the *same* table is re-exported through several layer files.

## 🤖 For agents

- **New `lib/utils/duplicate-tables.ts`** — `findDuplicateTables(resolvedPaths)`: jiti-imports each resolved file through **one** instance and flags a table name only when it maps to **≥2 objects of distinct identity** (`isTable` + `getTableName`). Same object reached via multiple files (a re-export) is benign; a distinct dup arriving via `export * from` is caught (a definition-regex misses it — the re-exporting file has no `sqliteTable(` call). Reports at the resolved-file level; import errors propagate (WS2 owns the failure contract).
- Consumes WS1a's `resolveSchemaSources` (#1446).

## 🧪 How to test

`pnpm --filter @fyit/crouton-cli test tests/unit/utils/duplicate-tables.test.ts` → **7 pass**: clean set, benign re-export (same object via two files → no clash), two distinct defs (→ clash naming both files), the `export * from` re-export hazard, single-file two-tables, three-way collision, and the **real booking-demo topology** (auth tables reachable via the bookings bridge AND the app barrel → no clash; verified 16/16 same object identity).

Mechanism grounded empirically: a benign re-export yields the same object through one jiti cache; two independent `sqliteTable('widgets')` calls yield distinct objects.

Closes #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)