### PR TITLE
fix(crouton-sales): printer LED goes red on failing jobs (attribution gap) (#1507)

### DIFF
--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -15,6 +15,7 @@ Event-based Point of Sale (POS) system for Nuxt Crouton. Provides products, cate
 | `server/plugins/printing-subscriber.ts` | Nitro plugin wiring the reactions to `printing:job:{created,completed,failed}` hooks (filtered to `source === 'sales'`, best-effort log+swallow) |
 | `app/composables/useHelperAuth.ts` | Helper authentication (wraps nuxt-crouton-auth; PIN login via generic redeem, gate-session adoption) |
 | `app/utils/voice-order.ts` | Talk-to-order pure logic (#1429): `parseVoiceOrder` maps a spoken nl utterance ("twee pils en een koffie") onto the event's products as `{ lines, unmatched }` draft cart lines (Dutch number words 1–20 + tens, plural/diminutive stemming, 1-edit STT fuzz; below-confidence segments → `unmatched`, never guessed). Also `classifyVoiceError(event)` → `{ code, message, report }` — decides which `SpeechRecognitionErrorEvent` codes are real failures vs benign pauses (`no-speech`/`aborted`/`no-match` → `report:false`). Behaviour contract: `test/voice-order.test.ts` |
+| `app/utils/printer-led.ts` | Printer online-LED attribution pure logic (#1507): `attributePrinterStates(printers, jobs)` → per-printer `LedState` (`online`/`offline`/`printing`/`unknown`). Matches a job to a printer row by `printerId` first, else by an **unambiguous** `printerTitle` (drift-proof so a re-created printer's failures still show red, not a false grey); latest job wins by `completedAt ?? createdAt`. Behaviour contract: `test/printer-led.test.ts` |
 | `app/composables/useVoiceOrder.ts` | Talk-to-order speech capture (#1429) — wraps VueUse `useSpeechRecognition` (on-device Web Speech API, `nl-BE`, one utterance per press) and feeds each final utterance through `parseVoiceOrder`. The ONLY module touching the STT engine — swap point for a server transcriber later. Errors route through `classifyVoiceError`: the raw code is always `console.warn`'d for diagnosis, and real failures reach `onError(code)` so the caller shows a reason-specific message (permission/mic/network/language) instead of a blanket "failed"; benign pauses are swallowed. Exposes `errorCode` (raw, for diagnostics) |
 | `server/plugins/scoped-access.ts` | Nitro hook handlers: before-redeem helperPin→grant sync + pages derive-scope (one PIN from page gate to POS) |
 | `app/plugins/viewport-meta.ts` | Replaces the default viewport meta via useHead: `viewport-fit=cover` (safe-area env() for the phone kassa) + `maximum-scale=1` (kills iOS input-focus auto-zoom; pinch still works) |
@@ -364,7 +365,13 @@ the printer subtitles. Each printer row carries an **online LED** derived from i
 print job** (slim `printqueues/status` endpoint, latest by `completedAt ?? createdAt`): green =
 last job completed (the spooler's DLE EOT pre-flight confirmed the printer online), red = last
 job failed, pulsing orange = job in flight, grey = never printed. There is no separate ping —
-"online" means online as of the last print attempt. `SettingsListCard` props: `title`, `collection`, `rows`
+"online" means online as of the last print attempt. Attribution is the pure
+`app/utils/printer-led.ts` (`attributePrinterStates`): a job is matched to a printer row by
+`printerId` **first, else by an unambiguous `printerTitle`** (the denormalized label every enqueue
+site writes) — so a printer whose id drifted from its jobs (deleted+recreated / regenerated
+collection) still lights red instead of a false grey (#1507); a title shared by two current rows
+is ambiguous and stays grey rather than guess. The `status` endpoint therefore also returns
+`printerTitle`. `SettingsListCard` props: `title`, `collection`, `rows`
 (`{ id, title, subtitle?, led? }` — `led: { class, label? }` renders a status dot with tooltip
 before the title), `pending?`, `emptyLabel?`, `createData?`, `orderField?`; slots
 `header-actions` and `footer` (UCard footer passthrough — the printers card uses it for the

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Ref, ComputedRef } from 'vue'
 import type { SalesEvent } from '~~/layers/sales/collections/events/types'
+import { attributePrinterStates, type LedJob, type LedState } from '../../utils/printer-led'
 
 const props = defineProps<{
   event: SalesEvent
@@ -38,43 +39,39 @@ const locationRows = computed(() => ((locations.value as any[] | null) || []))
 // Printer online LEDs. The spooler pre-flight-checks the printer (DLE EOT) on
 // every print job, so the most recent job's outcome is the last-known online
 // state — there is no separate ping.
-interface PrintJobRow {
-  id: string
-  printerId: string
-  status?: string | number
-  createdAt?: string | number
-  completedAt?: string | number
-}
-
-const { data: printJobs, refresh: refreshPrintJobs } = await useFetch<PrintJobRow[]>(
+const { data: printJobs, refresh: refreshPrintJobs } = await useFetch<LedJob[]>(
   () => `/api/crouton-sales/teams/${teamParam.value}/events/${props.event.id}/printqueues/status`,
   { default: () => [] }
 )
 
-function jobTime(job: PrintJobRow) {
-  const v = job.completedAt ?? job.createdAt
-  return v ? new Date(v).getTime() : 0
+// Attribute each job to a printer row by id, else by an unambiguous title —
+// so a printer whose failing jobs' printerId has drifted from its current row
+// (deleted+recreated / regenerated collection) still lights red, not grey (#1507).
+const printerLedStates = computed(() =>
+  attributePrinterStates(
+    (((printers.value as any[] | null) || [])).map(p => ({ id: p.id, title: p.title })),
+    printJobs.value || []
+  )
+)
+
+// class is static; label goes through t() at call time so it stays reactive to
+// a mid-session locale switch (printerRows recomputes on printers/jobs change).
+const LED_CLASS: Record<LedState, string> = {
+  online: 'bg-success',
+  offline: 'bg-error',
+  printing: 'bg-warning animate-pulse',
+  unknown: 'bg-accented'
+}
+const LED_LABEL: Record<LedState, () => string> = {
+  online: () => t('sales.workspace.printerOnline', 'Online at last print'),
+  offline: () => t('sales.workspace.printerOffline', 'Offline — last print failed'),
+  printing: () => t('sales.printQueue.statusPrinting', 'Printing'),
+  unknown: () => t('sales.workspace.printerUnknown', 'Not checked yet — no prints')
 }
 
-const lastJobByPrinter = computed(() => {
-  const map = new Map<string, PrintJobRow>()
-  for (const job of (printJobs.value || [])) {
-    const prev = map.get(job.printerId)
-    if (!prev || jobTime(job) >= jobTime(prev)) map.set(job.printerId, job)
-  }
-  return map
-})
-
 function printerLed(printerId: string) {
-  const job = lastJobByPrinter.value.get(printerId)
-  if (!job) {
-    return { class: 'bg-accented', label: t('sales.workspace.printerUnknown', 'Not checked yet — no prints') }
-  }
-  switch (String(job.status ?? '0')) {
-    case '2': return { class: 'bg-success', label: t('sales.workspace.printerOnline', 'Online at last print') }
-    case '9': return { class: 'bg-error', label: t('sales.workspace.printerOffline', 'Offline — last print failed') }
-    default: return { class: 'bg-warning animate-pulse', label: t('sales.printQueue.statusPrinting', 'Printing') }
-  }
+  const state = printerLedStates.value.get(printerId) ?? 'unknown'
+  return { class: LED_CLASS[state], label: LED_LABEL[state]() }
 }
 
 const printerRows = computed(() =>

--- a/packages/crouton-sales/app/utils/printer-led.ts
+++ b/packages/crouton-sales/app/utils/printer-led.ts
@@ -57,66 +57,83 @@ function stateForStatus(status: string | number | null | undefined): LedState {
   }
 }
 
-/** The latest job in a set, or undefined for an empty set. */
-function latest(jobs: LedJob[]): LedJob | undefined {
+/** The latest job in a set (by `jobTime`), or undefined for an empty/absent set. */
+function latest(jobs: LedJob[] | undefined): LedJob | undefined {
   let best: LedJob | undefined
-  for (const job of jobs) {
+  for (const job of (jobs ?? [])) {
     if (!best || jobTime(job) >= jobTime(best)) best = job
   }
   return best
 }
 
+/** Append `job` to the bucket at `key` (skips null keys). */
+function bucket(map: Map<string, LedJob[]>, key: string | null | undefined, job: LedJob): void {
+  if (key == null) return
+  const arr = map.get(key)
+  if (arr) arr.push(job)
+  else map.set(key, [job])
+}
+
+/** Bucket every job once by `printerId` and by `printerTitle`. */
+function indexJobs(jobs: LedJob[]): { byId: Map<string, LedJob[]>, byTitle: Map<string, LedJob[]> } {
+  const byId = new Map<string, LedJob[]>()
+  const byTitle = new Map<string, LedJob[]>()
+  for (const job of jobs) {
+    bucket(byId, job.printerId, job)
+    bucket(byTitle, job.printerTitle, job)
+  }
+  return { byId, byTitle }
+}
+
+/** Titles held by exactly one current printer row — the only safe fallback keys. */
+function unambiguousTitles(printers: LedPrinter[]): Set<string> {
+  const counts = new Map<string, number>()
+  for (const p of printers) {
+    if (p.title != null) counts.set(p.title, (counts.get(p.title) ?? 0) + 1)
+  }
+  const unique = new Set<string>()
+  for (const [title, n] of counts) {
+    if (n === 1) unique.add(title)
+  }
+  return unique
+}
+
 /**
- * Resolve every printer's LED state in one pass.
- *
- * Attribution per printer row:
- *   1. jobs whose `printerId` equals the row id — if any exist, the latest wins;
- *   2. otherwise, jobs whose `printerTitle` equals the row title, but ONLY when
- *      that title is unique among the current rows (unambiguous) — the latest
- *      wins;
- *   3. otherwise `unknown` (grey — genuinely never printed, or ambiguous).
- *
- * `id` always takes precedence: a row with any id-matched job ignores
- * title-only jobs entirely.
+ * The latest job attributable to one printer row: jobs matching by `printerId`
+ * win outright; only when there are none does an unambiguous `printerTitle`
+ * match apply. Undefined ⇒ nothing attributable (grey).
+ */
+function attributedJob(
+  printer: LedPrinter,
+  byId: Map<string, LedJob[]>,
+  byTitle: Map<string, LedJob[]>,
+  uniqueTitles: Set<string>
+): LedJob | undefined {
+  const idJob = latest(byId.get(printer.id))
+  if (idJob) return idJob
+  if (printer.title != null && uniqueTitles.has(printer.title)) {
+    return latest(byTitle.get(printer.title))
+  }
+  return undefined
+}
+
+/**
+ * Resolve every printer's LED state. Composes the pieces above:
+ *   1. jobs matching by `printerId` win (latest by `completedAt ?? createdAt`);
+ *   2. else an *unambiguous* `printerTitle` match (drift-proof fallback);
+ *   3. else `unknown` (grey — never printed, or an ambiguous title).
  */
 export function attributePrinterStates(
   printers: LedPrinter[],
   jobs: LedJob[]
 ): Map<string, LedState> {
-  // Titles shared by >1 current row are ambiguous — never a fallback key.
-  const titleCounts = new Map<string, number>()
-  for (const p of printers) {
-    if (p.title == null) continue
-    titleCounts.set(p.title, (titleCounts.get(p.title) ?? 0) + 1)
-  }
-
-  // Bucket jobs once: by printerId, and by printerTitle.
-  const byId = new Map<string, LedJob[]>()
-  const byTitle = new Map<string, LedJob[]>()
-  for (const job of jobs) {
-    if (job.printerId != null) {
-      const arr = byId.get(job.printerId)
-      if (arr) arr.push(job); else byId.set(job.printerId, [job])
-    }
-    if (job.printerTitle != null) {
-      const arr = byTitle.get(job.printerTitle)
-      if (arr) arr.push(job); else byTitle.set(job.printerTitle, [job])
-    }
-  }
+  const { byId, byTitle } = indexJobs(jobs)
+  const uniqueTitles = unambiguousTitles(printers)
 
   const states = new Map<string, LedState>()
   for (const p of printers) {
-    const idJobs = byId.get(p.id)
-    let job = idJobs && idJobs.length > 0 ? latest(idJobs) : undefined
-
-    // Fall back to an unambiguous title match only when no id-matched job.
-    if (!job && p.title != null && titleCounts.get(p.title) === 1) {
-      const titleJobs = byTitle.get(p.title)
-      if (titleJobs && titleJobs.length > 0) job = latest(titleJobs)
-    }
-
+    const job = attributedJob(p, byId, byTitle, uniqueTitles)
     states.set(p.id, job ? stateForStatus(job.status) : 'unknown')
   }
-
   return states
 }

--- a/packages/crouton-sales/app/utils/printer-led.ts
+++ b/packages/crouton-sales/app/utils/printer-led.ts
@@ -1,0 +1,122 @@
+/**
+ * @crouton-package crouton-sales
+ * @description Printer online-LED attribution (#1507).
+ *
+ * The settings-card LED shows each printer's last-known online state, derived
+ * from its most recent print job (the spooler pre-flight-checks the printer on
+ * every job, so the latest job's outcome IS the last-known state — no separate
+ * ping).
+ *
+ * The gap this closes: a job is attributed to a printer row by `printerId`, but
+ * that id can drift from the current row (a printer deleted + re-created with a
+ * fresh nanoid, a regenerated printers collection, jobs enqueued before the row
+ * existed). When it drifts, a printer with real, recent FAILED jobs matched
+ * nothing by id and fell back to grey ("never printed"), masking the failure at
+ * a live venue (Bar, 2026-07-11).
+ *
+ * Every job row already denormalizes `printerTitle` (written by every enqueue
+ * site), so we attribute by `id` FIRST, else by an **unambiguous** `printerTitle`
+ * — a title shared by two current rows is ambiguous, so we refuse to guess and
+ * leave both grey. Pure + unit-tested (test/printer-led.test.ts); the Vue
+ * component only maps the returned state → dot class + i18n label.
+ */
+
+/** LED state, decoupled from any styling/i18n (the component maps these). */
+export type LedState = 'online' | 'offline' | 'printing' | 'unknown'
+
+/** A current printer row the LED renders a dot for. */
+export interface LedPrinter {
+  id: string
+  title?: string | null
+}
+
+/** A slim print-job row from the printqueues status endpoint. */
+export interface LedJob {
+  printerId: string
+  /** Denormalized printer label on the job — the drift-proof fallback key. */
+  printerTitle?: string | null
+  status?: string | number | null
+  createdAt?: string | number | null
+  completedAt?: string | number | null
+}
+
+/** Comparable time for "latest job": completion beats creation. */
+function jobTime(job: LedJob): number {
+  const v = job.completedAt ?? job.createdAt
+  if (v == null) return 0
+  const t = new Date(v).getTime()
+  return Number.isNaN(t) ? 0 : t
+}
+
+/** Map a print-job status code to an LED state (2 = done, 9 = failed). */
+function stateForStatus(status: string | number | null | undefined): LedState {
+  switch (String(status ?? '0')) {
+    case '2': return 'online'
+    case '9': return 'offline'
+    default: return 'printing'
+  }
+}
+
+/** The latest job in a set, or undefined for an empty set. */
+function latest(jobs: LedJob[]): LedJob | undefined {
+  let best: LedJob | undefined
+  for (const job of jobs) {
+    if (!best || jobTime(job) >= jobTime(best)) best = job
+  }
+  return best
+}
+
+/**
+ * Resolve every printer's LED state in one pass.
+ *
+ * Attribution per printer row:
+ *   1. jobs whose `printerId` equals the row id — if any exist, the latest wins;
+ *   2. otherwise, jobs whose `printerTitle` equals the row title, but ONLY when
+ *      that title is unique among the current rows (unambiguous) — the latest
+ *      wins;
+ *   3. otherwise `unknown` (grey — genuinely never printed, or ambiguous).
+ *
+ * `id` always takes precedence: a row with any id-matched job ignores
+ * title-only jobs entirely.
+ */
+export function attributePrinterStates(
+  printers: LedPrinter[],
+  jobs: LedJob[]
+): Map<string, LedState> {
+  // Titles shared by >1 current row are ambiguous — never a fallback key.
+  const titleCounts = new Map<string, number>()
+  for (const p of printers) {
+    if (p.title == null) continue
+    titleCounts.set(p.title, (titleCounts.get(p.title) ?? 0) + 1)
+  }
+
+  // Bucket jobs once: by printerId, and by printerTitle.
+  const byId = new Map<string, LedJob[]>()
+  const byTitle = new Map<string, LedJob[]>()
+  for (const job of jobs) {
+    if (job.printerId != null) {
+      const arr = byId.get(job.printerId)
+      if (arr) arr.push(job); else byId.set(job.printerId, [job])
+    }
+    if (job.printerTitle != null) {
+      const arr = byTitle.get(job.printerTitle)
+      if (arr) arr.push(job); else byTitle.set(job.printerTitle, [job])
+    }
+  }
+
+  const states = new Map<string, LedState>()
+  for (const p of printers) {
+    const idJobs = byId.get(p.id)
+    let job = idJobs && idJobs.length > 0 ? latest(idJobs) : undefined
+
+    // Fall back to an unambiguous title match only when no id-matched job.
+    if (!job && p.title != null && titleCounts.get(p.title) === 1) {
+      const titleJobs = byTitle.get(p.title)
+      if (titleJobs && titleJobs.length > 0) job = latest(titleJobs)
+    }
+
+    states.set(p.id, job ? stateForStatus(job.status) : 'unknown')
+  }
+
+  return states
+}

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/status.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/status.get.ts
@@ -27,6 +27,10 @@ export default defineEventHandler(async (event) => {
       // The job's domain back-reference IS the orderId (refType='order').
       orderId: printJobs.refId,
       printerId: printJobs.printerId,
+      // Denormalized printer label — the drift-proof fallback key the LED uses
+      // when a job's printerId no longer matches a current salesPrinters row
+      // (deleted+recreated / regenerated collection). See app/utils/printer-led.ts (#1507).
+      printerTitle: printJobs.printerTitle,
       status: printJobs.status,
       // locationId + printMode let OrderItems list what each ticket printed
       // (kitchen jobs = that location's items, receipt jobs = whole order).

--- a/packages/crouton-sales/test/printer-led.test.ts
+++ b/packages/crouton-sales/test/printer-led.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Printer online-LED attribution — behaviour contract (#1507, test-first gate #774).
+ *
+ * The settings-card LED must light **red** for a printer whose latest print job
+ * failed. It went **grey** ("never printed") at a live venue while Bar's jobs
+ * were failing every time — because the LED attributes a job to a printer row by
+ * `printerId` only, and any drift between a failing job's stored `printerId` and
+ * the printer row's current `id` (a printer deleted + re-created with a new
+ * nanoid, a regenerated printers collection, jobs enqueued before the row
+ * existed) leaves the printer with zero id-matched jobs → grey.
+ *
+ * Every job row already denormalizes `printerTitle` (written by every enqueue
+ * site), so the contract is: attribute by `id` FIRST, else by an **unambiguous**
+ * `printerTitle`. Ambiguous (duplicate-title) or truly-absent → grey, never a
+ * guess.
+ *
+ * `attributePrinterStates(printers, jobs)` is the pure core; the Vue component
+ * only maps the returned state → dot class + i18n label.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  attributePrinterStates,
+  type LedJob,
+  type LedPrinter
+} from '../app/utils/printer-led'
+
+const printer = (id: string, title: string): LedPrinter => ({ id, title })
+
+const job = (over: Partial<LedJob>): LedJob => ({
+  printerId: 'x',
+  printerTitle: null,
+  status: '2',
+  createdAt: 1000,
+  completedAt: null,
+  ...over
+})
+
+const stateOf = (printers: LedPrinter[], jobs: LedJob[], id: string) =>
+  attributePrinterStates(printers, jobs).get(id)
+
+describe('attributePrinterStates', () => {
+  it('lights red when the latest id-matched job failed', () => {
+    const printers = [printer('bar', 'Bar')]
+    const jobs = [job({ printerId: 'bar', printerTitle: 'Bar', status: '9', createdAt: 2000 })]
+    expect(stateOf(printers, jobs, 'bar')).toBe('offline')
+  })
+
+  it('lights green when the latest id-matched job completed', () => {
+    const printers = [printer('bar', 'Bar')]
+    const jobs = [job({ printerId: 'bar', printerTitle: 'Bar', status: '2', createdAt: 2000 })]
+    expect(stateOf(printers, jobs, 'bar')).toBe('online')
+  })
+
+  it('pulses (printing) while the latest id-matched job is pending/printing', () => {
+    const printers = [printer('bar', 'Bar')]
+    const jobs = [job({ printerId: 'bar', printerTitle: 'Bar', status: '0', createdAt: 2000 })]
+    expect(stateOf(printers, jobs, 'bar')).toBe('printing')
+  })
+
+  it('stays grey (unknown) for a printer that genuinely never printed', () => {
+    const printers = [printer('bar', 'Bar')]
+    expect(stateOf(printers, [], 'bar')).toBe('unknown')
+  })
+
+  // The regression the issue is about: the printer row id drifted away from the
+  // jobs (deleted + re-created / regenerated collection), so NO job matches by
+  // id — but the failing jobs still carry printerTitle 'Bar'. Must go RED.
+  it('falls back to a unique printerTitle when no job matches by id', () => {
+    const printers = [printer('bar-new-id', 'Bar')]
+    const jobs = [
+      job({ printerId: 'bar-old-id', printerTitle: 'Bar', status: '9', createdAt: 2000 })
+    ]
+    expect(stateOf(printers, jobs, 'bar-new-id')).toBe('offline')
+  })
+
+  it('prefers the id match and ignores title-only jobs when any id job exists', () => {
+    const printers = [printer('bar', 'Bar')]
+    const jobs = [
+      // id-matched, newest, completed → should win
+      job({ printerId: 'bar', printerTitle: 'Bar', status: '2', createdAt: 3000 }),
+      // title-only, older, failed → must NOT override the id match
+      job({ printerId: 'stale', printerTitle: 'Bar', status: '9', createdAt: 1000 })
+    ]
+    expect(stateOf(printers, jobs, 'bar')).toBe('online')
+  })
+
+  it('does NOT guess when the title is ambiguous (two printers share it)', () => {
+    const printers = [printer('bar-a', 'Bar'), printer('bar-b', 'Bar')]
+    const jobs = [
+      job({ printerId: 'ghost', printerTitle: 'Bar', status: '9', createdAt: 2000 })
+    ]
+    // Neither current row can safely claim the orphaned job → both grey.
+    expect(stateOf(printers, jobs, 'bar-a')).toBe('unknown')
+    expect(stateOf(printers, jobs, 'bar-b')).toBe('unknown')
+  })
+
+  it('picks the latest attributed job by completedAt ?? createdAt', () => {
+    const printers = [printer('bar', 'Bar')]
+    const jobs = [
+      job({ printerId: 'bar', printerTitle: 'Bar', status: '9', createdAt: 1000, completedAt: null }),
+      // newer, completed (completedAt beats the older failure's createdAt)
+      job({ printerId: 'bar', printerTitle: 'Bar', status: '2', createdAt: 1500, completedAt: 2000 })
+    ]
+    expect(stateOf(printers, jobs, 'bar')).toBe('online')
+  })
+
+  it('treats a missing/blank status as pending, not failed', () => {
+    const printers = [printer('bar', 'Bar')]
+    const jobs = [job({ printerId: 'bar', printerTitle: 'Bar', status: undefined, createdAt: 2000 })]
+    expect(stateOf(printers, jobs, 'bar')).toBe('printing')
+  })
+
+  it('resolves every printer in one pass (multi-printer map)', () => {
+    const printers = [printer('bar', 'Bar'), printer('kitchen', 'Kitchen')]
+    const jobs = [
+      job({ printerId: 'bar', printerTitle: 'Bar', status: '9', createdAt: 2000 }),
+      job({ printerId: 'kitchen', printerTitle: 'Kitchen', status: '2', createdAt: 2000 })
+    ]
+    const states = attributePrinterStates(printers, jobs)
+    expect(states.get('bar')).toBe('offline')
+    expect(states.get('kitchen')).toBe('online')
+  })
+})


### PR DESCRIPTION
Fixes the grey-not-red printer LED (attribution gap).

## 👤 For humans
When a printer's jobs keep failing, its settings-card LED must go **red** — not
sit **grey** ("never printed") and hide the failure, which is what happened to
Bar at a live venue on 2026-07-11. This PR opens with the **agreed-behaviour
test** for the fix (test-first gate #774); the implementation lands after
sign-off.

## 🤖 For agents
Root-cause finding is on the issue. Summary: all three sales enqueue sites store
a real `salesPrinters.id` + correct `eventId`/`teamId`, so there is **no
id-generation bug**. The LED (`SettingsTab.printerLed`) attributes a job to a
printer row by `printerId` **only**, and treats *no id-matched job* identically
to *never printed* → grey. Any drift between a failing job's stored `printerId`
and the row's current `id` (printer deleted+recreated, regenerated collection,
jobs predating the row) hides the failure. The denormalized `printerTitle` —
already on every job — is dropped by `printqueues/status.get.ts`, so the LED has
no fallback.

**Planned fix (held for sign-off):**
- `app/utils/printer-led.ts` — pure `attributePrinterStates(printers, jobs)`:
  attribute by `id` first, else by an **unambiguous** `printerTitle`; latest job
  by `completedAt ?? createdAt`; `2`→online, `9`→offline, else printing; none →
  unknown.
- `printqueues/status.get.ts` — also select `printerTitle`.
- `SettingsTab.vue` — consume the helper; map state → dot class + i18n label.

**This PR so far:** only the proposed **failing** test
(`packages/crouton-sales/test/printer-led.test.ts`). Red before green.

## 🧪 How to test
1. `cd packages/crouton-sales && npx vitest run test/printer-led.test.ts` — fails
   now (module absent); goes green once the helper is implemented.
2. In-app (post-fix): a printer whose latest job failed → **red** LED; a printer
   that just printed → **green**; a never-printed printer → **grey** (unchanged).
   The key case: a printer re-created after failures (new id, same title) still
   lights **red** via the title fallback.

Closes #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
