### PR TITLE
fix(crouton-sales): align receipt-settings form defaults with what prints (#1514)

### DIFF
--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
@@ -144,11 +144,14 @@ interface ReceiptSettings {
 const receiptEndpoint = computed(() =>
   `/api/crouton-sales/teams/${teamParam.value}/events/${props.event.id}/receipt-settings`
 )
+// Pre-resolve fallback only — the endpoint returns crouton-printing's canonical
+// DEFAULT_RECEIPT_SETTINGS. Kept in sync with it (Dutch) so an unsaved event's
+// form matches what actually prints (#1514); client can't import the server util.
 const { data: receiptSaved } = await useFetch<ReceiptSettings>(receiptEndpoint, {
   default: () => ({
-    special_instructions_title: 'SPECIAL INSTRUCTIONS:',
-    staff_order_header: '*** STAFF ORDER ***',
-    footer_text: 'Thank you for your order!'
+    special_instructions_title: 'OPMERKING:',
+    staff_order_header: '*** PERSONEEL ***',
+    footer_text: 'Bedankt voor je bestelling!'
   })
 })
 const receiptForm = ref<ReceiptSettings>({ ...receiptSaved.value })
@@ -577,7 +580,7 @@ function helperExpiry(value: string): string {
                 v-model="receiptForm.special_instructions_title"
                 class="w-full"
                 size="sm"
-                placeholder="SPECIAL INSTRUCTIONS:"
+                placeholder="OPMERKING:"
               />
             </UFormField>
             <UFormField :label="t('sales.receipt.staffOrderHeader')" :help="t('sales.receipt.staffOrderHeaderHelp')">
@@ -585,7 +588,7 @@ function helperExpiry(value: string): string {
                 v-model="receiptForm.staff_order_header"
                 class="w-full"
                 size="sm"
-                placeholder="*** STAFF ORDER ***"
+                placeholder="*** PERSONEEL ***"
               />
             </UFormField>
             <UFormField :label="t('sales.receipt.footerText')" :help="t('sales.receipt.footerTextHelp')">
@@ -594,7 +597,7 @@ function helperExpiry(value: string): string {
                 class="w-full"
                 size="sm"
                 :rows="2"
-                placeholder="Thank you for your order!"
+                placeholder="Bedankt voor je bestelling!"
               />
             </UFormField>
           </div>

--- a/packages/crouton-sales/app/components/Settings/ReceiptSettingsModal.vue
+++ b/packages/crouton-sales/app/components/Settings/ReceiptSettingsModal.vue
@@ -17,14 +17,14 @@
           <UFormField :label="t('sales.receipt.specialInstructionsTitle')" :help="t('sales.receipt.specialInstructionsHelp')">
             <UInput
               v-model="settings.special_instructions_title"
-              placeholder="SPECIAL INSTRUCTIONS:"
+              placeholder="OPMERKING:"
             />
           </UFormField>
 
           <UFormField :label="t('sales.receipt.staffOrderHeader')" :help="t('sales.receipt.staffOrderHeaderHelp')">
             <UInput
               v-model="settings.staff_order_header"
-              placeholder="*** STAFF ORDER ***"
+              placeholder="*** PERSONEEL ***"
             />
           </UFormField>
         </div>
@@ -33,7 +33,7 @@
           <UTextarea
             v-model="settings.footer_text"
             :rows="2"
-            placeholder="Thank you for your order!"
+            placeholder="Bedankt voor je bestelling!"
           />
         </UFormField>
       </div>
@@ -84,10 +84,12 @@ const isOpen = computed({
 
 const saving = ref(false)
 
+// Defaults mirror crouton-printing's canonical DEFAULT_RECEIPT_SETTINGS (Dutch),
+// so the form matches what actually prints for an unsaved event (#1514).
 const settings = ref<ReceiptSettings>({
-  special_instructions_title: 'SPECIAL INSTRUCTIONS:',
-  staff_order_header: '*** STAFF ORDER ***',
-  footer_text: 'Thank you for your order!',
+  special_instructions_title: 'OPMERKING:',
+  staff_order_header: '*** PERSONEEL ***',
+  footer_text: 'Bedankt voor je bestelling!',
 })
 
 async function loadSettings() {

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/receipt-settings.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/receipt-settings.get.ts
@@ -1,18 +1,13 @@
 import { eq, and } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+// Single source of truth (#1514): the default an unsaved event shows in the
+// form MUST equal what the formatter prints when no settings row exists —
+// crouton-printing owns that canonical default. A local copy here diverged
+// (English) from the formatter (Dutch), so the form lied about what prints.
+import { DEFAULT_RECEIPT_SETTINGS, type ReceiptSettings } from '@fyit/crouton-printing/server/utils/receipt-formatter'
 import { salesEventsettings } from '~~/layers/sales/collections/eventsettings/server/database/schema'
 
-export interface ReceiptSettings {
-  special_instructions_title: string
-  staff_order_header: string
-  footer_text: string
-}
-
-const DEFAULT_RECEIPT_SETTINGS: ReceiptSettings = {
-  special_instructions_title: 'SPECIAL INSTRUCTIONS:',
-  staff_order_header: '*** STAFF ORDER ***',
-  footer_text: 'Thank you for your order!'
-}
+export type { ReceiptSettings }
 
 export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)


### PR DESCRIPTION
## 👤 Summary

The receipt-text settings **form showed different defaults than what prints.** An event with no saved settings displayed English placeholders (`*** STAFF ORDER ***`), but a printed ticket used the formatter's **Dutch** defaults (`*** PERSONEEL ***`) — so the form lied about what would print until Save. Found while verifying wiring for #1504.

## 🔎 Root cause (not a regression)
Two independently-authored default sets: crouton-printing owns the canonical `DEFAULT_RECEIPT_SETTINGS` (Dutch, what prints), while the sales form/endpoint each hardcoded an English copy (`b46ab8883`). They were never reconciled.

## 🤖 Fix
- `receipt-settings.get.ts` → imports + returns crouton-printing's `DEFAULT_RECEIPT_SETTINGS` (single source of truth) + re-exports the `ReceiptSettings` type.
- `SettingsTab.vue` / `ReceiptSettingsModal.vue` → pre-load fallback + input placeholders aligned to the same Dutch canonical (client can't import the server util; commented). `PrintersTab.vue`'s copy is removed by #1504 (PR #1513), left untouched here to avoid a merge collision.

## ✅ Verified
- `fixtures/with-sales` typecheck — **0 TS errors**.

## 🧪 How to test
1. Open an event with **no saved** receipt settings → the form fields now show the Dutch defaults.
2. Print a staff ticket (or the #1504 preview) → banner matches (`*** PERSONEEL ***`).
3. Save custom text → both form and print show it.

Closes #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)