### PR TITLE
fix(crouton-themes): stop blackandwhite layer leaking global Nuxt UI overrides

### DIFF
--- a/packages/crouton-themes/blackandwhite/app.config.ts
+++ b/packages/crouton-themes/blackandwhite/app.config.ts
@@ -1,38 +1,33 @@
 import { subtractThemeDefaults } from '../lib/subtractive'
 
+// Black & White theme layer config.
+//
+// House rule (matches every other theme, e.g. brutalist/app.config.ts): a theme
+// LAYER app.config carries ONLY `colors` (its palette — reset at runtime by
+// themeConfigs.ts → defaultConfig) plus per-component `slots.base: replacer` +
+// named `variants`. It must NOT set standard-variant `defaultVariants`, a global
+// `theme` size, or app-level component overrides (container / navigationMenu /
+// dashboardPanel) — those are merged into the CONSUMING app's global Nuxt UI
+// config on `extends` and would apply on EVERY theme, including default, with no
+// runtime reset (the kassa/fanfare leak, #1525). The scalar defaultVariants swap
+// for bw (subtle inputs etc.) lives in themeConfigs.ts, which resets on switch.
 export default defineAppConfig({
   ui: {
-    theme: {
-      defaultVariants: {
-        size: 'sm'
-      }
-    },
     colors: {
       primary: 'neutral',
       neutral: 'neutral'
     },
-    container: {
-      base: 'w-full max-w-full mx-auto px-4 sm:px-6 lg:px-8'
-    },
-    select: {
-      slots: {
-        content: 'min-w-fit'
-      },
-      defaultVariants: {
-        variant: 'subtle'
-      }
-    },
     button: {
       // NAMED bw-* variants + a defaultVariants pointer (#1304, was an override
-      // of the standard solid/outline/... slots). Same single-theme contract —
-      // a plain <UButton> in an app extending this layer resolves to bw-solid —
-      // but the standard variants stay untouched, so in a multi-theme app (the
-      // playground) this layer no longer restyles the other themes' buttons,
-      // and an explicit variant="outline" is the author's literal choice.
-      // The shared marker-gated replacer (#1304) strips the conflicting
-      // defaults (color/elevation/motion/underline) when a bw-* marker is
-      // present, so the CSS needs no !important; Nuxt UI's rounding, sizing
-      // and focus ring are kept.
+      // of the standard solid/outline/... slots). A plain <UButton> in a
+      // single-theme bw app (extending only this layer, no runtime switcher)
+      // resolves to bw-solid; in a multi-theme app the runtime themeConfigs swap
+      // owns the default. The standard variants stay untouched, so this layer no
+      // longer restyles other themes' buttons, and an explicit variant="outline"
+      // is the author's literal choice. The shared marker-gated replacer (#1304)
+      // strips the conflicting defaults (color/elevation/motion/underline) when a
+      // bw-* marker is present, so the CSS needs no !important; Nuxt UI's
+      // rounding, sizing and focus ring are kept.
       slots: {
         base: subtractThemeDefaults
       },
@@ -47,47 +42,6 @@ export default defineAppConfig({
           'bw-ghost': 'bw-ghost',
           'bw-link': 'bw-link'
         }
-      }
-    },
-    dashboardPanel: {
-      slots: {
-        body: 'p-4'
-      }
-    },
-    navigationMenu: {
-      props: {
-        color: 'primary',
-        variant: 'pill',
-        orientation: 'vertical',
-        highlight: false,
-        highlightColor: 'primary',
-        collapsed: false
-      },
-      slots: {
-        root: 'w-full'
-      }
-    },
-    card: {
-      defaultVariants: {
-        variant: 'outline'
-      }
-    },
-    input: {
-      variants: {
-        variant: {}
-      },
-      defaultVariants: {
-        variant: 'subtle'
-      }
-    },
-    alert: {
-      defaultVariants: {
-        variant: 'subtle'
-      }
-    },
-    textarea: {
-      defaultVariants: {
-        variant: 'subtle'
       }
     }
   }


### PR DESCRIPTION
Closes #1525

## 👤 For humans

The `blackandwhite` theme was quietly restyling **every** app that loads its layer — even on the **default** theme. kassa (`kassa.pmcp.dev` = `apps/fanfare`) extends all the theme layers so the Look-and-Feel switcher has CSS to show, which pulled in blackandwhite's `app.config.ts`. Unlike the other 11 themes, that config set **top-level, unscoped Nuxt UI overrides** — so all the time, on every theme:

- every component forced to size `sm`
- inputs / selects / textareas / alerts repointed to the `subtle` variant
- `container`, `navigationMenu`, `dashboardPanel` overridden

That's why the default theme drifted and modals/controls looked "off" (see #1525 for the reported screenshots). This trims blackandwhite's layer to just its palette + the `bw-*` button variants, matching every other theme. **bw looks identical when selected; the default theme goes back to stock Nuxt UI.**

## 🤖 For agents

**Root cause:** a theme layer's `app.config.ui` merges into the *consuming app's* global config on `extends`. Safe themes only add `colors` (reset at runtime by `themeConfigs.ts` → `defaultConfig`) + styling gated behind a **named variant**. blackandwhite instead carried unscoped globals that (a) were redundant with the runtime swap, or (b) were app-level cruft, and — for `theme.size`/`container`/`navigationMenu`/`dashboardPanel` — were **never reset**, so they leaked permanently onto default. Gap left by #1304 (which migrated only the button); epic #1303.

**Change (single file — `packages/crouton-themes/blackandwhite/app.config.ts`):**
- Removed `theme.defaultVariants.size:'sm'`, `container.base`, `navigationMenu.props/slots`, `dashboardPanel.body`, `select.slots.content:'min-w-fit'`, and the standard-variant `defaultVariants` on input/select/textarea/alert/card.
- Kept only `colors` + the `button` named `bw-*` variants + shared marker-gated replacer (house pattern, cf. `brutalist/app.config.ts`).
- **No runtime change:** `themeConfigs.ts` `blackandwhiteConfig` already owns bw's `subtle` scalars and `defaultConfig` resets every key.

**Leak path:** `apps/fanfare/nuxt.config.ts:37` `extends '@fyit/crouton-themes/blackandwhite'`.

## 🧪 How to test

**What changed:** blackandwhite stops imposing its sizing/variants/layout on the whole app; it only styles things when selected.
**Where:** kassa / `apps/fanfare` on the **default** theme — the order modal (name field, tabs, +/- steppers) and the settings page; plus the themes playground (all themes side-by-side).

1. On default theme (before): cramped `sm` controls, `subtle` inputs, stray framing in the order modal.
2. After merge → fanfare auto-deploys to `*.pmcp.dev`; default theme renders stock Nuxt UI sizing/variants; the "off" spacing/framing is gone.
3. Playground: switch **to** blackandwhite → still correct; switch **away** → nothing left behind.

**Verification done:** `pnpm --filter fanfare typecheck` ✅ · `crouton-themes-playground typecheck` ✅. Visual before/after on the playground attached in the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LApwiAZUsVUb1GscY8KUc4)_