### PR TITLE
fix(crouton-sales): persist kassa product drag-reorder (order, not sortOrder)

### DIFF
--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -266,13 +266,15 @@ The shell uses top-level `await`, so any non-page consumer must give it a `<Susp
 
 `ProductsTab.vue` renders products as a **drag-reorderable list** (not a table): a bespoke `<ul>`
 with `useSortable` (`@vueuse/integrations`, via crouton-core) and a `.drag-handle` grip. Drop
-persists the new visual index to each moved row's `sortOrder` via `useCollectionMutation('salesProducts').update`
-— no reorder endpoint needed (the existing PATCH accepts `sortOrder`). The list is sorted by
-`sortOrder` (nullable integer, null⇒0) then title, and reordering operates on the currently
-**visible** set (whole list, or within the selected category tab). Note: `sales_products.sortOrder`
-is an `integer` column (migration `0003_furry_lilith`); the old redundant `order` int column was
-dropped. The generic tree/sortable reorder path (`useTreeMutation`) is **not** used here because it
-re-fetches all team products un-scoped to the event. Each row also surfaces routing/flags: the
+persists the new visual index through the generated `/reorder` endpoint via
+`useTreeMutation('salesProducts').reorderSiblings` (`order = index`). The sortable position column
+is **`order`** (`integer`, null⇒0) — the one the `sortable: true` generator produces (default
+`orderField: 'order'`) and that the whole reorder chain is keyed on: the DB column, the `/reorder`
+query, `order-data`, and `useTreeMutation`'s hardwired `order` payload key. The list is sorted by
+`order` then title, and reordering operates on the currently **visible** set (whole list, or within
+the selected category tab). ⚠️ There is **no `sortOrder` column** — an earlier revision of the POS
+components read `sortOrder`, which never existed in any consumer's schema, so reorders silently
+reverted to alphabetical (#1524). Each row also surfaces routing/flags: the
 product's **location** name (📍) and the active **printer(s)** at that location (🖨️, joined —
 derived by matching `salesPrinters.locationId` to the product's `locationId`), plus **options**
 and **remark** badges (`hasOptions` / `requiresRemark`). The tab therefore also queries
@@ -667,7 +669,7 @@ Components are auto-imported with `Sales` prefix (e.g., `SalesClientCart`, `Sale
 pencil (not the "+"/chevron) and tapping any product row opens its edit form — adding to cart is
 disabled while editing** (`ProductList` `editable`; the old right-edge slide-out hover pencil was
 dropped in favour of the persistent trailing pencil; reorder persists via
-`useTreeMutation('salesProducts').reorderSiblings`); the list sorts by `sortOrder` then title. An admin toolbar row pinned above the product list carries "add product" and a labeled show-inactive switch — inactive products render dimmed + badged. The Category/Location/Product/Printer update forms put a `CroutonDeleteButton` (shared two-step pill: click arms "sure?", click again deletes; from crouton-core) left of the save button in one `flex items-stretch` footer row — no nested delete overlay. SettingsTab's "Evenement verwijderen" row uses the same pill (deletes directly; Shell's mutation hook navigates away). Single-select options with a required remark render as a `URadioGroup` (a solid selected button read too heavy); multi-select stays checkboxes. PrinterForm's footer lists the actual validation messages (schema fields without a rendered input — e.g. nullable DB columns failing `.optional()` — would otherwise surface as an opaque count) |
+`useTreeMutation('salesProducts').reorderSiblings`); the list sorts by `order` then title. An admin toolbar row pinned above the product list carries "add product" and a labeled show-inactive switch — inactive products render dimmed + badged. The Category/Location/Product/Printer update forms put a `CroutonDeleteButton` (shared two-step pill: click arms "sure?", click again deletes; from crouton-core) left of the save button in one `flex items-stretch` footer row — no nested delete overlay. SettingsTab's "Evenement verwijderen" row uses the same pill (deletes directly; Shell's mutation hook navigates away). Single-select options with a required remark render as a `URadioGroup` (a solid selected button read too heavy); multi-select stays checkboxes. PrinterForm's footer lists the actual validation messages (schema fields without a rendered input — e.g. nullable DB columns failing `.optional()` — would otherwise surface as an opaque count) |
 | `Selector.vue` | `SalesClientSelector` | Client selector with create-on-type: `USelectMenu create-item` — typing an unknown name surfaces an "\"<naam>\" toevoegen" row, Enter/click creates + selects it inline (`@create` → helper-scoped POST; exact-match guard falls back to selecting the existing client). This is the **only** create path — the old `#content-top` "create new" button + modal were dropped once type-to-create landed. **A client indication is always mandatory** at checkout: `requiresClient` events show this selector, all other events show a plain `UInput` (`sales.cart.namePlaceholder` — "Naam of tafelnummer…") bound to `selectedClientName`; OrderInterface's `hasClient` gates Betalen on id-or-name either way, and the Cart warning text comes from the `clientWarning` prop (`selectClient` vs `enterName`). Clients created inline live in a local `createdClients` bridge until the next order-data refetch confirms them (create emits the `salesClients` `crouton:mutation` hook itself; a `props.clients` watch prunes confirmed copies) — so a tab settled elsewhere drops the client from the list live, and a vanished selection auto-clears |
 | `OfflineBanner.vue` | `SalesClientOfflineBanner` | Offline mode indicator |
 

--- a/packages/crouton-sales/app/components/Client/OrderInterface.vue
+++ b/packages/crouton-sales/app/components/Client/OrderInterface.vue
@@ -530,12 +530,12 @@ const cartCountsByCategory = computed(() => {
 })
 
 // Filtered products based on selected category, in the same order the admin
-// arranged them (sortOrder, then title). Inactive products are hidden unless
+// arranged them (order, then title). Inactive products are hidden unless
 // the admin toggles them visible.
 const filteredProducts = computed(() => {
   const allProducts = ([...(products.value || [])] as SalesProduct[])
     .filter(p => p.isActive !== false || (editing.value && showInactive.value))
-    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || a.title.localeCompare(b.title))
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.title.localeCompare(b.title))
   if (selectedCategory.value === null) return allProducts
   return allProducts.filter(p => p.categoryId === selectedCategory.value)
 })

--- a/packages/crouton-sales/app/components/Client/ProductList.vue
+++ b/packages/crouton-sales/app/components/Client/ProductList.vue
@@ -232,7 +232,7 @@ const containerRef = ref<HTMLElement | null>(null)
 const orderedProducts = ref<SalesProduct[]>([])
 watch(() => props.products, (v) => { orderedProducts.value = [...(v || [])] }, { immediate: true })
 
-const orderOf = (p: SalesProduct) => p.sortOrder ?? 0
+const orderOf = (p: SalesProduct) => p.order ?? 0
 
 function emitNewOrder() {
   const updates: Array<{ id: string, order: number }> = []

--- a/packages/crouton-sales/app/composables/usePosOrder.ts
+++ b/packages/crouton-sales/app/composables/usePosOrder.ts
@@ -26,7 +26,10 @@ export interface SalesProduct {
   hasOptions?: boolean
   multipleOptionsAllowed?: boolean
   options?: ProductOption[]
-  sortOrder?: number
+  // Sortable position column. Named `order` to match the generated backend
+  // (schema column, /reorder query, order-data) and useTreeMutation's payload
+  // key — the whole reorder chain is keyed on `order`, not `sortOrder`.
+  order?: number
 }
 
 export interface CartItem {

--- a/packages/crouton-sales/schemas/products.json
+++ b/packages/crouton-sales/schemas/products.json
@@ -11,6 +11,5 @@
   "remarkPrompt": { "type": "string", "meta": { "label": "Remark Prompt" } },
   "hasOptions": { "type": "boolean", "meta": { "label": "Has Options", "default": false } },
   "multipleOptionsAllowed": { "type": "boolean", "meta": { "label": "Multiple Options", "default": false } },
-  "options": { "type": "repeater", "meta": { "label": "Options", "helpText": "Product variants like sizes or extras" } },
-  "sortOrder": { "type": "integer", "meta": { "label": "Sort Order", "default": 0 } }
+  "options": { "type": "repeater", "meta": { "label": "Options", "helpText": "Product variants like sizes or extras" } }
 }

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/duplicate.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/duplicate.post.ts
@@ -100,7 +100,7 @@ export default defineEventHandler(async (event) => {
       remarkPrompt: prod.remarkPrompt,
       hasOptions: prod.hasOptions,
       multipleOptionsAllowed: prod.multipleOptionsAllowed,
-      sortOrder: prod.sortOrder,
+      order: prod.order,
       createdBy: user.id,
       updatedBy: user.id
     })


### PR DESCRIPTION
Closes #1524

## 👤 For humans

Dragging to reorder products in the kassa now sticks. It was silently reverting to alphabetical order because the POS read a field (`sortOrder`) that doesn't exist in the database — the real column is `order`. Event duplication had the same bug and now carries product order to the clone.

## 🤖 Root cause

The reorder round-trips through `useTreeMutation('salesProducts').reorderSiblings`. The whole backend chain is keyed on the column **`order`**, but the POS frontend read/sorted by **`sortOrder`**, which is `undefined` on the returned rows:

| Layer | Field |
|---|---|
| DB column (`schema.ts`, fanfare + `with-sales`) | `order` |
| Reorder query `reorderSiblingsSalesProducts` (`.set({ order })`) | `order` |
| List `orderBy` + `events/[eventId]/order-data` | `order` |
| `useTreeMutation.reorderSiblings` wire payload key | `order` (hardwired) |
| `ProductsTab.vue` (older, unmounted) | `order` ✅ |
| `ProductList.vue` / `OrderInterface.vue` / `SalesProduct` type / `duplicate.post.ts` | `sortOrder` ❌ |

The drop **did** persist to the DB `order` column, but `OrderInterface` then sorted by `product.sortOrder` (always `0`) and fell back to `title.localeCompare` → alphabetical.

## Archaeology (bug-first gate)

Repo is a shallow clone, so this was established statically:
- **No `sortOrder`/`sort_order` column or migration exists in any consumer** — `sortable: true` generates the `order` column via the default `orderField: 'order'`.
- `useTreeMutation` hardwires the `order` payload key, so a `sortOrder` backend was never wired.
- `CLAUDE.md` + `schemas/products.json` claimed `sortOrder` was canonical (a "migration `0003_furry_lilith` dropped `order`") — that migration/column exists nowhere. The docs were stale and the POS components were written against a never-realized `sortOrder`.

Conclusion: `order` is the real canonical field. Fixed the frontend to read it (not migrate DBs to `sortOrder`, which would also break `useTreeMutation`'s `order` payload contract).

## Changes (all `packages/crouton-sales`)

- `app/composables/usePosOrder.ts` — `SalesProduct.sortOrder?` → `order?`
- `app/components/Client/ProductList.vue` — `orderOf` reads `p.order`
- `app/components/Client/OrderInterface.vue` — `filteredProducts` sorts by `order`
- `server/.../events/[eventId]/duplicate.post.ts` — copy `order: prod.order` (fixes the same latent bug in event duplication)
- `schemas/products.json` — drop the dead `sortOrder` field
- `CLAUDE.md` — correct the stale `sortOrder` / `0003_furry_lilith` claims

## 🧪 How to test

1. Open the kassa for an event with several products in one category (fanfare / the `vlaamsekermis` seed).
2. Enter edit mode (pencil), drag a product by its grip to a new position.
3. Reload / let `SalesPosPanel` refetch order-data.
4. **Before:** list reverts to alphabetical. **After:** the dragged order is preserved.
5. Duplicate the event → product order carries over to the clone.

Typecheck: `pnpm --filter fanfare typecheck` passes clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_