### PR TITLE
fix(crouton-sales): kassa fullscreen modal runs edge-to-edge on phones

### DIFF
--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -257,7 +257,13 @@ current event navigates back to the events list via a `crouton:mutation` hook (m
 `<Suspense>`.
 Props: `eventSlug` (required), `teamParam` (defaults to `route.params.team`, present in both admin
 and public CMS routes), `tabParam` (**legacy, ignored** — kept for consumer compatibility),
-`showSwitcher` / `showHeaderActions` / `showHeader` (default `true`).
+`showSwitcher` / `showHeaderActions` / `showHeader` (default `true`), and `fill` (default `false`) —
+set by the fullscreen-modal host (`EventWorkspaceRender`, narrow member) so the kassa runs
+**edge-to-edge**: the shell root flexes to the modal's height (`h-full`) and the kassa drops its
+`border rounded-xl` frame + the measured `100dvh` budget (the modal IS the budget). Without `fill`
+(admin page + wide inline shell) the kassa keeps the framed, viewport-measured card. The block's
+member modal also drops its `p-4` inset when passing `fill`, so nothing boxes the kassa inside the
+fullscreen modal.
 The `eventWorkspaceBlock` renderer mounts the shell **only for signed-in team members** and passes
 `:show-switcher="false"` (event fixed by the editor) — the header stays visible so the
 settings/orders toggles are reachable. Anonymous visitors (volunteers) get `<SalesPosPanel>`

--- a/packages/crouton-sales/app/components/Blocks/EventWorkspaceRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/EventWorkspaceRender.vue
@@ -146,12 +146,16 @@ function openPane(pane: 'orders' | 'clients' | 'data' | 'settings') {
                  strip on narrow, the header on wide) carries the exit ✕
                  (closable) — no separate close row wasting a line. -->
             <template v-if="loggedIn">
-              <div class="flex-1 min-h-0 overflow-y-auto p-4">
+              <!-- No inset padding: the shell runs edge-to-edge in the modal
+                   (fill) — a p-4 wrapper + the shell's own border frame made
+                   the kassa read as a boxed panel rather than full-screen. -->
+              <div class="flex-1 min-h-0">
                 <Suspense>
                   <SalesEventWorkspaceShell
                     :event-slug="eventSlug"
                     :show-switcher="false"
                     :show-strip="false"
+                    fill
                     closable
                     @close="kassaOpen = false"
                   />

--- a/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
@@ -63,11 +63,21 @@ const props = withDefaults(defineProps<{
    * tabs row and the ✕ beside it (closable pass-down).
    */
   showStrip?: boolean
+  /**
+   * Fill the host edge-to-edge instead of sitting as a bordered, rounded,
+   * viewport-measured card. Set by the fullscreen-modal host
+   * (EventWorkspaceRender, narrow member) so the kassa uses the modal's full
+   * height/width — no border frame, no measured `100dvh` budget (the modal is
+   * already the budget). The admin page + wide inline shell leave it off and
+   * keep the framed, measured card.
+   */
+  fill?: boolean
 }>(), {
   showSwitcher: true,
   showHeaderActions: true,
   showHeader: true,
-  showStrip: true
+  showStrip: true,
+  fill: false
 })
 
 const emit = defineEmits<{ close: [] }>()
@@ -222,7 +232,7 @@ const kassaHeightStyle = computed(() =>
     </div>
   </div>
 
-  <div v-else class="space-y-4">
+  <div v-else :class="fill ? 'h-full flex flex-col' : 'space-y-4'">
     <!-- No desktop header row anymore: the event switcher moved into the
          gutter, settings became a pane like orders/data, and the kassa is the
          page — the event name lives in the switcher and the page you came
@@ -339,14 +349,17 @@ const kassaHeightStyle = computed(() =>
          persist via autoSaveId). The vertical tabs hang just OUTSIDE the
          kassa's right edge (reserved gutter via pe-11, so they never
          overflow the page). -->
-    <div class="relative" :class="hasGutter ? 'pe-11' : ''">
+    <div class="relative" :class="[hasGutter ? 'pe-11' : '', fill ? 'flex-1 min-h-0' : '']">
     <!-- Height: measured to fill the viewport from the module's real top
          (kassaHeightStyle); the class budget is only the SSR/first-paint
-         fallback before the measurement lands. -->
+         fallback before the measurement lands. In `fill` mode the fullscreen
+         modal host IS the budget, so the kassa flexes to fill it edge-to-edge —
+         no border frame, no measured `100dvh` calc. -->
     <div
       ref="kassaRef"
-      class="flex border border-default rounded-xl overflow-clip bg-default h-[calc(100dvh-8.5rem)] min-h-[28rem]"
-      :style="kassaHeightStyle"
+      class="flex overflow-clip bg-default"
+      :class="fill ? 'h-full' : 'border border-default rounded-xl h-[calc(100dvh-8.5rem)] min-h-[28rem]'"
+      :style="fill ? undefined : kassaHeightStyle"
     >
       <SplitterGroup
         direction="horizontal"


### PR DESCRIPTION
## 👤 For humans

Opening the kassa on a phone — the CMS block's **"Open kassa"** for a logged-in team member — showed the register as a rounded, bordered panel inset inside the fullscreen modal. It read as "not full screen," with wasted space around the edges (see the reported screenshots). It now fills the modal **edge-to-edge, top to bottom**, so the phone kassa uses the whole viewport.

No visual change on the admin sales page or the wide-screen inline shell — those keep the framed, measured card. The volunteer POS and the Bestellingen/Klanten/Data/Instellingen panes already filled edge-to-edge.

## 🤖 For agents

Root cause: the member launcher's fullscreen `UModal` *was* edge-to-edge, but its content was boxed — `EventWorkspaceRender` wrapped the shell in a `p-4` inset, and `Shell` gave the kassa a `border rounded-xl` frame sized to `calc(100dvh − kassaTop − 1rem)`.

- **`Shell.vue`** — new `fill` prop (default `false`). When set: shell root becomes `h-full flex flex-col`, the kassa wrapper becomes `flex-1 min-h-0`, and the kassa drops `border rounded-xl` + the measured `100dvh` budget for `h-full` (the modal is already the budget). Off (admin page + wide inline shell) is byte-for-byte unchanged.
- **`EventWorkspaceRender.vue`** — the narrow member modal drops its `p-4` inset and passes `fill`.
- **`CLAUDE.md`** — documents the `fill` prop on the Shell entry.

`pnpm --filter fanfare typecheck` passes.

## 🧪 How to test

This PR only touches a shared package (`crouton-sales`), so no per-PR preview is spun up — it deploys to staging (**kassa.pmcp.dev**) on merge to `main`. Then, on a **phone-width** viewport, signed in as a **team member**:

1. Open a CMS page that hosts the `eventWorkspaceBlock` (e.g. the seeded `test1` team's `/test1/nl/vlaamsekermis`).
2. Tap **"Open kassa"**.
3. **Before:** the register sat as a rounded, bordered card inset ~16px inside the modal, with a bottom gap. **After:** it fills the modal edge-to-edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)