### PR TITLE
feat(crouton-pages): render event PIN as UPinInput in ScopedAccessGate

### DIFF
--- a/packages/crouton-pages/app/components/ScopedAccessGate.vue
+++ b/packages/crouton-pages/app/components/ScopedAccessGate.vue
@@ -40,6 +40,19 @@ const pin = ref('')
 const name = ref('')
 const errorMessage = ref<string | null>(null)
 
+// The event scope is the sales helper PIN — a fixed 4-digit numeric code the
+// POS panel already renders as a UPinInput (#1480). Match it here so the same
+// PIN entered through a scoped CMS page looks the same. Every other scope
+// (booking guest, arbitrary page code) isn't guaranteed numeric/fixed-length,
+// so it keeps the plain password input. (#1529)
+const isPinScope = computed(() => props.scope.resourceType === 'event')
+// UPinInput binds an array (one digit per cell); keep the joined string as the
+// source of truth so unlock()/canSubmit stay unchanged (same proxy as Pos/Panel.vue).
+const pinCells = computed<number[]>({
+  get: () => pin.value.split('').map(Number),
+  set: cells => { pin.value = cells.join('') }
+})
+
 const pending = computed(() => scopedAccess.isLoading.value)
 const nameMissing = computed(() => !!props.scope.nameRequired && !name.value.trim())
 const canSubmit = computed(() => !!pin.value.trim() && !nameMissing.value)
@@ -99,7 +112,17 @@ async function unlock() {
           autocomplete="off"
           :autofocus="!!scope.nameRequired"
         />
+        <UPinInput
+          v-if="isPinScope"
+          v-model="pinCells"
+          :length="4"
+          type="number"
+          mask
+          size="lg"
+          :aria-label="t('pages.scopedGate.pinPlaceholder', 'Access code')"
+        />
         <UInput
+          v-else
           v-model="pin"
           :placeholder="t('pages.scopedGate.pinPlaceholder', 'Access code')"
           icon="i-lucide-key-round"


### PR DESCRIPTION
Closes #1529

## 👤 For humans
A volunteer who opens the kassa through a **scoped CMS page** now enters the event PIN in the same 4-cell PIN input the POS panel already uses — instead of a plain password box. This was the one surface [#1480](https://github.com/FriendlyInternet/nuxt-crouton/issues/1480) missed: it switched the two **crouton-sales** PIN fields (volunteer POS login + admin settings) to `UPinInput`, but the **crouton-pages** access gate still showed `<UInput type="password">` for the same `helperPin`. Reported from the field (`kassa.pmcp.dev` login).

Only the **event-PIN scope** changes. The gate is generic — it also protects booking-guest and arbitrary page codes, which aren't guaranteed 4-digit numeric — so those keep the password field.

**Before → after:** the "Toegangscode" password box becomes a masked 4-cell numeric PIN input on scoped kassa pages.

## 🤖 For agents
- **File:** `packages/crouton-pages/app/components/ScopedAccessGate.vue`
- Gate on `scope.resourceType === 'event'` (`isPinScope`) — only the sales derive-scope hook answers `resourceType: 'event'`, so no backend or scope-contract change is needed.
- Render `<UPinInput :length="4" type="number" mask size="lg">` for that case; keep `<UInput type="password">` (with its `nameRequired` autofocus) for every other scope.
- `pinCells` computed proxy (split/join over the existing `pin` string ref) keeps `pin` the source of truth, so `unlock()` / `canSubmit` are unchanged. Same pattern as `Pos/Panel.vue` (L104-107).
- No new logic (UI/component swap) → test-first gate not triggered. Consistent with #1480's fixed 4-digit convention; a >4-char PIN is untypeable here, exactly as it already is in the POS panel.

## 🧪 How to test
1. Seed the `crouton-sales` demo → event `vlaamsekermis` (PIN `1234`), scoped page slug `vlaamsekermis`.
2. Open `/test1/nl/vlaamsekermis` without a session → the access gate's code field is now a **4-cell masked PinInput**, not a password box.
3. Enter a name + `1234` → unlocks and loads the kassa (redeem unchanged).
4. Open a non-event scoped page (plain page-code gate) → still shows the password `UInput`.
5. `pnpm -r --filter './apps/*' typecheck` — green (verified on velo / fanfare / triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Spq9yQzZ1JmgRUqcAUcfk9)_