### PR TITLE
Make the page-editor Save button solid

### DIFF
--- a/packages/crouton-pages/app/components/Editor/Toolbar.vue
+++ b/packages/crouton-pages/app/components/Editor/Toolbar.vue
@@ -345,10 +345,11 @@ const overflowItems = computed(() => {
         @confirm="emit('delete')"
       />
 
-      <!-- Save -->
+      <!-- Save — the toolbar's primary action, so it's a solid (filled) button,
+           not the muted soft variant the secondary actions use. -->
       <UButton
         type="submit"
-        variant="soft"
+        variant="solid"
         color="primary"
         size="xs"
         icon="i-lucide-save"


### PR DESCRIPTION
## 👤 For humans
The page editor's **Opslaan** (Save) button used the muted `soft` style, so it didn't stand out as the primary action. Now a solid filled button; the secondary toolbar actions (Preview / Open / Delete) keep their lighter style.

## 🤖 For agents
- `Editor/Toolbar.vue`: Save `UButton` `variant="soft"` → `"solid"` (color `primary`, size `xs` unchanged).

## 🧪 How to test
Open any page in the pages editor → the Save button (top-right) is now a filled green button, clearly the primary action.

Verified: `pnpm --filter fanfare typecheck` green.