### PR TITLE
Delete a category inline from POS edit mode

### DIFF
--- a/packages/crouton-sales/app/components/Client/CategoryTabs.vue
+++ b/packages/crouton-sales/app/components/Client/CategoryTabs.vue
@@ -60,6 +60,20 @@
       >
       <span v-else class="truncate">{{ withCount(cat.title, counts?.[cat.id] || 0) }}</span>
 
+      <!-- Delete (rename mode only): two-step — first tap arms, second deletes.
+           mousedown.prevent keeps the input focused so the click lands. -->
+      <span
+        v-if="editingId === cat.id"
+        role="button"
+        :aria-label="confirmDeleteId === cat.id ? t('sales.common.remove') : t('common.delete')"
+        class="inline-flex items-center justify-center size-6 rounded-full shrink-0 active:scale-95 transition-all"
+        :class="confirmDeleteId === cat.id ? 'bg-error text-inverted' : 'bg-black/15 hover:bg-black/30'"
+        @mousedown.stop.prevent
+        @click.stop="onDeleteClick(cat.id)"
+      >
+        <UIcon :name="confirmDeleteId === cat.id ? 'i-lucide-check' : 'i-lucide-trash-2'" class="size-3.5" />
+      </span>
+
       <!-- Rename pencil (right, active tab only) -->
       <span
         v-if="isActive(cat.id) && editingId !== cat.id"
@@ -138,6 +152,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: string | null]
   'rename': [payload: { id: string, title: string }]
   'create': [payload: { title: string }]
+  'delete': [payload: { id: string }]
   'reorder': [updates: Array<{ id: string, order: number }>]
 }>()
 
@@ -232,6 +247,7 @@ function commitEdit() {
   const title = editingTitle.value.trim()
   const original = orderedCategories.value.find(c => c.id === id)?.title
   editingId.value = null
+  confirmDeleteId.value = null
   if (title && title !== original) {
     emit('rename', { id, title })
   }
@@ -239,6 +255,23 @@ function commitEdit() {
 
 function cancelEdit() {
   editingId.value = null
+  confirmDeleteId.value = null
+}
+
+// Inline delete (two-step) — the trash in rename mode arms a confirm on the
+// first tap, deletes on the second. `@mousedown.prevent` on the button keeps
+// the rename input focused so its blur/click-outside doesn't exit edit mode
+// before the click lands (same touch-focus reality the rename input handles).
+const confirmDeleteId = ref<string | null>(null)
+function onDeleteClick(id: string) {
+  if (confirmDeleteId.value === id) {
+    confirmDeleteId.value = null
+    editingId.value = null
+    emit('delete', { id })
+  }
+  else {
+    confirmDeleteId.value = id
+  }
 }
 
 // --- Inline create (editable POS) -------------------------------------------

--- a/packages/crouton-sales/app/components/Client/OrderInterface.vue
+++ b/packages/crouton-sales/app/components/Client/OrderInterface.vue
@@ -32,6 +32,7 @@
                 :reorder-pending="reorderingCategories"
                 @rename="handleCategoryRename"
                 @create="handleCategoryCreate"
+                @delete="handleCategoryDelete"
                 @reorder="handleCategoryReorder"
               />
             </div>
@@ -597,10 +598,18 @@ function openCreateProduct() {
 }
 
 // Pencil on the active category tab → inline rename in the tab itself; we
-// just persist. (Full form incl. delete stays reachable via the settings
-// panel's category list.)
+// just persist. (Full form also reachable via the team-level categories page.)
 async function handleCategoryRename({ id, title }: { id: string, title: string }) {
   await updateCategory(id, { title })
+}
+
+// Two-step trash in the tab's rename mode → delete the category. Clear the
+// selection if it was the active one (falls back to "all"). Products keep their
+// (now dangling) categoryId — surface them via the show-inactive/uncategorised
+// paths or reassign on the team page; deletion here is the tab affordance only.
+async function handleCategoryDelete({ id }: { id: string }) {
+  await deleteCategory([id])
+  if (selectedCategory.value === id) selectedCategory.value = null
 }
 
 // Pencil on a product card → update form (same two-step delete).
@@ -621,7 +630,7 @@ async function handleReorder(updates: Array<{ id: string, order: number }>) {
 // Tab drag-reorder → persist into the categories' displayOrder. Sequential
 // updates (not parallel) so the panel's mutation-driven refresh lands once
 // with the final order.
-const { update: updateCategory, create: createCategory } = useCollectionMutation('salesCategories')
+const { update: updateCategory, create: createCategory, deleteItems: deleteCategory } = useCollectionMutation('salesCategories')
 const reorderingCategories = ref(false)
 
 async function handleCategoryReorder(updates: Array<{ id: string, order: number }>) {


### PR DESCRIPTION
## 👤 For humans
In the editable POS you could rename and reorder category tabs but not delete one. The active tab's rename mode now shows a **trash button** (two-step: tap to arm → tap again to delete), so a category can be removed without leaving the kassa.

## 🤖 For agents
- `CategoryTabs.vue`: rename-mode gains a two-step delete button (`confirmDeleteId`; `@mousedown.prevent` keeps the input focused so blur doesn't exit edit mode) → emits `delete { id }`.
- `OrderInterface.vue`: `@delete` → `useCollectionMutation('salesCategories').deleteItems([id])`; resets selection to "all" when the deleted category was active.

## 🧪 How to test
Arm POS edit mode (pencil) → tap a category tab's pencil to enter rename → a trash button appears; tap it (turns red ✓) then tap again → the category is deleted and the view falls back to "all".

## ⚠️ Note
Products in a deleted category keep their now-dangling `categoryId` (no cascade). They surface as uncategorised / via the team categories page for reassignment. If you'd rather block deleting a non-empty category, or cascade, say so and I'll add that.

Verified: `pnpm --filter fanfare typecheck` green.