### PR TITLE
fix(crouton-sales): pad narrow workspace slideovers for iOS safe-area

### DIFF
--- a/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
@@ -592,7 +592,11 @@ const kassaHeightStyle = computed(() =>
 
     <!-- Narrow-mode panes: same headers + bodies as the splitter panes, but
          as full-height slideovers (only mounted below lg). -->
-    <USlideover v-if="isNarrow" v-model:open="ordersSlideoverOpen">
+    <USlideover
+      v-if="isNarrow"
+      v-model:open="ordersSlideoverOpen"
+      :ui="{ content: 'pb-[env(safe-area-inset-bottom)]' }"
+    >
       <template #content>
         <div class="flex flex-col h-full min-h-0">
           <SalesEventWorkspacePaneHeader
@@ -630,6 +634,7 @@ const kassaHeightStyle = computed(() =>
     <USlideover
       v-if="isNarrow && event.requiresClient"
       v-model:open="clientsSlideoverOpen"
+      :ui="{ content: 'pb-[env(safe-area-inset-bottom)]' }"
     >
       <template #content>
         <div class="flex flex-col h-full min-h-0">
@@ -648,6 +653,7 @@ const kassaHeightStyle = computed(() =>
     <USlideover
       v-if="isNarrow && loggedIn"
       v-model:open="dataSlideoverOpen"
+      :ui="{ content: 'pb-[env(safe-area-inset-bottom)]' }"
     >
       <template #content>
         <div class="flex flex-col h-full min-h-0">
@@ -666,7 +672,11 @@ const kassaHeightStyle = computed(() =>
     <!-- Narrow-mode settings: same surface as the panes. Save lives in a fixed
          footer below the scroll area — only one SettingsTab instance ever
          mounts (the collapsible is gated on !isNarrow). -->
-    <USlideover v-if="isNarrow" v-model:open="settingsSlideoverOpen">
+    <USlideover
+      v-if="isNarrow"
+      v-model:open="settingsSlideoverOpen"
+      :ui="{ content: 'pb-[env(safe-area-inset-bottom)]' }"
+    >
       <template #content>
         <div class="flex flex-col h-full min-h-0">
           <SalesEventWorkspacePaneHeader


### PR DESCRIPTION
Closes #1545

## 👤 For humans

On a phone (iOS Safari), the workspace slide-up panels — **Data / Orders / Klanten / Instellingen** — stopped short of the bottom of the screen, leaving a grey strip above Safari's floating address bar and making the last rows awkward to reach (reported on `kassa.pmcp.dev`). The kassa itself already pads for the iPhone safe area; these panels didn't. This adds that padding so they extend cleanly to the bottom.

**bw/theme unrelated** — this is a separate mobile-layout fix from the #1526 theme-leak work.

## 🤖 For agents

- `packages/crouton-sales/app/components/EventWorkspace/Shell.vue`: added `:ui="{ content: 'pb-[env(safe-area-inset-bottom)]' }"` to the four **narrow-mode** (`isNarrow`) `USlideover`s.
- **Why:** Nuxt UI v4 slideover `content` is `fixed inset-y-0 right-0` — pinned to the **layout** viewport, whose bottom sits behind iOS Safari's floating toolbar. The padding shifts the whole panel (scroll body **and** the settings fixed footer) up clear of the toolbar / home indicator. The sales viewport plugin already sets `viewport-fit=cover`, so `env(safe-area-inset-bottom)` is available.
- **Scope-safe:** `env(safe-area-inset-bottom)` = 0 off iOS, so desktop/Android are unaffected; only the `isNarrow` slideovers changed — desktop splitter panes are untouched.

## 🧪 How to test

1. Open `kassa.pmcp.dev` on an **iPhone (Safari)**, default theme, an event workspace.
2. Tap **Data** (also Orders / Klanten / Instellingen).
3. Before: grey strip at the bottom, content stops short of the toolbar. After: the panel extends to and clears Safari's floating bar; the last row is fully reachable, and the Instellingen **Opslaan** footer sits above the home indicator.

**⚠️ Held as draft — needs on-device verification.** iOS Safari's dynamic toolbar can't be reproduced with the headless Chromium here, so I can't self-verify this one. `pnpm --filter fanfare typecheck` is green. Once you confirm on your iPhone, mark ready + merge (it'll auto-deploy to `kassa.pmcp.dev` staging). If the gap moves the wrong way, tell me what you see and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LApwiAZUsVUb1GscY8KUc4)_