### PR TITLE
Filter personnel orders out of the Data pane + personnel-only graph

### DIFF
--- a/packages/crouton-sales/app/components/Blocks/ProductMatrixRender.vue
+++ b/packages/crouton-sales/app/components/Blocks/ProductMatrixRender.vue
@@ -28,6 +28,8 @@ interface Matrix {
 interface SalesProductMatrixAttrs {
   eventScope?: string
   measure?: 'units' | 'revenue'
+  /** Personnel (staff) order filter: exclude / only / all (default all). */
+  personnel?: 'all' | 'exclude' | 'only'
   title?: string
 }
 
@@ -46,9 +48,12 @@ async function load() {
   pending.value = true
   error.value = null
   try {
+    const query: Record<string, string> = {}
+    if (props.attrs.eventScope) query.eventId = props.attrs.eventScope
+    if (props.attrs.personnel) query.personnel = props.attrs.personnel
     matrix.value = await $fetch<Matrix>(
       `/api/crouton-sales/teams/${toValue(teamId)}/charts/product-day-matrix`,
-      { query: props.attrs.eventScope ? { eventId: props.attrs.eventScope } : {} }
+      { query }
     )
   } catch (e: any) {
     error.value = e?.data?.message || e?.statusMessage || 'Failed to load table data'
@@ -58,7 +63,7 @@ async function load() {
 }
 
 onMounted(load)
-watch(() => props.attrs.eventScope, load)
+watch(() => [props.attrs.eventScope, props.attrs.personnel], load)
 
 // Live beside the kassa (Data pane): checkout emits the salesOrders mutation
 // hook, so a fresh order re-pivots the table — otherwise it only loaded on

--- a/packages/crouton-sales/app/components/Dashboard/SalesSummary.vue
+++ b/packages/crouton-sales/app/components/Dashboard/SalesSummary.vue
@@ -24,6 +24,8 @@ const props = withDefaults(defineProps<{
   currency?: string | null
   /** Poll cadence for the summary numbers. */
   pollMs?: number
+  /** Personnel (staff) order filter: exclude / only / all (default all). */
+  personnel?: 'all' | 'exclude' | 'only'
 }>(), {
   currency: 'EUR',
   pollMs: 15000,
@@ -38,7 +40,7 @@ const productRows = ref<ProductRow[]>([])
 const loaded = ref(false)
 
 const base = computed(() => `/api/crouton-sales/teams/${props.teamParam}/charts`)
-const query = computed(() => ({ eventId: props.eventId }))
+const query = computed(() => ({ eventId: props.eventId, personnel: props.personnel }))
 
 async function fetchAll() {
   try {
@@ -75,6 +77,9 @@ onMounted(() => {
   fetchAll()
   useIntervalFn(fetchAll, props.pollMs)
 })
+
+// Refetch immediately when the personnel filter flips (don't wait for the poll).
+watch(() => props.personnel, () => fetchAll())
 </script>
 
 <template>

--- a/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
@@ -31,7 +31,15 @@ const hasCharts = computed(() => hasApp('charts'))
 // Same catalogue entry the salesChartBlock renders — the widget interpolates
 // {teamId} in the apiPath itself; per-event scope goes as a query param.
 const revenueKind = SALES_CHART_KINDS['revenue-by-day']!
-const chartQuery = computed(() => ({ eventId: props.event.id }))
+
+// Staff (personnel) orders skew the headline totals — default this pane to
+// CUSTOMER sales only (exclude), with a toggle to fold staff back in. The
+// dedicated personnel chart below always shows staff orders on their own.
+const includePersonnel = ref(false)
+const personnelMode = computed(() => includePersonnel.value ? 'all' : 'exclude')
+
+const chartQuery = computed(() => ({ eventId: props.event.id, personnel: personnelMode.value }))
+const personnelChartQuery = computed(() => ({ eventId: props.event.id, personnel: 'only' }))
 
 // Checkout (right beside this pane) emits the salesOrders mutation hook —
 // remount the chart widget so it refetches; it has no refresh API of its own.
@@ -45,17 +53,28 @@ onUnmounted(unhookMutation)
 
 <template>
   <div class="space-y-4">
+    <!-- Exclude staff orders from the totals by default; toggle folds them in -->
+    <div class="flex items-center justify-end">
+      <USwitch
+        v-model="includePersonnel"
+        :label="t('sales.workspace.dataPanel.includePersonnel')"
+      />
+    </div>
+
     <!-- Headline numbers + top products (polls, tracks fresh orders) -->
     <SalesDashboardSalesSummary
       :team-param="teamParam"
       :event-id="event.id"
       :currency="event.currency"
+      :personnel="personnelMode"
     />
 
-    <!-- Revenue over time — only with the charts package installed -->
+    <!-- Revenue over time — only with the charts package installed. Keyed by
+         the personnel mode too so toggling refetches (the widget has no refresh
+         API of its own; a key change remounts it). -->
     <div v-if="hasCharts" class="rounded-2xl border border-default bg-elevated/40 p-4">
       <LazyCroutonChartsWidget
-        :key="chartRefreshKey"
+        :key="`${chartRefreshKey}-${personnelMode}`"
         :api-path="revenueKind.apiPath"
         :type="revenueKind.type"
         :x-field="revenueKind.xField"
@@ -66,11 +85,26 @@ onUnmounted(unhookMutation)
       />
     </div>
 
+    <!-- Personnel orders on their own — watch staff consumption regardless of
+         the toggle above (always personnel-only) -->
+    <div v-if="hasCharts" class="rounded-2xl border border-default bg-elevated/40 p-4">
+      <LazyCroutonChartsWidget
+        :key="chartRefreshKey"
+        :api-path="revenueKind.apiPath"
+        :type="revenueKind.type"
+        :x-field="revenueKind.xField"
+        :y-fields="revenueKind.yFields"
+        :title="t('sales.workspace.dataPanel.personnelChart')"
+        :height="220"
+        :query="personnelChartQuery"
+      />
+    </div>
+
     <!-- Product × day pivot (Units ⇄ Revenue toggle + CSV export) — the block
          renderer reused as-is; it scopes via attrs.eventScope -->
     <div class="rounded-2xl border border-default bg-elevated/40 p-4">
       <SalesBlocksProductMatrixRender
-        :attrs="{ eventScope: event.id, title: t('sales.workspace.dataPanel.productMatrix') }"
+        :attrs="{ eventScope: event.id, personnel: personnelMode, title: t('sales.workspace.dataPanel.productMatrix') }"
       />
     </div>
   </div>

--- a/packages/crouton-sales/i18n/locales/en.json
+++ b/packages/crouton-sales/i18n/locales/en.json
@@ -570,7 +570,9 @@
         "button": "Data",
         "title": "Data",
         "revenueChart": "Revenue by day",
-        "productMatrix": "Sales per product × day"
+        "productMatrix": "Sales per product × day",
+        "includePersonnel": "Include staff orders",
+        "personnelChart": "Staff orders"
       },
       "launcher": {
         "ordersDesc": "All orders for this event — status, tickets, reprints",

--- a/packages/crouton-sales/i18n/locales/fr.json
+++ b/packages/crouton-sales/i18n/locales/fr.json
@@ -569,7 +569,9 @@
         "button": "Données",
         "title": "Données",
         "revenueChart": "Revenu par jour",
-        "productMatrix": "Ventes par produit × jour"
+        "productMatrix": "Ventes par produit × jour",
+        "includePersonnel": "Inclure les commandes du personnel",
+        "personnelChart": "Commandes du personnel"
       },
       "launcher": {
         "ordersDesc": "Toutes les commandes de cet événement — statut, tickets, réimpressions",

--- a/packages/crouton-sales/i18n/locales/nl.json
+++ b/packages/crouton-sales/i18n/locales/nl.json
@@ -570,7 +570,9 @@
         "button": "Data",
         "title": "Data",
         "revenueChart": "Omzet per dag",
-        "productMatrix": "Verkoop per product × dag"
+        "productMatrix": "Verkoop per product × dag",
+        "includePersonnel": "Personeel meetellen",
+        "personnelChart": "Personeelsbestellingen"
       },
       "launcher": {
         "ordersDesc": "Alle bestellingen van dit event — status, tickets, opnieuw printen",

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/orders-by-status.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/orders-by-status.get.ts
@@ -7,13 +7,14 @@
  */
 import { and, count, desc, eq } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 
 export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   const rows = await db
@@ -22,7 +23,7 @@ export default defineEventHandler(async (event) => {
       count: count()
     })
     .from(salesOrders)
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(salesOrders.status)
     .orderBy(desc(count()))
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/product-day-matrix.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/product-day-matrix.get.ts
@@ -11,6 +11,7 @@
  */
 import { and, eq, sql } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -19,7 +20,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   const dateExpr = sql<string>`date(${salesOrders.createdAt}, 'unixepoch')`
@@ -34,7 +35,7 @@ export default defineEventHandler(async (event) => {
     .from(salesOrderitems)
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(dateExpr, salesProducts.title)
     .orderBy(dateExpr)
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-category.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-category.get.ts
@@ -8,6 +8,7 @@
  */
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -17,7 +18,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   const categoryExpr = sql<string>`coalesce(${salesCategories.title}, 'Uncategorized')`
@@ -32,7 +33,7 @@ export default defineEventHandler(async (event) => {
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
     .leftJoin(salesCategories, eq(salesProducts.categoryId, salesCategories.id))
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(categoryExpr)
     .orderBy(desc(revenueExpr))
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-day.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-day.get.ts
@@ -7,6 +7,7 @@
  */
 import { and, eq, sql } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 
@@ -14,7 +15,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   // createdAt is an integer Unix-seconds timestamp → bucket by calendar day.
@@ -27,7 +28,7 @@ export default defineEventHandler(async (event) => {
     })
     .from(salesOrderitems)
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(dateExpr)
     .orderBy(dateExpr)
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-product.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-product.get.ts
@@ -7,6 +7,7 @@
  */
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -15,7 +16,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   const revenueExpr = sql<number>`sum(${salesOrderitems.totalPrice})`
@@ -28,7 +29,7 @@ export default defineEventHandler(async (event) => {
     .from(salesOrderitems)
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(salesProducts.title)
     .orderBy(desc(revenueExpr))
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/sales-by-location.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/sales-by-location.get.ts
@@ -8,6 +8,7 @@
  */
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -17,7 +18,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   const locationExpr = sql<string>`coalesce(${salesLocations.title}, 'No location')`
@@ -32,7 +33,7 @@ export default defineEventHandler(async (event) => {
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
     .leftJoin(salesLocations, eq(salesProducts.locationId, salesLocations.id))
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(locationExpr)
     .orderBy(desc(revenueExpr))
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/top-products.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/top-products.get.ts
@@ -7,6 +7,7 @@
  */
 import { and, desc, eq, sql } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -15,7 +16,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   // quantity is stored as TEXT → cast to a number before summing.
@@ -29,7 +30,7 @@ export default defineEventHandler(async (event) => {
     .from(salesOrderitems)
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(salesProducts.title)
     .orderBy(desc(quantityExpr))
     .limit(10)

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/units-per-product-day.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/units-per-product-day.get.ts
@@ -14,6 +14,7 @@
  */
 import { and, eq, sql } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { personnelFilter } from '../../../../../utils/personnel-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -22,7 +23,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId } = getQuery(event)
+  const { eventId, personnel } = getQuery(event)
   const eventFilter = eventId ? eq(salesOrders.eventId, String(eventId)) : undefined
 
   // createdAt is an integer Unix-seconds timestamp; quantity is TEXT → cast.
@@ -37,7 +38,7 @@ export default defineEventHandler(async (event) => {
     .from(salesOrderitems)
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
-    .where(and(eq(salesOrders.teamId, team.id), eventFilter))
+    .where(and(eq(salesOrders.teamId, team.id), eventFilter, personnelFilter(personnel)))
     .groupBy(dateExpr, salesProducts.title)
     .orderBy(dateExpr)
 

--- a/packages/crouton-sales/server/utils/personnel-filter.ts
+++ b/packages/crouton-sales/server/utils/personnel-filter.ts
@@ -1,0 +1,36 @@
+/**
+ * Personnel (staff) order filter for the analytics/chart endpoints.
+ *
+ * Orders carry an `isPersonnel` boolean (the cart "Staff order" switch). By
+ * default every chart/total counts them; the Data pane lets an admin drop them
+ * so the headline numbers reflect customer sales, plus watch staff consumption
+ * on its own. This is the single place that translates the `?personnel=` query
+ * param into a WHERE condition, so all eight chart endpoints stay consistent.
+ *
+ * Modes:
+ *   - `all` (default / omitted) — no condition, unchanged behaviour. Keeps the
+ *     public `salesChartBlock` + live dashboard exactly as they were.
+ *   - `exclude` — customer sales only. The column is NULLABLE (its default is a
+ *     JS-side `$default`, not a DB default), so pre-existing / non-drizzle rows
+ *     can be NULL; NULL means "not a staff order", so it must be kept.
+ *   - `only` — personnel orders only (the dedicated staff graph).
+ */
+import { eq, isNull, or, type SQL } from 'drizzle-orm'
+import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
+
+export type PersonnelMode = 'all' | 'exclude' | 'only'
+
+export function parsePersonnelMode(value: unknown): PersonnelMode {
+  return value === 'exclude' || value === 'only' ? value : 'all'
+}
+
+/**
+ * Drizzle condition for a personnel mode, or `undefined` for `all` — safe to
+ * drop straight into `and(...)`, which ignores undefined args.
+ */
+export function personnelFilter(value: unknown): SQL | undefined {
+  const mode = parsePersonnelMode(value)
+  if (mode === 'only') return eq(salesOrders.isPersonnel, true)
+  if (mode === 'exclude') return or(eq(salesOrders.isPersonnel, false), isNull(salesOrders.isPersonnel))
+  return undefined
+}


### PR DESCRIPTION
## 👤 What & why
The event **Data** pane counted staff (personnel) orders in every total and graph, so the headline numbers didn't reflect real customer sales. Now:
- Staff orders are **excluded by default**, with a **toggle** ("Personeel meetellen" / "Include staff orders") to fold them back in.
- A **dedicated graph** shows staff orders on their own, so you can watch what staff consumes.

The `isPersonnel` flag already existed on orders (the cart "Staff order" switch) — it just wasn't used by any aggregation until now.

Closes #1538

## 🤖 Changes
- **`server/utils/personnel-filter.ts`** (new): `parsePersonnelMode` + `personnelFilter(value)` → `only` = `isPersonnel = true`; `exclude` = `OR(isPersonnel = false, IS NULL)` (column is nullable → NULL = customer); `all`/omitted = no-op (backward-compatible — `salesChartBlock` / live dashboard unchanged).
- **8 `teams/[id]/charts/*.get.ts`**: `?personnel=` threaded into the `and(...)` WHERE.
- **DataPanel.vue**: `includePersonnel` toggle (default off = exclude); `personnelMode` into SalesSummary + revenue chart (keyed by mode so toggling refetches) + product matrix; 2nd revenue chart pinned to `personnel: 'only'`.
- **SalesSummary.vue** / **ProductMatrixRender.vue**: new `personnel` prop/attr into their queries + watch→refetch.
- i18n en/nl/fr: `sales.workspace.dataPanel.includePersonnel` + `.personnelChart`.

## ✅ Status
- `pnpm --filter fanfare typecheck` clean.

## 👁 Needs a look (UI change)
This adds a toggle + a graph to the Data pane — worth an eyeball on the real thing. Happy to push a staging preview (`NUXT_PUBLIC_CROUTON_REVIEW=true`) before merge if you want to sign off on the look.

## 🧪 How to test
Open an event's **Data** pane with at least one staff order (cart → "Staff order" switch). Totals/graphs should exclude it by default; flip the toggle to include it; the **personnel-only** graph should show just that staff order's revenue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)