### PR TITLE
fix(crouton-sales): stop kassa catalog reorder snapping back (refetch race)

### DIFF
--- a/packages/crouton-sales/app/components/Pos/Panel.vue
+++ b/packages/crouton-sales/app/components/Pos/Panel.vue
@@ -119,17 +119,29 @@ async function loadEvent() {
   }
 }
 
+// Monotonic request id so out-of-order refetches can't clobber. A catalog
+// reorder fires one mutation per moved row (a loop of PATCHes), each triggering
+// a refetch below; without this guard an EARLY refetch (reading the DB before
+// the later writes land) can resolve LAST and overwrite the fresh result with a
+// stale snapshot — the "drag snaps back on save" bug. Only the newest-issued
+// refetch is allowed to apply; the last one is issued after every write, so it
+// reads the fully-updated catalog.
+let orderDataReq = 0
 async function loadOrderData() {
   if (!publicEvent.value || !sessionMatchesEvent.value) return
+  const req = ++orderDataReq
   loadError.value = null
   try {
-    orderData.value = await $fetch<OrderData>(
+    const data = await $fetch<OrderData>(
       `/api/crouton-sales/events/${publicEvent.value.id}/order-data`,
       { headers: { 'x-scoped-token': token.value } }
     )
+    if (req === orderDataReq) orderData.value = data
   }
   catch (err: any) {
-    loadError.value = err?.data?.message || err?.statusMessage || t('sales.helperLogin.loadDataError')
+    if (req === orderDataReq) {
+      loadError.value = err?.data?.message || err?.statusMessage || t('sales.helperLogin.loadDataError')
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1550

## 👤 For humans

Dragging to reorder **categories** (or products) in the kassa could snap back to the old order right after dropping, even though the save succeeded. A **rename** (one save) stuck fine; a **reorder** (many saves, one per moved row) did not.

## 🤖 Root cause

`SalesPosPanel` refetches `order-data` on every `crouton:mutation`, but the refetch was **fire-and-forget and un-sequenced**. A reorder emits one mutation per moved row → **N background `loadOrderData()` calls race**; an early refetch (reading the DB before later writes land) can resolve **last** and overwrite the fresh result with a **stale snapshot** → the UI reverts. A single-write op (rename) never races — which is exactly why rename stuck but reorder didn't.

Confirmed interactively with the reporter (an admin): the save returns **200**, and rename persists through the *same* endpoint/query, so it's not auth, team-scope, ownership, or the DB write path — it's the racing refetch on the multi-write path.

## Change

`app/components/Pos/Panel.vue` — a monotonic `orderDataReq` guard in `loadOrderData()`. Only the **newest-issued** refetch may apply its result; stale out-of-order responses are dropped. The last refetch is issued after every write completes, so it reads the fully-updated catalog.

```
let orderDataReq = 0
async function loadOrderData() {
  …
  const req = ++orderDataReq
  const data = await $fetch(…)
  if (req === orderDataReq) orderData.value = data   // stale responses dropped
}
```

## 🧪 How to test

1. Open the kassa (member/admin), enter edit mode.
2. Drag a **category** tab to a new spot (and a product card) → it stays put after dropping and after a reload.
3. Rename still works (was always fine — single write).

Related: the products half (#1524, frontend read `sortOrder` vs DB `order`) shipped in #1527 — a **hard refresh** loads that bundle. This PR is the separate refetch-race that also affected categories.

Typecheck: `pnpm --filter fanfare typecheck` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_