### PR TITLE
fix(crouton-sales): actually persist kassa drag-reorder (await useSortable's nextTick sync)

### DIFF
--- a/packages/crouton-sales/app/components/Client/CategoryTabs.vue
+++ b/packages/crouton-sales/app/components/Client/CategoryTabs.vue
@@ -320,8 +320,13 @@ if (import.meta.client && props.editable) {
     draggable: '[role="tab"]',
     ghostClass: 'opacity-50',
     disabled: props.reorderPending,
-    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex !== evt.newIndex) emitNewOrder()
+    // useSortable syncs the bound `orderedCategories` array on nextTick (async),
+    // so read it AFTER the tick — reading synchronously here sees the pre-drag
+    // order, diffs to zero changes, and the reorder never persists (#1550).
+    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
+      if (evt.oldIndex === evt.newIndex) return
+      await nextTick()
+      emitNewOrder()
     }
   })
   watch(() => props.reorderPending, (pending) => {

--- a/packages/crouton-sales/app/components/Client/ProductList.vue
+++ b/packages/crouton-sales/app/components/Client/ProductList.vue
@@ -251,8 +251,13 @@ if (import.meta.client && props.editable) {
     handle: '.drag-handle',
     ghostClass: 'opacity-50',
     chosenClass: 'bg-elevated',
-    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex !== evt.newIndex) emitNewOrder()
+    // useSortable syncs the bound `orderedProducts` array on nextTick (async),
+    // so read it AFTER the tick — reading synchronously here sees the pre-drag
+    // order, diffs to zero changes, and the reorder never persists (#1550).
+    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
+      if (evt.oldIndex === evt.newIndex) return
+      await nextTick()
+      emitNewOrder()
     }
   })
 }

--- a/packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue
@@ -61,15 +61,19 @@ async function persistOrder() {
   if (updates.length) await reorderSiblings(updates)
 }
 
-// useSortable mutates orderedProducts directly on drop; onEnd fires after.
+// useSortable mutates orderedProducts on drop, but only on nextTick (async),
+// so read it AFTER the tick — reading synchronously in onEnd sees the pre-drag
+// order, diffs to zero changes, and the reorder never persists (#1550).
 if (import.meta.client) {
   useSortable(listEl, orderedProducts, {
     animation: 150,
     handle: '.drag-handle',
     ghostClass: 'opacity-50',
     chosenClass: 'bg-elevated',
-    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex !== evt.newIndex) persistOrder()
+    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
+      if (evt.oldIndex === evt.newIndex) return
+      await nextTick()
+      persistOrder()
     }
   })
 }

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsListCard.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsListCard.vue
@@ -63,8 +63,13 @@ if (import.meta.client && props.orderField) {
     animation: 150,
     handle: '.drag-handle',
     ghostClass: 'opacity-50',
-    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex !== evt.newIndex) persistOrder()
+    // useSortable syncs the bound `ordered` array on nextTick (async), so read
+    // it AFTER the tick — reading synchronously here sees the pre-drag order,
+    // diffs to zero changes, and the reorder never persists (#1550).
+    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
+      if (evt.oldIndex === evt.newIndex) return
+      await nextTick()
+      persistOrder()
     }
   })
 }


### PR DESCRIPTION
Closes #1553

## 👤 For humans

Dragging to reorder products or categories in the kassa **never actually saved** — it snapped back on reload. I finally reproduced it in the running app: the drag fires but sends **zero** save requests. Now it saves — verified end-to-end (drag → 3× PATCH 200 → DB shows the dragged order).

This is the real fix. My two earlier attempts (#1527 `sortOrder`→`order`, #1551 refetch race) were misdiagnoses — the save was never firing, so neither could help. I should have booted the app and driven a real drag from the start instead of reasoning from the code; that's what found it.

## 🤖 Root cause (proved with logs + a live drag)

`useSortable` (VueUse) syncs its bound array (`orderedProducts`/`orderedCategories`) on **`nextTick`** — asynchronously. `onEnd` read that array **synchronously** to diff the new order, so it saw the **pre-drag** order → zero changed rows → no emit → no PATCH → nothing persisted.

```
onEnd oldIndex=2 newIndex=0  arrBEFORE=[Gamma,Beta,Alpha]  ← still pre-drag
onEnd afterTick              arr=[Alpha,Gamma,Beta]        ← synced only after nextTick
→ updates=[3 rows] → 3× PATCH 200 → DB persisted ✅
```

## Change

Make every `useSortable` `onEnd` `async` and `await nextTick()` before reading the bound array, across all four reorder surfaces:
- `Client/CategoryTabs.vue`, `Client/ProductList.vue` (POS)
- `EventWorkspace/SettingsListCard.vue` (printers), `EventWorkspace/ProductsTab.vue`

## 🧪 How to test

Kassa → edit mode → drag a category tab (and a product) → it sticks after dropping and after reload. Verified locally through the booted app: `PATCH … 200` ×3 and DB `displayOrder` matches the drag.

Typecheck: `pnpm --filter fanfare typecheck` passes (0 errors).

**Heads-up (separate, staging-only):** every staging deploy re-seeds the demo `vlaamsekermis` event and overwrites its categories' order back to seed defaults — so reorders of *seeded* rows still get wiped on the next deploy. Not in this PR; test on your own event/new categories, or we make the demo seed insert-if-absent as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_