### PR TITLE
refactor(crouton-sales): Nuxt UI 4 modal migration + requireTeamEvent adoption (review backlog)

### DIFF
--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsListCard.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsListCard.vue
@@ -109,17 +109,17 @@ if (import.meta.client && props.orderField) {
             class="drag-handle size-4 text-muted cursor-grab active:cursor-grabbing"
           />
         </div>
-        <button
-          type="button"
-          class="absolute right-0 top-0 bottom-0 z-10 flex items-center justify-center px-2.5
-                 bg-elevated/95 hover:bg-elevated text-muted hover:text-highlighted cursor-pointer
+        <UButton
+          icon="i-lucide-pencil"
+          variant="ghost"
+          color="neutral"
+          :aria-label="t('common.edit')"
+          class="absolute right-0 top-0 bottom-0 z-10 flex items-center justify-center px-2.5 rounded-none
+                 bg-elevated/95 hover:bg-elevated text-muted hover:text-highlighted
                  transition-all duration-200 ease-out translate-x-full group-hover/row:translate-x-0
                  pointer-coarse:translate-x-0"
-          :aria-label="t('common.edit')"
           @click.stop="openEdit(row.id)"
-        >
-          <UIcon name="i-lucide-pencil" class="size-4" />
-        </button>
+        />
         <div
           class="px-3 py-2 transition-[padding] duration-200 ease-out group-hover/row:pe-9 pointer-coarse:pe-9"
           :class="orderField ? 'group-hover/row:ps-7 pointer-coarse:ps-7' : ''"

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
@@ -789,17 +789,15 @@ function helperExpiry(value: string): string {
          the destructive button stays disabled until the event name is typed
          exactly, since this can't be undone. -->
     <UModal v-model:open="deleteOrdersOpen">
-      <template #header>
-        <div class="flex items-center gap-2.5">
-          <span class="flex size-8 items-center justify-center rounded-lg bg-error/10 text-error">
-            <UIcon name="i-lucide-alert-triangle" class="size-5" />
-          </span>
-          <span class="text-lg font-semibold">{{ t('sales.workspace.deleteAllOrdersTitle', 'Delete all orders?') }}</span>
-        </div>
-      </template>
+      <template #content="{ close }">
+        <div class="p-6 space-y-4">
+          <div class="flex items-center gap-2.5">
+            <span class="flex size-8 items-center justify-center rounded-lg bg-error/10 text-error">
+              <UIcon name="i-lucide-alert-triangle" class="size-5" />
+            </span>
+            <span class="text-lg font-semibold">{{ t('sales.workspace.deleteAllOrdersTitle', 'Delete all orders?') }}</span>
+          </div>
 
-      <template #body>
-        <div class="space-y-4">
           <p class="text-sm text-muted">
             {{ t('sales.workspace.deleteAllOrdersWarning', {
               params: { event: event.title },
@@ -820,23 +818,21 @@ function helperExpiry(value: string): string {
               @keydown.enter="deleteAllOrders"
             />
           </UFormField>
-        </div>
-      </template>
 
-      <template #footer="{ close }">
-        <div class="flex justify-end gap-2 w-full">
-          <UButton color="neutral" variant="ghost" @click="close">
-            {{ t('sales.common.cancel') }}
-          </UButton>
-          <UButton
-            color="error"
-            icon="i-lucide-trash-2"
-            :loading="deletingOrders"
-            :disabled="!canDeleteOrders"
-            @click="deleteAllOrders"
-          >
-            {{ t('sales.workspace.deleteAllOrdersConfirm', 'Delete all orders') }}
-          </UButton>
+          <div class="flex justify-end gap-2 w-full">
+            <UButton color="neutral" variant="ghost" @click="close">
+              {{ t('sales.common.cancel') }}
+            </UButton>
+            <UButton
+              color="error"
+              icon="i-lucide-trash-2"
+              :loading="deletingOrders"
+              :disabled="!canDeleteOrders"
+              @click="deleteAllOrders"
+            >
+              {{ t('sales.workspace.deleteAllOrdersConfirm', 'Delete all orders') }}
+            </UButton>
+          </div>
         </div>
       </template>
     </UModal>

--- a/packages/crouton-sales/app/components/Settings/PrintPreviewModal.vue
+++ b/packages/crouton-sales/app/components/Settings/PrintPreviewModal.vue
@@ -8,9 +8,11 @@
   Preview-only: Testprint lives in the printer form beside the Voorbeeld button.
 -->
 <template>
-  <UModal v-model:open="isOpen" :title="t('sales.print.previewTitle', 'Voorbeeld')">
-    <template #body>
-      <div class="space-y-4">
+  <UModal v-model:open="isOpen">
+    <template #content="{ close }">
+      <div class="p-6 space-y-4">
+        <h3 class="text-lg font-semibold">{{ t('sales.print.previewTitle', 'Voorbeeld') }}</h3>
+
         <div v-if="pending" class="p-10 flex justify-center">
           <UIcon name="i-lucide-loader-circle" class="size-6 animate-spin text-muted" />
         </div>
@@ -57,14 +59,11 @@
             {{ t('sales.print.previewNote', 'Zoals de printer hem afdrukt · met je opgeslagen instellingen') }}
           </p>
         </template>
-      </div>
-    </template>
-
-    <template #footer>
-      <div class="flex justify-end w-full">
-        <UButton variant="outline" color="neutral" @click="isOpen = false">
-          {{ t('sales.common.close', 'Sluiten') }}
-        </UButton>
+        <div class="flex justify-end w-full">
+          <UButton variant="outline" color="neutral" @click="close">
+            {{ t('sales.common.close', 'Sluiten') }}
+          </UButton>
+        </div>
       </div>
     </template>
   </UModal>

--- a/packages/crouton-sales/app/components/Settings/ReceiptSettingsModal.vue
+++ b/packages/crouton-sales/app/components/Settings/ReceiptSettingsModal.vue
@@ -1,14 +1,12 @@
 <template>
   <UModal v-model:open="isOpen">
-    <template #header>
-      <div class="flex items-center gap-2">
-        <UIcon name="i-lucide-receipt" class="w-5 h-5" />
-        <span>{{ t('sales.receipt.settingsTitle') }}</span>
-      </div>
-    </template>
+    <template #content="{ close }">
+      <div class="p-6 space-y-6">
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-receipt" class="w-5 h-5" />
+          <span class="text-lg font-semibold">{{ t('sales.receipt.settingsTitle') }}</span>
+        </div>
 
-    <template #body>
-      <div class="space-y-6">
         <p class="text-sm text-muted">
           {{ t('sales.receipt.customize') }}
         </p>
@@ -36,21 +34,19 @@
             placeholder="Bedankt voor je bestelling!"
           />
         </UFormField>
-      </div>
-    </template>
 
-    <template #footer>
-      <div class="flex justify-end gap-3">
-        <UButton variant="outline" @click="close">
-          {{ t('sales.common.cancel') }}
-        </UButton>
-        <UButton
-          color="primary"
-          :loading="saving"
-          @click="save"
-        >
-          {{ t('sales.receipt.saveSettings') }}
-        </UButton>
+        <div class="flex justify-end gap-3">
+          <UButton variant="outline" @click="close">
+            {{ t('sales.common.cancel') }}
+          </UButton>
+          <UButton
+            color="primary"
+            :loading="saving"
+            @click="save"
+          >
+            {{ t('sales.receipt.saveSettings') }}
+          </UButton>
+        </div>
       </div>
     </template>
   </UModal>

--- a/packages/crouton-sales/app/components/Sync/Status.vue
+++ b/packages/crouton-sales/app/components/Sync/Status.vue
@@ -86,16 +86,17 @@ function relativeLabel(ms: number | null): string {
 const ui = computed(() => {
   switch (state.value) {
     case 'live':
-      return { dot: 'bg-emerald-500', pulse: true, color: 'text-emerald-600 dark:text-emerald-400',
+      return { dot: 'bg-success', pulse: true, color: 'text-success',
         label: t('sales.sync.live'), detail: t('sales.sync.syncedAgo', { ago: relativeLabel(ageMs.value) }) }
     case 'stale':
-      return { dot: 'bg-amber-500', pulse: false, color: 'text-amber-600 dark:text-amber-400',
+      return { dot: 'bg-warning', pulse: false, color: 'text-warning',
         label: t('sales.sync.stale'), detail: t('sales.sync.staleDetail', { ago: relativeLabel(ageMs.value) }) }
     case 'never':
-      return { dot: 'bg-gray-400', pulse: false, color: 'text-muted',
+      // Neutral (not a semantic status) — kept muted rather than a status token.
+      return { dot: 'bg-muted', pulse: false, color: 'text-muted',
         label: t('sales.sync.waiting'), detail: t('sales.sync.waitingDetail') }
     default:
-      return { dot: 'bg-red-500', pulse: false, color: 'text-red-600 dark:text-red-400',
+      return { dot: 'bg-error', pulse: false, color: 'text-error',
         label: t('sales.sync.unavailable'), detail: t('sales.sync.unavailableDetail') }
   }
 })

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/active-helpers.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/active-helpers.get.ts
@@ -1,13 +1,11 @@
-import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { requireTeamEvent } from '../../../../../../utils/team-event'
 import { listScopedTokensForResource } from '@fyit/crouton-auth/server/utils/scoped-access'
 
 export default defineEventHandler(async (event) => {
-  await resolveTeamAndCheckMembership(event)
-  const eventId = getRouterParam(event, 'eventId')
-
-  if (!eventId) {
-    throw createError({ status: 400, statusText: 'Event ID is required' })
-  }
+  // requireTeamEvent validates the event belongs to this team, so a foreign
+  // eventId gets a 404 instead of leaking another team's helper tokens
+  // (this endpoint doesn't otherwise scope the token query by team).
+  const { eventId } = await requireTeamEvent(event)
 
   return listScopedTokensForResource('event', eventId)
 })

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/clients/summary.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/clients/summary.get.ts
@@ -5,20 +5,13 @@
  * client with nothing ordered has nothing to settle.
  */
 import { eq, and, ne, countDistinct, sql, asc } from 'drizzle-orm'
-import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { requireTeamEvent } from '../../../../../../../utils/team-event'
 import { salesClients } from '~~/layers/sales/collections/clients/server/database/schema'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 
 export default defineEventHandler(async (event) => {
-  const { team } = await resolveTeamAndCheckMembership(event)
-  const eventId = getRouterParam(event, 'eventId')
-
-  if (!eventId) {
-    throw createError({ status: 400, statusText: 'Event ID is required' })
-  }
-
-  const db = useDB()
+  const { team, db, eventId } = await requireTeamEvent(event)
 
   const clients = await db
     .select({

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/[queueId].get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/[queueId].get.ts
@@ -10,19 +10,16 @@
  * bulky base64 payload) so it stays cheap to poll every couple of seconds.
  */
 import { eq, and } from 'drizzle-orm'
-import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { requireTeamEvent } from '../../../../../../../utils/team-event'
 import { printJobs } from '@fyit/crouton-printing/server/database/schema'
 
 export default defineEventHandler(async (event) => {
-  const { team } = await resolveTeamAndCheckMembership(event)
-  const eventId = getRouterParam(event, 'eventId')
+  const { team, db, eventId } = await requireTeamEvent(event)
   const queueId = getRouterParam(event, 'queueId')
 
-  if (!eventId || !queueId) {
-    throw createError({ status: 400, statusText: 'Event ID and queue ID are required' })
+  if (!queueId) {
+    throw createError({ status: 400, statusText: 'Queue ID is required' })
   }
-
-  const db = useDB()
 
   const [job] = await db
     .select({

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/retry-failed.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/retry-failed.post.ts
@@ -18,7 +18,7 @@
  * translates the plan into drizzle conditions.
  */
 import { eq, and, or, lt, inArray } from 'drizzle-orm'
-import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { requireTeamEvent } from '../../../../../../../utils/team-event'
 import { printJobs } from '@fyit/crouton-printing/server/database/schema'
 import { planRequeue, type RequeueRequest } from '../../../../../../../utils/plan-requeue'
 
@@ -27,12 +27,7 @@ const STATUS_PRINTING = '1'
 const STALE_PRINTING_MS = 2 * 60 * 1000
 
 export default defineEventHandler(async (event) => {
-  const { team } = await resolveTeamAndCheckMembership(event)
-  const eventId = getRouterParam(event, 'eventId')
-
-  if (!eventId) {
-    throw createError({ status: 400, statusText: 'Event ID is required' })
-  }
+  const { team, db, eventId } = await requireTeamEvent(event)
 
   const body = await readBody<RequeueRequest>(event).catch(() => null)
   const plan = planRequeue(body)
@@ -72,8 +67,6 @@ export default defineEventHandler(async (event) => {
       conditions.push(eq(printJobs.id, plan.jobId))
     }
   }
-
-  const db = useDB()
 
   const requeued = await db
     .update(printJobs)

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/status.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/printqueues/status.get.ts
@@ -8,18 +8,11 @@
  * seconds.
  */
 import { eq, and } from 'drizzle-orm'
-import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { requireTeamEvent } from '../../../../../../../utils/team-event'
 import { printJobs } from '@fyit/crouton-printing/server/database/schema'
 
 export default defineEventHandler(async (event) => {
-  const { team } = await resolveTeamAndCheckMembership(event)
-  const eventId = getRouterParam(event, 'eventId')
-
-  if (!eventId) {
-    throw createError({ status: 400, statusText: 'Event ID is required' })
-  }
-
-  const db = useDB()
+  const { team, db, eventId } = await requireTeamEvent(event)
 
   return db
     .select({

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/receipt-settings.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/receipt-settings.get.ts
@@ -1,5 +1,5 @@
 import { eq, and } from 'drizzle-orm'
-import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { requireTeamEvent } from '../../../../../../utils/team-event'
 // Single source of truth (#1514): the default an unsaved event shows in the
 // form MUST equal what the formatter prints when no settings row exists —
 // crouton-printing owns that canonical default. A local copy here diverged
@@ -10,14 +10,7 @@ import { salesEventsettings } from '~~/layers/sales/collections/eventsettings/se
 export type { ReceiptSettings }
 
 export default defineEventHandler(async (event) => {
-  const { team } = await resolveTeamAndCheckMembership(event)
-  const eventId = getRouterParam(event, 'eventId')
-
-  if (!eventId) {
-    throw createError({ status: 400, statusText: 'Event ID is required' })
-  }
-
-  const db = useDB()
+  const { team, db, eventId } = await requireTeamEvent(event)
 
   const [existing] = await db
     .select()

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/receipt-settings.put.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/receipt-settings.put.ts
@@ -1,6 +1,6 @@
 import { eq, and } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
-import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
+import { requireTeamEvent } from '../../../../../../utils/team-event'
 import { salesEventsettings } from '~~/layers/sales/collections/eventsettings/server/database/schema'
 
 export interface ReceiptSettings {
@@ -10,12 +10,7 @@ export interface ReceiptSettings {
 }
 
 export default defineEventHandler(async (event) => {
-  const { team, user } = await resolveTeamAndCheckMembership(event)
-  const eventId = getRouterParam(event, 'eventId')
-
-  if (!eventId) {
-    throw createError({ status: 400, statusText: 'Event ID is required' })
-  }
+  const { team, user, db, eventId } = await requireTeamEvent(event)
 
   const body = await readBody<ReceiptSettings>(event)
 
@@ -23,7 +18,6 @@ export default defineEventHandler(async (event) => {
     throw createError({ status: 400, statusText: 'Request body is required' })
   }
 
-  const db = useDB()
   const settingValue = JSON.stringify(body)
 
   const [existing] = await db


### PR DESCRIPTION
Part of epic #1564 (whole-package code-smell / Nuxt UI 4 review of `@fyit/crouton-sales`). Clears the two highest-value sub-issues; the remaining cleanup (#1566 dedup, #1567 error-handling, #1568 dead code) stays tracked.

## 👤 For humans

Three focused, behaviour-preserving cleanups the package review surfaced:

1. **Nuxt UI 4 modals** — the receipt-settings, print-preview and delete-all-orders modals still used the old v3 `#header/#body/#footer` slot layout. Moved to the v4 single `#content` slot. This was the only hard 🔴 convention break in the whole sweep.
2. **Two frontend nits** — the settings list-card's slide-out edit pencil is now a `UButton` (like every other list in the package), and the sync-status banner uses the theme's `success`/`warning`/`error` tokens instead of hardcoded `emerald`/`amber`/`red`.
3. **`requireTeamEvent` adoption** — seven event-scoped endpoints hand-rolled the "check membership + read eventId" preamble instead of the shared guard. Adopting it removes the duplication and returns a proper `404` for a foreign/stale event id. Six were already team-scoped (hardening); the seventh — `active-helpers` — had **no** team filter on its token lookup, so this closes a genuine cross-team helper-token leak (see #1569 for the archaeology + the correction).

No visual or behavioural change to the happy path — same fields, buttons, copy, and data.

## 🤖 For agents

- **Modals → v4** (`refactor …migrate 3 modals`): `Settings/ReceiptSettingsModal.vue`, `Settings/PrintPreviewModal.vue`, `EventWorkspace/SettingsTab.vue` (delete-orders). `#header/#body/#footer` → `#content="{ close }"`, single `p-6` wrapper, no nested `UCard`; dropped PrintPreviewModal's now-inert `:title`. Remaining `#header/#footer` in SettingsTab are `UCard` slots.
- **Frontend nits** (`refactor …UButton + semantic sync colors`): `SettingsListCard.vue` raw `<button>` → `UButton` (matches ProductList/OrdersTab/ClientsPanel); `Sync/Status.vue` state colors → `bg-/text-success|warning|error` (neutral "never" stays `muted`).
- **Guard adoption** (`refactor …adopt requireTeamEvent`): `receipt-settings.get/put`, `printqueues/{status,[queueId],retry-failed}`, `clients/summary`, `active-helpers` → `const { team, db, eventId } = await requireTeamEvent(event)`. `[queueId]` keeps its own queueId 400; `put` keeps its body 400; `retry-failed` dropped a duplicate `useDB()`.

### Verification
- `pnpm --filter fanfare typecheck` → clean (exit 0)
- `pnpm --filter @fyit/crouton-sales test` → 71 passed
- Conventions-only; no schema/migration/API-shape change.

### 🧪 How to test
1. Open each of the three modals (receipt settings, print preview, delete-all-orders confirm) — renders, closes, buttons work as before.
2. Settings list-card: hover a printer/helper row → the edit pencil slides in and opens edit.
3. As a team-A member, hit any of the seven endpoints with a **team-B `eventId`** → now `404` (previously: empty-200, or for `active-helpers`, team B's helper tokens).

Closes #1565
Closes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVHBkTUU4nXYNZR8iQJGRj)_