### PR TITLE
refactor(crouton-sales): derive kassa reorder from the drag event, drop nextTick

### DIFF
--- a/packages/crouton-sales/app/components/Client/CategoryTabs.vue
+++ b/packages/crouton-sales/app/components/Client/CategoryTabs.vue
@@ -303,12 +303,22 @@ const listEl = ref<HTMLElement | null>(null)
 
 const orderOf = (c: SalesCategory) => (c as any).displayOrder ?? 0
 
-function emitNewOrder() {
+// Emit the changed rows (index-as-order) of an already-reordered list.
+function emitNewOrder(list: SalesCategory[]) {
   const updates: Array<{ id: string, order: number }> = []
-  orderedCategories.value.forEach((c, index) => {
+  list.forEach((c, index) => {
     if (orderOf(c) !== index) updates.push({ id: c.id, order: index })
   })
   if (updates.length) emit('reorder', updates)
+}
+
+// Apply SortableJS's move (oldIndex → newIndex) to a copy of the list.
+function withMove(list: SalesCategory[], from: number, to: number): SalesCategory[] {
+  const next = [...list]
+  const [moved] = next.splice(from, 1)
+  if (moved === undefined) return next
+  next.splice(to, 0, moved)
+  return next
 }
 
 if (import.meta.client && props.editable) {
@@ -320,13 +330,14 @@ if (import.meta.client && props.editable) {
     draggable: '[role="tab"]',
     ghostClass: 'opacity-50',
     disabled: props.reorderPending,
-    // useSortable syncs the bound `orderedCategories` array on nextTick (async),
-    // so read it AFTER the tick — reading synchronously here sees the pre-drag
-    // order, diffs to zero changes, and the reorder never persists (#1550).
-    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex === evt.newIndex) return
-      await nextTick()
-      emitNewOrder()
+    // Derive the new order from the drag event itself — SortableJS's
+    // oldIndex/newIndex are the source of truth. (Don't read the bound array
+    // here: useSortable syncs it on nextTick, so at this point it's still the
+    // pre-drag order — which is exactly why we apply the move to it, #1550.)
+    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
+      const { oldIndex, newIndex } = evt
+      if (oldIndex == null || newIndex == null || oldIndex === newIndex) return
+      emitNewOrder(withMove(orderedCategories.value, oldIndex, newIndex))
     }
   })
   watch(() => props.reorderPending, (pending) => {

--- a/packages/crouton-sales/app/components/Client/ProductList.vue
+++ b/packages/crouton-sales/app/components/Client/ProductList.vue
@@ -234,12 +234,22 @@ watch(() => props.products, (v) => { orderedProducts.value = [...(v || [])] }, {
 
 const orderOf = (p: SalesProduct) => p.order ?? 0
 
-function emitNewOrder() {
+// Emit the changed rows (index-as-order) of an already-reordered list.
+function emitNewOrder(list: SalesProduct[]) {
   const updates: Array<{ id: string, order: number }> = []
-  orderedProducts.value.forEach((p, index) => {
+  list.forEach((p, index) => {
     if (orderOf(p) !== index) updates.push({ id: p.id, order: index })
   })
   if (updates.length) emit('reorder', updates)
+}
+
+// Apply SortableJS's move (oldIndex → newIndex) to a copy of the list.
+function withMove(list: SalesProduct[], from: number, to: number): SalesProduct[] {
+  const next = [...list]
+  const [moved] = next.splice(from, 1)
+  if (moved === undefined) return next
+  next.splice(to, 0, moved)
+  return next
 }
 
 // Editable is fixed for the life of this component instance — OrderInterface
@@ -251,13 +261,14 @@ if (import.meta.client && props.editable) {
     handle: '.drag-handle',
     ghostClass: 'opacity-50',
     chosenClass: 'bg-elevated',
-    // useSortable syncs the bound `orderedProducts` array on nextTick (async),
-    // so read it AFTER the tick — reading synchronously here sees the pre-drag
-    // order, diffs to zero changes, and the reorder never persists (#1550).
-    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex === evt.newIndex) return
-      await nextTick()
-      emitNewOrder()
+    // Derive the new order from the drag event itself — SortableJS's
+    // oldIndex/newIndex are the source of truth. (Don't read the bound array
+    // here: useSortable syncs it on nextTick, so at this point it's still the
+    // pre-drag order — which is exactly why we apply the move to it, #1550.)
+    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
+      const { oldIndex, newIndex } = evt
+      if (oldIndex == null || newIndex == null || oldIndex === newIndex) return
+      emitNewOrder(withMove(orderedProducts.value, oldIndex, newIndex))
     }
   })
 }

--- a/packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue
@@ -52,28 +52,38 @@ const listEl = ref<HTMLElement | null>(null)
 // /reorder endpoint (order = index) instead of per-item PATCH.
 const { reorderSiblings, reordering } = useTreeMutation('salesProducts')
 
-async function persistOrder() {
+async function persistOrder(list: SalesProduct[]) {
   if (reordering.value) return
   const updates: Array<{ id: string, order: number }> = []
-  orderedProducts.value.forEach((p, index) => {
+  list.forEach((p, index) => {
     if (orderOf(p) !== index) updates.push({ id: p.id, order: index })
   })
   if (updates.length) await reorderSiblings(updates)
 }
 
-// useSortable mutates orderedProducts on drop, but only on nextTick (async),
-// so read it AFTER the tick — reading synchronously in onEnd sees the pre-drag
-// order, diffs to zero changes, and the reorder never persists (#1550).
+// Apply SortableJS's move (oldIndex → newIndex) to a copy of the list.
+function withMove(list: SalesProduct[], from: number, to: number): SalesProduct[] {
+  const next = [...list]
+  const [moved] = next.splice(from, 1)
+  if (moved === undefined) return next
+  next.splice(to, 0, moved)
+  return next
+}
+
 if (import.meta.client) {
   useSortable(listEl, orderedProducts, {
     animation: 150,
     handle: '.drag-handle',
     ghostClass: 'opacity-50',
     chosenClass: 'bg-elevated',
-    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex === evt.newIndex) return
-      await nextTick()
-      persistOrder()
+    // Derive the new order from the drag event itself — SortableJS's
+    // oldIndex/newIndex are the source of truth. (Don't read the bound array
+    // here: useSortable syncs it on nextTick, so at this point it's still the
+    // pre-drag order — which is exactly why we apply the move to it, #1550.)
+    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
+      const { oldIndex, newIndex } = evt
+      if (oldIndex == null || newIndex == null || oldIndex === newIndex) return
+      persistOrder(withMove(orderedProducts.value, oldIndex, newIndex))
     }
   })
 }

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsListCard.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsListCard.vue
@@ -49,13 +49,22 @@ watch(() => props.rows, (v) => { ordered.value = [...(v || [])] }, { immediate: 
 
 const listEl = ref<HTMLElement | null>(null)
 
-async function persistOrder() {
+async function persistOrder(list: typeof ordered.value) {
   const field = props.orderField
   if (!field) return
-  const changed = ordered.value
+  const changed = list
     .map((row, index) => ({ row, index }))
     .filter(({ row, index }) => (row[field] ?? 0) !== index)
   await Promise.all(changed.map(({ row, index }) => update(row.id, { [field]: index })))
+}
+
+// Apply SortableJS's move (oldIndex → newIndex) to a copy of the list.
+function withMove(list: typeof ordered.value, from: number, to: number) {
+  const next = [...list]
+  const [moved] = next.splice(from, 1)
+  if (moved === undefined) return next
+  next.splice(to, 0, moved)
+  return next
 }
 
 if (import.meta.client && props.orderField) {
@@ -63,13 +72,14 @@ if (import.meta.client && props.orderField) {
     animation: 150,
     handle: '.drag-handle',
     ghostClass: 'opacity-50',
-    // useSortable syncs the bound `ordered` array on nextTick (async), so read
-    // it AFTER the tick — reading synchronously here sees the pre-drag order,
-    // diffs to zero changes, and the reorder never persists (#1550).
-    onEnd: async (evt: { oldIndex?: number, newIndex?: number }) => {
-      if (evt.oldIndex === evt.newIndex) return
-      await nextTick()
-      persistOrder()
+    // Derive the new order from the drag event itself — SortableJS's
+    // oldIndex/newIndex are the source of truth. (Don't read the bound array
+    // here: useSortable syncs it on nextTick, so at this point it's still the
+    // pre-drag order — which is exactly why we apply the move to it, #1550.)
+    onEnd: (evt: { oldIndex?: number, newIndex?: number }) => {
+      const { oldIndex, newIndex } = evt
+      if (oldIndex == null || newIndex == null || oldIndex === newIndex) return
+      persistOrder(withMove(ordered.value, oldIndex, newIndex))
     }
   })
 }


### PR DESCRIPTION
Follow-up to #1554 — same fix, cleaner. Relates to #1553.

## 👤 For humans

The reorder fix worked, but it leaned on `await nextTick()` to wait for the sortable list to sync before reading it — a timing workaround. This replaces that: SortableJS's drop event already tells us exactly what moved and where, so we compute the new order straight from the event. No `nextTick`, no waiting on the library's internal schedule. Same behaviour, verified locally (drag → 3× PATCH 200 → DB persisted the dragged order).

## 🤖 What changed

`onEnd` now derives the new order from `evt.oldIndex`/`evt.newIndex` — the authoritative move — applied to a copy of the current list, instead of reading the async-synced bound array:

```ts
onEnd: (evt) => {
  const { oldIndex, newIndex } = evt
  if (oldIndex == null || newIndex == null || oldIndex === newIndex) return
  emitNewOrder(withMove(orderedCategories.value, oldIndex, newIndex))
}
// withMove: splice the moved item out and back in at the target; guards an
// out-of-range index (returns the list unchanged).
```

Applied to all four sortable surfaces: `Client/CategoryTabs.vue`, `Client/ProductList.vue`, `EventWorkspace/SettingsListCard.vue`, `EventWorkspace/ProductsTab.vue`. Removes the read-after-async-write coupling entirely.

## 🧪 How to test

Kassa → edit mode → drag a category tab (and a product) → sticks after dropping and after reload. Re-verified end-to-end through the booted app: `PATCH … 200` ×3 and DB `displayOrder` matches the drag.

Typecheck: `pnpm --filter fanfare typecheck` passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_