### PR TITLE
workflow: catch reactivity smells (frontend-review §6) + fallow/simplify in the session gate

### DIFF
--- a/.claude/agents/frontend-review.md
+++ b/.claude/agents/frontend-review.md
@@ -118,13 +118,31 @@ where a Nuxt UI color prop or a theme token (`text-primary`, `bg-muted`, the app
 token, 🔵 for a one-off). Don't flag Tailwind utility classes that are already
 token-based (`text-gray-500` is fine; `text-[#6b7280]` is the smell).
 
+### 6. Reactivity/composition anti-patterns — a note/warning
+
+Common Vue smells in `<script setup>` where a cleaner primitive exists → 🟡/🔵:
+
+- **`await nextTick()` (or `setTimeout`) to read state a library updates on its own
+  schedule.** The smell is *waiting for* an async side effect instead of *deriving from
+  the source*. Canonical case (#1550): a `useSortable` `onEnd` that `await nextTick()`s so
+  the bound array has synced, then reads it — when SortableJS's `evt.oldIndex`/`newIndex`
+  already say exactly what moved, so the new order should be **computed from the event**, not
+  read back from the racing array. Flag any `nextTick`/timer that exists to paper over
+  "the reactive value isn't updated *yet*". 🟡 when it's load-bearing (a real race, like
+  the reorder), 🔵 for a benign focus-after-render.
+- **Reaching past the framework to synchronise** — manual DOM reads/writes to reconcile
+  what a `ref`/`computed` should own, or duplicated state kept in lockstep by hand.
+
+Not in scope: legitimate `nextTick` for **DOM measurement after render** (focus, scroll,
+`getBoundingClientRect`) — that's the intended use, not a smell.
+
 ## Severity map (mirrors the review skill's 3 levels)
 
 | Finding | Level |
 |---------|-------|
 | v3 component name; `UCard` inside an overlay; Options API in a `.vue`; an overlay clearly missing the `#content` pattern | 🔴 **Critical** — a hard, documented convention break; **blocks** the CI gate |
-| raw `<button>`/`<input>`/`<select>`/`<textarea>`/internal `<a>` where a component applies; hand-rolled overlay markup; hardcoded brand/semantic color | 🟡 **Warning** — likely off-convention, advisory |
-| bare `export default {}` nit; one-off hardcoded color; minor stylistic drift | 🔵 **Note** — polish |
+| raw `<button>`/`<input>`/`<select>`/`<textarea>`/internal `<a>` where a component applies; hand-rolled overlay markup; hardcoded brand/semantic color; a load-bearing `nextTick`/timer papering over an async-state race (a cleaner event/data-derived form exists) | 🟡 **Warning** — likely off-convention, advisory |
+| bare `export default {}` nit; one-off hardcoded color; benign `nextTick` smell; minor stylistic drift | 🔵 **Note** — polish |
 
 Rank by **how clearly it breaks a documented rule**, not by taste. A `UDropdown` is
 🔴 (the rule is explicit); "I'd have used a `UCard` here" is not a finding at all —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,8 +251,26 @@ When a POC instead **graduates into `packages/*`** (it was incubating a future p
 
 A Cloudflare build (and any whole-monorepo `pnpm install`) runs *every* workspace's `postinstall`. On a fresh install the dist-consumed `@fyit/*` workspace packages aren't built yet, so a bare `nuxt prepare` errors with `Could not load '@fyit/crouton'`, exits 1, and **aborts the entire install — failing the deploy of every other app, including the docs site.** The `2>/dev/null || true` guard always exits 0; the real prepare/build still runs in each app's own deploy pipeline. When scaffolding a new app, copy the guarded form from `apps/velo/package.json`.
 
-## MANDATORY: TypeScript Checking
-**EVERY change requires `pnpm typecheck`** (runs per-app via `pnpm -r --filter './apps/*' typecheck`). Never run `npx nuxt typecheck` from root — it has no Nuxt app context and produces thousands of false positives. Fix errors immediately. Never skip.
+## MANDATORY: Post-change checks (typecheck + fallow + a quality pass)
+
+Three cheap gates run **in-session before committing**, mirroring what CI gates — so a
+session catches what the PR would, not after:
+
+1. **Typecheck (always).** `pnpm typecheck` (runs per-app via `pnpm -r --filter './apps/*'
+   typecheck`). Never run `npx nuxt typecheck` from root — it has no Nuxt app context and
+   produces thousands of false positives. Fix errors immediately. Never skip.
+2. **Fallow audit (always, it's fast + diff-scoped).** `npx fallow audit` — the same
+   structural gate CI runs (`fallow-audit` in `ci.yml`): dead code, duplication, complexity,
+   dependency hygiene, judged on **just your diff**. Run it before pushing so the PR's fallow
+   check can't be the thing that surprises you. (`npx fallow health --score` / `npx fallow
+   dead-code` for a wider look — see the Fallow MCP row in the artifacts table.)
+3. **A quality pass on a non-trivial diff (`/simplify` or `/code-review`).** Typecheck and
+   fallow don't catch *design smells* — e.g. reaching for `nextTick()` to paper over a
+   library's async state instead of deriving from the source event, an over-engineered
+   pipeline, a workaround where a cleaner primitive exists. The CI `frontend-review` gate only
+   covers **Nuxt UI 4 conventions**, not general Vue/reactivity smells, so **you** are the
+   reviewer for those: run `/simplify` (quality-only) or `/code-review` on any non-trivial
+   change before committing. If a reviewer would raise it, raise it on yourself first.
 
 ## Core Principles
 


### PR DESCRIPTION
Closes #1574

## 👤 For humans

Two process gaps the kassa reorder fix exposed — the first working fix used an `await nextTick()` workaround (#1554) and **no reviewer flagged it**; you did. This closes both:

1. **The CI `.vue` reviewer now looks for that smell.** `frontend-review` was scoped to Nuxt UI 4 conventions only — reactivity smells weren't in its checklist.
2. **The in-session gate now mirrors CI.** It was just `pnpm typecheck`; `fallow` runs on the PR but not in a session.

## 🤖 Changes

- **`.claude/agents/frontend-review.md`** — new checklist **§6 "Reactivity/composition anti-patterns"**: flag `nextTick`/timer used to *wait for* library-updated state instead of *deriving from the source* (the `useSortable onEnd` case from #1550), and manual DOM/state reconciliation the framework should own. **🟡 when load-bearing, 🔵 when benign** — advisory, doesn't 🔴-block the gate. Legit DOM-measurement `nextTick` (focus/scroll) is explicitly excluded. Added a severity-map row.
- **`CLAUDE.md`** — the mandatory post-change gate is now three cheap checks that mirror CI:
  - `pnpm typecheck`
  - `npx fallow audit` (same diff-scoped structural gate CI runs — verified it runs in-session)
  - `/simplify` or `/code-review` on a non-trivial diff — with the note that **typecheck and fallow don't catch design smells** like the nextTick, so the agent is the reviewer for those.

Honest caveat (stated in both the issue and the docs): fallow targets dead code / dupes / complexity — it would **not** have caught the nextTick. §6 + a self-run `/simplify` is the lever for the smell; fallow is the structural complement.

## 🧪 How to test

- `/frontend-review --file` on a `.vue` that `await nextTick()`s to read a `useSortable` array → surfaces a 🟡 §6 note.
- `npx fallow audit` runs and is diff-scoped in a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_