### PR TITLE
workflow: promote a code-smell / simplification reviewer into CI (advisory per-PR)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -104,6 +104,30 @@ critical convention break, diff-scoped so never the backlog). Its lens is conven
 only — not visual taste (`/ui-proposal`), accessibility (`/a11y`), or security
 (`/red-team`).
 
+## The simplify agent (standalone — the quality-pass analog of frontend-review)
+
+`simplify.md` is a **simplification / code-smell prober** (#1576), the quality sibling of
+`frontend-review`. Given `{ scope, depth, fix }` it reads the **diff** the way a senior
+doing a quality pass would — reactivity/async workarounds (`nextTick`/timers papering over
+state a library syncs on its own schedule — the #1550 `useSortable`-`onEnd` case),
+hand-rolled boilerplate that Nuxt/VueUse already do (`useFetch`/`onClickOutside`/
+`useLocalStorage`…), DRY violations the change introduces, over-engineered abstractions for
+one call site, non-idiomatic reactivity — and **returns structured severity-rated
+findings**. It reports; it patches only the safe deterministic set under `fix:true`.
+
+| Agent | File | Recurses? | Writes code? | Model |
+|-------|------|-----------|--------------|-------|
+| `simplify` | `simplify.md` | no | only under `fix:true` (safe set) | `sonnet` |
+
+**It is ADVISORY — it has no 🔴 and NEVER blocks a merge.** Simplification is a judgment
+call, so its whole point is to *inform*, and precision beats recall (a noisy taste call
+teaches people to mute it). It's the CI form of the on-demand `/simplify` built-in, run by
+`.github/workflows/simplify-review.yml` (per-PR `quick`, diff-scoped, report-only — posts a
+sticky comment + writes a verdict for the outage-check, always exits 0). Sonnet (not Haiku)
+because judgment/false-positive cost dominates here — see `routing.json`. Its lens is
+**simpler/less-duplicated/more-idiomatic** only — not bugs (`/code-review`, `red-team`),
+conventions (`frontend-review`), a11y (`/a11y`), or visual taste (`/ui-proposal`).
+
 ### The agent contract
 
 - **Input is passed in the prompt** as a small JSON-ish object — e.g.

--- a/.claude/agents/simplify.md
+++ b/.claude/agents/simplify.md
@@ -1,0 +1,130 @@
+---
+name: simplify
+layer: method
+description: A simplification / code-smell prober for this monorepo. Given a scope and a depth, it reads the diff the way a senior reviewer doing a quality pass would — hunting for reactivity smells (nextTick/timers papering over async state), DRY violations, hand-rolled boilerplate that Nuxt/VueUse already do, reinvented wheels, and over-engineered abstractions — and returns structured, severity-rated findings. It is QUALITY-ONLY (not a bug hunter — that's `/code-review`/`red-team`); it reports, and patches the working tree ONLY when called with fix=true. Every finding is ADVISORY.
+tools: Read, Grep, Glob, Bash, Edit
+model: sonnet
+---
+
+# Simplify — read our own diff as a senior doing a quality pass, then report what could be simpler
+
+You are a **simplification** reviewer. Your job is **not** to find bugs (that's
+`/code-review` and `red-team`), judge how a screen looks (`/ui-proposal`), check
+accessibility (`a11y`), or police Nuxt UI 4 component conventions (`frontend-review`).
+Your one question is: **could this code be meaningfully simpler, more idiomatic, or
+less duplicated — is a cleaner primitive already sitting right there?** You **read and
+probe; you report**. You edit `apps/`/`packages/` code **only** when called with
+`fix: true`.
+
+This is the quality-pass analog of the `red-team` / `a11y` / `frontend-review` agents:
+same "read the diff, rate findings, report" shape, pointed at **smells and
+over-engineering** instead of exploits, WCAG, or component conventions. It is the CI
+form of the on-demand `/simplify` skill.
+
+**Everything you find is ADVISORY.** Simplification is a judgment call, not a hard rule
+— there is no "critical" that should block a merge. Your findings inform; they never
+gate. A noisy advisory that cries wolf gets muted, so **precision beats recall**: only
+raise a finding when a *concretely cleaner* alternative exists and you can name it.
+
+## Input (from the prompt)
+
+A small object: `{ scope, depth, fix }`.
+
+- `scope`: `"diff"` (the PR/working diff — the default and the CI shape), `"<pkg>"` (one
+  package), or a single file path.
+- `depth`: `quick` (diff only, static, fast — the CI default) or `standard` (a package sweep).
+- `fix`: `false` (report only — CI) or `true` (apply the safe, deterministic subset).
+
+## Depth ladder
+
+| depth | scope | what you do | dynamic? |
+|-------|-------|-------------|----------|
+| `quick` | a diff / one file | **Static, fast.** Read the changed lines (+ enough surrounding context to judge intent) through the smell checklist below. Flag only what the diff **introduces or touches** — never the pre-existing backlog. Minutes, not more. | no |
+| `standard` | one package | **Full static sweep** of that package's changed-or-named files through the checklist. The on-demand default. | no |
+
+## What counts as a smell (the checklist)
+
+Rate each 🟡 (a real, load-bearing simplification — worth doing) or 🔵 (minor polish).
+**There is no 🔴** — nothing here blocks. When unsure whether something is a smell or
+just taste, **don't raise it**.
+
+### 1. Reactivity / async workarounds — the #1550 class
+`await nextTick()` / `setTimeout` / a `watch` used to **wait for** state a library
+updates on its own schedule, when the value could be **derived from the source** instead.
+Canonical case (#1550): a `useSortable` `onEnd` that `await nextTick()`s so the bound
+array has synced, then reads it — when SortableJS's `evt.oldIndex`/`newIndex` already say
+exactly what moved, so the new order should be computed from the event. 🟡 when
+load-bearing (a real race), 🔵 for a benign focus-after-render. **Not** a smell:
+`nextTick` for genuine DOM measurement (focus, scroll, `getBoundingClientRect`).
+
+### 2. Hand-rolled boilerplate the framework already does
+Manual `fetch` + loading/error `ref`s where `useFetch`/`useAsyncData`/`$fetch` +
+`useCollectionQuery` apply; a hand-written debounce/throttle/clickOutside/localStorage-sync
+where a **VueUse** composable exists (`useDebounceFn`, `onClickOutside`, `useLocalStorage`,
+…); a manual event-listener add/remove that `useEventListener` owns. 🟡. (Pairs with the
+`ecosystem-check` skill's "don't reinvent" rule, but scoped to a diff.)
+
+### 3. DRY violations introduced by the diff
+The same non-trivial logic copy-pasted 2–3× in the change (a mapper, a guard, a query
+shape) where a local helper or an existing util would do. Flag the duplication + name the
+shared home. 🟡. Don't flag trivial two-line repeats or test fixtures.
+
+### 4. Over-engineered abstraction for the actual need
+A factory / generic / options-bag / multi-layer indirection introduced for a single
+call site; a config-driven mechanism where a plain function would do; premature
+generalization. 🟡/🔵 by how much indirection it adds. Be careful — an abstraction with
+several real consumers is **not** a smell; one speculative consumer is.
+
+### 5. Non-idiomatic Vue/Nuxt in the diff
+Options API in a new `.vue` (defer the hard-rule form to `frontend-review`; note it here
+only if that agent wouldn't see it), manual reactivity where `computed` is the primitive,
+`ref` state kept in lockstep by hand instead of `computed`, reaching past the framework to
+the DOM to reconcile what a `ref` should own. 🟡/🔵.
+
+## Severity map (mirrors the review skill's 3 levels)
+
+| Finding | Level |
+|---------|-------|
+| a load-bearing simplification with a concrete cleaner form (a real race worked around by `nextTick`; a reinvented VueUse composable; duplicated non-trivial logic; indirection for one call site) | 🟡 **Warning** — worth doing, advisory |
+| minor polish (a benign `nextTick`; a two-line tidy; a stylistic nit) | 🔵 **Note** |
+
+Rank by **how much simpler the code gets**, not by taste. "I'd have named this
+differently" is **not a finding**. Never emit 🔴 — this agent does not block.
+
+## Remediation (only when `fix: true`)
+
+Apply **only** the safe, deterministic subset where the cleaner form is unambiguous and
+mechanical (e.g. swap a hand-rolled clickOutside for `onClickOutside`; derive a reorder
+from the drag event instead of `nextTick`-then-read). Anything requiring a judgment call
+about intent → leave as a reported 🟡, don't touch. Then run `pnpm typecheck` on the
+affected app and report the result. Obey the `packages/` HARD GATE — never edit
+`packages/` unless the run was explicitly approved for it.
+
+## How to work
+
+1. **Resolve scope.** For `diff`: `git diff --name-only origin/<base>...HEAD`, keep code
+   files (`.vue`, `.ts`, `.js`, `.mjs`), drop generated/`dist`/`_archive`/fixtures.
+2. **Read each changed hunk** with enough context to judge intent, and walk the checklist.
+   Grep the cheap deterministic spine first (`nextTick(`, `setTimeout(`, `new Promise`,
+   `addEventListener`, a literal `fetch(`), then read to confirm it's actually a smell and
+   not the legitimate use.
+3. **Precision over recall.** Every false 🟡 on taste erodes trust in the whole check.
+   If you can't name the concretely-cleaner form, don't raise it.
+4. Produce the two outputs the CI contract asks for (a sticky PR comment + a verdict file),
+   or, on-demand, just the findings list.
+
+## Output
+
+A severity-rated findings list — each with `file:line`, the smell class (1–5 above), a
+one-line "why simpler", and the concrete cleaner form. In CI you ALSO write the verdict
+file the workflow reads. Empty is a perfectly good result: "quick scan found nothing —
+the diff reads clean."
+
+## Guardrails
+
+- **Advisory only** — you never block a merge; you have no 🔴.
+- **Diff-scoped** — flag only what the change introduces/touches, never the backlog.
+- **Quality only** — not bugs (`/code-review`), not security (`red-team`), not a11y
+  (`a11y`), not component conventions (`frontend-review`), not visual taste (`/ui-proposal`).
+- **Precision beats recall** — a wrong 🟡 is worse than a missed 🔵.
+- **`packages/` HARD GATE** applies under `fix: true`.

--- a/.claude/routing.json
+++ b/.claude/routing.json
@@ -17,7 +17,8 @@
     "task-decomposer":   { "tier": "medium", "why": "LEAF test + split issues; no code written. Moved opus→Sonnet 5 with the orchestrator on the same N=4 A/B evidence. Refines #824." },
     "red-team":          { "tier": "medium", "why": "security analysis, reports only — opus was overkill; moved to Sonnet 5 (no code written, daily deep sweep is the cost). Free win per #823/#824." },
     "a11y":              { "tier": "small", "why": "template review, reports only — Sonnet→Haiku (#1272/#823); reversible if the #865 scoreboard shows missed axe findings" },
-    "frontend-review":   { "tier": "small", "why": "convention review, reports only — Sonnet→Haiku (#1272/#823); reversible if it stops catching v3 names" }
+    "frontend-review":   { "tier": "small", "why": "convention review, reports only — Sonnet→Haiku (#1272/#823); reversible if it stops catching v3 names" },
+    "simplify":          { "tier": "medium", "why": "simplification / code-smell review, reports-only + ADVISORY (never blocks). Judgment-heavy and false-positive-sensitive (a noisy taste call teaches people to mute the check), so Sonnet not Haiku — mirrors red-team's reports-but-judgment tier. Reversible via the #865 scoreboard if it proves noisy (#1576)." }
   },
 
   "_overrides": "Per-flow exceptions that pin an exact model regardless of tier. This is where a one-off flow declares itself VISIBLY instead of burying the decision in a branch.",

--- a/.github/workflows/simplify-review.yml
+++ b/.github/workflows/simplify-review.yml
@@ -1,0 +1,131 @@
+name: Simplify Review (PR)
+
+# Per-PR simplification / code-smell scan (#1576). Runs the `simplify` subagent at
+# depth=quick over the PR diff (reactivity smells like nextTick-as-workaround, DRY
+# violations, reinvented VueUse/Nuxt boilerplate, over-engineered abstractions on the
+# changed code) and posts an advisory sticky comment.
+#
+# ADVISORY ONLY — this check NEVER fails / blocks a merge. Simplification is a judgment
+# call, not a hard rule (unlike frontend-review, which blocks on 🔴 convention breaks), so
+# the agent has no 🔴 and this workflow always exits 0. It informs; it never gates.
+# Diff-scoped, so it only ever comments on what THIS PR introduces, never the backlog.
+# Mirrors frontend-review.yml / a11y.yml minus the gate step.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      # Smells live in code — scan PRs that touch source. (The agent further drops
+      # generated layers / dist / fixtures when it resolves the diff.)
+      - '**/*.vue'
+      - '**/*.ts'
+      - '**/*.mjs'
+      # Known-bad smoke fixtures are diff-scope-excluded so touching them never self-flags.
+      - '!.claude/gate-fixtures/**'
+
+concurrency:
+  group: simplify-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  simplify-review:
+    # Skip drafts and bot-authored PRs (agent/Dependabot noise isn't worth a quality pass).
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot'
+    # Fork PRs never land on the self-hosted box (untrusted code on our hardware — runbook §5).
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    # permissions MUST be job-level: GitHub job-level `permissions` fully OVERRIDES (does not
+    # merge with) any workflow-level block, so `id-token: write` has to be here or the
+    # claude-code-action OIDC token request fails.
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the agent can diff the PR against its base branch.
+          fetch-depth: 0
+
+      # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
+      - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
+        id: agent
+        # Report-only workflow, but keep continue-on-error so a `max_turns`/SDK flake can't turn
+        # the run red — the sticky comment + verdict are the deliverable; the final step never
+        # fails regardless.
+        continue-on-error: true
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
+          # --allowedTools is REQUIRED (#834): the prompt has the top-level agent *act as* the
+          # subagent and call Bash/Write DIRECTLY (no sub-agent spawn to auto-grant frontmatter
+          # tools). Headless CI has no human to approve tool use, so without the allowlist every
+          # Bash/Write is DENIED — the agent computes the right findings but can't write the
+          # verdict or post the comment, burns turns on denied retries, and fails open (hollow).
+          # Bash covers `gh` (comment) + writing the verdict; Write/Edit for the file; Read/Grep/
+          # Glob for the scan.
+          # Sonnet, not Haiku: simplification is a JUDGMENT call and this check is advisory, so a
+          # noisy false positive is the failure mode — precision matters more than the cheaper
+          # tier here (mirrors red-team's reports-but-judgment tier). Reversible via routing.json
+          # + the #865 scoreboard.
+          claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
+          prompt: |
+            Act as the **simplify subagent** defined in `.claude/agents/simplify.md`.
+            Input: { scope: "diff", depth: "quick", fix: false }.
+
+            The PR diff is this branch vs its base. The base branch is
+            `origin/${{ github.event.pull_request.base.ref }}` — diff against it
+            (`git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD`),
+            keep only the changed code files (`.vue`/`.ts`/`.mjs`; drop generated layers, `dist`,
+            `_archive`, fixtures), and scan ONLY those through the smell checklist in the agent
+            definition. Be precise and avoid false positives — a wrong advisory on taste teaches
+            people to ignore the whole check, so PRECISION BEATS RECALL: only raise a finding when
+            a concretely cleaner form exists and you can name it. This agent has NO 🔴 and NEVER
+            blocks.
+
+            Then do exactly two outputs:
+
+            1. **Post a single PR comment** summarising the findings using the review skill's
+               3-level format (🟡 Warning / 🔵 Note — there is no 🔴 here) — a short table + each
+               finding's `file:line`, smell class, one-line "why simpler", and the concrete cleaner
+               form. Make it a sticky comment containing the literal marker `<!-- simplify -->` on
+               its own line, and EDIT that comment in place if it already exists rather than posting
+               a new one. If there are no findings, post/update the comment saying the quick scan
+               found nothing — the diff reads clean.
+
+            2. **Write `simplify-verdict.json`** at the repo root, exactly:
+               `{"highest":"<none|note|warning>","warning":N,"note":N}`
+               where `highest` is the most severe finding's level (🟡→warning, 🔵→note, or `none`).
+               This is the machine signal the outage-check reads — always write it, even for a
+               clean scan.
+
+            Do NOT edit any `apps/`/`packages/` code (quick scan is report-only; `--fix` is a
+            separate, human-invoked path). Do NOT file GitHub issues. Reporting + the verdict file
+            is all.
+
+      # Ship the payload-free invocation trace for the weekly usage rollup (#1064).
+      - uses: ./.github/actions/loop-station-trace
+        if: always()
+      # Fail-open must be VISIBLE (#1037): when no verdict exists, classify why (billing /
+      # max-turns / auth / silent no-write) and emit a warning annotation, so a dead agent
+      # can't be mistaken for a clean scan. (This check never FAILS, but a silent no-write
+      # should still surface as a warning rather than a hollow green.)
+      - uses: ./.github/actions/gate-outage-check
+        if: always()
+        with:
+          gate: simplify
+          verdict-file: simplify-verdict.json
+          agent-outcome: ${{ steps.agent.outcome }}
+      - name: Report (advisory — never blocks)
+        if: always()
+        run: |
+          if [ ! -f simplify-verdict.json ]; then
+            echo "No verdict file — outage classified by gate-outage-check above. Advisory check, not blocking."
+            exit 0
+          fi
+          echo "Verdict: $(cat simplify-verdict.json)"
+          HIGHEST=$(node -e "process.stdout.write((require('./simplify-verdict.json').highest||'none').toLowerCase())")
+          echo "simplify highest severity: ${HIGHEST}. Advisory only — see the simplify PR comment. Never blocks."
+          exit 0

--- a/writeups/architecture/routing-registry.md
+++ b/writeups/architecture/routing-registry.md
@@ -21,6 +21,7 @@ Default tier: **medium**
 | `red-team` | medium | claude-sonnet-5 | zai/glm-5.2 | $15 | — | security analysis, reports only — opus was overkill; moved to Sonnet 5 (no code written, daily deep sweep is the cost). Free win per #823/#824. |
 | `a11y` | small | claude-haiku-4-5 | zai/glm-5.2 | $5 | — | template review, reports only — Sonnet→Haiku (#1272/#823); reversible if the #865 scoreboard shows missed axe findings |
 | `frontend-review` | small | claude-haiku-4-5 | zai/glm-5.2 | $5 | — | convention review, reports only — Sonnet→Haiku (#1272/#823); reversible if it stops catching v3 names |
+| `simplify` | medium | claude-sonnet-5 | zai/glm-5.2 | $15 | — | simplification / code-smell review, reports-only + ADVISORY (never blocks). Judgment-heavy and false-positive-sensitive (a noisy taste call teaches people to mute the check), so Sonnet not Haiku — mirrors red-team's reports-but-judgment tier. Reversible via the #865 scoreboard if it proves noisy (#1576). |
 
 ## Overrides (per-flow exact-model pins)
 - **a11y-daily-pidev** → `zai/glm-5.2` — #1409 eval: matched engine ground truth (153/152), beat the metered Haiku baseline (+28% overcount, $0.347/run) at $0 marginal on the flat GLM Coding Plan. Workflow default since #1413.


### PR DESCRIPTION
Closes #1576

## 👤 For humans

The smell-catchers (`/simplify`, `/code-review`, the `review` skill) were all **on-demand** — nothing ran per-PR, which is exactly how the kassa `nextTick` slipped through. This adds a per-PR **"Simplify Review"** check that scans the diff for reactivity smells (nextTick-as-workaround), DRY violations, reinvented VueUse/Nuxt boilerplate, and over-engineered abstractions, and posts a comment.

**It's advisory — it comments, it never blocks.** Simplification is a judgment call, not a hard rule (unlike `frontend-review`, which blocks on 🔴 convention breaks), so this agent has no 🔴 and the check always exits 0. Precision beats recall: it only raises a finding when a concretely cleaner form exists.

## 🤖 What's here (mirrors the frontend-review/a11y/red-team pattern)

- **`.claude/agents/simplify.md`** — the prober. Diff-scoped smell checklist: reactivity/async workarounds (the #1550 `useSortable onEnd` case), hand-rolled boilerplate a framework already owns (`useFetch`/`onClickOutside`/`useLocalStorage`…), DRY the change introduces, over-abstraction for one call site, non-idiomatic reactivity. Reports; patches the safe set only under `fix:true`.
- **`.github/workflows/simplify-review.yml`** — per-PR `quick`, diff-scoped, report-only (sticky `<!-- simplify -->` comment + a verdict file for the outage-check; always exits 0). Carries every claude-action workflow standard: job-level `id-token`, `anthropic_api_key`, `show_full_output`, the shared pinned SHA, `--allowedTools`, `loop-station-trace`, `gate-outage-check`. Verified all 7 present.
- **`.claude/routing.json`** — `simplify` → `medium` (Sonnet, not Haiku: judgment/false-positive-sensitive, per the red-team precedent). Regenerated `routing-registry.md`; `gen-routing.mjs --check` clean.
- **`.claude/agents/CLAUDE.md`** — registered the agent + its advisory/report-only contract.

## 🧪 How to test

- A PR that adds a `nextTick`-as-workaround (or an obvious reinvented composable) → advisory 🟡 comment; the check stays green.
- A clean PR → "quick scan found nothing"; green.
- Diff-scoped, so it never comments on the pre-existing backlog.

## Note / knob for you

The trigger is `**/*.vue` + `**/*.ts` + `**/*.mjs`, so it runs a Sonnet pass on most code PRs. That's the cost of a per-PR advisory. If it's too chatty or too costly, easy dials: narrow the paths (e.g. drop `**/*.ts`), or demote to Haiku in `routing.json` + the workflow `--model`. I sized it for quality first since a noisy advisory is the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_