### PR TITLE
fix(crouton-sales): seed demo rows if-absent so re-seed keeps user edits

### DIFF
--- a/packages/crouton-core/CLAUDE.md
+++ b/packages/crouton-core/CLAUDE.md
@@ -119,10 +119,14 @@ runtime), exported at `@fyit/crouton-core/shared/seed`:
 - `SeedProvider` (`{ id, dependsOn?, seed(ctx) }`) + `SeedContext` (`teamId`,
   `teamSlug`, `locale`, `upsert(table, byId, values)`, `now`, optional
   `createPageWithBlocks`). Each package ships a provider at `<pkg>/seed`.
-- `buildUpsert(table, byId, values)` → idempotent `INSERT … ON CONFLICT(byId)
-  DO UPDATE SET …` SQL (identifiers double-quoted so `order` is safe;
-  `createdAt` held immutable on update). `seedId(...parts)` / `seedOrgId(slug)`
-  derive stable ids so re-runs upsert instead of duplicating.
+- `buildUpsert(table, byId, values, options?)` → idempotent `INSERT … ON
+  CONFLICT(byId) DO UPDATE SET …` SQL (identifiers double-quoted so `order` is
+  safe; `createdAt` held immutable on update). `options.insertOnly: true` forces
+  `ON CONFLICT DO NOTHING` — seed the row once, never overwrite it on a re-run;
+  surfaced on `ctx.upsert(table, byId, values, { ifAbsent: true })` for demo rows
+  a user may edit so a redeploy's re-seed doesn't clobber their changes (#1579).
+  `seedId(...parts)` / `seedOrgId(slug)` derive stable ids so re-runs upsert
+  instead of duplicating.
 - `topoSort(providers)` + `collectSeedSql({ providers, teamSlug, teamId, locale,
   withStaff, createPageWithBlocks })` order providers by `dependsOn` and return
   the combined SQL. The CLI `crouton-seed` command wraps this with discovery +

--- a/packages/crouton-core/shared/seed/runner.ts
+++ b/packages/crouton-core/shared/seed/runner.ts
@@ -64,8 +64,11 @@ export async function collectSeedSql(options: CollectSeedSqlOptions): Promise<st
     locale: options.locale,
     withStaff: Boolean(options.withStaff),
     now: raw('unixepoch()'),
-    upsert(table, byId, values) {
-      statements.push(buildUpsert(table, byId, values ?? {}, { immutable: ['createdAt'] }))
+    upsert(table, byId, values, opts) {
+      statements.push(buildUpsert(table, byId, values ?? {}, {
+        immutable: ['createdAt'],
+        insertOnly: opts?.ifAbsent
+      }))
     },
     raw(sql) {
       const trimmed = sql.trim()

--- a/packages/crouton-core/shared/seed/sql.ts
+++ b/packages/crouton-core/shared/seed/sql.ts
@@ -52,6 +52,13 @@ export function sqlValue(value: unknown): string {
 export interface UpsertOptions {
   /** Columns never overwritten on conflict (e.g. `createdAt`). */
   immutable?: string[]
+  /**
+   * Insert-if-absent: emit `ON CONFLICT DO NOTHING` regardless of updatable
+   * columns, so an existing row is never overwritten. For demo/seed rows a
+   * user may edit — the row seeds once, then belongs to the user (a re-seed
+   * on redeploy leaves their edits intact). #1579.
+   */
+  insertOnly?: boolean
 }
 
 /**
@@ -84,7 +91,7 @@ export function buildUpsert(
   const updateCols = cols.filter(c => !conflictCols.includes(c) && !immutable.has(c))
 
   let stmt = `INSERT INTO ${quoteIdent(table)} (${insertCols}) VALUES (${insertVals})`
-  if (updateCols.length > 0) {
+  if (!options.insertOnly && updateCols.length > 0) {
     const setClause = updateCols
       .map(c => `${quoteIdent(c)} = excluded.${quoteIdent(c)}`)
       .join(', ')

--- a/packages/crouton-core/shared/seed/types.ts
+++ b/packages/crouton-core/shared/seed/types.ts
@@ -52,7 +52,13 @@ export type CreatePageWithBlocksFn = (options: CreatePageWithBlocksOptions) => s
 export type UpsertFn = (
   table: string,
   byId: Record<string, unknown>,
-  values?: Record<string, unknown>
+  values?: Record<string, unknown>,
+  /**
+   * `ifAbsent: true` → insert the row only when it's missing; never overwrite an
+   * existing row on a re-seed. Use for demo rows a user may edit (order, title,
+   * price) so a redeploy's re-seed doesn't clobber their changes (#1579).
+   */
+  options?: { ifAbsent?: boolean }
 ) => void
 
 export interface SeedContext {

--- a/packages/crouton-core/tests/seed-upsert.test.ts
+++ b/packages/crouton-core/tests/seed-upsert.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { buildUpsert } from '../shared/seed/sql'
+import { collectSeedSql } from '../shared/seed/runner'
+import type { SeedProvider } from '../shared/seed/types'
+
+// The demo seed re-runs on every staging deploy. Its default upsert overwrites
+// existing rows (DO UPDATE), which wipes a user's edits (reorder/rename/reprice)
+// on the seeded event every deploy (#1579). `ifAbsent` makes a demo row seed once
+// and then belong to the user: insert-if-missing, never clobber.
+
+describe('buildUpsert insertOnly', () => {
+  it('default: DO UPDATE SET on conflict (overwrites)', () => {
+    const sql = buildUpsert('t', { id: 'x' }, { title: 'A', displayOrder: 1 })
+    expect(sql).toContain('ON CONFLICT("id") DO UPDATE SET')
+    expect(sql).toContain('"title" = excluded."title"')
+    expect(sql).not.toContain('DO NOTHING')
+  })
+
+  it('insertOnly: forces DO NOTHING even with updatable columns (preserves edits)', () => {
+    const sql = buildUpsert('t', { id: 'x' }, { title: 'A', displayOrder: 1 }, { insertOnly: true })
+    expect(sql).toContain('ON CONFLICT("id") DO NOTHING')
+    expect(sql).not.toContain('DO UPDATE')
+    // still inserts the values when the row is absent
+    expect(sql).toContain('"title"')
+    expect(sql).toContain('"displayOrder"')
+  })
+
+  it('insertOnly takes precedence over immutable', () => {
+    const sql = buildUpsert('t', { id: 'x' }, { title: 'A' }, { insertOnly: true, immutable: ['createdAt'] })
+    expect(sql).toContain('DO NOTHING')
+    expect(sql).not.toContain('DO UPDATE')
+  })
+})
+
+describe('ctx.upsert ifAbsent (seed context)', () => {
+  it('ifAbsent: true → the emitted statement is DO NOTHING', async () => {
+    const provider: SeedProvider = {
+      id: 'test',
+      seed(ctx) {
+        ctx.upsert('sales_categories', { id: 'c1' }, { title: 'Dranken', displayOrder: 1 }, { ifAbsent: true })
+      }
+    }
+    const sql = await collectSeedSql({ providers: [provider], teamSlug: 't', teamId: 'team', locale: 'nl' })
+    expect(sql).toContain('ON CONFLICT("id") DO NOTHING')
+    expect(sql).not.toContain('DO UPDATE')
+  })
+
+  it('default upsert (no options) still DO UPDATE — behaviour unchanged for other seeds', async () => {
+    const provider: SeedProvider = {
+      id: 'test',
+      seed(ctx) {
+        ctx.upsert('some_table', { id: 'r1' }, { name: 'x' })
+      }
+    }
+    const sql = await collectSeedSql({ providers: [provider], teamSlug: 't', teamId: 'team', locale: 'nl' })
+    expect(sql).toContain('DO UPDATE SET')
+  })
+})

--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -840,6 +840,11 @@ Part of the composable seeding system (epic #82, contract in
   the event's helper PIN.
 
 Idempotent (stable ids). Run via an app's `crouton-seed` / `db:seed:*` scripts.
+**All sales demo rows are seeded `{ ifAbsent: true }`** (#1579): `db:seed:staging`
+re-runs on every staging deploy, and a plain upsert (`DO UPDATE`) would overwrite
+a user's edits (reorder/rename/reprice) on the seeded event every deploy. `ifAbsent`
+makes each row insert-once-then-belong-to-the-user (`DO NOTHING` on conflict) — a
+deleted row is still re-created, an existing one is left alone.
 
 ## Dependencies
 

--- a/packages/crouton-sales/seed/index.ts
+++ b/packages/crouton-sales/seed/index.ts
@@ -59,7 +59,10 @@ function seedCatalog(ctx: SeedContext) {
     updatedAt: ctx.now,
     createdBy: 'seed',
     updatedBy: 'seed'
-  })
+  // ifAbsent: seed the demo once — a re-seed on every staging deploy must NOT
+  // overwrite the user's edits (title/pin/order/price). Deleted rows are still
+  // re-created; only existing ones are left alone (#1579).
+  }, { ifAbsent: true })
 
   const categoryIds: Record<SeedProduct['category'], string> = {
     drinks: seedId('cat', ctx.teamSlug, EVENT_SLUG, 'drinks'),
@@ -76,7 +79,7 @@ function seedCatalog(ctx: SeedContext) {
     updatedAt: ctx.now,
     createdBy: 'seed',
     updatedBy: 'seed'
-  })
+  }, { ifAbsent: true })
   ctx.upsert('sales_categories', { id: categoryIds.food }, {
     teamId: ctx.teamId,
     owner: 'seed',
@@ -87,7 +90,7 @@ function seedCatalog(ctx: SeedContext) {
     updatedAt: ctx.now,
     createdBy: 'seed',
     updatedBy: 'seed'
-  })
+  }, { ifAbsent: true })
 
   for (const product of PRODUCTS) {
     ctx.upsert('sales_products', { id: seedId('prd', ctx.teamSlug, EVENT_SLUG, product.slug) }, {
@@ -106,7 +109,7 @@ function seedCatalog(ctx: SeedContext) {
       updatedAt: ctx.now,
       createdBy: 'seed',
       updatedBy: 'seed'
-    })
+    }, { ifAbsent: true })
   }
 }
 


### PR DESCRIPTION
## 👤 For humans

The demo kassa (Vlaamse Kermis) re-seeds on **every** staging deploy (`db:seed:staging`). That re-seed used a plain upsert (`ON CONFLICT DO UPDATE`), so it overwrote the seeded event's rows on each deploy — wiping any **reorder, rename, or price change** a user made. This is the deploy-time counterpart of the drag-reorder persistence bug: reorders would persist to the DB, then get clobbered by the next staging deploy.

Now the sales demo rows seed **once and then belong to the user**: insert-if-missing, never overwrite. A redeploy leaves their edits intact; a *deleted* row is still re-created.

## 🤖 For agents

New opt-in on the seed contract, default behaviour unchanged for every other provider:

- `crouton-core/shared/seed/sql.ts` — `buildUpsert` gains `UpsertOptions.insertOnly`; when set it emits `ON CONFLICT(...) DO NOTHING` regardless of updatable/immutable columns.
- `crouton-core/shared/seed/types.ts` — `UpsertFn` gains a 4th arg `{ ifAbsent?: boolean }`.
- `crouton-core/shared/seed/runner.ts` — `ctx.upsert` threads `ifAbsent` → `insertOnly`.
- `crouton-sales/seed/index.ts` — `sales_events`, both `sales_categories` (Dranken/Eten), and each `sales_products` upsert marked `{ ifAbsent: true }`.

### Test-first (#774 gate — this is `packages/*` logic)

`crouton-core/tests/seed-upsert.test.ts` (5 cases), written and signed off before the code:
- `insertOnly` → `DO NOTHING` even with updatable columns
- default (no option) → `DO UPDATE SET` unchanged
- `insertOnly` takes precedence over `immutable`
- `ctx.upsert({ ifAbsent: true })` → emitted statement is `DO NOTHING` (via `collectSeedSql`)
- default `ctx.upsert` still `DO UPDATE` — other seeds unaffected

Full `crouton-core` suite green (694 passed); `e2e-fixture-with-sales` typecheck clean.

## 🧪 How to test

For someone who knows the seed system, not this diff:

1. On a fresh DB, run the sales seed (`db:seed:*`) — the `vlaamsekermis` event, its two categories, and five products appear as before (insert path unchanged).
2. In the kassa, **reorder** a couple of products/categories, **rename** one, or **change a price**. Confirm it persists (PATCH → DB).
3. Run the seed **again** (simulating a staging redeploy).
   - **Before:** your reorder/rename/reprice is reverted to the seed defaults.
   - **After:** your edits survive — the existing rows are left untouched (`DO NOTHING`).
4. **Delete** a seeded product, then re-seed → it is re-created (absent rows still insert).

Closes #1579

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_