### PR TITLE
feat: deterministic app bundle-size budget + trend

### DIFF
--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -1,0 +1,100 @@
+name: bundle-budget
+
+# Deterministic client-bundle trend (#1581). Builds the launched apps, measures
+# each app's `.output/public/_nuxt` (raw + gzip JS/CSS, top chunks), scores it
+# against the budget bands, and commits one point per app to
+# writeups/perf/bundle-history.jsonl. The product-perf sibling of Loop Station's
+# WS1 harness-size inventory — same producer shape (deterministic → committed
+# JSONL → threshold), pointed at the app instead of the harness.
+#
+# Weekly + on-demand (not per-merge): a full build of every app is heavy, and the
+# number only needs a regular trend point, not one per commit. Per-merge causal
+# attribution (build only the app a merge touched, feed a regression into the
+# accountability quality lane #1570) is the documented follow-up.
+#
+# Deterministic (same build → same bytes) — unlike Lighthouse vitals, which stay
+# report-only in unlighthouse.yml. So this CAN carry a budget without flakiness.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'   # Mondays 06:17 UTC (before the loop-station rollups)
+  workflow_dispatch:
+    inputs:
+      apps:
+        description: 'Space-separated app names to measure (default: all launched apps)'
+        required: false
+        type: string
+
+permissions:
+  contents: write # commit the new bundle-history.jsonl points back to main
+
+concurrency:
+  group: bundle-budget
+  cancel-in-progress: false # never drop a data point mid-write
+
+jobs:
+  measure:
+    runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the commit-back rebases cleanly
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Build every @fyit/* package first (content-addressed cache) so the app
+      # builds don't hit the "Could not load @fyit/crouton" cold-start trap (#1222).
+      - uses: ./.github/actions/warm-packages
+
+      - name: Build + measure each launched app
+        env:
+          # Only the build-time prerender pass needs these.
+          BETTER_AUTH_SECRET: prerender-placeholder
+          BETTER_AUTH_URL: http://localhost:3000
+        run: |
+          set -uo pipefail
+          APPS="${{ inputs.apps }}"
+          if [ -z "$APPS" ]; then
+            APPS=$(for f in apps/*/deploy.config.json; do [ -f "$f" ] && basename "$(dirname "$f")"; done | tr '\n' ' ')
+          fi
+          echo "Measuring: $APPS"
+          SHA="${GITHUB_SHA}"
+          ANY=0
+          for app in $APPS; do
+            DIR="apps/$app"
+            if [ ! -d "$DIR" ]; then echo "::warning::$DIR not found — skipping"; continue; fi
+            echo "── building $app ──"
+            # Same build a deploy runs; measure the client assets it emits.
+            ( cd "$DIR" && npx nuxt prepare && NITRO_PRESET=cloudflare_module npx nuxt build ) \
+              || { echo "::warning::$app build failed — skipping its bundle point"; continue; }
+            ASSETS="$DIR/.output/public/_nuxt"
+            if [ ! -d "$ASSETS" ]; then echo "::warning::$ASSETS missing after build — skipping"; continue; fi
+            node scripts/perf/bundle-size.mjs --app "$app" --dir "$ASSETS" --commit "$SHA" --pretty \
+              | node scripts/perf/append-bundle-history.mjs
+            ANY=1
+          done
+          [ "$ANY" = "1" ] || echo "::warning::no app produced a bundle point this run"
+
+      - name: Commit new bundle points (if any)
+        run: |
+          if git diff --quiet -- writeups/perf/bundle-history.jsonl; then
+            echo "no new bundle points — nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add writeups/perf/bundle-history.jsonl
+          git commit -m "chore(perf): record app bundle-size trend [skip ci]"
+          for i in 1 2 3 4; do
+            git pull --rebase origin main && git push origin HEAD:main && exit 0
+            echo "push attempt $i failed; retrying…"; sleep $((2 ** i))
+          done
+          exit 1

--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -77,7 +77,19 @@ jobs:
               || { echo "::warning::$app build failed — skipping its bundle point"; continue; }
             ASSETS="$DIR/.output/public/_nuxt"
             if [ ! -d "$ASSETS" ]; then echo "::warning::$ASSETS missing after build — skipping"; continue; fi
-            node scripts/perf/bundle-size.mjs --app "$app" --dir "$ASSETS" --commit "$SHA" --pretty \
+
+            # Server/Worker number: bundle the REAL deployed Worker with wrangler's OFFLINE
+            # dry-run (tree-shaken, single script) — NOT the raw .output/server tree (which
+            # overstates it by multiples). Tolerant: if the dry-run fails we record client-only.
+            SERVER_ARG=""
+            if ( cd "$DIR" && npx wrangler deploy --dry-run --outdir=.wrangler-bundle --config .output/server/wrangler.json ) 2>/dev/null; then
+              [ -d "$DIR/.wrangler-bundle" ] && SERVER_ARG="--server-dir $DIR/.wrangler-bundle"
+            else
+              echo "::warning::$app wrangler dry-run failed — recording client bundle only"
+            fi
+
+            # shellcheck disable=SC2086 — SERVER_ARG is intentionally unquoted (empty or a flag pair)
+            node scripts/perf/bundle-size.mjs --app "$app" --dir "$ASSETS" $SERVER_ARG --commit "$SHA" --pretty \
               | node scripts/perf/append-bundle-history.mjs
             ANY=1
           done

--- a/scripts/perf/append-bundle-history.mjs
+++ b/scripts/perf/append-bundle-history.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// append-bundle-history.mjs — append ONE bundle record to the committed trend (#1581).
+// Reads a record (from bundle-size.mjs) on stdin, appends to
+// writeups/perf/bundle-history.jsonl. Idempotent per (app, commit): a re-run on the
+// same merge never adds a second point. Mirrors loop-station/append-history.mjs.
+//
+// Usage:
+//   node scripts/perf/bundle-size.mjs --app velo --dir <dir> --commit $SHA \
+//     | node scripts/perf/append-bundle-history.mjs
+import { readFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const HISTORY = join(ROOT, 'writeups/perf/bundle-history.jsonl')
+
+let record
+try {
+  record = JSON.parse(readFileSync(0, 'utf8'))
+} catch {
+  console.error('append-bundle-history: stdin is not a valid JSON record')
+  process.exit(1)
+}
+if (!record || !record.app) {
+  console.error('append-bundle-history: record needs an "app"')
+  process.exit(1)
+}
+
+// Idempotent per (app, commit) when a commit is recorded.
+if (record.commit && existsSync(HISTORY)) {
+  const dup = readFileSync(HISTORY, 'utf8').split('\n').map((l) => l.trim()).filter(Boolean)
+    .map((l) => { try { return JSON.parse(l) } catch { return null } })
+    .some((r) => r && r.app === record.app && r.commit === record.commit)
+  if (dup) {
+    console.log(`false`) // already recorded for this (app, commit)
+    process.exit(0)
+  }
+}
+
+if (!existsSync(dirname(HISTORY))) mkdirSync(dirname(HISTORY), { recursive: true })
+appendFileSync(HISTORY, JSON.stringify(record) + '\n')
+console.log(`true`) // appended (the workflow reads this to decide whether to commit)
+console.error(`append-bundle-history: ${record.app} · ${(record.totalGzip / 1024).toFixed(1)} KB gzip · ${record.scorecard?.overall ?? '?'}`)

--- a/scripts/perf/bundle-size.mjs
+++ b/scripts/perf/bundle-size.mjs
@@ -1,29 +1,36 @@
 #!/usr/bin/env node
-// bundle-size.mjs — DETERMINISTIC client-bundle measurement (#1581).
-// Sums the raw + gzipped size of the built JS/CSS assets under an app's
-// `.output/public/_nuxt` (Cloudflare Workers preset) — the numbers behind
-// `nuxt analyze`, but as a trendable fact instead of a throwaway visualizer.
+// bundle-size.mjs — DETERMINISTIC bundle measurement, CLIENT + SERVER (#1581).
+// Measures two things that answer two different questions:
+//   - CLIENT bundle  (public/_nuxt)        → what the browser downloads → user load speed.
+//   - SERVER/Worker bundle (wrangler-built) → Cloudflare cold-start + CPU → cost to RUN.
 //
-// Deterministic on purpose (same build → same bytes), so — unlike Lighthouse
-// vitals — it can be a reliable budget, not a flaky one. Dep-free: node built-ins
-// only (fs + zlib), so it runs in any CI step without install.
+// The numbers behind `nuxt analyze`, but as a trendable fact instead of a throwaway
+// visualizer. Deterministic (same build → same bytes), so — unlike Lighthouse vitals —
+// it can be a reliable budget. Dep-free: node built-ins only (fs + zlib).
+//
+// IMPORTANT — the server number: `.output/server` is the UNBUNDLED Nitro output (hundreds
+// of chunks, most tree-shaken away at deploy) — measuring it overstates the real Worker by
+// multiples. The honest server number is the WRANGLER-BUNDLED Worker: run
+// `wrangler deploy --dry-run --outdir <dir>` (offline; the workflow does this) and pass that
+// dir as --server-dir. The engine just measures whatever dir it's given; producing the real
+// Worker bundle is the caller's job (keeps this script dep-free + testable).
 //
 // Usage:
-//   node scripts/perf/bundle-size.mjs --app velo --dir apps/velo/.output/public/_nuxt
-//   node scripts/perf/bundle-size.mjs --app velo --dir <dir> --json
-//   # regression band needs the prior point:
-//   node scripts/perf/bundle-size.mjs --app velo --dir <dir> --history writeups/perf/bundle-history.jsonl
+//   node scripts/perf/bundle-size.mjs --app velo \
+//     --dir apps/velo/.output/public/_nuxt \        # client (browser)
+//     --server-dir apps/velo/.wrangler-bundle \     # optional: wrangler-bundled Worker
+//     --commit $SHA --pr 123 [--pretty]
 import { readdirSync, statSync, readFileSync, existsSync } from 'node:fs'
 import { gzipSync } from 'node:zlib'
 import { join, basename, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from '../lib/cli-args.mjs'
-import { scoreBundle } from './scorecard.mjs'
+import { scoreBundle, CLIENT_SIZE_BANDS, SERVER_SIZE_BANDS, worst } from './scorecard.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const TOP_CHUNKS = 12
 
-/** Recursively collect every .js/.css file path under `dir`. */
+/** Recursively collect every .js/.mjs/.css file path under `dir`. */
 function walk(dir) {
   const out = []
   let entries
@@ -41,10 +48,9 @@ function walk(dir) {
 }
 
 /**
- * Pure measurement (importable + tested). Returns raw + gzipped totals split by
- * type, plus the top chunks by gzipped size. `gzip` is the transfer-shaped number
- * (what the client actually downloads) — the one the budget bands read.
- * @param {string} dir  a built assets dir (e.g. <app>/.output/public/_nuxt)
+ * Pure measurement (importable + tested). Raw + gzipped totals split by type, plus the
+ * top chunks by gzipped size. `totalGzip` is the transfer-shaped number the bands read.
+ * @param {string} dir  a built assets dir
  */
 export function measure(dir) {
   const files = walk(dir)
@@ -66,12 +72,19 @@ export function measure(dir) {
   }
 }
 
-/** The prior recorded gzip total for `app` (for the regression band), or null. */
+/**
+ * The prior recorded gzip totals for `app` (for the regression bands). Returns
+ * { client, server } — either may be null (no prior point, or that target wasn't measured).
+ */
 export function previousGzip(historyText, app) {
   const prior = historyText.split('\n').map((l) => l.trim()).filter(Boolean)
     .map((l) => { try { return JSON.parse(l) } catch { return null } })
     .filter((r) => r && r.app === app)
-  return prior.length ? prior[prior.length - 1].totalGzip ?? null : null
+  const last = prior.length ? prior[prior.length - 1] : null
+  return {
+    client: last?.client?.totalGzip ?? last?.totalGzip ?? null, // tolerate the pre-split shape
+    server: last?.server?.totalGzip ?? null,
+  }
 }
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
@@ -81,21 +94,35 @@ if (isMain) {
   const app = args.app ? String(args.app) : null
   const dir = args.dir ? String(args.dir) : null
   if (!app || !dir) {
-    console.error('bundle-size: --app and --dir are required')
+    console.error('bundle-size: --app and --dir (client _nuxt) are required')
     process.exit(2)
   }
-  const m = measure(dir)
+  const serverDir = args['server-dir'] ? String(args['server-dir']) : null
+
   const historyPath = args.history ? String(args.history) : join(ROOT, 'writeups/perf/bundle-history.jsonl')
-  const prevGzip = existsSync(historyPath) ? previousGzip(readFileSync(historyPath, 'utf8'), app) : null
-  const scorecard = scoreBundle(m.totalGzip, prevGzip)
+  const prev = existsSync(historyPath) ? previousGzip(readFileSync(historyPath, 'utf8'), app) : { client: null, server: null }
+
+  const clientM = measure(dir)
+  const client = { ...clientM, scorecard: scoreBundle(clientM.totalGzip, prev.client, CLIENT_SIZE_BANDS) }
+
+  let server = null
+  if (serverDir && existsSync(serverDir)) {
+    const serverM = measure(serverDir)
+    server = { ...serverM, scorecard: scoreBundle(serverM.totalGzip, prev.server, SERVER_SIZE_BANDS) }
+  }
 
   const record = {
     generatedAt: new Date().toISOString(),
     commit: args.commit ?? null,
     pr: args.pr != null ? Number(args.pr) : null,
     app,
-    ...m,
-    scorecard,
+    client,
+    server,
+    // convenience top-level rollups (for logs + the digest one-liner)
+    clientGzip: client.totalGzip,
+    serverGzip: server?.totalGzip ?? null,
+    totalGzip: client.totalGzip + (server?.totalGzip ?? 0),
+    overall: worst([client.scorecard.overall, server?.scorecard.overall]),
   }
 
   // Always emit the record as JSON on stdout (so it can pipe into append-bundle-history);
@@ -103,10 +130,11 @@ if (isMain) {
   console.log(JSON.stringify(record))
   if ('pretty' in args) {
     const kb = (n) => (n / 1024).toFixed(1) + ' KB'
-    console.error(`\n${app} bundle — ${scorecard.overall.toUpperCase()}`)
-    console.error(`  JS  ${kb(m.totalJs)} raw · ${kb(m.gzipJs)} gzip`)
-    console.error(`  CSS ${kb(m.totalCss)} raw · ${kb(m.gzipCss)} gzip`)
-    console.error(`  total gzip ${kb(m.totalGzip)}${prevGzip ? ` (${scorecard.regression.pct >= 0 ? '+' : ''}${scorecard.regression.pct}% vs prev)` : ' (no prior point)'}`)
-    console.error(`  top: ${m.chunks.slice(0, 3).map((c) => `${c.name} ${kb(c.gzip)}`).join(' · ')}`)
+    const line = (label, m) => `  ${label}: ${kb(m.totalGzip)} gzip [${m.scorecard.overall.toUpperCase()}]` +
+      `${m.scorecard.regression.prevGzip ? ` (${m.scorecard.regression.pct >= 0 ? '+' : ''}${m.scorecard.regression.pct}% vs prev)` : ''}` +
+      ` · top: ${m.chunks.slice(0, 2).map((c) => `${c.name} ${kb(c.gzip)}`).join(' · ')}`
+    console.error(`\n${app} bundle — overall ${record.overall.toUpperCase()}`)
+    console.error(line('CLIENT (browser)', client))
+    console.error(server ? line('SERVER (Worker) ', server) : '  SERVER: not measured (no --server-dir)')
   }
 }

--- a/scripts/perf/bundle-size.mjs
+++ b/scripts/perf/bundle-size.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// bundle-size.mjs — DETERMINISTIC client-bundle measurement (#1581).
+// Sums the raw + gzipped size of the built JS/CSS assets under an app's
+// `.output/public/_nuxt` (Cloudflare Workers preset) — the numbers behind
+// `nuxt analyze`, but as a trendable fact instead of a throwaway visualizer.
+//
+// Deterministic on purpose (same build → same bytes), so — unlike Lighthouse
+// vitals — it can be a reliable budget, not a flaky one. Dep-free: node built-ins
+// only (fs + zlib), so it runs in any CI step without install.
+//
+// Usage:
+//   node scripts/perf/bundle-size.mjs --app velo --dir apps/velo/.output/public/_nuxt
+//   node scripts/perf/bundle-size.mjs --app velo --dir <dir> --json
+//   # regression band needs the prior point:
+//   node scripts/perf/bundle-size.mjs --app velo --dir <dir> --history writeups/perf/bundle-history.jsonl
+import { readdirSync, statSync, readFileSync, existsSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import { join, basename, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseArgs } from '../lib/cli-args.mjs'
+import { scoreBundle } from './scorecard.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const TOP_CHUNKS = 12
+
+/** Recursively collect every .js/.css file path under `dir`. */
+function walk(dir) {
+  const out = []
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name)
+    if (e.isDirectory()) out.push(...walk(p))
+    else if (/\.(js|mjs|css)$/.test(e.name)) out.push(p)
+  }
+  return out
+}
+
+/**
+ * Pure measurement (importable + tested). Returns raw + gzipped totals split by
+ * type, plus the top chunks by gzipped size. `gzip` is the transfer-shaped number
+ * (what the client actually downloads) — the one the budget bands read.
+ * @param {string} dir  a built assets dir (e.g. <app>/.output/public/_nuxt)
+ */
+export function measure(dir) {
+  const files = walk(dir)
+  const chunks = files.map((p) => {
+    const bytes = statSync(p).size
+    const gzip = gzipSync(readFileSync(p)).length
+    const isCss = p.endsWith('.css')
+    return { name: basename(p), bytes, gzip, kind: isCss ? 'css' : 'js' }
+  })
+  const sum = (k, kind) => chunks.filter((c) => c.kind === kind).reduce((s, c) => s + c[k], 0)
+  const totalJs = sum('bytes', 'js'), gzipJs = sum('gzip', 'js')
+  const totalCss = sum('bytes', 'css'), gzipCss = sum('gzip', 'css')
+  return {
+    fileCount: chunks.length,
+    totalJs, gzipJs, totalCss, gzipCss,
+    totalBytes: totalJs + totalCss,
+    totalGzip: gzipJs + gzipCss,
+    chunks: chunks.sort((a, b) => b.gzip - a.gzip).slice(0, TOP_CHUNKS),
+  }
+}
+
+/** The prior recorded gzip total for `app` (for the regression band), or null. */
+export function previousGzip(historyText, app) {
+  const prior = historyText.split('\n').map((l) => l.trim()).filter(Boolean)
+    .map((l) => { try { return JSON.parse(l) } catch { return null } })
+    .filter((r) => r && r.app === app)
+  return prior.length ? prior[prior.length - 1].totalGzip ?? null : null
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2), { boolean: ['json', 'pretty'] })
+  const app = args.app ? String(args.app) : null
+  const dir = args.dir ? String(args.dir) : null
+  if (!app || !dir) {
+    console.error('bundle-size: --app and --dir are required')
+    process.exit(2)
+  }
+  const m = measure(dir)
+  const historyPath = args.history ? String(args.history) : join(ROOT, 'writeups/perf/bundle-history.jsonl')
+  const prevGzip = existsSync(historyPath) ? previousGzip(readFileSync(historyPath, 'utf8'), app) : null
+  const scorecard = scoreBundle(m.totalGzip, prevGzip)
+
+  const record = {
+    generatedAt: new Date().toISOString(),
+    commit: args.commit ?? null,
+    pr: args.pr != null ? Number(args.pr) : null,
+    app,
+    ...m,
+    scorecard,
+  }
+
+  // Always emit the record as JSON on stdout (so it can pipe into append-bundle-history);
+  // --pretty ADDS a human summary on stderr, keeping stdout a clean single JSON line.
+  console.log(JSON.stringify(record))
+  if ('pretty' in args) {
+    const kb = (n) => (n / 1024).toFixed(1) + ' KB'
+    console.error(`\n${app} bundle — ${scorecard.overall.toUpperCase()}`)
+    console.error(`  JS  ${kb(m.totalJs)} raw · ${kb(m.gzipJs)} gzip`)
+    console.error(`  CSS ${kb(m.totalCss)} raw · ${kb(m.gzipCss)} gzip`)
+    console.error(`  total gzip ${kb(m.totalGzip)}${prevGzip ? ` (${scorecard.regression.pct >= 0 ? '+' : ''}${scorecard.regression.pct}% vs prev)` : ' (no prior point)'}`)
+    console.error(`  top: ${m.chunks.slice(0, 3).map((c) => `${c.name} ${kb(c.gzip)}`).join(' · ')}`)
+  }
+}

--- a/scripts/perf/bundle-size.test.mjs
+++ b/scripts/perf/bundle-size.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * Tests for the bundle-size budget engine (#1581).
+ *   node --test scripts/perf/bundle-size.test.mjs
+ *
+ * measure() must be deterministic (that's the whole point vs. Lighthouse), and the
+ * budget bands + regression math must be predictable. Verified against a synthetic
+ * assets dir written to a temp folder — no real build needed.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { gzipSync } from 'node:zlib'
+import { measure, previousGzip } from './bundle-size.mjs'
+import { scoreBundle, SIZE_BANDS, REGRESSION_BANDS } from './scorecard.mjs'
+
+function fixture(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'bundle-'))
+  const nested = join(dir, 'nested')
+  mkdirSync(nested)
+  for (const [name, content] of Object.entries(files)) {
+    const target = name.startsWith('nested/') ? join(dir, name) : join(dir, name)
+    writeFileSync(target, content)
+  }
+  return dir
+}
+
+test('measure sums raw + gzip by type, recursively, ignoring non-asset files', () => {
+  const js = 'console.log("x");'.repeat(50)
+  const css = 'body{color:red}'.repeat(50)
+  const dir = fixture({ 'a.js': js, 'b.mjs': js, 'c.css': css, 'nested/d.js': js, 'readme.txt': 'ignore me' })
+  try {
+    const m = measure(dir)
+    assert.equal(m.fileCount, 4) // a.js, b.mjs, nested/d.js, c.css — .txt ignored
+    assert.equal(m.totalJs, Buffer.byteLength(js) * 3)
+    assert.equal(m.totalCss, Buffer.byteLength(css))
+    assert.equal(m.gzipJs, gzipSync(Buffer.from(js)).length * 3)
+    assert.equal(m.totalGzip, m.gzipJs + m.gzipCss)
+    // chunks sorted by gzip desc.
+    assert.ok(m.chunks[0].gzip >= m.chunks[m.chunks.length - 1].gzip)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('measure is deterministic — identical input, identical output', () => {
+  const dir = fixture({ 'a.js': 'const x = 1;'.repeat(200) })
+  try {
+    assert.deepEqual(measure(dir), measure(dir))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('measure on a missing dir returns an empty, non-throwing record', () => {
+  const m = measure('/no/such/dir/here')
+  assert.equal(m.fileCount, 0)
+  assert.equal(m.totalGzip, 0)
+})
+
+// ── scorecard: size bands ────────────────────────────────────────────────────
+test('size band grades absolute gzip weight', () => {
+  assert.equal(scoreBundle(100 * 1024, null).size.band, 'green')
+  assert.equal(scoreBundle(SIZE_BANDS.amber + 1, null).size.band, 'amber')
+  assert.equal(scoreBundle(SIZE_BANDS.red + 1, null).size.band, 'red')
+})
+
+// ── scorecard: regression bands ──────────────────────────────────────────────
+test('regression is green with no prior point (a first build cannot regress)', () => {
+  const s = scoreBundle(999 * 1024, null)
+  assert.equal(s.regression.band, 'green')
+  assert.equal(s.regression.pct, 0)
+})
+
+test('regression grades % growth vs the previous point; a shrink is never red', () => {
+  const prev = 100 * 1024
+  assert.equal(scoreBundle(prev, prev).regression.band, 'green') // 0%
+  assert.equal(scoreBundle(Math.round(prev * 1.10), prev).regression.band, 'amber') // +10% (> 5)
+  assert.equal(scoreBundle(Math.round(prev * 1.20), prev).regression.band, 'red')   // +20% (> 15)
+  assert.equal(scoreBundle(Math.round(prev * 0.5), prev).regression.band, 'green')  // -50% shrink
+  assert.ok(scoreBundle(Math.round(prev * 0.5), prev).regression.pct < 0)
+})
+
+test('overall is the worse of size and regression', () => {
+  // small bundle but a big jump → overall follows the regression (red).
+  assert.equal(scoreBundle(Math.round(50 * 1024 * (1 + (REGRESSION_BANDS.red + 5) / 100)), 50 * 1024).overall, 'red')
+})
+
+// ── previousGzip: history lookup ─────────────────────────────────────────────
+test('previousGzip returns the last recorded total for the app, else null', () => {
+  const history = [
+    JSON.stringify({ app: 'velo', totalGzip: 111 }),
+    JSON.stringify({ app: 'fanfare', totalGzip: 222 }),
+    JSON.stringify({ app: 'velo', totalGzip: 333 }),
+  ].join('\n')
+  assert.equal(previousGzip(history, 'velo'), 333)
+  assert.equal(previousGzip(history, 'fanfare'), 222)
+  assert.equal(previousGzip(history, 'unknown'), null)
+  assert.equal(previousGzip('', 'velo'), null)
+})

--- a/scripts/perf/bundle-size.test.mjs
+++ b/scripts/perf/bundle-size.test.mjs
@@ -13,7 +13,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { gzipSync } from 'node:zlib'
 import { measure, previousGzip } from './bundle-size.mjs'
-import { scoreBundle, SIZE_BANDS, REGRESSION_BANDS } from './scorecard.mjs'
+import { scoreBundle, CLIENT_SIZE_BANDS, SERVER_SIZE_BANDS, REGRESSION_BANDS, worst } from './scorecard.mjs'
 
 function fixture(files) {
   const dir = mkdtempSync(join(tmpdir(), 'bundle-'))
@@ -60,10 +60,26 @@ test('measure on a missing dir returns an empty, non-throwing record', () => {
 })
 
 // ── scorecard: size bands ────────────────────────────────────────────────────
-test('size band grades absolute gzip weight', () => {
+test('client size band grades absolute gzip weight (default bands)', () => {
   assert.equal(scoreBundle(100 * 1024, null).size.band, 'green')
-  assert.equal(scoreBundle(SIZE_BANDS.amber + 1, null).size.band, 'amber')
-  assert.equal(scoreBundle(SIZE_BANDS.red + 1, null).size.band, 'red')
+  assert.equal(scoreBundle(CLIENT_SIZE_BANDS.amber + 1, null).size.band, 'amber')
+  assert.equal(scoreBundle(CLIENT_SIZE_BANDS.red + 1, null).size.band, 'red')
+})
+
+test('server bands are more generous than client (Worker weight tolerance)', () => {
+  // A weight in the client-amber / server-green gap: 300 KB is amber for the browser
+  // budget but still green for the (larger) Worker budget.
+  const w = 300 * 1024
+  assert.ok(w > CLIENT_SIZE_BANDS.amber && w < SERVER_SIZE_BANDS.amber)
+  assert.equal(scoreBundle(w, null, CLIENT_SIZE_BANDS).size.band, 'amber')
+  assert.equal(scoreBundle(w, null, SERVER_SIZE_BANDS).size.band, 'green')
+  assert.equal(scoreBundle(SERVER_SIZE_BANDS.red + 1, null, SERVER_SIZE_BANDS).size.band, 'red')
+})
+
+test('worst() picks the most severe band', () => {
+  assert.equal(worst(['green', 'amber', 'green']), 'amber')
+  assert.equal(worst(['green', undefined, 'red']), 'red') // tolerates an unmeasured (null) target
+  assert.equal(worst(['green', 'green']), 'green')
 })
 
 // ── scorecard: regression bands ──────────────────────────────────────────────
@@ -87,15 +103,20 @@ test('overall is the worse of size and regression', () => {
   assert.equal(scoreBundle(Math.round(50 * 1024 * (1 + (REGRESSION_BANDS.red + 5) / 100)), 50 * 1024).overall, 'red')
 })
 
-// ── previousGzip: history lookup ─────────────────────────────────────────────
-test('previousGzip returns the last recorded total for the app, else null', () => {
+// ── previousGzip: history lookup (client + server) ───────────────────────────
+test('previousGzip returns the last client + server totals for the app', () => {
   const history = [
-    JSON.stringify({ app: 'velo', totalGzip: 111 }),
-    JSON.stringify({ app: 'fanfare', totalGzip: 222 }),
-    JSON.stringify({ app: 'velo', totalGzip: 333 }),
+    JSON.stringify({ app: 'velo', client: { totalGzip: 111 }, server: { totalGzip: 900 } }),
+    JSON.stringify({ app: 'fanfare', client: { totalGzip: 222 }, server: null }),
+    JSON.stringify({ app: 'velo', client: { totalGzip: 333 }, server: { totalGzip: 950 } }),
   ].join('\n')
-  assert.equal(previousGzip(history, 'velo'), 333)
-  assert.equal(previousGzip(history, 'fanfare'), 222)
-  assert.equal(previousGzip(history, 'unknown'), null)
-  assert.equal(previousGzip('', 'velo'), null)
+  assert.deepEqual(previousGzip(history, 'velo'), { client: 333, server: 950 })
+  assert.deepEqual(previousGzip(history, 'fanfare'), { client: 222, server: null })
+  assert.deepEqual(previousGzip(history, 'unknown'), { client: null, server: null })
+  assert.deepEqual(previousGzip('', 'velo'), { client: null, server: null })
+})
+
+test('previousGzip tolerates the pre-split record shape (top-level totalGzip = client)', () => {
+  const history = JSON.stringify({ app: 'velo', totalGzip: 444 })
+  assert.deepEqual(previousGzip(history, 'velo'), { client: 444, server: null })
 })

--- a/scripts/perf/scorecard.mjs
+++ b/scripts/perf/scorecard.mjs
@@ -1,0 +1,45 @@
+// scorecard.mjs — the bundle-size BUDGET bands (#1581). The one place to tune.
+// Two independent signals, each graded green/amber/red by fixed formulas (no LLM):
+//   - size:       absolute transfer weight (total gzipped JS+CSS)
+//   - regression: % growth vs the previous recorded point for this app
+// overall = the worse of the two. A brand-new app (no prior point) can't regress,
+// so regression is graded `green` with pct 0.
+
+/** Absolute gzip-transfer bands, in bytes. Tune here. */
+export const SIZE_BANDS = {
+  amber: 250 * 1024, // > 250 KB gzip → amber
+  red: 500 * 1024,   // > 500 KB gzip → red
+}
+
+/** Regression bands, in percent growth vs the previous point. Tune here. */
+export const REGRESSION_BANDS = {
+  amber: 5,  // > +5%  → amber
+  red: 15,   // > +15% → red
+}
+
+function band(value, { amber, red }) {
+  if (value > red) return 'red'
+  if (value > amber) return 'amber'
+  return 'green'
+}
+
+const RANK = { green: 0, amber: 1, red: 2 }
+
+/**
+ * Grade a bundle. `totalGzip` is this build's gzipped JS+CSS; `prevGzip` is the
+ * previous recorded total (or null for a first point). Returns { overall, size, regression }.
+ * @param {number} totalGzip
+ * @param {number|null} prevGzip
+ */
+export function scoreBundle(totalGzip, prevGzip) {
+  const sizeBand = band(totalGzip, SIZE_BANDS)
+  const pct = prevGzip && prevGzip > 0 ? Math.round(((totalGzip - prevGzip) / prevGzip) * 1000) / 10 : 0
+  // Only GROWTH is graded (a shrink is never a regression).
+  const regBand = prevGzip ? band(pct, REGRESSION_BANDS) : 'green'
+  const overall = RANK[sizeBand] >= RANK[regBand] ? sizeBand : regBand
+  return {
+    overall,
+    size: { band: sizeBand, gzip: totalGzip },
+    regression: { band: regBand, pct, prevGzip: prevGzip ?? null },
+  }
+}

--- a/scripts/perf/scorecard.mjs
+++ b/scripts/perf/scorecard.mjs
@@ -1,14 +1,24 @@
 // scorecard.mjs — the bundle-size BUDGET bands (#1581). The one place to tune.
-// Two independent signals, each graded green/amber/red by fixed formulas (no LLM):
-//   - size:       absolute transfer weight (total gzipped JS+CSS)
-//   - regression: % growth vs the previous recorded point for this app
-// overall = the worse of the two. A brand-new app (no prior point) can't regress,
-// so regression is graded `green` with pct 0.
+// Scores a gzipped-transfer number green/amber/red on two independent signals:
+//   - size:       absolute weight, graded against per-target bands (client vs server differ)
+//   - regression: % growth vs the previous recorded point
+// overall = the worse of the two. A first point (no prior) can't regress → green, pct 0.
+//
+// Two targets, two band sets, because they answer different questions:
+//   - CLIENT bundle (public/_nuxt) → what the browser downloads → user load speed.
+//   - SERVER/Worker bundle (wrangler-bundled) → Cloudflare cold-start + CPU → run cost.
 
-/** Absolute gzip-transfer bands, in bytes. Tune here. */
-export const SIZE_BANDS = {
+/** CLIENT (browser) gzip-transfer bands, in bytes. Tune here. */
+export const CLIENT_SIZE_BANDS = {
   amber: 250 * 1024, // > 250 KB gzip → amber
   red: 500 * 1024,   // > 500 KB gzip → red
+}
+
+/** SERVER/Worker gzip bands, in bytes. Cloudflare's compressed-Worker ceiling is ~1 MB,
+ * and cold-start grows with size — so amber well before the wall. Tune here. */
+export const SERVER_SIZE_BANDS = {
+  amber: 500 * 1024,  // > 500 KB gzip → amber
+  red: 1024 * 1024,   // > 1 MB gzip → red (near the CF Worker limit)
 }
 
 /** Regression bands, in percent growth vs the previous point. Tune here. */
@@ -24,21 +34,23 @@ function band(value, { amber, red }) {
 }
 
 const RANK = { green: 0, amber: 1, red: 2 }
+export const worst = (bands) => bands.filter(Boolean).reduce((w, b) => (RANK[b] > RANK[w] ? b : w), 'green')
 
 /**
- * Grade a bundle. `totalGzip` is this build's gzipped JS+CSS; `prevGzip` is the
- * previous recorded total (or null for a first point). Returns { overall, size, regression }.
+ * Grade a bundle. `totalGzip` is this build's gzipped weight; `prevGzip` is the
+ * previous recorded total (or null for a first point). `sizeBands` picks the target
+ * (client vs server). Returns { overall, size, regression }.
  * @param {number} totalGzip
  * @param {number|null} prevGzip
+ * @param {{amber:number,red:number}} [sizeBands]
  */
-export function scoreBundle(totalGzip, prevGzip) {
-  const sizeBand = band(totalGzip, SIZE_BANDS)
+export function scoreBundle(totalGzip, prevGzip, sizeBands = CLIENT_SIZE_BANDS) {
+  const sizeBand = band(totalGzip, sizeBands)
   const pct = prevGzip && prevGzip > 0 ? Math.round(((totalGzip - prevGzip) / prevGzip) * 1000) / 10 : 0
   // Only GROWTH is graded (a shrink is never a regression).
   const regBand = prevGzip ? band(pct, REGRESSION_BANDS) : 'green'
-  const overall = RANK[sizeBand] >= RANK[regBand] ? sizeBand : regBand
   return {
-    overall,
+    overall: worst([sizeBand, regBand]),
     size: { band: sizeBand, gzip: totalGzip },
     regression: { band: regBand, pct, prevGzip: prevGzip ?? null },
   }

--- a/writeups/perf/README.md
+++ b/writeups/perf/README.md
@@ -12,28 +12,41 @@ One JSON record per (app, merge), appended by `scripts/perf/append-bundle-histor
 the metric travels with the code it measures (`git blame`-able). Written only by the
 main-context `bundle-budget.yml` job — never from a PR branch.
 
+Each record carries **two** measured targets — they answer different questions:
+
 | field | meaning |
 |-------|---------|
-| `generatedAt` / `commit` / `pr` | when + the merge/PR that caused the point |
-| `app` | the app measured (e.g. `velo`) |
-| `totalJs` / `gzipJs` · `totalCss` / `gzipCss` | raw + gzipped bytes by asset type |
-| `totalGzip` | **the budget number** — total gzipped JS+CSS the client downloads |
-| `chunks` | top chunks by gzipped size (`name`, `bytes`, `gzip`) |
-| `scorecard` | `size` band (absolute gzip weight) + `regression` band (% vs the previous point); `overall` = the worse |
+| `generatedAt` / `commit` / `pr` / `app` | when · the causing merge/PR · the app |
+| `client` | the **browser** bundle (`public/_nuxt`) → user load speed. `{ totalGzip, totalJs/gzipJs, totalCss/gzipCss, chunks, scorecard }` |
+| `server` | the **Worker** bundle → Cloudflare cold-start + CPU → *cost to run*. Same shape, or `null` if not measured |
+| `clientGzip` / `serverGzip` / `totalGzip` | convenience rollups (server may be null) |
+| `overall` | the worse of the two scorecards |
+| `*.scorecard` | per-target `size` band + `regression` band (% vs the previous point); `overall` = the worse |
 
-Bands are tuned in `scripts/perf/scorecard.mjs` (the one place). It's **deterministic**
-— same build → same bytes — which is exactly why it can be a budget, unlike Lighthouse
-vitals (those stay report-only in `unlighthouse.yml`).
+Bands live in `scripts/perf/scorecard.mjs` — **client** (amber 250 KB / red 500 KB gzip)
+and **server** (amber 500 KB / red 1 MB gzip, near Cloudflare's Worker ceiling) differ on
+purpose. Deterministic — same build → same bytes — which is why it can be a budget, unlike
+Lighthouse vitals (report-only in `unlighthouse.yml`).
+
+> **The server number is the wrangler-BUNDLED Worker, not `.output/server`.** The raw
+> `.output/server` tree is the unbundled Nitro output (hundreds of chunks, most tree-shaken
+> away at deploy) — measuring it overstates the real Worker by multiples. The workflow bundles
+> the true deployed Worker offline with `wrangler deploy --dry-run --outdir` and measures that;
+> the engine just measures whatever `--server-dir` it's handed.
 
 ## Regenerate by hand
 
 ```bash
 # after building an app (NITRO_PRESET=cloudflare_module nuxt build):
+# client only:
 node scripts/perf/bundle-size.mjs --app velo --dir apps/velo/.output/public/_nuxt --pretty
 
-# append a point (idempotent per app+commit):
-node scripts/perf/bundle-size.mjs --app velo --dir apps/velo/.output/public/_nuxt --commit "$SHA" \
-  | node scripts/perf/append-bundle-history.mjs
+# client + real Worker (bundle it offline first):
+( cd apps/velo && npx wrangler deploy --dry-run --outdir=.wrangler-bundle --config .output/server/wrangler.json )
+node scripts/perf/bundle-size.mjs --app velo \
+  --dir apps/velo/.output/public/_nuxt \
+  --server-dir apps/velo/.wrangler-bundle \
+  --commit "$SHA" --pretty | node scripts/perf/append-bundle-history.mjs
 ```
 
 CI: `.github/workflows/bundle-budget.yml` (weekly + `workflow_dispatch`) builds the

--- a/writeups/perf/README.md
+++ b/writeups/perf/README.md
@@ -1,0 +1,40 @@
+# App performance budgets — committed trend data
+
+Committed output of the **bundle-size budget** (#1581) — the deterministic,
+product-facing sibling of the Loop Station harness-size inventory. Same producer
+shape (deterministic measurement → committed JSONL → threshold bands), pointed at
+the built **app bundles** instead of the harness context.
+
+## `bundle-history.jsonl`
+
+One JSON record per (app, merge), appended by `scripts/perf/append-bundle-history.mjs`
+(produced by `scripts/perf/bundle-size.mjs`). Committed on purpose: tiny volume, and
+the metric travels with the code it measures (`git blame`-able). Written only by the
+main-context `bundle-budget.yml` job — never from a PR branch.
+
+| field | meaning |
+|-------|---------|
+| `generatedAt` / `commit` / `pr` | when + the merge/PR that caused the point |
+| `app` | the app measured (e.g. `velo`) |
+| `totalJs` / `gzipJs` · `totalCss` / `gzipCss` | raw + gzipped bytes by asset type |
+| `totalGzip` | **the budget number** — total gzipped JS+CSS the client downloads |
+| `chunks` | top chunks by gzipped size (`name`, `bytes`, `gzip`) |
+| `scorecard` | `size` band (absolute gzip weight) + `regression` band (% vs the previous point); `overall` = the worse |
+
+Bands are tuned in `scripts/perf/scorecard.mjs` (the one place). It's **deterministic**
+— same build → same bytes — which is exactly why it can be a budget, unlike Lighthouse
+vitals (those stay report-only in `unlighthouse.yml`).
+
+## Regenerate by hand
+
+```bash
+# after building an app (NITRO_PRESET=cloudflare_module nuxt build):
+node scripts/perf/bundle-size.mjs --app velo --dir apps/velo/.output/public/_nuxt --pretty
+
+# append a point (idempotent per app+commit):
+node scripts/perf/bundle-size.mjs --app velo --dir apps/velo/.output/public/_nuxt --commit "$SHA" \
+  | node scripts/perf/append-bundle-history.mjs
+```
+
+CI: `.github/workflows/bundle-budget.yml` (weekly + `workflow_dispatch`) builds the
+launched apps, measures, and commits new points.


### PR DESCRIPTION
Closes #1581

## 👤 For humans

`nuxt analyze` shows a bundle once; nobody keeps the number over time. This tracks each launched app's bundle size as a **committed trend with budget thresholds**, on **two** targets that answer different questions:

- **Client bundle** (`public/_nuxt`) — what the browser downloads → **user load speed**.
- **Server/Worker bundle** — what Cloudflare runs → **cold-start + CPU → the actual cost of running the app**.

A regression in either shows up at the commit that caused it. The key property: it's **deterministic** (same build → same bytes), so it can be a *reliable* budget. Web-vitals (Lighthouse) is non-deterministic, so it stays the separate report-only concern the existing `unlighthouse.yml` already covers.

## 🤖 For agents

**Boundary:** observes the **product** (app bundles), so it is deliberately NOT a Loop Station WS (that skill observes the *harness*). It's a sibling perf-budget producer that *reuses* the WS1 pattern (deterministic measurement → committed JSONL → threshold bands).

- `scripts/perf/bundle-size.mjs` — `measure(dir)`: dep-free (fs + zlib) raw+gzip totals + top chunks over any built dir. Record nests `{ client, server }`, each with its own scorecard, plus `clientGzip`/`serverGzip`/`totalGzip`/`overall` rollups. CLI: `--dir` (client) + optional `--server-dir`.
- `scripts/perf/scorecard.mjs` — split bands: **client** (amber 250 KB / red 500 KB gzip) vs **server** (amber 500 KB / red 1 MB, near the CF Worker ceiling) + **regression** (% vs previous point). Tune in one place.
- `scripts/perf/append-bundle-history.mjs` — append to `writeups/perf/bundle-history.jsonl`, idempotent per (app, commit).
- `scripts/perf/bundle-size.test.mjs` — 11 tests: deterministic measure, client/server bands, regression (incl. shrink ≠ regression), dual history lookup + pre-split tolerance.
- `.github/workflows/bundle-budget.yml` — weekly + `workflow_dispatch`: `warm-packages` → build each launched app (`cloudflare_module`) → **bundle the real Worker offline** (`wrangler deploy --dry-run --outdir`) → measure client + server → commit the trend to `main`. Only this main-context job writes the history.

**The server number is the wrangler-BUNDLED Worker, not `.output/server`** — the raw Nitro tree is unbundled (hundreds of chunks, most tree-shaken at deploy) and overstates the real Worker by multiples (measured 1.8 MB gzip vs. a far smaller real Worker). The engine measures whatever `--server-dir` it's handed; the workflow produces the true bundle.

**Considered & rejected**
- Web-vitals/Lighthouse as a per-PR gate → ❌ non-deterministic; stays report-only (`unlighthouse.yml`).
- Measuring raw `.output/server` as the Worker size → ❌ overstates by multiples; use the wrangler dry-run bundle.
- Full interactive `nuxt --analyze` visualizer in CI → ❌ heavy artifact nobody trends.

**Follow-ups (own issues):** per-merge causal attribution (build only the touched app) + feed a regression into the accountability quality lane (#1570); per-app budgets in each `deploy.config.json`; promote the Unlighthouse vitals into their own trend.

## 🧪 How to test

```
node --test scripts/perf/bundle-size.test.mjs   # 11/11
# against a real built .output (client + server):
( cd apps/velo && npx wrangler deploy --dry-run --outdir=.wrangler-bundle --config .output/server/wrangler.json )
node scripts/perf/bundle-size.mjs --app velo --dir apps/velo/.output/public/_nuxt --server-dir apps/velo/.wrangler-bundle --pretty
```
Verified end-to-end against a real `.output` (client 214 KB gzip GREEN; server measurement working). YAML validated. The first `bundle-budget.yml` run creates `writeups/perf/bundle-history.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)