### PR TITLE
ci(root): feed /simplify verdict into the accountability scoreboard quality lane

### DIFF
--- a/.github/workflows/simplify-review.yml
+++ b/.github/workflows/simplify-review.yml
@@ -96,9 +96,11 @@ jobs:
                found nothing — the diff reads clean.
 
             2. **Write `simplify-verdict.json`** at the repo root, exactly:
-               `{"highest":"<none|note|warning>","warning":N,"note":N}`
-               where `highest` is the most severe finding's level (🟡→warning, 🔵→note, or `none`).
-               This is the machine signal the outage-check reads — always write it, even for a
+               `{"highest":"<none|note|warning>","warning":N,"note":N,"fixes":F}`
+               where `highest` is the most severe finding's level (🟡→warning, 🔵→note, or `none`),
+               and `fixes` is the TOTAL count of findings raised (`warning + note`; `0` for a clean
+               scan). `highest` is the signal the outage-check reads; `fixes` is the count the
+               accountability scoreboard's quality lane reads (#1584) — always write both, even for a
                clean scan.
 
             Do NOT edit any `apps/`/`packages/` code (quick scan is report-only; `--fix` is a
@@ -108,6 +110,32 @@ jobs:
       # Ship the payload-free invocation trace for the weekly usage rollup (#1064).
       - uses: ./.github/actions/loop-station-trace
         if: always()
+      # Feed the accountability scoreboard's QUALITY lane (#1584, engine from #1570/#1578).
+      # /simplify is a cleanup on CORRECT code, not a defect — so it captures with
+      # `--class quality`: any reported cleanup (verdict `fixes > 0`) becomes a low-severity
+      # candidate in the SEPARATE quality lane (author `Qual +1`, never their defect Net/Rate).
+      # Same shape as the frontend-review / a11y / red-team capture steps (#1578). The candidate
+      # is an artifact; the main-context rollup (loop-station-findings.yml) confirms it on the
+      # durable PR-merge fact (merged → the simplification was accepted) and commits — a
+      # PR-branch run never writes findings.jsonl. report-only: `continue-on-error` so a missing
+      # script (before #1578 lands) or any hiccup never turns the advisory /simplify job red.
+      - name: Capture finding candidate
+        if: always()
+        continue-on-error: true
+        run: |
+          node scripts/eval-ledger/capture-finding.mjs \
+            --gate simplify --class quality \
+            --verdict simplify-verdict.json \
+            --pr ${{ github.event.pull_request.number }} \
+            --author_ref https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} \
+            --out finding-candidate.json || true
+      - name: Upload finding candidate
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: loop-station-finding-${{ github.run_id }}
+          path: finding-candidate.json
+          if-no-files-found: ignore
       # Fail-open must be VISIBLE (#1037): when no verdict exists, classify why (billing /
       # max-turns / auth / silent no-write) and emit a warning annotation, so a dead agent
       # can't be mistaken for a clean scan. (This check never FAILS, but a silent no-write


### PR DESCRIPTION
Closes #1584 · part of #1570 · **depends on #1578**

## 👤 For humans

The per-PR `/simplify` check now feeds the accountability scoreboard. Because `/simplify` is a cleanup on *correct* code — not a defect gate — its findings go into a **separate low-weight "quality" lane**: an author earns `Qual +1` when a simplification is accepted (the PR merges), and **nobody's defect Net/Rate is ever touched**. It just calls the scoring engine that #1578 already built — no new pipeline.

## 🤖 For agents

Scope is **`.github/workflows/simplify-review.yml` only**. The scoring engine (`scripts/eval-ledger/*`, `loop-station-findings.yml`) is owned by #1570/#1578 and left untouched.

- **Verdict** now emits `fixes` (total findings = `warning + note`) alongside the existing `highest`/`warning`/`note`, so `capture-finding.mjs --class quality` writes a truthful note (`"N cleanup(s)"`) instead of the `highest !== 'none' ? 1` fallback.
- **Two capture steps** added after `loop-station-trace`, before `gate-outage-check` — identical shape to the frontend-review / a11y / red-team wiring in #1578:
  - `Capture finding candidate` → `capture-finding.mjs --gate simplify --class quality … --out finding-candidate.json` (`continue-on-error`).
  - `Upload finding candidate` → `loop-station-finding-${{ github.run_id }}` artifact (`if-no-files-found: ignore`).

### Dependency & safety

`capture-finding.mjs --class quality` lands via **#1578** (not on `main` yet). The capture step is `continue-on-error`, so this change is **inert until #1578 merges** — a missing script can never turn the advisory `/simplify` job red — and goes **live automatically** once #1578 is on `main`. No rollup changes: `loop-station-findings.yml` is gate-agnostic and already ingests any `loop-station-finding-*` artifact.

### Verified against #1578's actual script

Ran `origin/claude/loop-station-scoring-1k3box`'s `capture-finding.mjs` against this verdict format:

| Verdict | Result |
|---|---|
| `{"highest":"warning","warning":1,"note":1,"fixes":2}` | ✅ candidate: `class:quality`, `severity:low`, `status:pending`, note *"2 cleanup(s)"* |
| `{"highest":"none",…,"fixes":0}` | ✅ nothing captured — *"quality verdict reports 0 changes"* |

## 🧪 How to test

1. Open a PR touching code with a real simplification smell.
2. `Simplify Review (PR)` posts its advisory comment **and** (once #1578 is on `main`) uploads a `loop-station-finding-*` artifact with the pending quality candidate.
3. On merge, `loop-station-findings.yml` confirms it → the author gets `Qual +1` in the "🧹 Quality gates" lane; the defect leaderboard is unchanged.
4. A clean scan (`fixes:0`) uploads no candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_