### PR TITLE
refactor(root): flatten scoreboard tally()/validate() under fallow complexity threshold

### DIFF
--- a/scripts/eval-ledger/accountability.mjs
+++ b/scripts/eval-ledger/accountability.mjs
@@ -38,9 +38,11 @@ export function tally(findings, ledger) {
   const authors = new Map() // agent → { net, defects, clean, qualityFixes }
   const gates = new Map()   // agent → { net, catches, falsePositives }  (defect lane)
   const qGates = new Map()  // agent → { net, fixes }                    (quality lane)
-  const A = (a) => authors.get(a) || authors.set(a, { agent: a, net: 0, defects: 0, clean: 0, qualityFixes: 0 }).get(a)
-  const G = (g) => gates.get(g) || gates.set(g, { agent: g, net: 0, catches: 0, falsePositives: 0 }).get(g)
-  const Q = (g) => qGates.get(g) || qGates.set(g, { agent: g, net: 0, fixes: 0 }).get(g)
+  const acc = {
+    A: (a) => authors.get(a) || authors.set(a, { agent: a, net: 0, defects: 0, clean: 0, qualityFixes: 0 }).get(a),
+    G: (g) => gates.get(g) || gates.set(g, { agent: g, net: 0, catches: 0, falsePositives: 0 }).get(g),
+    Q: (g) => qGates.get(g) || qGates.set(g, { agent: g, net: 0, fixes: 0 }).get(g),
+  }
 
   const transactions = []
   // Author refs that carry a CONFIRMED DEFECT — these runs don't earn the clean reward.
@@ -52,35 +54,11 @@ export function tally(findings, ledger) {
     if (!isQuality && f.status === 'confirmed' && f.author_ref) dirtyRefs.add(f.author_ref)
     for (const t of transactionsFor(f)) {
       transactions.push({ ...t, ts: f.ts, gate: f.gate, severity: f.severity, class: f.class || 'defect' })
-      if (isQuality) {
-        // Quality lane: authors get a fix COUNT (not a net); the gate gets its own net.
-        if (t.role === 'author') { if (t.delta < 0) A(t.agent).qualityFixes++ }
-        else { const g = Q(t.agent); g.net += t.delta; if (t.delta > 0) g.fixes++ }
-      } else {
-        if (t.role === 'author') {
-          const a = A(t.agent)
-          a.net += t.delta
-          if (t.delta < 0) a.defects++
-        } else {
-          const g = G(t.agent)
-          g.net += t.delta
-          if (t.delta > 0) g.catches++
-          else if (t.delta < 0) g.falsePositives++
-        }
-      }
+      applyTransaction(t, isQuality, acc)
     }
   }
 
-  // Clean-merge author reward: a merged, successful run with no confirmed defect.
-  for (const r of ledger) {
-    if (r.outcome !== 'merged' || !isSuccess(r)) continue
-    if (r.ref && dirtyRefs.has(r.ref)) continue
-    const flow = r.flow
-    if (!flow) continue
-    const a = A(flow)
-    a.net += CLEAN_MERGE_REWARD
-    a.clean++
-  }
+  applyCleanMergeRewards(ledger, dirtyRefs, acc.A)
 
   const authorRows = [...authors.values()]
     .map((a) => ({ ...a, rate: a.defects + a.clean > 0 ? a.defects / (a.defects + a.clean) : 0 }))
@@ -91,6 +69,53 @@ export function tally(findings, ledger) {
     .sort((x, y) => y.net - x.net || x.agent.localeCompare(y.agent))
 
   return { authors: authorRows, gates: gateRows, qualityGates: qualityGateRows, transactions }
+}
+
+/**
+ * Route one scoring transaction into the right accumulator. Quality-class findings
+ * feed the separate low-weight lane; everything else feeds the defect board.
+ * `acc` bundles the get-or-create accessors `{ A, G, Q }`.
+ */
+function applyTransaction(t, isQuality, acc) {
+  if (isQuality) applyQualityTx(t, acc)
+  else applyDefectTx(t, acc)
+}
+
+/** Quality lane: authors accrue a fix COUNT (not a net); the gate gets its own net. */
+function applyQualityTx(t, { A, Q }) {
+  if (t.role === 'author') {
+    if (t.delta < 0) A(t.agent).qualityFixes++
+    return
+  }
+  const g = Q(t.agent)
+  g.net += t.delta
+  if (t.delta > 0) g.fixes++
+}
+
+/** Defect board: author −w / +clean-reward; gate +w for a catch, −w for a false positive. */
+function applyDefectTx(t, { A, G }) {
+  if (t.role === 'author') {
+    const a = A(t.agent)
+    a.net += t.delta
+    if (t.delta < 0) a.defects++
+    return
+  }
+  const g = G(t.agent)
+  g.net += t.delta
+  if (t.delta > 0) g.catches++
+  else if (t.delta < 0) g.falsePositives++
+}
+
+/** Clean-merge author reward: a merged, successful run with no confirmed defect. */
+function applyCleanMergeRewards(ledger, dirtyRefs, A) {
+  for (const r of ledger) {
+    if (r.outcome !== 'merged' || !isSuccess(r)) continue
+    if (r.ref && dirtyRefs.has(r.ref)) continue
+    if (!r.flow) continue
+    const a = A(r.flow)
+    a.net += CLEAN_MERGE_REWARD
+    a.clean++
+  }
 }
 
 // ── CLI ───────────────────────────────────────────────────────────────────────

--- a/scripts/eval-ledger/findings-schema.mjs
+++ b/scripts/eval-ledger/findings-schema.mjs
@@ -72,11 +72,22 @@ const REQUIRED_STR = ['ts', 'gate']
  * @param {any} rec
  */
 export function validate(rec) {
-  const errors = []
   if (rec == null || typeof rec !== 'object') {
     return { ok: false, errors: ['record is not an object'] }
   }
 
+  const errors = []
+  checkRawFields(rec, errors)
+  const withDefaults = applyDefaults(rec)
+  checkEnums(withDefaults, errors)
+  checkAttribution(withDefaults, errors)
+
+  if (errors.length) return { ok: false, errors }
+  return { ok: true, record: withDefaults }
+}
+
+/** Required non-empty strings + a parseable timestamp, read off the RAW record. */
+function checkRawFields(rec, errors) {
   for (const k of REQUIRED_STR) {
     if (typeof rec[k] !== 'string' || rec[k].length === 0) {
       errors.push(`"${k}" is required and must be a non-empty string`)
@@ -85,8 +96,11 @@ export function validate(rec) {
   if (typeof rec.ts === 'string' && Number.isNaN(Date.parse(rec.ts))) {
     errors.push(`"ts" is not a parseable ISO-8601 date: ${rec.ts}`)
   }
+}
 
-  const withDefaults = {
+/** Fill every optional field with its default; `escaped` normalizes to a strict boolean. */
+function applyDefaults(rec) {
+  return {
     ts: rec.ts,
     gate: rec.gate,
     severity: rec.severity ?? 'medium',
@@ -100,20 +114,22 @@ export function validate(rec) {
     finding_ref: rec.finding_ref ?? null,
     notes: rec.notes ?? null,
   }
+}
 
+/** Every enum-typed field must hold one of its allowed values. */
+function checkEnums(withDefaults, errors) {
   for (const k of ['severity', 'status', 'confirmed_via', 'class']) {
     if (!ENUMS[k].includes(withDefaults[k])) {
       errors.push(`"${k}" must be one of ${JSON.stringify(ENUMS[k])} (got ${JSON.stringify(withDefaults[k])})`)
     }
   }
+}
 
-  // An attributable finding needs SOMETHING to blame — a ledger ref or a flow.
+/** A confirmed, caught finding needs SOMETHING to blame — a ledger ref or a flow. */
+function checkAttribution(withDefaults, errors) {
   if (withDefaults.status === 'confirmed' && !withDefaults.author_ref && !withDefaults.author_flow && !withDefaults.escaped) {
     errors.push('a confirmed, caught finding needs "author_ref" or "author_flow" to attribute the −w')
   }
-
-  if (errors.length) return { ok: false, errors }
-  return { ok: true, record: withDefaults }
 }
 
 /** @param {FindingRecord} f — is this finding one that moves the board? */


### PR DESCRIPTION
Closes #1586 · follow-up to #1570 / #1578

## 👤 For humans

#1578 merged with a red diff-scoped `Fallow Audit` — two functions in the scoreboard engine tripped the CRITICAL complexity threshold. This is the cleanup: both are split into small, single-purpose helpers. **Pure refactor — the scoring is identical**: all 22 tests stay green and the CLI board renders byte-for-byte the same. The payoff is that a future edit to `scripts/eval-ledger/*` won't re-trip the gate, and the engine reads cleaner.

## 🤖 For agents

Behaviour-preserving extract-method, **no scoring-model change**:

- **`accountability.mjs` `tally()`** (was cyclomatic 21 / cognitive 51) — the `isQuality × role × delta` branching is out of the loop body. Extracted `applyTransaction` → `applyQualityTx` / `applyDefectTx`, plus `applyCleanMergeRewards`; the get-or-create accessors travel as an `acc = { A, G, Q }` bundle. `tally()` is now a thin orchestrator: loop → dispatch → rewards → sort → return.
- **`findings-schema.mjs` `validate()`** (was cyclomatic 24 / cognitive 23) — split into `checkRawFields` / `applyDefaults` / `checkEnums` / `checkAttribution`. Same `errors[]`, same filled defaults, same `{ ok, record }` / `{ ok, errors }` return.

### Verification

| Check | Before (#1578) | After |
|---|---|---|
| `npx fallow audit` (diff-scoped, = CI gate) | ✗ `complexity: 2 CRITICAL findings` | ✅ **No issues in 2 changed files** |
| `node --test accountability.test.mjs` | 22/22 | 22/22 |
| `accountability.mjs` CLI board (markdown/json/html) | — | byte-identical output |

Not `packages/` (no edit-guard); not test-first-gated — the existing 22-test suite is the behaviour contract and stayed green throughout.

## 🧪 How to test

```
node --test scripts/eval-ledger/accountability.test.mjs   # 22/22
node scripts/eval-ledger/accountability.mjs               # same two leaderboards as before
npx fallow audit                                          # clean on the 2 changed files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5kjVUwP96VpCha11hsjg6)_