### PR TITLE
Themes own their complete base UI token set + playground on themes.pmcp.dev (epic #1593)

### DIFF
--- a/.github/workflows/deploy-themes-playground.yml
+++ b/.github/workflows/deploy-themes-playground.yml
@@ -1,0 +1,69 @@
+name: Deploy Themes Playground
+
+# Self-contained Workers deploy for the crouton-themes PLAYGROUND (#1598), the
+# theme sign-off surface at themes.pmcp.dev. Modeled on deploy-docs.yml — the
+# playground is NOT an apps/<name> app, so it is NOT picked up by the generic
+# deploy-apps.yml (which scans apps/*/deploy.config.json). It's a public gallery
+# with no DB/KV/auth, single env, so nitro's cloudflare_module preset generates
+# the deploy config and we `wrangler deploy` directly.
+#
+# Trunk = staging (#347): a themes change ships continuously on merge to main, so
+# the gallery always reflects the current themes. themes.pmcp.dev is a staging
+# preview domain (public gallery) — NOT a #318 prod cash-register app, so this is
+# not the prod gate.
+#
+# The custom domain (themes.pmcp.dev, custom_domain route in the playground's
+# wrangler.jsonc) auto-attaches on deploy; repo-level CLOUDFLARE_* secrets carry
+# the zone DNS/Routes edit scope pmcp.dev needs.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/crouton-themes/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-themes-playground.yml'
+  pull_request:
+    paths:
+      - 'packages/crouton-themes/**'
+      - '.github/workflows/deploy-themes-playground.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy themes playground to Cloudflare Workers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      NODE_OPTIONS: '--max-old-space-size=8192'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # build (cloudflare_module → nitro writes .output/server/wrangler.json,
+      # picking up the custom_domain route) then deploy. cf:staging runs from the
+      # playground dir, so `wrangler deploy` reads that package's wrangler.jsonc.
+      - name: Build + deploy
+        if: github.event_name != 'pull_request'
+        run: pnpm --filter crouton-themes-playground cf:staging
+
+      # On PRs, build only (no deploy) as a smoke test that the cloudflare_module
+      # build succeeds.
+      - name: Build only (PR smoke test)
+        if: github.event_name == 'pull_request'
+        run: NITRO_PRESET=cloudflare_module pnpm --filter crouton-themes-playground build

--- a/packages/crouton-admin/app/composables/useTeamTheme.ts
+++ b/packages/crouton-admin/app/composables/useTeamTheme.ts
@@ -197,12 +197,18 @@ export function applyThemeSettings(settings: TeamThemeSettings, colorMode?: { pr
   }
 
   if (import.meta.client) {
-    document.documentElement.style.setProperty('--ui-radius', `${radius}rem`)
-    // Set data-theme for ambient CSS (e.g. background colors, global font overrides)
+    // Set data-theme for ambient CSS (background, fonts) — and let radius follow
+    // the right owner (#1595). A preset theme declares its own --ui-radius base
+    // token in CSS (#1594); an inline style would BEAT that stylesheet rule, so
+    // for a preset we must NOT set radius inline — clear any left by a prior
+    // custom selection so the theme's token wins. Only "custom" (the slider)
+    // owns radius inline.
     if (preset === 'custom') {
+      document.documentElement.style.setProperty('--ui-radius', `${radius}rem`)
       document.documentElement.removeAttribute('data-theme')
     }
     else {
+      document.documentElement.style.removeProperty('--ui-radius')
       document.documentElement.dataset.theme = preset
     }
   }

--- a/packages/crouton-admin/app/plugins/team-theme.ts
+++ b/packages/crouton-admin/app/plugins/team-theme.ts
@@ -7,6 +7,7 @@
  */
 import type { TeamThemeSettings } from '../composables/useTeamTheme'
 import { applyThemeSettings } from '../composables/useTeamTheme'
+import { THEME_PRESET_REGISTRY, type ThemePresetName } from '@fyit/crouton-themes/presets'
 
 export default defineNuxtPlugin({
   name: 'team-theme',
@@ -33,12 +34,43 @@ export default defineNuxtPlugin({
       themeFetched.value = true
     }
 
-    applyThemeSettings(themeState.value, useColorMode())
-
     // Expose the allowUserThemes flag so crouton-auth components can read it
     // without importing from crouton-admin. Defaults to true when not set.
     const allowUserThemes = useState<boolean>('crouton:allowUserThemes', () => true)
     allowUserThemes.value = themeState.value.allowUserThemes ?? true
+
+    // The team theme is the BASE; a user's personal pick (the theme pill →
+    // @fyit/crouton-themes useThemeSwitcher, saved in localStorage) WINS on
+    // reload when the team allows it (#1596). Without this the plugin re-applied
+    // the team theme on every load and stomped the override. Resolve it
+    // client-side only — the server can't read localStorage, so SSR paints the
+    // team theme and the override settles just after hydration (one frame, like
+    // any localStorage theme restore). ⚠️ When no override is stored, `effective`
+    // stays `themeState.value`, i.e. byte-for-byte the previous behaviour.
+    let effective: TeamThemeSettings = themeState.value
+    if (import.meta.client) {
+      // Keys owned by useThemeSwitcher: STORAGE_KEY 'nuxt-crouton-theme' + the
+      // 'crouton-theme' useState. We sync the state so the pill highlights the
+      // active theme AND useThemeSwitcher's own onMounted restore becomes a
+      // no-op (its guard is storedTheme !== currentTheme) — no double-apply.
+      const stored = localStorage.getItem('nuxt-crouton-theme')
+      const validOverride = !!stored && stored !== 'default' && stored in THEME_PRESET_REGISTRY
+      if (allowUserThemes.value && validOverride) {
+        effective = { ...themeState.value, preset: stored as ThemePresetName }
+      }
+      else if (!allowUserThemes.value && stored && stored !== 'default') {
+        // Locked (admins stay exempt via the switcher's canSwitchTheme, but the
+        // team theme is authoritative on load): drop a lingering personal
+        // override so it can't reappear on the next reload.
+        localStorage.setItem('nuxt-crouton-theme', 'default')
+      }
+      const activePreset = effective.preset && effective.preset !== 'custom'
+        ? effective.preset
+        : 'default'
+      useState<string>('crouton-theme').value = activePreset
+    }
+
+    applyThemeSettings(effective, useColorMode())
 
     // Fetch site settings (for custom favicon) and apply team favicon
     const siteSettings = useState<{ favicon?: string } | null>('team-site-settings', () => null)

--- a/packages/crouton-admin/app/plugins/team-theme.ts
+++ b/packages/crouton-admin/app/plugins/team-theme.ts
@@ -9,6 +9,54 @@ import type { TeamThemeSettings } from '../composables/useTeamTheme'
 import { applyThemeSettings } from '../composables/useTeamTheme'
 import { THEME_PRESET_REGISTRY, type ThemePresetName } from '@fyit/crouton-themes/presets'
 
+// Storage + state keys owned by @fyit/crouton-themes useThemeSwitcher (its
+// STORAGE_KEY + the 'crouton-theme' useState). Named here so the coupling is
+// explicit and greppable.
+const OVERRIDE_KEY = 'nuxt-crouton-theme'
+
+// The three deciders below are split into trivially-small pure functions on
+// purpose: the fallow CRAP gate degrades to cyc²+cyc at zero coverage, so each
+// unit stays tiny and independently testable (theme-override.test.ts).
+
+/** The user's saved pick, or null when none / 'default' / not a real preset. */
+function pickThemeOverride(stored: string | null, allowUserThemes: boolean): ThemePresetName | null {
+  if (!allowUserThemes || !stored || stored === 'default') return null
+  return stored in THEME_PRESET_REGISTRY ? (stored as ThemePresetName) : null
+}
+
+/** A locked team (allowUserThemes=false) drops a lingering saved override so it
+ *  can't reappear on the next reload (admins still preview live via the switcher). */
+function shouldClearOverride(stored: string | null, allowUserThemes: boolean): boolean {
+  return !allowUserThemes && !!stored && stored !== 'default'
+}
+
+/** The preset useThemeSwitcher's 'crouton-theme' state shows as active
+ *  ('default' for a custom/absent preset) — keeps the pill in sync and makes its
+ *  onMounted restore a no-op (guard: storedTheme !== currentTheme). */
+function activePresetName(theme: TeamThemeSettings): string {
+  const preset = theme.preset
+  return preset && preset !== 'custom' ? preset : 'default'
+}
+
+/**
+ * Resolve the theme to actually apply (#1596): the team theme is the BASE; a
+ * user's saved pick (the theme pill → useThemeSwitcher localStorage) WINS on
+ * reload when the team allows it — without this the plugin re-applied the team
+ * theme every load and stomped the override. Client-only — SSR paints the team
+ * theme and the override settles just after hydration (one frame, like any
+ * localStorage theme restore). ⚠️ No override stored ⇒ returns `teamTheme`
+ * unchanged, byte-for-byte the previous behaviour.
+ */
+function resolveEffectiveTheme(teamTheme: TeamThemeSettings, allowUserThemes: boolean): TeamThemeSettings {
+  if (!import.meta.client) return teamTheme
+  const stored = localStorage.getItem(OVERRIDE_KEY)
+  if (shouldClearOverride(stored, allowUserThemes)) localStorage.setItem(OVERRIDE_KEY, 'default')
+  const override = pickThemeOverride(stored, allowUserThemes)
+  const effective = override ? { ...teamTheme, preset: override } : teamTheme
+  useState<string>('crouton-theme').value = activePresetName(effective)
+  return effective
+}
+
 export default defineNuxtPlugin({
   name: 'team-theme',
   enforce: 'post',
@@ -39,37 +87,8 @@ export default defineNuxtPlugin({
     const allowUserThemes = useState<boolean>('crouton:allowUserThemes', () => true)
     allowUserThemes.value = themeState.value.allowUserThemes ?? true
 
-    // The team theme is the BASE; a user's personal pick (the theme pill →
-    // @fyit/crouton-themes useThemeSwitcher, saved in localStorage) WINS on
-    // reload when the team allows it (#1596). Without this the plugin re-applied
-    // the team theme on every load and stomped the override. Resolve it
-    // client-side only — the server can't read localStorage, so SSR paints the
-    // team theme and the override settles just after hydration (one frame, like
-    // any localStorage theme restore). ⚠️ When no override is stored, `effective`
-    // stays `themeState.value`, i.e. byte-for-byte the previous behaviour.
-    let effective: TeamThemeSettings = themeState.value
-    if (import.meta.client) {
-      // Keys owned by useThemeSwitcher: STORAGE_KEY 'nuxt-crouton-theme' + the
-      // 'crouton-theme' useState. We sync the state so the pill highlights the
-      // active theme AND useThemeSwitcher's own onMounted restore becomes a
-      // no-op (its guard is storedTheme !== currentTheme) — no double-apply.
-      const stored = localStorage.getItem('nuxt-crouton-theme')
-      const validOverride = !!stored && stored !== 'default' && stored in THEME_PRESET_REGISTRY
-      if (allowUserThemes.value && validOverride) {
-        effective = { ...themeState.value, preset: stored as ThemePresetName }
-      }
-      else if (!allowUserThemes.value && stored && stored !== 'default') {
-        // Locked (admins stay exempt via the switcher's canSwitchTheme, but the
-        // team theme is authoritative on load): drop a lingering personal
-        // override so it can't reappear on the next reload.
-        localStorage.setItem('nuxt-crouton-theme', 'default')
-      }
-      const activePreset = effective.preset && effective.preset !== 'custom'
-        ? effective.preset
-        : 'default'
-      useState<string>('crouton-theme').value = activePreset
-    }
-
+    // Team theme is the base; a user's saved override wins when allowed (#1596).
+    const effective = resolveEffectiveTheme(themeState.value, allowUserThemes.value)
     applyThemeSettings(effective, useColorMode())
 
     // Fetch site settings (for custom favicon) and apply team favicon

--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -465,6 +465,35 @@ Use theme-prefixed CSS custom properties:
 }
 ```
 
+## Base geometry token — `--ui-radius` (#1594)
+
+A theme's **border-radius is a base UI token it owns**, not something squared per
+named-variant. Nuxt UI derives its whole radius scale from one token —
+`--radius-sm: var(--ui-radius)`, `--radius-md: calc(var(--ui-radius) * 1.5)`,
+`--radius-lg: calc(var(--ui-radius) * 2)` (a `UCard` = `rounded-lg`) — so setting
+`--ui-radius` once re-shapes **every** rounded surface, including *calm/unmarked*
+ones (a plain `variant="soft"` card, e.g. the kassa POS rows). Squaring only via a
+theme's marker CSS (`.brutalist-card { border-radius:0 }`) reaches solely the
+components using that named variant, leaving calm surfaces at Nuxt UI's default
+`0.25rem` — the "themed chrome, rounded data rows" mismatch #1594 fixes.
+
+**Every theme declares `--ui-radius`** in an ambient block scoped to **both**
+activation paths (`[data-theme="x"]` app-preset + `.theme-x` switcher), next to its
+`--ui-*` color tokens. Current values (rounded themes tie it to their own radius
+token so `card = --ui-radius * 2` equals the theme's card/panel radius):
+
+| Theme | `--ui-radius` | | Theme | `--ui-radius` |
+|---|---|---|---|---|
+| minimal, brutalist, gameboy, terminal, eink, blueprint, mtv | `0` | | ko | `calc(var(--ko-wrapper-radius) / 2)` |
+| kr11 | `calc(var(--kr-card-radius) / 2)` | | braun | `calc(var(--braun-radius) / 2)` |
+| riso | `1px` (card 2px) | | blackandwhite | *(unset — deliberate `0.25rem` pass)* |
+
+**When adding a theme, set `--ui-radius`** — it's a base token, filled in first
+(before the named-variant CSS). ⚠️ The crouton-admin **team-preset** path
+(`applyThemeSettings`) sets `--ui-radius` **inline** on `<html>`, which beats a
+theme's stylesheet rule; #1595 makes presets defer to the theme's token (the
+inline set is kept only for the "custom" preset's radius slider).
+
 ## Chrome vs data (#1333)
 
 Themes style the **interaction chrome** — buttons, inputs, selects, textareas,

--- a/packages/crouton-themes/CLAUDE.md
+++ b/packages/crouton-themes/CLAUDE.md
@@ -494,6 +494,30 @@ token so `card = --ui-radius * 2` equals the theme's card/panel radius):
 theme's stylesheet rule; #1595 makes presets defer to the theme's token (the
 inline set is kept only for the "custom" preset's radius slider).
 
+## Complete base `--ui-*` token set per theme (#1597)
+
+Radius is one token of a set. A theme owns its **whole** base semantic layer so
+*calm/unmarked* surfaces read as the theme, not Nuxt UI's default slate. The
+canonical set every theme declares (ambient block, both `[data-theme="x"]` +
+`.theme-x`, both light **and** dark via #1395):
+
+- **surfaces** `--ui-bg`, `--ui-bg-muted`, `--ui-bg-elevated`, `--ui-bg-accented`
+- **text** `--ui-text-dimmed`, `--ui-text-muted`, `--ui-text-toned`, `--ui-text`, `--ui-text-highlighted`
+- **border** `--ui-border`, `--ui-border-muted`, `--ui-border-accented`
+- **geometry** `--ui-radius`
+
+Prefer mapping onto the theme's **own** palette vars (e.g. minimal → its
+`--minimal-gray-*` scale, brutalist → `var(--brutalist-paper)`) so the dual-scheme
+flip is inherited for free — one declaration covers light + dark. Literal hex is
+fine too but then the dark counterpart block must re-tune it. **`--ui-bg` (the base
+surface) is easy to forget** — several themes set the muted/elevated variants but
+not the base, leaving a `bg-default` surface Nuxt-UI-white; #1597 filled those.
+
+**blackandwhite is the one deliberate exception** — it drives its palette from the
+`neutral` color alias in its `app.config` (so `--ui-color-neutral-*` resolve the
+default tokens to greys) rather than declaring explicit `--ui-*`; leave it stock.
+When adding a theme, declare the full set (or, like bw, document why it derives them).
+
 ## Chrome vs data (#1333)
 
 Themes style the **interaction chrome** — buttons, inputs, selects, textareas,

--- a/packages/crouton-themes/blueprint/assets/css/main.css
+++ b/packages/crouton-themes/blueprint/assets/css/main.css
@@ -27,6 +27,9 @@
   background-size: 24px 24px;
   color: var(--bp-line);
   --ui-bg: var(--bp-blue);
+  /* Base geometry token (#1594): drafting-sheet line-work is square — drive
+     Nuxt UI's radius scale to 0 so calm surfaces square too. */
+  --ui-radius: 0;
 }
 
 /* ============================================

--- a/packages/crouton-themes/braun/assets/css/main.css
+++ b/packages/crouton-themes/braun/assets/css/main.css
@@ -29,6 +29,15 @@
   --ui-bg: var(--braun-cream);
 }
 
+/* Base geometry token (#1594): tie Nuxt UI's radius scale to the theme's own
+   machined radius so calm surfaces (unmarked cards/rows) match the chassis, not
+   just named variants. card = --ui-radius * 2 = braun-radius. Scoped to both
+   activation paths. */
+[data-theme="braun"],
+.theme-braun {
+  --ui-radius: calc(var(--braun-radius) / 2);
+}
+
 /* ============================================
    BUTTONS — machined keys
    ============================================ */

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -590,6 +590,9 @@
 
 [data-theme="brutalist"] body,
 body.theme-brutalist {
+  /* Base surface token (#1597): was unset, so a calm bg-default surface stayed
+     Nuxt UI white instead of the paper. Ref the paper var (flips in dark, #1395). */
+  --ui-bg: var(--brutalist-paper);
   --ui-text-dimmed: #75716a;
   --ui-text-muted: #5c5952;
   --ui-text-toned: #33312c;

--- a/packages/crouton-themes/brutalist/assets/css/main.css
+++ b/packages/crouton-themes/brutalist/assets/css/main.css
@@ -33,6 +33,14 @@
   background-color: var(--brutalist-paper);
 }
 
+/* Base geometry token (#1594): brutalism is hard square corners — drive Nuxt
+   UI's radius scale to 0 so calm surfaces (unmarked cards/rows) square too, not
+   just the theme's named variants. Scoped to both activation paths. */
+[data-theme="brutalist"],
+.theme-brutalist {
+  --ui-radius: 0;
+}
+
 /* Chrome without a variant hook (owner feedback on #1307: "the switcher could
    be more in style"). USwitch has no `variant` dimension, so the marker-gated
    replacer can never fire for it — theme it ambiently, scoped to the active

--- a/packages/crouton-themes/eink/assets/css/main.css
+++ b/packages/crouton-themes/eink/assets/css/main.css
@@ -20,6 +20,9 @@
 .theme-eink {
   background-color: var(--eink-paper);
   --ui-bg: var(--eink-paper);
+  /* Base geometry token (#1594): newspaper geometry is square — drive Nuxt UI's
+     radius scale to 0 so calm surfaces square too, not just named variants. */
+  --ui-radius: 0;
 }
 
 /* ============================================

--- a/packages/crouton-themes/gameboy/assets/css/main.css
+++ b/packages/crouton-themes/gameboy/assets/css/main.css
@@ -25,6 +25,9 @@
   background-color: var(--gb-3);
   color: var(--gb-0);
   --ui-bg: var(--gb-3);
+  /* Base geometry token (#1594): chunky pixel corners are square — drive Nuxt
+     UI's radius scale to 0 so calm surfaces square too, not just named variants. */
+  --ui-radius: 0;
 }
 
 /* ============================================

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -68,6 +68,15 @@
   background-color: var(--ko-surface-light);
 }
 
+/* Base geometry token (#1594): tie Nuxt UI's radius scale to the theme's own
+   panel radius so calm surfaces (unmarked cards/rows) match the hardware panels,
+   not just named variants. card = --ui-radius * 2 = ko-wrapper-radius. Scoped
+   to both activation paths. */
+[data-theme="ko"],
+.theme-ko {
+  --ui-radius: calc(var(--ko-wrapper-radius) / 2);
+}
+
 /* The display font is CHROME, not body copy (#1304 readability feedback):
    putting ko-tech on the root made every form label and paragraph read like
    a spec sheet. Scope it to headings + explicit .ko-font opt-ins; tactile

--- a/packages/crouton-themes/ko/assets/css/main.css
+++ b/packages/crouton-themes/ko/assets/css/main.css
@@ -868,6 +868,9 @@
 
 [data-theme="ko"] body,
 body.theme-ko {
+  /* Base surface token (#1597): ref the chassis var (flips in dark, #1395) so a
+     calm bg-default surface is the ko chassis, not Nuxt UI white. */
+  --ui-bg: var(--ko-surface-light);
   --ui-text-dimmed: #6b6763;
   --ui-text-muted: #57534f;
   --ui-text-toned: #4a4744;

--- a/packages/crouton-themes/kr11/assets/css/main.css
+++ b/packages/crouton-themes/kr11/assets/css/main.css
@@ -691,6 +691,9 @@
 
 [data-theme="kr11"] body,
 body.theme-kr11 {
+  /* Base surface token (#1597): ref the chassis var (flips in dark, #1395) so a
+     calm bg-default surface is the kr11 chassis, not Nuxt UI white. */
+  --ui-bg: var(--kr-chassis);
   --ui-text-dimmed: #8a8a86;
   --ui-text-muted: #666663;
   --ui-text-toned: #4c4c49;

--- a/packages/crouton-themes/kr11/assets/css/main.css
+++ b/packages/crouton-themes/kr11/assets/css/main.css
@@ -645,6 +645,10 @@
 [data-theme="kr11"],
 .theme-kr11 {
   background-color: var(--kr-chassis);
+  /* Base geometry token (#1594): tie Nuxt UI's radius scale to the theme's own
+     card radius so calm surfaces (unmarked cards/rows) match the tactile pads,
+     not just the theme's named variants. card = --ui-radius * 2 = kr-card-radius. */
+  --ui-radius: calc(var(--kr-card-radius) / 2);
 }
 
 /* USwitch as hardware: a cream pad track with an LED thumb — USwitch has

--- a/packages/crouton-themes/minimal/assets/css/main.css
+++ b/packages/crouton-themes/minimal/assets/css/main.css
@@ -548,6 +548,14 @@
    (no variant hook; scoped to both activation paths)
    ============================================ */
 
+/* Base geometry token (#1594): minimal is sharp square corners — drive Nuxt
+   UI's radius scale to 0 so calm surfaces (unmarked cards/rows) square too, not
+   just the theme's named variants. Scoped to both activation paths. */
+[data-theme="minimal"],
+.theme-minimal {
+  --ui-radius: 0;
+}
+
 [data-theme="minimal"] button[role="switch"],
 .theme-minimal button[role="switch"] {
   border-radius: 9999px;

--- a/packages/crouton-themes/minimal/assets/css/main.css
+++ b/packages/crouton-themes/minimal/assets/css/main.css
@@ -554,6 +554,22 @@
 [data-theme="minimal"],
 .theme-minimal {
   --ui-radius: 0;
+  /* Complete base palette (#1597): minimal declared no --ui-* surface/text/border
+     tokens, so calm surfaces fell back to Nuxt UI's default slate instead of its
+     own monochrome. Map them onto minimal's greyscale — which .dark flips
+     (#1395) — so both schemes follow from one declaration. */
+  --ui-bg: var(--minimal-white);
+  --ui-bg-muted: var(--minimal-gray-50);
+  --ui-bg-elevated: var(--minimal-gray-100);
+  --ui-bg-accented: var(--minimal-gray-200);
+  --ui-text-dimmed: var(--minimal-gray-400);
+  --ui-text-muted: var(--minimal-gray-500);
+  --ui-text-toned: var(--minimal-gray-600);
+  --ui-text: var(--minimal-gray-800);
+  --ui-text-highlighted: var(--minimal-black);
+  --ui-border: var(--minimal-gray-300);
+  --ui-border-muted: var(--minimal-gray-200);
+  --ui-border-accented: var(--minimal-gray-400);
 }
 
 [data-theme="minimal"] button[role="switch"],

--- a/packages/crouton-themes/mtv/assets/css/main.css
+++ b/packages/crouton-themes/mtv/assets/css/main.css
@@ -31,6 +31,9 @@
 [data-theme="mtv"],
 .theme-mtv {
   background-color: var(--mtv-paper);
+  /* Base geometry token (#1594): hard-edged slabs — drive Nuxt UI's radius
+     scale to 0 so calm surfaces square too, not just named variants. */
+  --ui-radius: 0;
 }
 
 /* ============================================

--- a/packages/crouton-themes/mtv/assets/css/main.css
+++ b/packages/crouton-themes/mtv/assets/css/main.css
@@ -559,6 +559,9 @@
 
 [data-theme="mtv"] body,
 body.theme-mtv {
+  /* Base surface token (#1597): ref the paper var (flips in dark, #1395) so a
+     calm bg-default surface is mtv paper, not Nuxt UI white. */
+  --ui-bg: var(--mtv-paper);
   --ui-text-dimmed: #7f7685;
   --ui-text-muted: #675f6d;
   --ui-text-toned: #3d3644;

--- a/packages/crouton-themes/playground/wrangler.jsonc
+++ b/packages/crouton-themes/playground/wrangler.jsonc
@@ -1,18 +1,20 @@
 {
   // Cloudflare WORKERS config for the crouton-themes PLAYGROUND (#1306).
   //
-  // Same shape as the (now-retired) minimal-theme-demo sandbox: a gallery has no
-  // auth, no DB, and no custom domain, so there are NO d1/kv bindings, NO routes,
-  // and NO env.staging block. It publishes to the zero-config *.workers.dev
-  // subdomain (workers_dev defaults true) — the deploy token needs only account
-  // Workers-Scripts edit, no zone/DNS scope, and there's nothing to auto-provision
-  // or migrate.
+  // A gallery has no auth, no DB — so NO d1/kv bindings and no migrations. It IS
+  // the theme sign-off surface, so it gets a stable custom domain,
+  // `themes.pmcp.dev` (single env — a public gallery has no per-PR data to
+  // isolate, so no separate env.staging block). The `custom_domain` route
+  // auto-attaches the domain (+ its DNS record) on deploy; the repo-level deploy
+  // token has the zone DNS/Routes edit scope pmcp.dev needs.
   //
   // Nitro's `cloudflare_module` preset (NITRO_PRESET in cf:staging) reads this
   // file at build time and writes the deployable config to
   // .output/server/wrangler.json, injecting `main` + the static `assets` binding
-  // automatically.
+  // automatically. `cf:staging` runs from this dir, so `wrangler deploy` also
+  // picks up the route below.
   "name": "crouton-themes-playground",
   "compatibility_date": "2025-07-15",
-  "compatibility_flags": ["nodejs_compat"]
+  "compatibility_flags": ["nodejs_compat"],
+  "routes": [{ "pattern": "themes.pmcp.dev", "custom_domain": true }]
 }

--- a/packages/crouton-themes/riso/assets/css/main.css
+++ b/packages/crouton-themes/riso/assets/css/main.css
@@ -28,6 +28,14 @@
   --ui-bg: var(--riso-paper);
 }
 
+/* Base geometry token (#1594): riso print has a tiny 2px radius — drive Nuxt
+   UI's radius scale so calm surfaces (unmarked cards/rows) match, not just the
+   theme's named variants (card = --ui-radius * 2 = 2px). Both activation paths. */
+[data-theme="riso"],
+.theme-riso {
+  --ui-radius: 1px;
+}
+
 /* ============================================
    BUTTONS — misregistered ink blocks
    The second color prints slightly OFF — that's the whole charm.

--- a/packages/crouton-themes/terminal/assets/css/main.css
+++ b/packages/crouton-themes/terminal/assets/css/main.css
@@ -29,6 +29,10 @@
   /* Drive Nuxt UI's surface token too — app shells (incl. the playground
      wrapper) paint with var(--ui-bg), which would otherwise stay light. */
   --ui-bg: var(--term-bg);
+  /* Base geometry token (#1594): a CRT has square corners — drive Nuxt UI's
+     radius scale to 0 so calm surfaces (unmarked cards/rows) square too, not
+     just the theme's named variants. */
+  --ui-radius: 0;
 }
 
 /* Scanlines: subtle, pure-CSS, on a non-interactive overlay. */


### PR DESCRIPTION
Epic #1593. Started from the kassa (`kassa.pmcp.dev`) where themed chrome was square/coloured but "calm" surfaces (the POS product rows) stayed rounded and default-slate — because themes weren't declaring their **base UI tokens**, only per-named-variant CSS.

## 👤 For humans
Every theme now owns its complete base design-token set, so calm/unmarked surfaces follow the theme instead of Nuxt UI's defaults; a user's theme pick survives a reload; and the themes playground gets a live URL to sign the work off on.

- **Radius follows the theme.** A squared theme (brutalist/minimal/gameboy/…) now squares *every* rounded surface, not just its own variant components; rounded themes round to their own radius.
- **Team presets keep the theme's geometry.** Picking a preset no longer forces the default radius over it (the slider is for "custom" only).
- **minimal got its whole palette** (it had none → calm surfaces were default slate); **brutalist/mtv/ko/kr11** got the base `--ui-bg` they were missing. Both light + dark.
- **User theme override persists** across reloads when the team allows it (was reverting to the team theme).
- **Playground → `themes.pmcp.dev`** on every merge, so the whole gallery is one click to review in both schemes.

## 🤖 For agents
Commits (kept separate — atomic, one concern each):
- `1a74102` **#1594** — base `--ui-radius` per theme (0 for squared; `calc(token/2)` tied to each rounded theme's own radius var, so dual-scheme is free).
- `2a20369` **#1595** — `applyThemeSettings` stops force-setting `--ui-radius` inline for presets (inline beat the stylesheet rule); custom-only inline.
- `6f81eab` **#1597** — complete base `--ui-*` set per theme (minimal full palette via its `--minimal-gray-*` scale; `--ui-bg` for the four themes that only had the muted/elevated variants). 11/12 complete; blackandwhite is the documented neutral-alias exception.
- `c596e41` **#1598** — playground custom_domain route + `deploy-themes-playground.yml` (modeled on `deploy-docs.yml`; not the #318 prod gate).
- `a847133` **#1596** — team-theme plugin resolves the user's saved override over the team theme (client-only; **no override stored ⇒ byte-for-byte the previous behaviour**).

Mechanic: `@nuxt/ui@4.9` derives `--radius-*` from `--ui-radius`; each theme maps `--ui-*` onto its own palette vars so `.dark` (#1395) flips both schemes from one declaration. Convention documented in `packages/crouton-themes/CLAUDE.md`. Typecheck green (fanfare).

Closes #1594
Closes #1595
Closes #1596
Closes #1597
Closes #1598

## 🧪 How to test
Once `themes.pmcp.dev` is live (deploys on merge), open `/crouton`, flip every theme in **light and dark**: calm cards + muted text + borders read as the theme's own palette; squared themes square the plain cards; minimal's calm surfaces are its greys, not slate. Locally: `pnpm --filter crouton-themes-playground dev` → http://localhost:3031/crouton.

## ⚠️ Verify before merge
- **The token/palette values were derived principledly from each theme's own tokens but not rendered from here** — the playground preview is the visual acceptance step.
- **`a847133` (#1596)** touches shared theme-application code; its correctness is a *rendering* question (override settling post-hydration, no `data-theme`/`.theme-x` hook conflict/flash) that needs a **live team-admin app** to confirm. Safe-fallback property bounds the risk, but verify it live before relying on it. If you'd rather land the token/deploy work first, this commit can be split out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)