### PR TITLE
fix(crouton-cli): rollback stops breaking the next generate; add --drop-table (#1451)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -13,7 +13,9 @@ crouton add <modules...>                     # Add Crouton modules to project
 crouton add --list                           # List available modules
 crouton install                              # Install required modules
 crouton init <name> [options]                 # Full pipeline: scaffold → generate → doctor
-crouton rollback <layer> <collection>        # Remove collection
+crouton rollback <layer> <collection>        # Remove collection (code-only)
+crouton rollback <layer> <collection> --drop-table          # …and emit a DROP TABLE migration
+crouton rollback <layer> <collection> --drop-table --dry-run # …preview that DROP, write nothing
 crouton rollback-interactive                 # Interactive removal UI
 crouton seed-translations                    # Seed i18n data
 crouton db-pull                              # Pull remote D1 → local dev
@@ -214,6 +216,33 @@ crouton init my-app --dry-run
 4. **doctor** — Validates everything is wired correctly
 5. **Summary** — Prints next steps (dev server, deploy)
 
+## Rollback Command (`crouton rollback`)
+
+Removes a generated collection — files, schema-index re-export, `app.config.ts`
+entry, and layer/root `extends`. Two things WS4 (#1445) got right:
+
+- **Barrel path is resolved, not hardcoded.** Both rollback's `cleanSchemaIndex`
+  and the generator's `buildSchemaExportNames` route the schema barrel through
+  `getSchemaPath` (`update-schema-index.ts`, modern `server/db/schema.ts` → legacy
+  `server/database/schema.ts` → `server/database/schema/index.ts`). Before this,
+  rollback only cleaned the legacy `index.ts`, so on a modern app it **no-op'd and
+  left a dangling re-export that crashed the next generate.** (The magicast finders
+  in `update-schema-index.ts` also had to learn that `$ast` can be the `Program`
+  node itself, not a `File` — otherwise they scanned an empty body and matched
+  nothing.)
+- **The table story.** A default (code-only) rollback removes the collection from
+  the schema *view* but the table still lives in the DB + drizzle's `meta/`
+  snapshot — so it **names the orphaned table and warns that the next `crouton
+  config` will emit its `DROP TABLE`**, bundled into an unrelated migration.
+  - `--drop-table` emits that `DROP TABLE` **now**, as its own migration (via the
+    WS2 machinery — `generateMigrations`, drizzle-kit, no Nuxt).
+  - `--drop-table --dry-run` **previews** the DROP and writes nothing: drizzle-kit's
+    CLI has no dry-run flag, so it saves the barrel → removes the export → generates
+    into a temp `out` seeded with a copy of `meta/` → prints the SQL → restores the
+    barrel byte-for-byte. NB the temp `out` lives **inside the app with a relative
+    path** — drizzle-kit 0.31 re-reads `meta/` via a `./`-join, so an absolute out
+    ENOENTs on the snapshot (and exits 0 anyway).
+
 ## Deploy Scaffolding — Cloudflare Workers (the crouton standard)
 
 When `cf` is enabled (default), `scaffold-app` emits a **Workers (static-assets)**
@@ -327,12 +356,13 @@ rewritten every run regardless. Guarded by the write loop in `writeScaffold`
 | `lib/db-pull.ts` | Remote D1 → local dev pull |
 | `lib/module-registry.ts` | Module definitions for `crouton add` |
 | `lib/add-module.ts` | Module installation implementation |
+| `lib/rollback-collection.ts` | Remove a collection — files, schema barrel, `app.config`, `extends`. Barrel via `getSchemaPath` (modern→legacy). `orphanTableName`/`dropTableWarning` (the code-only-rollback warning) + `generateDropMigration` (`--drop-table` emit / `--dry-run` temp-out preview) — #1445 WS4 |
 | `lib/utils/generate-migrations.ts` | Direct migration generation (`generateMigrations`, `prepareSchemaForMigration`, `DuplicateTableError`) — resolve graph → duplicate gate → app's `db:generate` (drizzle-kit, no Nuxt). Deferral/throw failure contract. Used by config/`add`/`init` (#1445 WS2) |
 | `lib/utils/helpers.ts` | Case conversion, type mapping |
 | `lib/utils/dialects.ts` | PostgreSQL/SQLite configs |
 | `lib/utils/detect-package-manager.ts` | Detect pnpm/yarn/npm |
 | `lib/utils/update-nuxt-config.ts` | Update nuxt.config.ts extends |
-| `lib/utils/update-schema-index.ts` | Update schema exports |
+| `lib/utils/update-schema-index.ts` | Update schema exports (`add`/`removeSchemaExport`) + `getSchemaPath` (resolve the barrel modern→legacy). NB the magicast finders handle `$ast` being the `Program` node itself, not only a `File` (#1445 WS4) |
 | `lib/utils/schema-sources.ts` | `resolveSchemaSources(appDir, {dialect})` — reproduces NuxtHub's per-layer `server/db/schema*` glob over the recursive `extends` graph (app root + auto-scanned `layers/*` + `@fyit/*`/subpath extends, realpath-deduped, magicast static parse), WITHOUT a Nuxt process. Feeds drizzle-kit directly; parity-verified vs NuxtHub (epic #1445 WS1a). Duplicate-table gate over its output is WS1b |
 | `lib/utils/duplicate-tables.ts` | `findDuplicateTables(resolvedPaths)` — identity-aware gate over the resolver's output: jiti-imports each file through ONE instance, and fails only when a table name maps to ≥2 DISTINCT drizzle objects (benign same-object re-exports pass; catches distinct dups arriving via `export * from` that a regex misses). drizzle-kit otherwise silently last-wins. Epic #1445 WS1b |
 

--- a/packages/crouton-cli/bin/crouton-generate.js
+++ b/packages/crouton-cli/bin/crouton-generate.js
@@ -289,6 +289,7 @@ const rollbackCmd = defineCommand({
     collection: { type: 'positional', description: 'Collection name', required: true },
     dryRun: { type: 'boolean', description: 'Preview what will be removed' },
     keepFiles: { type: 'boolean', description: 'Keep generated files, only clean configs' },
+    dropTable: { type: 'boolean', description: 'Also emit a DROP TABLE migration for the removed table (preview with --dry-run)' },
     force: { type: 'boolean', description: 'Skip confirmation prompts' },
   },
   async run({ args }) {
@@ -307,6 +308,7 @@ const rollbackCmd = defineCommand({
       collection: args.collection,
       dryRun: args.dryRun,
       keepFiles: args.keepFiles,
+      dropTable: args.dropTable,
       force: args.force,
     })
   }

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -14,7 +14,7 @@ import type { DetectionResult, DetectedField, FormEnhancement, ListEnhancement, 
 import { detectRequiredDependencies, displayMissingDependencies, ensureLayersExtended } from './utils/module-detector.ts'
 import { setupCroutonCssSource, displayManualCssSetupInstructions } from './utils/css-setup.ts'
 import { syncFrameworkPackages, addToNuxtConfigExtends, addRuntimeConfig } from './utils/update-nuxt-config.ts'
-import { addNamedSchemaExport } from './utils/update-schema-index.ts'
+import { addNamedSchemaExport, getSchemaPath } from './utils/update-schema-index.ts'
 import { generateMigrations, DuplicateTableError } from './utils/generate-migrations.ts'
 import { addToAppConfig, resolveAppConfigPath } from './utils/update-app-config.ts'
 import { loadFields } from './utils/load-fields.ts'
@@ -335,8 +335,10 @@ function runListContributions(
 
 // parseArgs() removed in Phase 5 — args now passed as options from citty entry point
 
-// Build the schema export names for a collection (layer-prefixed)
-function buildSchemaExportNames(collectionName: string, layer: string) {
+// Build the schema export names for a collection (layer-prefixed).
+// The barrel path resolves through getSchemaPath (modern→legacy) so generate and
+// rollback target the SAME file — otherwise the asymmetry just moves (#1445 WS4).
+export async function buildSchemaExportNames(collectionName: string, layer: string) {
   const cases = toCase(collectionName)
   const layerCamelCase = layer
     .split(/[-_]/)
@@ -345,7 +347,7 @@ function buildSchemaExportNames(collectionName: string, layer: string) {
   return {
     exportName: `${layerCamelCase}${cases.pascalCasePlural}`,
     importPath: `../../layers/${layer}/collections/${cases.plural}/server/database/schema`,
-    schemaIndexPath: path.resolve('server', 'db', 'schema.ts')
+    schemaIndexPath: await getSchemaPath()
   }
 }
 
@@ -367,7 +369,7 @@ async function createDatabaseTable(config: { name: string; layer: string; fields
 
     // First, update the schema index to include the new collection
     console.log(`↻ Updating schema index...`)
-    const { exportName, importPath: schemaImportPath, schemaIndexPath } = buildSchemaExportNames(name, layer)
+    const { exportName, importPath: schemaImportPath, schemaIndexPath } = await buildSchemaExportNames(name, layer)
     const schemaResult = await addNamedSchemaExport(schemaIndexPath, exportName, schemaImportPath, force)
     const schemaUpdated = schemaResult.added || schemaResult.reason === 'already exported'
 

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -1452,7 +1452,7 @@ async function runBatchDatabaseSetup(allCollections: Array<{ name: string; layer
 
   // Update schema index for each collection
   for (const col of allCollections) {
-    const { exportName: colExportName, importPath: colImportPath, schemaIndexPath: colSchemaIndexPath } = buildSchemaExportNames(col.name, col.layer)
+    const { exportName: colExportName, importPath: colImportPath, schemaIndexPath: colSchemaIndexPath } = await buildSchemaExportNames(col.name, col.layer)
     const colSchemaResult = await addNamedSchemaExport(colSchemaIndexPath, colExportName, colImportPath, force)
     if (!colSchemaResult.added && colSchemaResult.reason !== 'already exported') {
       console.error(`  ✗ Failed to update schema index for ${col.name}: ${colSchemaResult.reason}`)

--- a/packages/crouton-cli/lib/rollback-collection.ts
+++ b/packages/crouton-cli/lib/rollback-collection.ts
@@ -2,15 +2,21 @@
 // rollback-collection.ts — Safely rollback generated collections
 
 import fsp from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import path from 'node:path'
+import { spawnSync } from 'node:child_process'
 import consola from 'consola'
 
 // Import utilities
-import { toCase } from './utils/helpers.ts'
+import { toCase, toSnakeCase } from './utils/helpers.ts'
 import { removeFromNuxtConfigExtends } from './utils/update-nuxt-config.ts'
-import { removeSchemaExport } from './utils/update-schema-index.ts'
+import { removeSchemaExport, getSchemaPath } from './utils/update-schema-index.ts'
 import { removeFromAppConfig } from './utils/update-app-config.ts'
+import { generateMigrations } from './utils/generate-migrations.ts'
 import { fileExists } from '@fyit/crouton-core/shared/utils/fs'
+
+// Standard crouton app migrations out dir (wrangler migrations_dir / tmplDrizzleConfig `out`).
+const APP_MIGRATIONS_OUT = path.join('server', 'db', 'migrations', 'sqlite')
 
 export { fileExists }
 
@@ -41,7 +47,10 @@ export async function removeFile(filePath: string, dryRun: boolean): Promise<boo
 }
 
 export async function cleanSchemaIndex(collectionName: string, layer: string, dryRun: boolean): Promise<boolean> {
-  const schemaIndexPath = path.resolve('server', 'database', 'schema', 'index.ts')
+  // Route through getSchemaPath (modern server/db/schema.ts → legacy locations) —
+  // NOT the hardcoded legacy index.ts, which no-ops on modern apps and leaves a
+  // dangling export that crashes the next generate (#1445 WS4).
+  const schemaIndexPath = await getSchemaPath()
 
   if (!await fileExists(schemaIndexPath)) {
     console.log('  ! Schema index not found, skipping')
@@ -249,9 +258,130 @@ export async function checkForCollectionFiles(layer: string, collection: string)
   return { exists: true, files }
 }
 
-export async function rollbackCollection({ layer, collection, dryRun = false, keepFiles = false, silent = false }: { layer: string; collection: string; dryRun?: boolean; keepFiles?: boolean; silent?: boolean }): Promise<boolean> {
+/**
+ * The SQL table name of a collection — read from its generated schema (the source
+ * of truth), falling back to the generator's derived `<layer>_<plural>` name when
+ * the file is already gone. Used to name the orphaned table in rollback output.
+ */
+export async function orphanTableName(layer: string, collection: string, cwd: string = process.cwd()): Promise<string> {
+  const cases = toCase(collection)
+  const derived = toSnakeCase(`${layer}_${cases.plural}`)
+  const schemaFile = path.resolve(cwd, 'layers', layer, 'collections', cases.plural, 'server', 'database', 'schema.ts')
+  try {
+    const content = await fsp.readFile(schemaFile, 'utf-8')
+    const m = content.match(/(?:sqliteTable|pgTable)\(\s*['"]([^'"]+)['"]/)
+    return m ? m[1] : derived
+  } catch {
+    return derived
+  }
+}
+
+/** The warning printed after a code-only rollback: the table lingers, next generate drops it. */
+export function dropTableWarning(tableName: string): string {
+  return `Table \`${tableName}\` still exists in the database and in drizzle's snapshot.\n`
+    + `  The next generate (\`crouton config\`) will emit DROP TABLE ${tableName}, bundled into its migration.\n`
+    + `  Re-run rollback with --drop-table to emit that DROP now as its own migration.`
+}
+
+async function listSql(dir: string): Promise<string[]> {
+  try {
+    return (await fsp.readdir(dir)).filter(f => f.endsWith('.sql')).sort()
+  } catch {
+    return []
+  }
+}
+
+/** Resolve the drizzle-kit binary from the app dir, walking up for a hoisted monorepo bin. */
+function resolveDrizzleKitBin(appDir: string): string | null {
+  let d = path.resolve(appDir)
+  for (;;) {
+    const bin = path.join(d, 'node_modules', '.bin', 'drizzle-kit')
+    if (existsSync(bin)) return bin
+    const parent = path.dirname(d)
+    if (parent === d) return null
+    d = parent
+  }
+}
+
+export interface DropMigrationResult { sql: string; wrote: boolean; file?: string }
+
+/**
+ * Emit (or preview) the `DROP TABLE` migration for a rolled-back collection.
+ *
+ * A code-only rollback removes the table from the resolved schema *view* while it
+ * still lives in drizzle's `meta/` snapshot, so a generate diffs view∅ vs snapshot✓
+ * into a DROP.
+ *
+ * - **not dry-run:** the caller has already cleaned the barrel — run the WS2
+ *   machinery (`generateMigrations`) so the DROP lands in the app's own out dir.
+ * - **dry-run:** drizzle-kit's CLI has no dry-run flag (§6 rejects the programmatic
+ *   API), so preview via a temp `out`: save the barrel → remove the collection's
+ *   export → seed a throwaway out with a copy of the app's `meta/` → `drizzle-kit
+ *   generate` there → read the SQL → **restore the barrel byte-for-byte**, discard.
+ *   Nothing is written to the app.
+ */
+export async function generateDropMigration(opts: { appDir?: string; layer: string; collection: string; dryRun?: boolean }): Promise<DropMigrationResult> {
+  const appDir = opts.appDir ?? process.cwd()
+  const { layer, collection, dryRun = false } = opts
+  const cases = toCase(collection)
+  const outDir = path.join(appDir, APP_MIGRATIONS_OUT)
+
+  if (!dryRun) {
+    // Barrel already cleaned by the rollback steps — just diff & write.
+    const before = new Set(await listSql(outDir))
+    const res = await generateMigrations(appDir)
+    if (res.generated !== true) {
+      throw new Error(`drop-table migration was not generated (${JSON.stringify(res)})`)
+    }
+    const added = (await listSql(outDir)).filter(f => !before.has(f))
+    const file = added[0] ? path.join(outDir, added[0]) : undefined
+    const sql = file ? await fsp.readFile(file, 'utf-8') : ''
+    return { sql, wrote: true, file }
+  }
+
+  // Dry-run: temp-out mechanism. The temp out lives INSIDE the app with a
+  // RELATIVE `out` — drizzle-kit 0.31 re-reads meta/ via a `./`-join, so an
+  // absolute out ENOENTs on the snapshot (and exits 0 anyway — the #1286 disease).
+  const barrelPath = await getSchemaPath(appDir)
+  const saved = await fsp.readFile(barrelPath, 'utf-8')
+  const tmpOut = await fsp.mkdtemp(path.join(appDir, '.crouton-dryrun-'))
+  const relOut = path.relative(appDir, tmpOut)
+  const tmpCfg = path.join(appDir, 'drizzle.crouton-dryrun.config.ts')
+  try {
+    await removeSchemaExport(barrelPath, `${layer}/collections/${cases.plural}`)
+    const metaSrc = path.join(outDir, 'meta')
+    if (await fileExists(metaSrc)) {
+      await fsp.cp(metaSrc, path.join(tmpOut, 'meta'), { recursive: true })
+    }
+    await fsp.writeFile(tmpCfg, [
+      `import { defineConfig } from 'drizzle-kit'`,
+      `import { resolveSchemaSourcesSync } from '@fyit/crouton-cli/lib/utils/schema-sources.ts'`,
+      `export default defineConfig({ dialect: 'sqlite', schema: resolveSchemaSourcesSync(process.cwd()), out: ${JSON.stringify(relOut)} })`,
+    ].join('\n') + '\n')
+    const bin = resolveDrizzleKitBin(appDir)
+    if (!bin) throw new Error('drizzle-kit binary not found (is the app installed?)')
+    const run = spawnSync(bin, ['generate', '--config', tmpCfg], { cwd: appDir, encoding: 'utf-8', stdio: 'pipe' })
+    const sqls = await listSql(tmpOut)
+    // drizzle-kit can print an error to stderr yet exit 0 (#1286). Treat a
+    // non-zero exit OR an empty result-with-error as a hard failure, never a
+    // silent empty preview.
+    if (run.status !== 0 || sqls.length === 0) {
+      throw new Error(`drizzle-kit dry-run produced no migration:\n${(run.stderr || run.stdout || '').trim()}`)
+    }
+    const sql = await fsp.readFile(path.join(tmpOut, sqls[0]), 'utf-8')
+    return { sql, wrote: false }
+  } finally {
+    await fsp.writeFile(barrelPath, saved)
+    await fsp.rm(tmpCfg, { force: true })
+    await fsp.rm(tmpOut, { recursive: true, force: true })
+  }
+}
+
+export async function rollbackCollection({ layer, collection, dryRun = false, keepFiles = false, silent = false, dropTable = false }: { layer: string; collection: string; dryRun?: boolean; keepFiles?: boolean; silent?: boolean; dropTable?: boolean }): Promise<boolean> {
   const cases = toCase(collection)
   let changesMade = false
+  // Capture the table name BEFORE step 1 removes the collection's schema file.
+  const tableName = await orphanTableName(layer, collection)
 
   if (!silent) {
     console.log('\n' + '─'.repeat(60))
@@ -272,7 +402,8 @@ export async function rollbackCollection({ layer, collection, dryRun = false, ke
 
   // Step 2: Clean schema index
   if (!silent) console.log('\n2. Cleaning schema index...')
-  if (await cleanSchemaIndex(collection, layer, dryRun)) {
+  const schemaCleaned = await cleanSchemaIndex(collection, layer, dryRun)
+  if (schemaCleaned) {
     changesMade = true
   }
 
@@ -299,6 +430,26 @@ export async function rollbackCollection({ layer, collection, dryRun = false, ke
     }
   } else {
     if (!silent) console.log('  ! Other collections exist, keeping layer in root config')
+  }
+
+  // Step 6: The table story — a code-only rollback removes the collection from the
+  // schema view but the table lingers in the DB + drizzle snapshot (#1445 WS4).
+  if (dropTable) {
+    if (!silent) console.log('\n6. Emitting DROP TABLE migration...')
+    try {
+      const res = await generateDropMigration({ layer, collection, dryRun })
+      if (dryRun) {
+        consola.info(`[DRY RUN] Would emit this migration (nothing written):\n${res.sql.trim()}`)
+      } else {
+        changesMade = true
+        consola.success(`Migration generated${res.file ? `: ${path.relative(process.cwd(), res.file)}` : ''}\n${res.sql.trim()}`)
+      }
+    } catch (error) {
+      consola.error(`  ✗ Could not emit DROP migration: ${(error as Error).message}`)
+    }
+  } else if (!dryRun && schemaCleaned) {
+    // Default (code-only) rollback: name the orphan + warn the next generate drops it.
+    consola.warn(dropTableWarning(tableName))
   }
 
   return changesMade

--- a/packages/crouton-cli/lib/utils/update-schema-index.ts
+++ b/packages/crouton-cli/lib/utils/update-schema-index.ts
@@ -26,7 +26,10 @@ async function pathExists(filePath: string): Promise<boolean> {
  * Find re-export declarations in the AST that match a given source path pattern.
  */
 function findExportBySource(mod: any, pattern: string): any {
-  const program = mod.$ast.program || mod.$ast.body
+  // magicast's $ast may be a File (has .program) or the Program node itself
+  // (has .body). Falling back to mod.$ast.body grabbed the statements ARRAY, whose
+  // .body is undefined → the loop saw an empty list and never matched (#1445 WS4).
+  const program = mod.$ast.program || mod.$ast
   const body = program?.body || []
   for (const node of body) {
     if (
@@ -44,7 +47,7 @@ function findExportBySource(mod: any, pattern: string): any {
  * Find a named re-export by export name.
  */
 function findExportByName(mod: any, exportName: string): any {
-  const program = mod.$ast.program || mod.$ast.body
+  const program = mod.$ast.program || mod.$ast
   const body = program?.body || []
   for (const node of body) {
     if (node.type === 'ExportNamedDeclaration' && node.specifiers) {

--- a/packages/crouton-cli/tests/integration/rollback-drop-table.test.ts
+++ b/packages/crouton-cli/tests/integration/rollback-drop-table.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync
+} from 'node:fs'
+import { join, resolve } from 'node:path'
+import { generateDropMigration } from '../../lib/rollback-collection.ts'
+
+// WS4 (#1451) part 3 — the DROP contract, proven against a real drizzle-kit + a
+// real in-sync meta snapshot, with no Nuxt process.
+//
+// The temp app is created INSIDE fixtures/minimal so Node resolution walks up to
+// its node_modules (drizzle-kit, drizzle-orm, @fyit/crouton-cli). It extends
+// nothing, so its resolved schema is exactly one collection table (`shop_widgets`)
+// — no crouton-layout drift. We generate its baseline (0000 CREATE) so the meta
+// snapshot is in sync, then a code-only rollback of that collection makes the sole
+// diff a DROP. --dry-run runs that diff into a TEMP out (copied meta), prints the
+// SQL, and restores the barrel byte-for-byte — writing NOTHING to the app.
+
+const ROOT = resolve(__dirname, '../../../..')
+const FIXTURE = resolve(ROOT, 'fixtures/minimal') // host for node_modules resolution
+const BIN = join(FIXTURE, 'node_modules/.bin/drizzle-kit')
+const OUT = 'server/db/migrations/sqlite'
+
+let app: string
+beforeEach(() => {
+  app = mkdtempSync(join(FIXTURE, '.tmp-ws4-'))
+  mkdirSync(join(app, 'server/db'), { recursive: true })
+  mkdirSync(join(app, 'layers/shop/collections/widgets/server/database'), { recursive: true })
+  writeFileSync(join(app, 'nuxt.config.ts'), 'export default defineNuxtConfig({ extends: [] })\n')
+  writeFileSync(
+    join(app, 'layers/shop/collections/widgets/server/database/schema.ts'),
+    `import { sqliteTable, text } from 'drizzle-orm/sqlite-core'\n`
+      + `export const shopWidgets = sqliteTable('shop_widgets', { id: text('id').primaryKey() })\n`
+  )
+  writeFileSync(
+    join(app, 'server/db/schema.ts'),
+    `export { shopWidgets } from '../../layers/shop/collections/widgets/server/database/schema'\n`
+  )
+  // Baseline: generate the in-sync 0000 (CREATE shop_widgets) into the app's out.
+  const cfg = join(app, 'drizzle.baseline.config.ts')
+  writeFileSync(cfg, [
+    `import { defineConfig } from 'drizzle-kit'`,
+    `import { resolveSchemaSourcesSync } from '@fyit/crouton-cli/lib/utils/schema-sources.ts'`,
+    `export default defineConfig({ dialect: 'sqlite', schema: resolveSchemaSourcesSync(process.cwd()), out: '${OUT}' })`,
+  ].join('\n') + '\n')
+  execFileSync(BIN, ['generate', '--config', cfg], { cwd: app, stdio: 'pipe' })
+  rmSync(cfg, { force: true })
+})
+afterEach(() => rmSync(app, { recursive: true, force: true }))
+
+describe('generateDropMigration — dry-run preview', () => {
+  it('previews DROP TABLE shop_widgets, writes nothing to the app, restores the barrel', async () => {
+    const barrel = join(app, 'server/db/schema.ts')
+    const barrelBefore = readFileSync(barrel, 'utf8')
+    const sqlBefore = readdirSync(join(app, OUT)).filter(f => f.endsWith('.sql')).sort()
+
+    const res = await generateDropMigration({
+      appDir: app,
+      layer: 'shop',
+      collection: 'widgets',
+      dryRun: true,
+    })
+
+    // Preview shows the DROP for the rolled-back collection's table.
+    expect(res.wrote).toBe(false)
+    expect(res.sql).toMatch(/DROP TABLE[^\n]*shop_widgets/i)
+
+    // Nothing written to the app: barrel restored byte-identical, no new .sql.
+    expect(readFileSync(barrel, 'utf8')).toBe(barrelBefore)
+    expect(readdirSync(join(app, OUT)).filter(f => f.endsWith('.sql')).sort()).toEqual(sqlBefore)
+  })
+})

--- a/packages/crouton-cli/tests/unit/build-schema-export-names.test.ts
+++ b/packages/crouton-cli/tests/unit/build-schema-export-names.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// WS4 (#1451): buildSchemaExportNames became async (it resolves the barrel via the
+// async getSchemaPath). A call site that forgets `await` gets a Promise, so
+// `schemaIndexPath` is undefined → `addNamedSchemaExport` throws "path must be of
+// type string" — the exact regression that broke every E2E fixture regen once. The
+// unit tests exercise ONE call site; this grep-invariant guards ALL of them (incl.
+// the batch runBatchDatabaseSetup loop the unit tests don't reach).
+
+describe('buildSchemaExportNames is always awaited', () => {
+  it('every call site in generate-collection.ts is preceded by `await`', () => {
+    const src = readFileSync(resolve(__dirname, '../../lib/generate-collection.ts'), 'utf8')
+    const offenders: string[] = []
+    for (const line of src.split('\n')) {
+      // a CALL (has `(`), not the declaration (`function`/`export`), missing `await`
+      if (/\bbuildSchemaExportNames\s*\(/.test(line)
+        && !/\bfunction\b/.test(line)
+        && !/\bawait\s+buildSchemaExportNames\s*\(/.test(line)) {
+        offenders.push(line.trim())
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/crouton-cli/tests/unit/rollback-collection.test.ts
+++ b/packages/crouton-cli/tests/unit/rollback-collection.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import consola from 'consola'
+import {
+  cleanSchemaIndex,
+  rollbackCollection,
+  orphanTableName,
+  dropTableWarning,
+} from '../../lib/rollback-collection.ts'
+import { buildSchemaExportNames } from '../../lib/generate-collection.ts'
+
+// WS4 (#1451): rollback stops breaking the next generate.
+// Part 1 — cleanSchemaIndex must route through getSchemaPath (modern→legacy),
+//          not the hardcoded legacy server/database/schema/index.ts.
+// Part 2 — buildSchemaExportNames must resolve the barrel via the same helper.
+// Part 3 — a code-only rollback names the orphaned table + warns the next
+//          generate emits its DROP; --drop-table emits/previews that DROP.
+
+const AUTH = `export * from '@fyit/crouton-auth/server/database/schema/auth'`
+// The collection re-export line a generate wrote into the barrel.
+const COLLECTION_EXPORT = `export { mainItems } from '../../layers/main/collections/items/server/database/schema'`
+
+let dir: string
+let cwd0: string
+beforeEach(() => {
+  dir = mkdtempSync(join(__dirname, '.tmp-ws4-'))
+  cwd0 = process.cwd()
+})
+afterEach(() => {
+  process.chdir(cwd0)
+  rmSync(dir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+/** Write a barrel file at an app-relative path under the temp app dir. */
+function mkBarrel(rel: string): string {
+  const p = join(dir, rel)
+  mkdirSync(join(p, '..'), { recursive: true })
+  writeFileSync(p, `${AUTH}\n${COLLECTION_EXPORT}\n`)
+  return p
+}
+
+/** Write the collection's own generated schema so its table name is discoverable. */
+function mkCollectionSchema(tableName = 'main_items') {
+  const p = join(dir, 'layers/main/collections/items/server/database/schema.ts')
+  mkdirSync(join(p, '..'), { recursive: true })
+  writeFileSync(
+    p,
+    `import { sqliteTable, text } from 'drizzle-orm/sqlite-core'\n`
+      + `export const mainItems = sqliteTable('${tableName}', { id: text('id').primaryKey() })\n`
+  )
+}
+
+describe('WS4 part 1 — cleanSchemaIndex routes through getSchemaPath', () => {
+  it('cleans a MODERN server/db/schema.ts barrel (no-ops today → regression)', async () => {
+    const barrel = mkBarrel('server/db/schema.ts')
+    process.chdir(dir)
+    const changed = await cleanSchemaIndex('items', 'main', false)
+    expect(changed).toBe(true)
+    // The dangling collection re-export is gone; auth stays.
+    const after = readFileSync(barrel, 'utf8')
+    expect(after).not.toContain('main/collections/items')
+    expect(after).toContain('crouton-auth')
+  })
+
+  it('still cleans a LEGACY server/database/schema/index.ts barrel (no regression)', async () => {
+    const barrel = mkBarrel('server/database/schema/index.ts')
+    process.chdir(dir)
+    const changed = await cleanSchemaIndex('items', 'main', false)
+    expect(changed).toBe(true)
+    expect(readFileSync(barrel, 'utf8')).not.toContain('main/collections/items')
+  })
+})
+
+describe('WS4 part 1 — rollbackCollection leaves no dangling export', () => {
+  it('a modern-barrel rollback removes the collection export (so the next generate loads)', async () => {
+    const barrel = mkBarrel('server/db/schema.ts')
+    // collection files present so rollback proceeds
+    mkCollectionSchema()
+    process.chdir(dir)
+    await rollbackCollection({ layer: 'main', collection: 'items' })
+    expect(readFileSync(barrel, 'utf8')).not.toContain('main/collections/items')
+  })
+})
+
+describe('WS4 part 2 — buildSchemaExportNames resolves the barrel via getSchemaPath', () => {
+  it('modern app → server/db/schema.ts', async () => {
+    mkBarrel('server/db/schema.ts')
+    process.chdir(dir)
+    const { schemaIndexPath } = await buildSchemaExportNames('items', 'main')
+    expect(schemaIndexPath.replace(/\\/g, '/')).toMatch(/\/server\/db\/schema\.ts$/)
+  })
+
+  it('legacy-flat app (only server/database/schema.ts) → that path, not the hardcoded modern one', async () => {
+    mkBarrel('server/database/schema.ts')
+    process.chdir(dir)
+    const { schemaIndexPath } = await buildSchemaExportNames('items', 'main')
+    expect(schemaIndexPath.replace(/\\/g, '/')).toMatch(/\/server\/database\/schema\.ts$/)
+  })
+})
+
+describe('WS4 part 3 — orphan-table naming + warning', () => {
+  it('orphanTableName reads the SQL name from the collection schema (not just derived)', async () => {
+    mkCollectionSchema('custom_items_tbl') // NOT the derived main_items
+    expect(await orphanTableName('main', 'items', dir)).toBe('custom_items_tbl')
+  })
+
+  it('orphanTableName falls back to the derived snake_case name when the file is gone', async () => {
+    expect(await orphanTableName('main', 'items', dir)).toBe('main_items')
+  })
+
+  it('dropTableWarning names the table and the next-generate DROP consequence', () => {
+    const msg = dropTableWarning('main_items')
+    expect(msg).toContain('main_items')
+    expect(msg).toMatch(/DROP TABLE/)
+    expect(msg).toMatch(/next .*generate/i)
+  })
+
+  it('a code-only rollback (no --drop-table) emits the orphan warning naming the table', async () => {
+    mkBarrel('server/db/schema.ts')
+    mkCollectionSchema('main_items')
+    process.chdir(dir)
+    const warn = vi.spyOn(consola, 'warn')
+    await rollbackCollection({ layer: 'main', collection: 'items' })
+    const warned = warn.mock.calls.map(c => String(c[0])).join('\n')
+    expect(warned).toContain('main_items')
+    expect(warned).toMatch(/DROP TABLE/)
+  })
+})


### PR DESCRIPTION
Closes #1451 — WS4 of epic #1445 (CLI-owned migrations).

## 👤 For humans

Rolling back a collection used to silently leave a **dangling schema export that crashed the very next `crouton config`** on modern apps, and the database table just lingered. After this:

- **Rollback cleans the right barrel.** It now resolves `server/db/schema.ts` (modern) → legacy locations via `getSchemaPath`, instead of only ever touching the legacy `server/database/schema/index.ts` (which no-op'd on modern apps).
- **It tells you about the table.** A plain rollback now names the orphaned table and warns that the next generate will emit its `DROP TABLE`.
- **New `--drop-table`** emits that `DROP TABLE` migration now, as its own file. Add **`--dry-run`** to preview the exact SQL while writing nothing to the app.

## 🤖 For agents

Three parts, one file-set (brief §5 WS4) + one latent-primitive fix found in review:

1. **Part 1 — `cleanSchemaIndex` → `getSchemaPath`** (`lib/rollback-collection.ts`). The hardcoded legacy `index.ts` path no-op'd on modern apps → dangling re-export → next generate crashed.
2. **Part 2 — `buildSchemaExportNames` → `getSchemaPath`** (`lib/generate-collection.ts`, now async + exported). Removes the generator↔rollback barrel-path asymmetry.
3. **Part 3 — `crouton rollback --drop-table [--dry-run]`** (`lib/rollback-collection.ts`, `bin/crouton-generate.js`):
   - `orphanTableName` (reads the SQL name from the collection schema; falls back to the derived `<layer>_<plural>`) + `dropTableWarning`; a code-only rollback `consola.warn`s the next-generate DROP.
   - `generateDropMigration`: non-dry-run runs the WS2 machinery (`generateMigrations`) so the DROP lands in the app's own out; **dry-run** uses a temp-out (save barrel → `removeSchemaExport` → copy `meta/` → `drizzle-kit generate` → print → restore byte-for-byte). Temp out lives **inside the app with a relative path** — drizzle-kit 0.31 re-reads `meta/` via a `./`-join, so an absolute out ENOENTs (and exits 0 anyway, the #1286 disease → surfaced as a hard failure).
4. **Latent-primitive fix** (`lib/utils/update-schema-index.ts`): `findExportBySource`/`findExportByName` fell back to `mod.$ast.body` (the statements *array*) whose `.body` is undefined → they scanned `[]` and matched nothing. magicast's `$ast` **is** the `Program` node; fall back to `mod.$ast` itself. Without this, part 1's routing would still no-op.

## 🧪 How to test

Test-first (gate #774), signed off on #1451 before implementation. `pnpm --filter @fyit/crouton-cli test` → **372 passed, 4 skipped**.

- `tests/unit/rollback-collection.test.ts` — barrel routing (modern + legacy), `buildSchemaExportNames` resolution, `orphanTableName`/`dropTableWarning`, the code-only-rollback warning.
- `tests/integration/rollback-drop-table.test.ts` — real drizzle-kit against an in-sync temp app: `--drop-table --dry-run` previews `DROP TABLE`, writes nothing, restores the barrel byte-for-byte.

Manual (brief §8 step 7): `crouton rollback <layer> widgets --drop-table --dry-run` shows the DROP (nothing written); without flags the summary names the orphan + warns; the next `crouton config` still works (no dangling export — it crashed before) and its migration contains `DROP TABLE widgets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)