### PR TITLE
chore(root): add concurrency groups (cancel-in-progress) to PR workflows (#1523)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci.yml'
 
+# Cancel superseded PR runs when a new commit is pushed; each PR is its own group
+# (ref in the key). cancel-in-progress is event-conditional so a push→main run is
+# NEVER cancelled mid-flight. (#1523)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Was `lint-and-typecheck` — renamed under #1097: the job never ran eslint and
   # only typechecks the MCP server, so the old name overclaimed. App typecheck

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -69,6 +69,16 @@ on:
         default: false
         type: boolean
 
+# Cancel superseded PR *preview* runs when a new commit is pushed to the same PR branch.
+# cancel-in-progress is event-conditional (`pull_request` only) so a push→main STAGING
+# deploy + D1 migration and a workflow_dispatch PRODUCTION deploy are NEVER cancelled
+# mid-flight — cancelling a running deploy/migration is dangerous (#318, #1523). This
+# concurrency sits on the caller; the reusable deploy-app.yml inherits it, so groups are
+# per-app/PR here (not on the leaf) — no cross-app cancellation.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Figure out which opted-in apps to deploy (and to which env) → a matrix the deploy
   # job fans out over. push/pull_request → STAGING only (env hard-coded below, #318).

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,6 +30,13 @@ on:
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
+# Cancel superseded PR *preview* runs when a new commit is pushed to the same PR branch.
+# cancel-in-progress is event-conditional (`pull_request` only) so a push→main deploy and
+# a manual workflow_dispatch are NEVER cancelled mid-flight. (#1523)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   deploy:
     name: Deploy docs to Cloudflare Workers

--- a/.github/workflows/deploy-pocs.yml
+++ b/.github/workflows/deploy-pocs.yml
@@ -49,6 +49,15 @@ on:
         required: false
         type: string
 
+# Cancel superseded PR *preview* runs when a new commit is pushed to the same PR branch.
+# cancel-in-progress is event-conditional (`pull_request` only) so a manual
+# workflow_dispatch preview is NEVER cancelled mid-flight. This concurrency sits on the
+# caller; the reusable deploy-app.yml inherits it, so groups are per-POC/PR (not on the
+# leaf) — no cross-POC cancellation. (#1523)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Figure out which opted-in POCs to deploy → a matrix the deploy job fans out over.
   detect:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,13 @@ on:
     - cron: '0 4 * * *'   # nightly full-matrix backstop (selection can't silently hide a regression)
   workflow_dispatch:        # manual full-matrix run
 
+# Cancel superseded PR runs when a new commit is pushed; each PR is its own group
+# (ref in the key). cancel-in-progress is event-conditional so the push→main backstop,
+# the nightly schedule, and manual dispatches are NEVER cancelled mid-flight. (#1523)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Decide which fixtures to run. PR → only what's affected; everything else → all.
   detect:

--- a/.github/workflows/routing-registry.yml
+++ b/.github/workflows/routing-registry.yml
@@ -20,6 +20,13 @@ on:
       - '.claude/agents/**'
       - 'scripts/gen-routing.mjs'
 
+# Cancel superseded PR runs when a new commit is pushed; each PR is its own group
+# (ref in the key). cancel-in-progress is event-conditional so a push→main run is
+# NEVER cancelled mid-flight. (#1523)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/skills-doc.yml
+++ b/.github/workflows/skills-doc.yml
@@ -20,6 +20,13 @@ on:
       - 'scripts/gen-skills-doc.mjs'
       - 'scripts/harness-layers.mjs'
 
+# Cancel superseded PR runs when a new commit is pushed; each PR is its own group
+# (ref in the key). cancel-in-progress is event-conditional so a push→main run is
+# NEVER cancelled mid-flight. (#1523)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 👤 Why

Every push to a PR re-fires the whole ~10-workflow check ladder plus agent-pipeline workflows. Intermediate pushes' runs aren't cancelled, so a PR pushed N times runs the suite N× — flooding Actions and burning minutes on runs obsolete seconds after they start (#1523).

## 🤖 What

Added a top-level `concurrency` block to each **PR-triggered** workflow:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **Ref in the group key** → each PR is its own group; runs are never cancelled *across* PRs.
- **`cancel-in-progress` is event-conditional** → it only cancels `pull_request` runs. A `push`→`main` (staging deploy + D1 migration) and a `workflow_dispatch` (production) are **never** cancelled mid-flight (#318 integrity).

### Workflows that GOT the guard (7)

| Workflow | PR triggers | Non-PR paths protected from cancel |
|---|---|---|
| `ci.yml` | PR→main | `push`→main |
| `e2e.yml` | PR→main | `push`→main backstop, nightly `schedule`, `workflow_dispatch` |
| `deploy-apps.yml` | PR (staging preview) | `push`→main STAGING deploy+migrate, `workflow_dispatch` PRODUCTION |
| `deploy-docs.yml` | PR (preview) | `push`→main deploy, `workflow_dispatch` |
| `deploy-pocs.yml` | PR (preview) | `workflow_dispatch` |
| `routing-registry.yml` | PR | `push`→main |
| `skills-doc.yml` | PR | `push`→main |

For `deploy-apps` / `deploy-pocs` the concurrency sits on the **caller**; the reusable `deploy-app.yml` leaf inherits it → groups are per-app/PR, so there is **no cross-app cancellation** (leaf left untouched).

### Agent-pipeline / meta workflows deliberately LEFT WITHOUT cancel-in-progress

Cancelling these mid-run could leave pipeline state inconsistent, so no group was added:

- `automerge-epic-subpr.yml` — drives the auto-merge chain (pull_request + check_suite).
- `pipeline-pr-status.yml` — already has an intentional `head_sha`-keyed group that only collapses duplicate check_suite completions for the *same commit*; left as-is.
- `guard-package-approval.yml` — the packages-edit guard; must run to completion.
- `schedule-waves.yml` — the "baton pass" that releases dependent workstreams on close; cancelling could stall the chain.
- `project-status.yml` — mutates the project board; cancelling could drop a card move.
- `warn-closes-blocked.yml` — advisory warning on `Closes` of a blocked issue.
- `cleanup-epic-branches.yml` — branch cleanup on PR close; should complete.
- `claude.yml` — the Claude agent action (issue/review comments); never cancel mid-run.

### Already correctly guarded (unchanged)

`a11y.yml`, `frontend-review.yml`, `red-team.yml`, `skill-freshness-pr.yml` already carry a PR-scoped `cancel-in-progress: true` keyed by `github.event.pull_request.number` and are `pull_request`-only, so they already do the right thing.

## 🧪 How to test

CI could **not** validate this PR: the self-hosted GitHub Actions runner is **offline**. Validated by inspection instead:

- `actionlint` v1.7.7 on all 7 changed files → **exit 0, no findings**.
- YAML parse of all 7 files (node `yaml`) → valid; every `concurrency` block has `group` + `cancel-in-progress`.
- Manually re-checked: **every** `cancel-in-progress` is `${{ github.event_name == 'pull_request' }}` — no deploy/prod/dispatch/push path is cancel-in-progress.

Once the runner is back, the live acceptance check:
1. Push commit A to a PR → ladder runs; push commit B before A finishes → A's runs show **cancelled**, B's run fresh and green-gating.
2. A brand-new PR still runs the full ladder once.
3. A merge to `main` / production dispatch is **not** cancelled by a subsequent push — deploy/migration integrity preserved.

Closes #1523

🤖 Generated with [Claude Code](https://claude.com/claude-code)