### PR TITLE
docs(root): harden ui-proposal image-embed — verify the posted body renders (#1615)

### DIFF
--- a/.claude/skills/ui-proposal/SKILL.md
+++ b/.claude/skills/ui-proposal/SKILL.md
@@ -156,6 +156,11 @@ it lands in "Files changed" so the reviewer can inline-comment a specific change
    ```
    Use the actual **head branch** in the URL (e.g. `receiptDesign`, `claude/issue-<NN>-<slug>`);
    the image re-renders whenever the committed file changes, so editing in place (step 5) works.
+   > **Confirm it rendered, not just that the URL is 200 (step 3).** Read the posted body back:
+   > if the image shows as *code* not an image (the #569/#613 symptom), the GitHub-MCP writer
+   > mangled the Markdown URL (backtick-wrapped it / dropped the `src`) — a break `curl`-ing the
+   > URL can't detect. Re-post with an HTML `<img src="<raw-url>" alt="…" width="380">` tag (a URL
+   > in an attribute can't be auto-wrapped) and re-read to confirm. (#1615)
 5. **Steer feedback to the `.md`** — inline comments in the diff (PR) or on the committed file.
 6. Apply `status:blocked`, @mention `@pmcp`, and **stop**.
 


### PR DESCRIPTION
Closes #1615

## For humans

While embedding proposal images into the kassa epic's issues this session, one rendered as raw code on GitHub mobile (#1609) — the exact "opens as code" symptom that #569/#613 already tried to kill. The `ui-proposal` recipe already says push-first + verify-the-URL-200, and both passed — but the GitHub-MCP write path had wrapped the raw URL in backticks, which `curl`-ing the URL can't detect. This adds the missing step: **read the posted body back and confirm the image actually rendered**; if not, re-post as an HTML `<img>` tag.

## For agents

- `.claude/skills/ui-proposal/SKILL.md`, Step 4: adds a verify-rendered blockquote — read the body back; if it opens as code, the writer mangled the Markdown URL; re-post with ``'&lt;img src="&lt;raw-url&gt;" alt="…" width="380"&gt;'`` (URL in an attribute can't be auto-wrapped) and re-read.
- Body-only edit; `gen-skills-doc` META unchanged, no regen (skills-doc CI stays green).
- Honest root note (in #1615): the guidance already existed — I hit the failure because I hand-created issues *outside* the ui-proposal flow, so I didn't follow the recipe. Whether by-hand embeds should route through a shared helper is left as a follow-up thought on the issue.

## How to test
Read the skill's Step 4 — after posting, it now instructs a body read-back + the `<img>` fallback. The recipe would have caught #1609 before hand-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB)_