### PR TITLE
Fix fanfare prod deploy: keep sales_printers.locationId nullable

### DIFF
--- a/apps/fanfare/schemas/printers.json
+++ b/apps/fanfare/schemas/printers.json
@@ -1,7 +1,7 @@
 {
   "id": { "type": "uuid", "meta": { "primaryKey": true } },
   "eventId": { "type": "uuid", "refTarget": "events", "meta": { "required": true, "label": "Event" } },
-  "locationId": { "type": "uuid", "refTarget": "locations", "meta": { "required": true, "label": "Location" } },
+  "locationId": { "type": "uuid", "refTarget": "locations", "meta": { "label": "Location", "helpText": "Routing key for kitchen printers only — receipt printers ignore it (PrinterForm requires it for type kitchen)" } },
   "title": { "type": "string", "meta": { "required": true, "label": "Printer Name", "maxLength": 100 } },
   "ipAddress": { "type": "string", "meta": { "required": true, "label": "IP Address" } },
   "port": { "type": "string", "meta": { "label": "Port", "default": "9100", "helpText": "ESC/POS raw TCP port. 9100 is universal." } },

--- a/apps/fanfare/server/db/migrations/sqlite/0016_wooden_kitty_pryde.sql
+++ b/apps/fanfare/server/db/migrations/sqlite/0016_wooden_kitty_pryde.sql
@@ -21,7 +21,7 @@ CREATE TABLE `__new_sales_printers` (
 	`teamId` text NOT NULL,
 	`owner` text NOT NULL,
 	`eventId` text NOT NULL,
-	`locationId` text NOT NULL,
+	`locationId` text,
 	`title` text NOT NULL,
 	`ipAddress` text NOT NULL,
 	`port` text,

--- a/apps/fanfare/server/db/migrations/sqlite/0019_nullable_printer_location.sql
+++ b/apps/fanfare/server/db/migrations/sqlite/0019_nullable_printer_location.sql
@@ -1,0 +1,32 @@
+-- Corrective: sales_printers.locationId must be NULLABLE (receipt printers store
+-- NULL — they ignore it; routing reads it for kitchen printers only). Migration
+-- 0016 wrongly rebuilt the table with locationId NOT NULL (a schema-drift
+-- regression, undoing 0011_rainy_zemo). 0016 is fixed in place for envs that
+-- hadn't applied it; this migration heals envs that already ran the bad 0016
+-- (staging) by rebuilding with the column nullable. Redundant-but-harmless where
+-- locationId is already nullable.
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_sales_printers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`teamId` text NOT NULL,
+	`owner` text NOT NULL,
+	`eventId` text NOT NULL,
+	`locationId` text,
+	`title` text NOT NULL,
+	`ipAddress` text NOT NULL,
+	`port` text,
+	`status` text,
+	`type` text,
+	`driver` text,
+	`config` text,
+	`showPrices` integer,
+	`isActive` integer,
+	`createdAt` integer NOT NULL,
+	`updatedAt` integer NOT NULL,
+	`createdBy` text NOT NULL,
+	`updatedBy` text NOT NULL
+);--> statement-breakpoint
+INSERT INTO `__new_sales_printers`("id", "teamId", "owner", "eventId", "locationId", "title", "ipAddress", "port", "status", "type", "driver", "config", "showPrices", "isActive", "createdAt", "updatedAt", "createdBy", "updatedBy") SELECT "id", "teamId", "owner", "eventId", "locationId", "title", "ipAddress", "port", "status", "type", "driver", "config", "showPrices", "isActive", "createdAt", "updatedAt", "createdBy", "updatedBy" FROM `sales_printers`;--> statement-breakpoint
+DROP TABLE `sales_printers`;--> statement-breakpoint
+ALTER TABLE `__new_sales_printers` RENAME TO `sales_printers`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/apps/fanfare/server/db/migrations/sqlite/meta/_journal.json
+++ b/apps/fanfare/server/db/migrations/sqlite/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1783685145462,
       "tag": "0018_redundant_blizzard",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1784000000000,
+      "tag": "0019_nullable_printer_location",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 👤 What & why
The fanfare **production deploy was dying** on the remote D1 migration — `NOT NULL constraint failed: __new_sales_printers.locationId`. A schema drift had made the printer *location* required, but **receipt printers legitimately have no location** (they store NULL). Prod has a receipt printer, so migration `0016` couldn't copy it. This realigns fanfare with the package schema and fixes the migration so prod (and any env) deploys again.

Closes #1620

## 🤖 Changes
- `schemas/printers.json` — drop `locationId: required: true` (realign with the `@fyit/crouton-sales` package schema).
- `0016_wooden_kitty_pryde.sql` — `locationId text NOT NULL` → `text`; heals envs that hadn't applied it (**prod**, fresh). Staging recorded 0016 by name → won't re-run the edit.
- `0019_nullable_printer_location.sql` (new) — corrective `sales_printers` rebuild with nullable `locationId`, to heal **staging** (which ran the bad 0016 and is now latently NOT NULL). + journal entry.

## ✅ Verified
Full chain 0001→0019 (incl. edited 0016 + new 0019) applies clean on a fresh local D1; end state `locationId text` (nullable); a NULL-location receipt-printer INSERT succeeds — the exact op that was failing on prod.

## 🧪 After merge
1. Staging auto-redeploys → applies `0019` → staging `locationId` back to nullable.
2. Re-dispatch the production deploy → corrected `0016` + `0019` apply → prod deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)