### PR TITLE
fix(crouton-cli): seed --local into .data/db/sqlite.db, where nuxt dev reads (#1612)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -26,14 +26,21 @@ crouton-seed --db <name> [--remote]          # Seed an app DB from its packages'
 ## App Seeding (`crouton-seed`)
 
 `crouton-seed` (separate bin, `bin/crouton-seed.mjs` → `lib/seed-app.ts`) fills an
-app's D1 with the demo data its extended packages ship (epic #82). It mirrors the
-`db:migrate` local/remote split via `wrangler d1 execute`:
+app's D1 with the demo data its extended packages ship (epic #82):
 
 ```bash
-crouton-seed --db fanfare-db            # local  (→ wrangler d1 execute --local)
+crouton-seed --db fanfare-db            # local  (→ .data/db/sqlite.db — what nuxt dev reads, #1612)
 crouton-seed --db fanfare-db --remote   # remote (→ wrangler d1 execute --remote)
 crouton-seed --db fanfare-db --dry-run  # print the generated SQL, don't execute
 ```
+
+**Local seeds land where `nuxt dev` reads (#1612).** A local seed writes straight into
+`<app>/.data/db/sqlite.db` (the NuxtHub `hub: { db: 'sqlite' }` dev DB) via `better-sqlite3` —
+NOT the miniflare `.wrangler` DB that `wrangler d1 execute --local` writes and that dev never
+opens (the split that used to make locally-seeded data "disappear"). If `.data/db/sqlite.db`
+doesn't exist yet, the seed fails with a recipe (run `pnpm dev` once to create + migrate it).
+`--remote` is unchanged (`wrangler d1 execute --remote`). Routing lives in `resolveSeedTarget` /
+`runLocalSeed` (`lib/seed-app.ts`); contract: `tests/unit/seed-local-{target,write}.test.ts`.
 
 | Flag | Default | Purpose |
 |------|---------|---------|
@@ -51,7 +58,8 @@ loads each package's `./seed` export via **jiti** (no build step), topo-sorts th
 providers by `dependsOn` (`auth → sales → pages`), then calls
 `collectSeedSql()` from `@fyit/crouton-core/shared/seed` to turn their declarative
 `ctx.upsert(...)` calls into idempotent `INSERT … ON CONFLICT(id) DO UPDATE` SQL,
-which it runs via `wrangler d1 execute --command`. Stable, namespace-derived ids
+which it executes against the local `.data/db/sqlite.db` (#1612) or, with `--remote`,
+via `wrangler d1 execute --command`. Stable, namespace-derived ids
 (`seed:org:test1`, `seed:event:test1:vlaamsekermis`) make re-runs upsert in place.
 
 **Resilient per-chunk execution (#1370):** the seed runs as INDEPENDENT chunks — one

--- a/packages/crouton-cli/lib/seed-app.ts
+++ b/packages/crouton-cli/lib/seed-app.ts
@@ -15,6 +15,7 @@ import { execFileSync } from 'node:child_process'
 import { readFileSync, existsSync, readdirSync } from 'node:fs'
 import { join, resolve, dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { createRequire } from 'node:module'
 
 export interface SeedAppOptions {
   /** App directory (defaults to cwd). */
@@ -241,14 +242,141 @@ function collectDefaultLayoutSql(appDir: string, core: any, teamId: string): str
   return core.buildUpsert('layout_configs', { id }, values, { immutable: ['createdAt'] })
 }
 
+/** Where a LOCAL seed must land: the sqlite file `nuxt dev` (`hub: { db: 'sqlite' }`) reads. */
+export function localSeedDbPath(appDir: string): string {
+  return join(appDir, '.data', 'db', 'sqlite.db')
+}
+
+export type SeedTarget =
+  | { kind: 'sqlite', path: string }
+  | { kind: 'wrangler', db: string, remote: true }
+
 /**
- * Run the seed: discover → order → collect SQL → execute via wrangler.
- * Returns the generated SQL (handy for tests / dry runs).
+ * Route a seed to its executor (#1612). LOCAL seeds go straight to the DB `nuxt dev` actually
+ * reads (`.data/db/sqlite.db`) — NOT the miniflare `.wrangler` DB that `wrangler d1 execute
+ * --local` writes and that dev never opens (the split that made local seed data "disappear").
+ * REMOTE is unchanged: `wrangler d1 execute --remote`.
+ */
+export function resolveSeedTarget(opts: { db: string, remote: boolean, appDir: string }): SeedTarget {
+  return opts.remote
+    ? { kind: 'wrangler', db: opts.db, remote: true }
+    : { kind: 'sqlite', path: localSeedDbPath(opts.appDir) }
+}
+
+/**
+ * A local seed needs the DB `nuxt dev` created + migrated at its first boot. If it isn't there
+ * yet, fail with the recipe rather than seeding an absent/empty file (#1612).
+ */
+export function assertLocalSeedReady(appDir: string): void {
+  if (!existsSync(localSeedDbPath(appDir))) {
+    throw new Error(
+      `No local database at ${localSeedDbPath(appDir)} — run \`pnpm dev\` once to create and `
+      + `migrate it, then re-run the seed.`,
+    )
+  }
+}
+
+// better-sqlite3 is a native module — require it LAZILY (only when a local seed actually runs),
+// so remote/dry-run paths and non-seed CLI commands never load it.
+const requireCjs = createRequire(import.meta.url)
+
+/** Execute seed SQL directly against the local `.data` sqlite DB — what `nuxt dev` reads (#1612). */
+export function runLocalSeed(appDir: string, sql: string): void {
+  assertLocalSeedReady(appDir)
+  const Database = requireCjs('better-sqlite3')
+  const db = new Database(localSeedDbPath(appDir))
+  try {
+    db.exec(sql)
+  }
+  finally {
+    db.close()
+  }
+}
+
+/**
+ * Assemble the INDEPENDENT seed chunks (#1370): one per provider, plus the app's collection
+ * fixtures and default layout. Independent (not one atomic batch) so a provider whose table
+ * isn't in this app (e.g. bookings, pulled in transitively but never extended) warns + is
+ * skipped rather than sinking the auth team + the app's own rows.
+ */
+async function buildSeedChunks(opts: {
+  core: any
+  providers: LoadedProviders['providers']
+  createPageWithBlocks?: Function
+  appDir: string
+  teamSlug: string
+  teamId: string
+  locale: string
+  withStaff?: boolean
+}): Promise<Array<{ label: string, sql: string }>> {
+  const { core, providers, createPageWithBlocks, appDir, teamSlug, teamId, locale, withStaff } = opts
+  const chunks: Array<{ label: string, sql: string }> = []
+  for (const provider of providers) {
+    const psql: string = await core.collectSeedSql({
+      providers: [provider], teamSlug, teamId, locale, withStaff, createPageWithBlocks,
+    })
+    if (psql.trim()) chunks.push({ label: `provider:${provider.id}`, sql: psql })
+  }
+  const fixtureSql = collectCollectionFixtureSql(appDir, core, teamId)
+  if (fixtureSql.trim()) chunks.push({ label: 'collection-fixtures', sql: fixtureSql })
+  const layoutSql = collectDefaultLayoutSql(appDir, core, teamId)
+  if (layoutSql.trim()) chunks.push({ label: 'default-layout', sql: layoutSql })
+  return chunks
+}
+
+/**
+ * Build the per-chunk executor for the resolved target (#1612): LOCAL writes straight into
+ * `.data/db/sqlite.db` (what `nuxt dev` reads) via better-sqlite3; REMOTE goes through
+ * `wrangler d1 execute --remote` (--command uses the D1 query API — the only D1 permission a
+ * deploy token needs; execFileSync passes SQL as one argv entry, no shell, so JSON/quotes in
+ * fixture data need no escaping).
+ */
+function makeSeedChunkRunner(db: string, appDir: string, remote: boolean): (sql: string) => void {
+  const target = resolveSeedTarget({ db, remote, appDir })
+  if (target.kind === 'sqlite') {
+    assertLocalSeedReady(appDir) // fail fast with the recipe
+    return (chunkSql: string) => runLocalSeed(appDir, chunkSql)
+  }
+  return (chunkSql: string) => {
+    execFileSync(
+      'npx',
+      ['wrangler', 'd1', 'execute', db, '--remote', `--command=${chunkSql}`, '--yes'],
+      { cwd: appDir, stdio: 'inherit', env: process.env },
+    )
+  }
+}
+
+/** Resolve the seed's effective inputs (app dir + team + locale defaults). */
+function normalizeSeedOptions(options: SeedAppOptions): { appDir: string, teamSlug: string, locale: string } {
+  return {
+    appDir: resolve(options.dir ?? process.cwd()),
+    teamSlug: options.team ?? 'test1',
+    locale: options.locale ?? 'nl',
+  }
+}
+
+/** Report the per-chunk outcome: throw if EVERYTHING failed, else warn (partial) / success. */
+function reportSeedOutcome(r: { ok: number, skipped: string[], db: string, remote: boolean }): void {
+  if (r.ok === 0 && r.skipped.length > 0) {
+    // Nothing seeded at all → a real problem (bad DB / token / all tables missing), not a
+    // tolerable partial skip. Surface it so the deploy's seed step can warn loudly.
+    throw new Error(`All ${r.skipped.length} seed chunk(s) failed: ${r.skipped.join(', ')}`)
+  }
+  if (r.skipped.length > 0) {
+    consola.warn(`Seeded ${r.ok} chunk(s) into ${r.db}; skipped ${r.skipped.length} (${r.skipped.join(', ')}) — see warnings above.`)
+  }
+  else {
+    consola.success(`Seeded ${r.ok} chunk(s) into ${r.db} (${r.remote ? 'remote' : 'local'}).`)
+  }
+}
+
+/**
+ * Run the seed: discover → order → collect SQL → execute against the resolved target
+ * (local `.data` sqlite, or remote via wrangler). Returns the generated SQL (handy for tests /
+ * dry runs).
  */
 export async function seedApp(options: SeedAppOptions): Promise<string> {
-  const appDir = resolve(options.dir ?? process.cwd())
-  const teamSlug = options.team ?? 'test1'
-  const locale = options.locale ?? 'nl'
+  const { appDir, teamSlug, locale } = normalizeSeedOptions(options)
 
   consola.start(`Seeding ${options.db} (${options.remote ? 'remote' : 'local'}) — team "${teamSlug}", locale "${locale}"`)
 
@@ -264,25 +392,12 @@ export async function seedApp(options: SeedAppOptions): Promise<string> {
   const core: any = await tsImport(jiti, '@fyit/crouton-core/shared/seed')
   const teamId = core.seedOrgId(teamSlug)
 
-  // Build the seed as INDEPENDENT chunks — one per provider, plus the app's collection
-  // fixtures and default layout — instead of one atomic batch. Why (#1370, the snippets
-  // dogfood): `@fyit/crouton` pulls in `@fyit/crouton-bookings` transitively, so the BFS
-  // discovers a bookings provider even for an app that never extends bookings as a layer
-  // (its migrations never created `bookings_settings`). As one `--command` batch, that single
-  // missing table aborted EVERYTHING — no auth team, no collection rows → an empty preview.
-  // Per-chunk, a failing provider warns + is skipped and the auth team + the app's own rows
-  // + layout still seed.
-  const chunks: Array<{ label: string; sql: string }> = []
-  for (const provider of providers) {
-    const psql: string = await core.collectSeedSql({
-      providers: [provider], teamSlug, teamId, locale, withStaff: options.withStaff, createPageWithBlocks,
-    })
-    if (psql.trim()) chunks.push({ label: `provider:${provider.id}`, sql: psql })
-  }
-  const fixtureSql = collectCollectionFixtureSql(appDir, core, teamId)
-  if (fixtureSql.trim()) chunks.push({ label: 'collection-fixtures', sql: fixtureSql })
-  const layoutSql = collectDefaultLayoutSql(appDir, core, teamId)
-  if (layoutSql.trim()) chunks.push({ label: 'default-layout', sql: layoutSql })
+  // Independent chunks (#1370) — see buildSeedChunks: a provider whose table isn't in this app
+  // warns + is skipped instead of sinking the whole seed.
+  const chunks = await buildSeedChunks({
+    core, providers, createPageWithBlocks, appDir,
+    teamSlug, teamId, locale, withStaff: options.withStaff,
+  })
 
   const sql = chunks.map(c => c.sql).join('\n')
   if (!chunks.length) {
@@ -295,28 +410,9 @@ export async function seedApp(options: SeedAppOptions): Promise<string> {
     return sql
   }
 
-  // Run each chunk as its own `wrangler d1 execute --command`. --command (not --file) uses the
-  // D1 query API — the only D1 permission a deploy token needs (a --file bulk import needs
-  // User-Details:Read the token lacks). execFileSync passes SQL as one argv entry (no shell),
-  // so JSON/quotes in fixture data need no escaping. Curated seeds are small (arg-length is fine).
-  const runChunk = (chunkSql: string) => {
-    execFileSync(
-      'npx',
-      ['wrangler', 'd1', 'execute', options.db, options.remote ? '--remote' : '--local', `--command=${chunkSql}`, '--yes'],
-      { cwd: appDir, stdio: 'inherit', env: process.env },
-    )
-  }
-  const { ok, skipped } = runSeedChunks(chunks, runChunk)
-  if (ok === 0 && skipped.length > 0) {
-    // Nothing seeded at all → a real problem (bad DB / token / all tables missing), not a
-    // tolerable partial skip. Surface it so the deploy's seed step can warn loudly.
-    throw new Error(`All ${skipped.length} seed chunk(s) failed: ${skipped.join(', ')}`)
-  }
-  if (skipped.length > 0) {
-    consola.warn(`Seeded ${ok} chunk(s) into ${options.db}; skipped ${skipped.length} (${skipped.join(', ')}) — see warnings above.`)
-  } else {
-    consola.success(`Seeded ${ok} chunk(s) into ${options.db} (${options.remote ? 'remote' : 'local'}).`)
-  }
+  // Route each chunk to its executor (#1612) — local `.data` sqlite or remote wrangler.
+  const { ok, skipped } = runSeedChunks(chunks, makeSeedChunkRunner(options.db, appDir, !!options.remote))
+  reportSeedOutcome({ ok, skipped, db: options.db, remote: !!options.remote })
   return sql
 }
 

--- a/packages/crouton-cli/package.json
+++ b/packages/crouton-cli/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.0.1",
+    "better-sqlite3": "^12.4.1",
     "c12": "^3.0.0",
     "citty": "^0.2.1",
     "consola": "^3.4.0",
@@ -68,6 +69,7 @@
     "node": ">=18.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^22.0.0",
     "@types/pluralize": "^0.0.33",
     "vitest": "^2.1.0"

--- a/packages/crouton-cli/tests/unit/seed-local-target.test.ts
+++ b/packages/crouton-cli/tests/unit/seed-local-target.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveSeedTarget, assertLocalSeedReady } from '../../lib/seed-app'
+
+// #1612 — a local `crouton-seed` used to write the miniflare `.wrangler` DB, but `nuxt dev`
+// (hub: { db: 'sqlite' }) reads `.data/db/sqlite.db`, so seeded data never showed up. Local seeds
+// must land in the DB dev actually reads; remote is untouched.
+describe('resolveSeedTarget — local seeds go where nuxt dev reads (#1612)', () => {
+  it('local (default) → the app .data sqlite file, not wrangler/miniflare', () => {
+    expect(resolveSeedTarget({ db: 'fanfare-db', remote: false, appDir: '/app' }))
+      .toMatchObject({ kind: 'sqlite', path: join('/app', '.data', 'db', 'sqlite.db') })
+  })
+
+  it('remote → untouched, still wrangler --remote', () => {
+    expect(resolveSeedTarget({ db: 'fanfare-db', remote: true, appDir: '/app' }))
+      .toMatchObject({ kind: 'wrangler', db: 'fanfare-db', remote: true })
+  })
+})
+
+describe('assertLocalSeedReady — a missing local DB fails with a recipe (#1612)', () => {
+  it('no .data/db/sqlite.db yet → throws the run-`pnpm dev`-first recipe', () => {
+    const appDir = mkdtempSync(join(tmpdir(), 'seed-target-')) // empty: no .data
+    try {
+      expect(() => assertLocalSeedReady(appDir)).toThrow(/pnpm dev/i)
+    }
+    finally {
+      rmSync(appDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/crouton-cli/tests/unit/seed-local-write.test.ts
+++ b/packages/crouton-cli/tests/unit/seed-local-write.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, mkdirSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+import { runLocalSeed } from '../../lib/seed-app'
+
+// #1612 (behavioural proof) — the local runner must write into `<appDir>/.data/db/sqlite.db`
+// (the file nuxt dev reads) and never touch the miniflare `.wrangler` dir.
+// Local-only: CI lacks the better-sqlite3 native binding (same reason as crouton-printing #1539).
+describe.skipIf(process.env.CI)('local seed writes into .data/db/sqlite.db (#1612)', () => {
+  it('a row from the local runner lands in the .data DB, and .wrangler is never touched', () => {
+    const appDir = mkdtempSync(join(tmpdir(), 'seed-write-'))
+    try {
+      mkdirSync(join(appDir, '.data', 'db'), { recursive: true })
+      const path = join(appDir, '.data', 'db', 'sqlite.db')
+      // nuxt dev has already created + migrated .data at boot — simulate an existing table.
+      const setup = new Database(path)
+      setup.exec('CREATE TABLE t (id TEXT PRIMARY KEY)')
+      setup.close()
+
+      runLocalSeed(appDir, "INSERT INTO t (id) VALUES ('x')")
+
+      const db = new Database(path, { readonly: true })
+      expect(db.prepare('SELECT count(*) AS c FROM t').get()).toMatchObject({ c: 1 })
+      db.close()
+      // The whole point: the miniflare DB is never written.
+      expect(existsSync(join(appDir, '.wrangler'))).toBe(false)
+    }
+    finally {
+      rmSync(appDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -957,6 +957,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
+      better-sqlite3:
+        specifier: ^12.4.1
+        version: 12.6.2
       c12:
         specifier: ^3.0.0
         version: 3.3.3(magicast@0.3.5)
@@ -991,6 +994,9 @@ importers:
         specifier: 4.2.1
         version: 4.2.1
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.7


### PR DESCRIPTION
Closes #1612

## For humans

A local `crouton-seed` wrote the miniflare `.wrangler` DB, but `nuxt dev` (`hub: { db: 'sqlite' }`) reads `.data/db/sqlite.db` — so locally-seeded data never showed up in the running app (the split that cost a debugging detour last session). Local seeds now land in the DB dev actually reads. If the local DB doesn't exist yet, the seed fails with a clear recipe (*run `pnpm dev` once to create + migrate it*) instead of seeding nowhere. `--remote` is unchanged.

## For agents

- `lib/seed-app.ts`:
  - `resolveSeedTarget({ db, remote, appDir })` → local `{ kind:'sqlite', path:<appDir>/.data/db/sqlite.db }` / remote `{ kind:'wrangler', … }`.
  - `assertLocalSeedReady(appDir)` → throws the run-`pnpm dev`-first recipe when the local DB is absent.
  - `runLocalSeed(appDir, sql)` → executes via `better-sqlite3` (lazily `require`d, so remote/dry-run/other CLI commands never load the native module).
  - `seedApp` dispatches on the target; the remote `wrangler d1 execute --remote` path is untouched, and the resilient per-chunk skip (#1370) still applies (a missing table throws → warns + skips).
- Dep: `better-sqlite3 ^12.4.1` (already an approved built dep — root `onlyBuiltDependencies`; docs uses the same range) + `@types/better-sqlite3` devDep.

## Test-first (#774) — signed off before code

- `tests/unit/seed-local-target.test.ts` (CI-safe, pure): local → `.data` path; remote → wrangler untouched; missing local DB → recipe thrown.
- `tests/unit/seed-local-write.test.ts` (`skipIf(CI)` — CI lacks the `better-sqlite3` native binding, same as crouton-printing #1539): a row from the local runner lands in the `.data` DB and `.wrangler` is never created.

Full `crouton-cli` suite green (32 files, 377 passed + 4 skipped); `npx fallow audit` clean on the 6 changed files.

## How to test
```
cd apps/fanfare && pnpm dev   # once, to create + migrate .data/db/sqlite.db, then stop
pnpm db:seed:local
pnpm dev                      # log in as the seeded admin; the Vlaamse Kermis event lists its products
```
No manual `.wrangler`→`.data` copy. `--remote` seed behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB)_