### PR TITLE
fix(crouton-sales): stop page bleed above sticky Data-pane toggle (#1608)

### DIFF
--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -253,8 +253,11 @@ open pane's tab hides — the pane header (icon + title, mirroring the tab) carr
   `SalesBlocksProductMatrixRender` (product × day pivot, reused as-is via `attrs.eventScope`).
   The chart/matrix endpoints are team-members-only, matching the gate. The
   **"Personeel meetellen" (include-staff) toggle is sticky** to the top of the
-  scrolling pane (`sticky top-0`, bleeds over the host `p-4` via negative margins
+  scrolling pane (`sticky -top-2`, bleeds over the host `p-4` via negative margins
   + solid `bg-default`), so it stays reachable while the numbers below scroll (#1608).
+  `-top-2` cancels the host's `pt-2` so no content scrolls into the 8px gap above the
+  bar (the IMG_1493 bleed regression), and symmetric `py-3` keeps the toggle centered
+  both at rest and when stuck (an earlier `pt-4 pb-2` looked top-heavy at rest).
 Per-order print status lives on the order rows as LED dots. Event dates are deliberately not shown
 anywhere in the workspace (irrelevant to the POS flow; columns remain in the DB). Deleting the
 current event navigates back to the events list via a `crouton:mutation` hook (matched on

--- a/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
@@ -56,8 +56,10 @@ onUnmounted(unhookMutation)
     <!-- Exclude staff orders from the totals by default; toggle folds them in.
          Sticky to the top of the scrolling pane (bleeds over the host's p-4
          padding via negative margins + a solid bg) so the personnel toggle
-         stays reachable while the numbers below scroll. -->
-    <div class="sticky top-0 z-10 -mx-4 -mt-2 flex items-center border-b border-default bg-default px-4 py-2">
+         stays reachable while the numbers below scroll. `-top-2` cancels the
+         host's pt-2 so nothing scrolls into the 8px gap above the bar (#1608),
+         and symmetric py-3 keeps the toggle centered at rest and when stuck. -->
+    <div class="sticky -top-2 z-10 -mx-4 -mt-2 flex items-center border-b border-default bg-default px-4 py-3">
       <USwitch
         v-model="includePersonnel"
         :label="t('sales.workspace.dataPanel.includePersonnel')"


### PR DESCRIPTION
Closes #1608

## For humans

The "Personeel meetellen" toggle at the top of the Data pane is sticky, but content **bled through the thin gap above it** while the numbers below scrolled (IMG_1493 — "the sticky shows the page scroll behind it, not clean"). It now pins **flush** with no bleed, and the toggle reads **centered** whether the pane is at rest or scrolled.

Earlier I'd staged a `pt-4 pb-2` fix — that killed the bleed but looked **top-heavy at rest** (16px above / 8px below). This lands the balanced version instead.

| | before | after |
|---|---|---|
| at rest | toggle centered, but 8px scroll-gap above it when you scroll | toggle centered, no gap |
| scrolled | page content bleeds into the gap | opaque bar, clean border, content clipped below |

<img src="https://raw.githubusercontent.com/FriendlyInternet/nuxt-crouton/5a0d3d1/screenshots/sticky-pad.png" width="720" alt="left: current top-heavy; middle: py-3 balanced at rest; right: py-3 scrolled, no bleed" />

## For agents

- `packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue`: the sticky bar's classes `sticky top-0 … py-2` → `sticky -top-2 … py-3`.
  - The host scroll body is `p-4 pt-2`. The bar's `-mt-2` cancels that 8px **at rest**, but with `top-0` an 8px scroll-gap opened above the *stuck* bar (content scrolled into it). `-top-2` sticks the bar 8px higher so that gap is clipped away.
  - `top-0` + `-top-2` clips 8px off the top when stuck, so a symmetric `py-2` would look bottom-heavy when stuck and the earlier `pt-4 pb-2` looked top-heavy at rest. `py-3` reads centered in **both** states.
- `packages/crouton-sales/CLAUDE.md`: Data-pane note updated (`sticky top-0` → `sticky -top-2`, with the why).
- Verified via a standalone render (rest + scrolled). `fanfare` typecheck + diff-scoped `fallow audit` clean.

## How to test

1. Open the fanfare kassa, sign in as a team member, open the **Data** pane.
2. Scroll the pane. **Before:** a sliver of the cards below shows in the gap just above the "Personeel meetellen" toggle. **After:** the toggle bar is opaque and flush — only its bottom border shows, nothing bleeds above it.
3. At rest (pane not scrolled), the toggle sits vertically centered in its bar (not hugging the top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB)_