### PR TITLE
Fix theme bleed: pill clears the team-theme <html> hooks on switch (#1625)

### DIFF
--- a/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
+++ b/packages/crouton-themes/themes/composables/useThemeSwitcher.ts
@@ -191,6 +191,19 @@ export function useThemeSwitcher() {
       })
     }
 
+    // The pill is the authority when the user switches (#1625). The team-theme
+    // plugin (crouton-admin) styles via `data-theme` + an inline `--ui-radius`
+    // on <html>; the pill styles via the `theme-x` body class. Those two hooks
+    // don't reset each other, so a stale `data-theme` (or inline radius) left by
+    // the team plugin bleeds the previous theme's tokens into the newly-picked
+    // one — most visibly "default stays squared". Clear them so the body-class
+    // theme is the sole source: default → no class, no attr, no inline →
+    // Nuxt UI's own rounded 0.25rem.
+    if (import.meta.client) {
+      document.documentElement.removeAttribute('data-theme')
+      document.documentElement.style.removeProperty('--ui-radius')
+    }
+
     // The theme's designed scheme is a DEFAULT, not a lock (#1395 relaxed the
     // #1387 pin): applied only while the user has no explicit preference
     // ('system'). Every theme now carries a designed counterpart palette for


### PR DESCRIPTION
Fixes the regression reported on the live kassa after #1599 merged: switching themes via the pill and returning to **Default** left the app **squared** (a previous theme's `--ui-radius: 0` bled into default).

## 👤 For humans
The theme pill and the team Look-and-Feel style the app through **different DOM hooks that didn't clean up after each other**, so an old theme's styling leaked past its boundary. The pill now fully resets on every switch, so going back to Default returns to the normal rounded look.

## 🤖 For agents
- **Root cause** (regression from #1599): `useThemeSwitcher.setTheme` (pill) styles via a `theme-x` class on `<body>`; `applyThemeSettings` (crouton-admin team plugin) styles via `data-theme` + inline `--ui-radius` on `<html>`. #1596 routes the pill's saved pick through the team's `data-theme` path on reload; the pill's own switch never cleared that attribute, so `[data-theme=x] { --ui-radius: 0 }` (added in #1594) kept applying → "default" stayed squared.
- **Fix**: `setTheme` now (client) `removeAttribute('data-theme')` + `removeProperty('--ui-radius')` on `<html>`, making the `.theme-x` body class the sole source. Default → no class/attr/inline → Nuxt UI's 0.25rem rounded. One-file, +13 lines. Fallow ✓, playground typecheck ✓.

Closes #1625

## 🧪 How to test
On a **team-admin app** (kassa): pill → Game Boy (squares) → pill → **Default** → **rounds** (before this fix it stayed squared); reload after each. Switch between two non-default themes and confirm the first doesn't linger. NB `themes.pmcp.dev` can't repro — it has no team-theme plugin; this needs a team-admin app. **Please verify on staging before relying on it** (I can't drive the pill + team-plugin interaction from here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQF8PF916qLpKvLkQT8idY)_