### PR TITLE
feat(root): PR-time CI gate for undeclared packages/** edits (#1611)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -272,3 +272,6 @@
 - name: "ui-approved"
   color: "0e8a16"
   description: "Informational UI sign-off marker — resumes NOTHING (approval = lgtm comment, #572); digest badge"
+- name: "packages:approved"
+  color: "5319e7"
+  description: "PR: the packages/** edit is declared/approved — one signal that satisfies the packages-guard CI gate (#1611)"

--- a/.github/workflows/packages-guard.yml
+++ b/.github/workflows/packages-guard.yml
@@ -1,0 +1,100 @@
+name: Packages guard
+
+# #1611 — the PR-time half of the packages/ HARD GATE. The local PreToolUse hook
+# (.claude/hooks/gate-package-edits.sh) only runs inside an agent session, so a PR can
+# quietly change shared `packages/**` code with nothing catching it on the way to main.
+# This fails such a PR unless the edit is *declared* — a `packages:approved` label, a
+# `Packages-approved:` body line, or a linked signed-off `pkg:*` issue. Not prohibition:
+# package work is legitimate, but shared code ripples across every consuming app, so it
+# must be declared and the blast radius made visible.
+#
+# The decision lives in the pure, unit-tested scripts/packages-guard.mjs; this workflow only
+# resolves the impure inputs (changed files, labels, body, linked-issue labels) and posts the
+# blast-radius comment. Distinct from guard-package-approval.yml, which only fails a *committed*
+# .claude/.package-edit-approved override file.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  declared:
+    name: Packages edit declared
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Gather PR inputs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const pr = context.payload.pull_request
+
+            // Changed files (paginated).
+            const files = await github.paginate(github.rest.pulls.listFiles,
+              { ...context.repo, pull_number: pr.number })
+            const changedFiles = files.map(f => f.filename)
+
+            const prLabels = (pr.labels || []).map(l => (typeof l === 'string' ? l : l.name))
+            const body = pr.body || ''
+
+            // A linked signed-off pkg:* issue counts as a declaration — resolve the body's
+            // closing/refs references (Closes/Fixes/Resolves/Refs #NN) and collect their labels.
+            const refRe = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)\s*:?\s+#(\d+)/gi
+            const refNums = [...new Set([...body.matchAll(refRe)].map(m => Number(m[1])))]
+            const linkedIssueLabels = []
+            for (const issue_number of refNums) {
+              try {
+                const issue = (await github.rest.issues.get({ ...context.repo, issue_number })).data
+                if (issue.pull_request) continue // a PR reference, not an issue
+                for (const l of issue.labels || []) linkedIssueLabels.push(typeof l === 'string' ? l : l.name)
+              } catch (e) { core.warning(`could not resolve #${issue_number}: ${e.message}`) }
+            }
+
+            fs.writeFileSync('guard-input.json',
+              JSON.stringify({ changedFiles, prLabels, body, linkedIssueLabels }))
+            core.info(`Changed files: ${changedFiles.length}; PR labels: ${prLabels.join(', ') || '(none)'}`)
+
+      - name: Evaluate packages guard
+        run: node scripts/packages-guard.mjs guard-input.json guard-output.json
+
+      - name: Verdict — comment on the blast radius / set check state
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const marker = '<!-- packages-guard -->'
+            const pr = context.payload.pull_request
+
+            let out
+            try { out = JSON.parse(fs.readFileSync('guard-output.json', 'utf8')) }
+            catch (e) { core.setFailed(`packages-guard did not produce a result: ${e.message}`); return }
+
+            // Find any prior guard comment (marker dedup — an `edited`/`synchronize` re-run updates it).
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { ...context.repo, issue_number: pr.number })
+            const prior = comments.find(c => (c.body || '').includes(marker))
+
+            if (out.declared) {
+              if (!out.touched.length) { core.info('No packages/** files changed — no-op.'); return }
+              core.info(`Declared via ${out.signal} — guard satisfied.`)
+              if (prior) {
+                await github.rest.issues.updateComment({ ...context.repo, comment_id: prior.id,
+                  body: `${marker}\n✅ Packages edit declared (via ${out.signal}) — guard satisfied.\n\n<sub>🤖 agent pipeline (CI) · packages-guard (#1611)</sub>` })
+              }
+              return
+            }
+
+            const bodyText = out.commentBody
+            if (prior) await github.rest.issues.updateComment({ ...context.repo, comment_id: prior.id, body: bodyText })
+            else await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number, body: bodyText })
+
+            core.setFailed(out.reason)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,8 @@ The approval file is gitignored and session-scoped. Always clean it up after fin
 
 This applies to all agents and sub-agents.
 
+**PR-time backstop (#1611).** The PreToolUse hook only runs *in an agent session*, so it can't catch a `packages/**` change on its way to `main`. The `packages-guard` CI check (`.github/workflows/packages-guard.yml`, decision in the unit-tested `scripts/packages-guard.mjs`) is the authoritative PR-time gate: a PR touching `packages/**` **fails** unless the edit is *declared* — a **`packages:approved`** label, a **`Packages-approved: <why>`** body line, **or** a linked signed-off **`pkg:*`** issue — and it comments the blast-radius (which package files changed). It's declaration, not prohibition. (Distinct from `guard-package-approval.yml`, which only fails a *committed* `.package-edit-approved` override file.)
+
 ### Context Clearing Between Tasks
 After each task: announce completion, STOP. User runs `/clear`. Fresh agent reads the relevant GitHub issue/epic (and PROGRESS_TRACKER.md if a phase rollup exists) and continues.
 

--- a/scripts/packages-guard.mjs
+++ b/scripts/packages-guard.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// packages-guard.mjs — the PR-time half of the packages/ HARD GATE (#1611).
+//
+// The local PreToolUse hook (.claude/hooks/gate-package-edits.sh) only runs inside an
+// agent session, so a PR can quietly change shared `packages/**` code with nothing catching
+// it on the way to main. This is the authoritative, PR-time version: a PR that touches
+// `packages/**` must *declare* the edit — shared packages ripple across every consuming app.
+//
+// This module is PURE + unit-tested (packages-guard.test.mjs). All impure lookups (the PR's
+// changed files, labels, body, and the labels of any linked issue) are resolved by the caller
+// — the CI workflow (`.github/workflows/packages-guard.yml`) via github-script — and passed in
+// as plain data, so the decision itself is deterministic and testable. Run locally via the CLI
+// at the bottom: `node scripts/packages-guard.mjs <input.json>`.
+//
+// Distinct from guard-package-approval.yml, which only fails a *committed*
+// `.claude/.package-edit-approved` override file — a narrower safety net.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+export const PACKAGES_PREFIX = 'packages/'
+export const APPROVED_LABEL = 'packages:approved'
+// A body attestation line, mirroring the `Dedup-checked:` / provenance-header hook patterns.
+export const ATTESTATION_RE = /^\s*Packages-approved:/im
+export const COMMENT_MARKER = '<!-- packages-guard -->'
+
+/** The changed files that live under `packages/` — the blast radius. */
+export function packagesTouched(changedFiles = []) {
+  return changedFiles.filter(f => typeof f === 'string' && f.startsWith(PACKAGES_PREFIX))
+}
+
+/** Group touched files by package name → `{ 'crouton-sales': [files…], … }`. */
+export function blastRadius(changedFiles = []) {
+  const byPkg = {}
+  for (const f of packagesTouched(changedFiles)) {
+    const pkg = f.slice(PACKAGES_PREFIX.length).split('/')[0] || '(root)'
+    ;(byPkg[pkg] ||= []).push(f)
+  }
+  return byPkg
+}
+
+/**
+ * The decision. Pure — the caller resolves and passes in the impure data.
+ * @param {{changedFiles?: string[], prLabels?: string[], body?: string, linkedIssueLabels?: string[]}} input
+ * @returns {{touched: string[], packages: string[], declared: boolean, signal: string|null, reason: string}}
+ */
+export function evaluatePackagesGuard({
+  changedFiles = [],
+  prLabels = [],
+  body = '',
+  linkedIssueLabels = [],
+} = {}) {
+  const touched = packagesTouched(changedFiles)
+  if (touched.length === 0) {
+    return { touched, packages: [], declared: true, signal: 'none', reason: 'No packages/** files changed — no-op.' }
+  }
+
+  const hasLabel = prLabels.includes(APPROVED_LABEL)
+  const hasAttestation = ATTESTATION_RE.test(body)
+  const hasPkgIssue = linkedIssueLabels.some(l => typeof l === 'string' && l.startsWith('pkg:'))
+  const declared = hasLabel || hasAttestation || hasPkgIssue
+  const signal = hasLabel ? 'label' : hasAttestation ? 'attestation' : hasPkgIssue ? 'pkg-issue' : null
+
+  return {
+    touched,
+    packages: Object.keys(blastRadius(changedFiles)).sort(),
+    declared,
+    signal,
+    reason: declared
+      ? `Packages edit declared via ${signal}.`
+      : `This PR changes ${touched.length} packages/** file(s) across [${Object.keys(blastRadius(changedFiles)).sort().join(', ')}] with no declared approval.`,
+  }
+}
+
+/** The blast-radius comment body (markdown) — marker-deduped + 🤖 provenance. */
+export function formatComment(changedFiles = []) {
+  const byPkg = blastRadius(changedFiles)
+  const lines = [
+    COMMENT_MARKER,
+    '🚫 **This PR changes shared `packages/**` code but declares no approval.**',
+    '',
+    'Shared packages ripple across every consuming app, so a package edit must be *declared* (not prohibited). To make this check pass, do **one** of:',
+    '',
+    '- add the **`packages:approved`** label to this PR, **or**',
+    '- add a body line **`Packages-approved: <why / who signed off>`**, **or**',
+    '- link a signed-off **`pkg:*`** issue (`Closes #NN` / `Refs #NN`).',
+    '',
+    '**Blast radius — changed `packages/**` files:**',
+  ]
+  for (const pkg of Object.keys(byPkg).sort()) {
+    lines.push('', `- **${pkg}** (${byPkg[pkg].length})`)
+    for (const f of byPkg[pkg]) lines.push(`  - \`${f}\``)
+  }
+  lines.push('', '<sub>🤖 agent pipeline (CI) · packages-guard (#1611) · required check — declare the edit to pass</sub>')
+  return lines.join('\n')
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────────
+// `node scripts/packages-guard.mjs <input.json> [<output.json>]`
+// input.json:  { changedFiles, prLabels, body, linkedIssueLabels }
+// output.json: { ...evaluate(), commentBody }  (also printed to stdout)
+function main(argv) {
+  const [inPath, outPath] = argv
+  if (!inPath) {
+    console.error('usage: node scripts/packages-guard.mjs <input.json> [<output.json>]')
+    process.exit(2)
+  }
+  const input = JSON.parse(readFileSync(inPath, 'utf8'))
+  const result = evaluatePackagesGuard(input)
+  const out = { ...result, commentBody: result.declared ? null : formatComment(input.changedFiles || []) }
+  const json = JSON.stringify(out, null, 2)
+  if (outPath) writeFileSync(outPath, json)
+  console.log(json)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main(process.argv.slice(2))
+}

--- a/scripts/packages-guard.test.mjs
+++ b/scripts/packages-guard.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * #1611 contract — the PR-time packages/ gate: a diff touching `packages/**` fails unless the
+ * edit is *declared* (a `packages:approved` label, a `Packages-approved:` body line, or a linked
+ * `pkg:*` issue), and the blast-radius comment names every changed package file.
+ *
+ *   node --test scripts/packages-guard.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  packagesTouched,
+  blastRadius,
+  evaluatePackagesGuard,
+  formatComment,
+  APPROVED_LABEL,
+  COMMENT_MARKER,
+} from './packages-guard.mjs'
+
+const PKG_FILE = 'packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue'
+const APP_FILE = 'apps/fanfare/nuxt.config.ts'
+
+test('packagesTouched filters to packages/ only', () => {
+  assert.deepEqual(
+    packagesTouched([APP_FILE, PKG_FILE, 'scripts/x.mjs']),
+    [PKG_FILE],
+  )
+})
+
+test('blastRadius groups changed files by package name', () => {
+  const r = blastRadius([PKG_FILE, 'packages/crouton-core/a.ts', 'packages/crouton-sales/b.ts', APP_FILE])
+  assert.deepEqual(Object.keys(r).sort(), ['crouton-core', 'crouton-sales'])
+  assert.equal(r['crouton-sales'].length, 2)
+})
+
+test('no packages/** changed → declared (no-op), signal none', () => {
+  const r = evaluatePackagesGuard({ changedFiles: [APP_FILE, 'scripts/x.mjs'] })
+  assert.equal(r.declared, true)
+  assert.equal(r.signal, 'none')
+  assert.deepEqual(r.touched, [])
+})
+
+test('packages/** changed with NO signal → NOT declared (the gate fires)', () => {
+  const r = evaluatePackagesGuard({ changedFiles: [PKG_FILE], prLabels: ['type:chore'], body: 'just a fix' })
+  assert.equal(r.declared, false)
+  assert.equal(r.signal, null)
+  assert.deepEqual(r.packages, ['crouton-sales'])
+})
+
+test('the packages:approved label declares the edit', () => {
+  const r = evaluatePackagesGuard({ changedFiles: [PKG_FILE], prLabels: [APPROVED_LABEL] })
+  assert.equal(r.declared, true)
+  assert.equal(r.signal, 'label')
+})
+
+test('a Packages-approved: body line declares the edit', () => {
+  const r = evaluatePackagesGuard({ changedFiles: [PKG_FILE], body: 'Fixes it.\n\nPackages-approved: signed off by owner' })
+  assert.equal(r.declared, true)
+  assert.equal(r.signal, 'attestation')
+})
+
+test('a linked pkg:* issue declares the edit', () => {
+  const r = evaluatePackagesGuard({ changedFiles: [PKG_FILE], linkedIssueLabels: ['type:feat', 'pkg:crouton-sales'] })
+  assert.equal(r.declared, true)
+  assert.equal(r.signal, 'pkg-issue')
+})
+
+test('signal precedence: label wins over attestation + pkg-issue', () => {
+  const r = evaluatePackagesGuard({
+    changedFiles: [PKG_FILE],
+    prLabels: [APPROVED_LABEL],
+    body: 'Packages-approved: x',
+    linkedIssueLabels: ['pkg:crouton-sales'],
+  })
+  assert.equal(r.signal, 'label')
+})
+
+test('formatComment carries the marker, every touched file, and the 🤖 provenance', () => {
+  const body = formatComment([PKG_FILE, 'packages/crouton-core/a.ts', APP_FILE])
+  assert.match(body, new RegExp(COMMENT_MARKER))
+  assert.match(body, /crouton-sales/)
+  assert.match(body, /crouton-core/)
+  assert.ok(body.includes(PKG_FILE), 'names the exact changed package file')
+  assert.ok(!body.includes(APP_FILE), 'does not list non-package files')
+  assert.match(body, /🤖 agent pipeline \(CI\)/)
+})


### PR DESCRIPTION
Closes #1611

## For humans

The `packages/` HARD GATE was only enforced by a **local, session-scoped** hook (`.claude/hooks/gate-package-edits.sh`) — it doesn't travel to CI, so a PR could quietly change shared package code with nothing catching it on the way to `main` (this session's `crouton-sales` edits had no PR-time signal — the motivating case).

This adds a CI check that fails a PR touching `packages/**` **unless the edit is declared**, and comments exactly which package files changed (the blast radius). It's **declaration, not prohibition** — package work is legitimate, it just shouldn't land unnoticed.

**Three ways to declare** (any one passes the check):
- add the **`packages:approved`** label, **or**
- a body line **`Packages-approved: <why / who signed off>`**, **or**
- link a signed-off **`pkg:*`** issue (`Closes #NN` / `Refs #NN`).

A PR touching no package files is a green no-op (like this very PR — it changes only `scripts/`, `.github/`, and `CLAUDE.md`, so the new guard self-tests as a clean pass here).

## For agents

- **`scripts/packages-guard.mjs`** — the pure, unit-tested decision. `evaluatePackagesGuard({ changedFiles, prLabels, body, linkedIssueLabels })` → `{ touched, packages, declared, signal, reason }`; plus `blastRadius()` / `formatComment()`. All impure lookups are resolved by the caller and passed in as data, so the decision is deterministic. Thin CLI (`node scripts/packages-guard.mjs <in.json> [out.json]`) for the workflow + local runs.
- **`scripts/packages-guard.test.mjs`** — `node --test` contract (9 cases): no-op, undeclared→fail, each of the 3 declare signals, precedence, blast-radius formatting. Same convention as `scripts/harness-stages.test.mjs`.
- **`.github/workflows/packages-guard.yml`** — on `pull_request`→`main`: **gather** (github-script: `listFiles` + PR labels + body + linked-issue labels) → **evaluate** (node CLI) → **verdict** (github-script: marker-deduped blast-radius comment + `core.setFailed`). Impure I/O isolated to the workflow; mirrors `warn-closes-blocked.yml`'s pattern + `🤖 agent pipeline (CI)` provenance.
- **`.github/labels.yml`** — new `packages:approved` label (synced to the repo by `labels.yml` on merge to main).
- **`CLAUDE.md`** — Packages Boundary section documents the PR-time backstop.

**Considered & rejected** (from #1611): rely on the local hook only → ❌ session-scoped/invisible at PR time; block all `packages/**` PRs → ❌ package work is legitimate, the gate is about *declaration*.

**Distinct from `guard-package-approval.yml`**, which only fails a *committed* `.claude/.package-edit-approved` override file — a narrower safety net. **Follow-ups:** making this a *required* branch-protection check (so it blocks merge, not just reds), and the "later tier" scope-declaration check (flag diffs outside a declared `Scope:`).

## How to test

1. **Undeclared → red:** open a PR editing one `packages/**` file with no label / no body line / no linked `pkg:*` issue → the `Packages edit declared` check fails and a comment lists the changed package files.
2. **Declared → green:** add the `packages:approved` label (or a `Packages-approved:` body line, or link a `pkg:*` issue) → the check re-runs green and the comment flips to ✅.
3. **No package touched → green no-op:** a PR touching no `packages/**` file (like this one) passes with no comment.
4. Unit contract: `node --test scripts/packages-guard.test.mjs` (9 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjWM7cEV8UgX6GD7RGhgCB)_