### PR TITLE
chore(root): deploy-pipeline housekeeping — epic initiatives + digest (#1637), deploy-detect fix (#1499), watchdog dedup (#1639)

### DIFF
--- a/.claude/skills/epic-digest/SKILL.md
+++ b/.claude/skills/epic-digest/SKILL.md
@@ -48,6 +48,16 @@ Build the JSON object described in **Step 3** using these calls (all `owner: pmc
    child's labels (or the `get_sub_issues` state) to set its `status`
    (`in-progress` / `blocked` from the `status:*` label) and `state`.
    Mark the epic `blocked` if it carries `status:blocked` or any child is blocked.
+   **Initiatives (super-epics).** Among the `label:epic` results, treat an issue as an
+   **initiative** if it carries `label:initiative` **or** its title starts with `Initiative:`.
+   An initiative *groups other epics*: parse its member epic numbers from the `#NN` links in
+   its body's `## Member epics` / `## …constituent epics` section (that section only — a `#NN`
+   in a prose/"consolidation" section is not a member), keep only those that are themselves
+   gathered open epics, and roll them up into an `initiatives[]` entry (`epicsTotal`,
+   `activeCount`, `blockedCount`, `childrenTotal`/`childrenDone` summed from the members, and a
+   `members[]` list of `{number,title,url,done,total,status,blocked}`). **Remove initiatives
+   from `epics[]`** so they don't render as misleading `0/0` epics. `gather.mjs` does all this
+   deterministically; the interactive flow mirrors it.
 3. **Activity in the window** (the "since yesterday" band) — use date-filtered search,
    substituting `<cutoff>` (YYYY-MM-DD):
    - Closed: `search_issues` → `repo:FriendlyInternet/nuxt-crouton is:issue is:closed closed:>=<cutoff>`
@@ -121,7 +131,18 @@ Shape (`example.data.json` next to this skill is a complete, renderable sample):
       "testSteps": ["Open Bookings…", "Each row shows a status pill", "Filter by pending → amber only"]
     }
   ],
-  "epics": [
+  "initiatives": [                        // optional — the "🎛 Initiatives" band (super-epics grouping epics)
+    {
+      "number": 1632, "url": "https://github.com/...",
+      "title": "🎨 Visual Layout & Builder",   // the "Initiative:" prefix is stripped
+      "epicsTotal": 5, "activeCount": 2, "blockedCount": 1, "blocked": true,
+      "childrenTotal": 31, "childrenDone": 14,  // summed across member epics
+      "members": [
+        { "number": 983, "title": "...", "url": "...", "done": 7, "total": 12, "status": "blocked", "blocked": true }
+      ]
+    }
+  ],
+  "epics": [                              // regular epics only — initiatives are pulled out into `initiatives`
     {
       "number": 249, "title": "...", "url": "https://github.com/...",
       "status": "in-progress",          // in-progress | blocked | open | done
@@ -162,7 +183,9 @@ node .claude/skills/epic-digest/render.mjs digest.data.json --out-dir .         
 # → email the HTML (+ text mirror) via Resend
 ```
 - **`gather.mjs`** parses `Hypothesis` (or legacy `The bet`) / `We'll know by` from each epic body and
-  **computes** `whereWeAre` from child counts — no model in the loop.
+  **computes** `whereWeAre` from child counts — no model in the loop. It also detects **initiatives**
+  (super-epics; `label:initiative` or an `Initiative:` title), rolls their member epics up into
+  `initiatives[]`, and removes them from `epics[]` — no model in the loop.
 - **Delivery is email-only, via Resend** (#551). The job emails the rendered HTML
   (+ text mirror) when `secrets.RESEND_API_KEY`, `vars.RESEND_FROM` (shared with the
   red-team daily) and `vars.DIGEST_REPORT_EMAIL` are set; unset ⇒ the step warns and

--- a/.claude/skills/epic-digest/example.data.json
+++ b/.claude/skills/epic-digest/example.data.json
@@ -54,6 +54,26 @@
       ]
     }
   ],
+  "initiatives": [
+    {
+      "number": 1632,
+      "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/1632",
+      "title": "🎨 Visual Layout & Builder — the AI-composed, human-editable layout stack",
+      "epicsTotal": 5,
+      "activeCount": 2,
+      "blockedCount": 1,
+      "blocked": true,
+      "childrenTotal": 31,
+      "childrenDone": 14,
+      "members": [
+        { "number": 983, "title": "Graduate the Crouton Builder POC → crouton-layout package", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/983", "done": 7, "total": 12, "status": "blocked", "blocked": true },
+        { "number": 703, "title": "Lean layout engine", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/703", "done": 1, "total": 4, "status": "open", "blocked": false },
+        { "number": 868, "title": "Maquette — the semantic-zoom layout builder", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/868", "done": 0, "total": 3, "status": "open", "blocked": false },
+        { "number": 905, "title": "App-canvas on Vue Flow", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/905", "done": 6, "total": 12, "status": "open", "blocked": false },
+        { "number": 855, "title": "Mini-apps everywhere — one block, three renderers", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/855", "done": 0, "total": 0, "status": "open", "blocked": false }
+      ]
+    }
+  ],
   "epics": [
     {
       "number": 318,

--- a/.claude/skills/epic-digest/gather.mjs
+++ b/.claude/skills/epic-digest/gather.mjs
@@ -157,11 +157,40 @@ async function subIssues(number) {
   }
 }
 
+// ── initiatives (super-epics grouping several epics) ─────────────────────────
+// An initiative is an epic that groups OTHER epics. It's detected by the
+// `initiative` label OR an `Initiative:` title prefix (the label was added to
+// .github/labels.yml but may not have synced to GitHub yet — the title prefix
+// makes this work in the meantime). Its member epics are the `#NN` links in its
+// body's "Member epics" / "constituent epics" section, intersected with the set
+// of gathered open epics (so closed/non-epic refs drop out automatically). (#1637)
+const isInitiativeEpic = (names, title) =>
+  names.includes('initiative') || /^\s*Initiative:/i.test(title || '')
+
+function parseMemberNumbers(body, self, initiativeNums, epicByNum) {
+  // Prefer the explicit member list so a #NN mentioned elsewhere in the body
+  // (e.g. a "moved out" note in a consolidation section) isn't miscounted.
+  const scoped = section(body, /^##\s.*(member epics|constituent epics|building blocks)/i)
+  const src = scoped || body
+  const seen = new Set()
+  const out = []
+  for (const m of String(src).matchAll(/#(\d+)/g)) {
+    const n = Number(m[1])
+    if (n === self || seen.has(n)) continue
+    if (initiativeNums.has(n)) continue // an initiative isn't a member of another
+    if (!epicByNum.has(n)) continue // must be a gathered OPEN epic
+    seen.add(n)
+    out.push(n)
+  }
+  return out
+}
+
 // ── gather ───────────────────────────────────────────────────────────────────
 const childNumbers = new Set()
 
 const epicItems = await search(`repo:${REPO} is:issue is:open label:epic`)
 const epics = []
+const bodyByNum = new Map()
 for (const e of epicItems) {
   const kids = await subIssues(e.number)
   let done = 0, anyBlocked = false, inProgress = 0, closedInWindow = 0
@@ -202,15 +231,58 @@ for (const e of epicItems) {
     : inProgress ? 'in-progress'
     : 'open'
 
+  bodyByNum.set(e.number, e.body || '')
   epics.push({
     number: e.number, title: e.title, url: e.html_url,
     status, blocked, total, done, readyToClose, needsPostmortem,
+    isInitiative: isInitiativeEpic(epicNames, e.title),
     theHypothesis: parseHypothesis(e.body),
     weWillKnowBy: parseKnowBy(e.body),
     whereWeAre,
     children
   })
 }
+
+// Split the gathered epics into initiatives (super-epics) and regular epics, and
+// roll each initiative's member epics up into an aggregate. Initiatives are
+// pulled OUT of the flat epic list so they don't render as misleading 0/0 epics.
+const epicByNum = new Map(epics.map((e) => [e.number, e]))
+const initiativeNums = new Set(epics.filter((e) => e.isInitiative).map((e) => e.number))
+const regularEpics = []
+const initiatives = []
+for (const e of epics) {
+  if (!e.isInitiative) {
+    delete e.isInitiative
+    regularEpics.push(e)
+    continue
+  }
+  const memberNums = parseMemberNumbers(bodyByNum.get(e.number), e.number, initiativeNums, epicByNum)
+  const members = memberNums.map((n) => epicByNum.get(n)).filter(Boolean)
+  const childrenTotal = members.reduce((s, m) => s + (m.total || 0), 0)
+  const childrenDone = members.reduce((s, m) => s + (m.done || 0), 0)
+  const blockedCount = members.filter((m) => m.blocked || m.status === 'blocked').length
+  const activeCount = members.filter(
+    (m) => m.blocked || m.status === 'blocked' || m.status === 'in-progress' || (m.done || 0) > 0
+  ).length
+  initiatives.push({
+    number: e.number,
+    url: e.url,
+    title: e.title.replace(/^\s*Initiative:\s*/i, ''),
+    epicsTotal: members.length,
+    activeCount,
+    blockedCount,
+    blocked: blockedCount > 0,
+    childrenTotal,
+    childrenDone,
+    members: members.map((m) => ({
+      number: m.number, title: m.title, url: m.url,
+      done: m.done, total: m.total, status: m.status,
+      blocked: !!(m.blocked || m.status === 'blocked')
+    }))
+  })
+}
+// Most-substantial / blocked initiatives first so the eye lands on what matters.
+initiatives.sort((a, b) => (b.blocked ? 1 : 0) - (a.blocked ? 1 : 0) || b.childrenTotal - a.childrenTotal)
 
 const [closed, opened, mergedPRs, openNonEpic] = await Promise.all([
   search(`repo:${REPO} is:issue is:closed closed:>=${cutoff}`),
@@ -248,7 +320,7 @@ const prDetailed = await Promise.all(
 )
 prDetailed.sort((a, b) => (b.testSteps.length ? 1 : 0) - (a.testSteps.length ? 1 : 0))
 const prActionables = prDetailed.slice(0, PR_ACTIONABLE_CAP)
-const completeEpics = epics.filter((e) => e.total > 0 && e.done >= e.total)
+const completeEpics = regularEpics.filter((e) => e.total > 0 && e.done >= e.total)
 const epicActionables = await Promise.all(
   completeEpics.map(async (e) => {
     const cmts = await issueComments(e.number)
@@ -275,7 +347,8 @@ const data = {
     mergedPRs: mergedPRs.map((i) => slim(i, 'pr'))
   },
   actionables,
-  epics,
+  initiatives,
+  epics: regularEpics,
   loose
 }
 

--- a/.claude/skills/epic-digest/render.mjs
+++ b/.claude/skills/epic-digest/render.mjs
@@ -90,6 +90,11 @@ const epics = (data.epics || []).slice().sort((a, b) => {
   return pct(b) - pct(a)
 })
 
+// Initiatives: super-epics that group several epics. Rendered as a compact
+// rollup band above the flat epic list — the gather step already computed the
+// aggregate + pulled them out of `epics`, so they don't double-render. (#1637)
+const initiatives = (data.initiatives || []).slice()
+
 // Loose tickets: open issues that belong to no epic (no `epic` label, no parent).
 // Grouped by type so a pile of chores reads as one block, not noise.
 const loose = (data.loose || []).slice()
@@ -205,6 +210,36 @@ function actionableCard(a) {
     ${stepsBlock}
     <div style="margin-top:18px;font-size:13px">${links.join(' &nbsp;·&nbsp; ')}</div>
   </td></tr>`
+}
+
+// Compact initiative rollup — title + aggregate progress + member epic links.
+// Not a full epicCard: an initiative is a lens, so it reads in three lines.
+const memberSep = `<span class="mut" style="color:${C.faint}"> · </span>`
+function initiativeRow(it) {
+  const blockedChip = it.blockedCount ? '&nbsp;&nbsp;' + statusChip(`${it.blockedCount} blocked`, 'orange') : ''
+  const headline =
+    `${it.activeCount}/${it.epicsTotal} epic${it.epicsTotal === 1 ? '' : 's'} active` +
+    ` · ${it.childrenDone}/${it.childrenTotal} child issue${it.childrenTotal === 1 ? '' : 's'} done`
+  const members = (it.members || [])
+    .map((m) => `<a href="${esc(m.url)}" ${linkS}>#${esc(m.number)}</a>${m.blocked ? `<span class="mut" style="color:${C.faint}"> ⛔</span>` : ''}`)
+    .join(memberSep)
+  return `
+  <tr><td class="rule" style="padding:18px 0;border-top:1px solid ${C.border}">
+    <div style="font-size:17px;font-weight:400;line-height:1.5;color:${C.ink}">
+      <a href="${esc(it.url)}" class="ink lnk" style="color:${C.ink};text-decoration:none">${esc(it.title)}</a> ${num(it.number)}${blockedChip}
+    </div>
+    <div class="mut" style="font-style:italic;color:${C.mut};font-size:13px;margin-top:6px">${headline}</div>
+    <div class="sub" style="color:${C.sub};font-size:14px;line-height:1.9;margin-top:8px">${members || '<span style="font-style:italic">no open member epics</span>'}</div>
+  </td></tr>`
+}
+function initiativesSection(items) {
+  if (!items || !items.length) return ''
+  return `
+    <tr><td style="padding:34px 0 6px">
+      ${sectionLabel('Initiatives', 'cyan')}
+      <div class="mut" style="font-style:italic;color:${C.mut};font-size:14px;margin-top:8px">${items.length} initiative${items.length === 1 ? '' : 's'} grouping the open epics.</div>
+    </td></tr>
+    ${items.map(initiativeRow).join('')}`
 }
 
 function actionablesSection(items) {
@@ -417,6 +452,8 @@ const html = `<!doctype html>
 
     ${actionablesSection(actionables)}
 
+    ${initiativesSection(initiatives)}
+
     <tr><td style="padding:34px 0 0">${sectionLabel('Since yesterday')}</td></tr>
     <tr><td style="padding:20px 0 0">
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>
@@ -489,6 +526,24 @@ const txtActionables = (items) => {
   )
 }
 
+const txtInitiatives = (items) => {
+  if (!items || !items.length) return ''
+  return (
+    `INITIATIVES (${items.length})\n\n` +
+    items
+      .map((it) => {
+        const head = `${it.title}  (#${it.number})${it.blockedCount ? `  [${it.blockedCount} blocked]` : ''}`
+        const stat = `  ${it.activeCount}/${it.epicsTotal} epics active · ${it.childrenDone}/${it.childrenTotal} child issues done`
+        const mem = (it.members || []).length
+          ? '  ' + it.members.map((m) => `#${m.number}${m.blocked ? '⛔' : ''}`).join(' · ')
+          : '  (no open member epics)'
+        return `${head}\n${stat}\n${mem}\n      ${it.url}`
+      })
+      .join('\n\n') +
+    `\n\n${'='.repeat(64)}\n\n`
+  )
+}
+
 const txtReadyToClose = (allEpics) => {
   const items = (allEpics || []).filter(isCloseable)
   if (!items.length) return ''
@@ -510,6 +565,7 @@ const txt =
   `${repo} · last ${windowHours}h · ${epics.length} open epic(s)\n` +
   `${'='.repeat(64)}\n\n` +
   txtActionables(actionables) +
+  txtInitiatives(initiatives) +
   txtReadyToClose(epics) +
   `SINCE YESTERDAY\n` +
   `  ${(activity.opened || []).length} opened · ${(activity.closed || []).length} closed · ${(activity.mergedPRs || []).length} PRs merged\n\n` +
@@ -602,6 +658,28 @@ const mdActionables = (items) => {
   )
 }
 
+const mdInitiatives = (items) => {
+  if (!items || !items.length) return ''
+  const block = items
+    .map((it) => {
+      const blocked = it.blockedCount ? ` · ⛔ ${it.blockedCount} blocked` : ''
+      const mem = (it.members || []).length
+        ? it.members.map((m) => `[#${m.number}](${m.url})${m.blocked ? ' ⛔' : ''}`).join(' · ')
+        : '_no open member epics_'
+      return (
+        `- **[${it.title}](${it.url})** — \`${it.activeCount}/${it.epicsTotal} epics active · ` +
+        `${it.childrenDone}/${it.childrenTotal} issues done\`${blocked}\n  ${mem}`
+      )
+    })
+    .join('\n')
+  return (
+    `### 🎛 Initiatives\n` +
+    `_${items.length} initiative${items.length === 1 ? '' : 's'} grouping the open epics._\n\n` +
+    block +
+    `\n\n`
+  )
+}
+
 const mdReadyToClose = (allEpics) => {
   const items = (allEpics || []).filter(isCloseable)
   if (!items.length) return ''
@@ -624,6 +702,7 @@ const md =
   `## 📊 Daily epic digest — ${prettyDate}\n` +
   `_${repo} · last ${windowHours}h · ${epics.length} open epic${epics.length === 1 ? '' : 's'}_\n\n` +
   mdActionables(actionables) +
+  mdInitiatives(initiatives) +
   mdReadyToClose(epics) +
   `**Since yesterday:** ${(activity.opened || []).length} opened · ${(activity.closed || []).length} closed · ${(activity.mergedPRs || []).length} PRs merged\n\n` +
   `<details><summary>Activity detail</summary>\n\n` +

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -191,6 +191,9 @@
   description: "Performance"
 
 # ── Meta ──
+- name: "transient-infra"
+  color: "fbca04"
+  description: "A CI/deploy failure that self-healed — a transient runner/Cloudflare blip, not a code bug (#1639)"
 - name: "initiative"
   color: "0e2a63"
   description: "Umbrella grouping several epics toward one end-goal (super-epic rollup)"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -191,6 +191,9 @@
   description: "Performance"
 
 # ── Meta ──
+- name: "initiative"
+  color: "0e2a63"
+  description: "Umbrella grouping several epics toward one end-goal (super-epic rollup)"
 - name: "epic"
   color: "3e4b9e"
   description: "Tracking epic with child issues"

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -98,80 +98,16 @@ jobs:
           DISPATCH_ENV: ${{ github.event.inputs.environment }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
-        run: |
-          set -euo pipefail
-          include='[]'
-
-          # Append one app (read from its deploy.config.json) to the matrix include.
-          add_app() {
-            local app="$1" env="$2"
-            local cfg="apps/$app/deploy.config.json"
-            if [ ! -f "$cfg" ]; then
-              echo "skip: apps/$app has no deploy.config.json (not opted in)"
-              return
-            fi
-            local su pu lp rq
-            su=$(jq -r '.stagingUrl // ""' "$cfg")
-            pu=$(jq -r '.productionUrl // ""' "$cfg")
-            lp=$(jq -r '.layerPackages // ""' "$cfg")
-            # secrets.required → the deploy fails loudly if WORKER_SECRETS_JSON
-            # resolves empty (the Environment-scoping trap, #1094)
-            rq=$(jq '.secrets.required // false' "$cfg")
-            include=$(printf '%s' "$include" | jq \
-              --arg a "$app" --arg e "$env" --arg su "$su" --arg pu "$pu" --arg lp "$lp" --argjson rq "$rq" \
-              '. + [{app:$a, environment:$e, stagingUrl:$su, productionUrl:$pu, layerPackages:$lp, requireWorkerSecrets:$rq}]')
-          }
-
-          if [ "$EVENT" = "workflow_dispatch" ]; then
-            # Single named app. environment honours the input; anything other than the
-            # explicit "production" choice falls back to staging (defensive whitelist).
-            env="staging"
-            [ "${DISPATCH_ENV:-staging}" = "production" ] && env="production"
-            [ -n "${DISPATCH_APP:-}" ] && add_app "$DISPATCH_APP" "$env"
-          else
-            # push / pull_request → STAGING ONLY (#318). Deploy each opted-in app whose
-            # watchPaths match a changed file.
-            if [ -z "${BASE_SHA:-}" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
-              changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
-            else
-              changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
-            fi
-            echo "Changed files:"; printf '%s\n' "$changed"
-
-            for cfg in apps/*/deploy.config.json; do
-              [ -f "$cfg" ] || continue
-              app=$(basename "$(dirname "$cfg")")
-              # Rung split (#1297): a pull_request deploys ONLY the app whose OWN paths
-              # (apps/<app>/**) changed. A shared-package change that breaks a consuming
-              # app is caught by the fixture smoke (fast, no deploy) + the rung-2 push
-              # deploy — NOT a per-PR fan-out redeploy of every consuming app, which
-              # saturated the runners and starved the changed app's own deploy (#1297).
-              # push (merge to main) keeps the full watchPaths incl. shared packages.
-              if [ "$EVENT" = "pull_request" ]; then
-                pats=("apps/$app/**")
-              else
-                mapfile -t pats < <(jq -r '.watchPaths[]? // empty' "$cfg")
-              fi
-              hit=false
-              while IFS= read -r f; do
-                [ -z "$f" ] && continue
-                for pat in "${pats[@]:-}"; do
-                  [ -z "$pat" ] && continue
-                  # In [[ ]] pattern matching '*' spans '/', so 'packages/foo/**'
-                  # matches any file under packages/foo and 'pnpm-lock.yaml' is exact.
-                  if [[ "$f" == $pat ]]; then hit=true; break; fi
-                done
-                $hit && break
-              done <<< "$changed"
-              if $hit; then add_app "$app" "staging"; fi
-            done
-          fi
-
-          matrix=$(jq -cn --argjson inc "$include" '{include:$inc}')
-          if [ "$(printf '%s' "$include" | jq 'length')" -gt 0 ]; then any=true; else any=false; fi
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-          echo "any=$any" >> "$GITHUB_OUTPUT"
-          echo "Detected matrix: $matrix"
+        # The decision lives in the pure, unit-tested scripts/deploy-detect.mjs (mirrors
+        # scripts/packages-guard.mjs). It fixes #1499: the old inline bash used
+        # `git diff … 2>/dev/null || true`, which turned a FAILED diff into an empty one —
+        # indistinguishable from "nothing changed" — so a merge that should have deployed was
+        # silently skipped while the run went green. The script never swallows a diff failure:
+        # on push it prefers the merge's first-parent diff (robust to concurrent pushes) and
+        # exits NON-ZERO (loud red → report-failed-deploy fires) if it can't compute a diff or
+        # the changed-file set comes back empty on a triggered push/PR. Contract:
+        # scripts/deploy-detect.test.mjs (`node --test`).
+        run: node scripts/deploy-detect.mjs
 
   # One deploy-app.yml call per detected app. Skipped cleanly when nothing opted-in changed.
   deploy:

--- a/.github/workflows/report-failed-deploy.yml
+++ b/.github/workflows/report-failed-deploy.yml
@@ -2,14 +2,22 @@ name: Report failed post-merge deploy
 
 # (#340, epic #336) The dangerous failures happen AFTER merge: a staging/prod deploy
 # breaks once the PR is already closed and the task ticket is done, so it can vanish
-# silently. This opens exactly ONE new, labelled issue (pinging the owner) whenever a
-# post-merge deploy fails — nothing is lost.
+# silently. This watchdog makes sure the breakage isn't lost.
 #
-# Trigger: workflow_run[completed] of the per-app/poc deploy workflows. We act only on
-# conclusion==failure for a deploy that ran off `main` (i.e. post-merge — these deploys
-# fire on push to main now that trunk = staging, #347; they don't run on PRs). Idempotent:
-# a hidden `run:<id>` marker in the issue body means a re-run of the same failed deploy
-# never opens a duplicate.
+# Trigger: workflow_run[completed] of the deploy workflows. We act only on
+# conclusion==failure for a deploy that ran off `main` (post-merge; these deploys fire on
+# push to main now that trunk = staging, #347 — they don't run on PRs).
+#
+# The DECISION is the pure, unit-tested scripts/deploy-failure-report.mjs (#1639); this
+# workflow only does the GitHub I/O. Three behaviours it replaced (they produced the
+# duplicate/misleading tickets #1617/#1548/#1535):
+#   • Rolling dedup — ONE ticket per workflow[+app], commented on re-failure (keyed by a
+#     hidden marker), not one issue per failed run.
+#   • Transient-flake classification — the failed-job logs are fetched and classified; a CF
+#     infra blip (D1 7429, fetch-failed) is labelled `transient-infra` and does NOT @-ping;
+#     a real regression pings loudly.
+#   • Honest attribution — a non-`push` run (workflow_dispatch) caveats that the commit is
+#     the branch tip at run time, not necessarily the cause (the #1617 misattribution).
 
 on:
   workflow_run:
@@ -22,9 +30,12 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: read   # read the failed run's jobs + logs for flake classification
 
+# Serialise reports for the same workflow+branch so the find-existing-then-create step can't
+# race two failing runs into two duplicate rolling tickets.
 concurrency:
-  group: report-failed-deploy-${{ github.event.workflow_run.id }}
+  group: report-failed-deploy-${{ github.event.workflow_run.name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 jobs:
@@ -34,59 +45,69 @@ jobs:
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4   # needed to import scripts/deploy-failure-report.mjs
       - uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo
-            const run = context.payload.workflow_run
-            const MARKER = `<!-- failed-deploy run:${run.id} -->`
-            const HEADER = '> 🤖 **Claude Code** · agent pipeline (CI) · _post-merge deploy watchdog (#340)_'
+            const wr = context.payload.workflow_run
+            const { classifyLogs, slugFromPath, decideReport, keyMarker } =
+              await import(`${process.env.GITHUB_WORKSPACE}/scripts/deploy-failure-report.mjs`)
 
-            // Idempotency: scan recent OPEN issues for this run's marker (listForRepo is
-            // immediately consistent, unlike the search index). One issue per failing run.
-            const since = new Date(Date.now() - 14 * 24 * 3600 * 1000).toISOString()
-            const recent = await github.paginate(github.rest.issues.listForRepo,
+            const run = {
+              id: wr.id, name: wr.name, event: wr.event, path: wr.path,
+              head_sha: wr.head_sha, head_commit: wr.head_commit, html_url: wr.html_url,
+              head_branch: wr.head_branch, repoFullName: `${owner}/${repo}`
+            }
+            const slug = slugFromPath(run.path)
+
+            // ── fetch the failed jobs' logs (best-effort) → classify transient vs real ──
+            let logsText = ''
+            try {
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun,
+                { owner, repo, run_id: run.id, per_page: 100 })
+              const failed = jobs.filter(j => j.conclusion === 'failure')
+              for (const j of failed) {
+                try {
+                  const res = await github.rest.actions.downloadJobLogsForWorkflowRun({ owner, repo, job_id: j.id })
+                  logsText += '\n' + String(res.data || '')
+                } catch (e) { core.info(`log fetch failed for job ${j.id}: ${e.message}`) }
+              }
+            } catch (e) { core.info(`could not list jobs for run ${run.id}: ${e.message}`) }
+            // Bound the text we classify (tail — the error is at the end).
+            logsText = logsText.slice(-40000)
+            const classification = classifyLogs(logsText)
+            core.info(`classification: ${classification.transient ? 'transient' : 'real'} (${classification.reason || 'no signature'})`)
+
+            // ── find the existing OPEN rolling ticket for this workflow[+slug] ──
+            const marker = keyMarker(run.name, slug)
+            const since = new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString()
+            const openIssues = await github.paginate(github.rest.issues.listForRepo,
               { owner, repo, state: 'open', since, per_page: 100 })
-            if (recent.some(i => !i.pull_request && (i.body || '').includes(MARKER))) {
-              core.info(`Issue for run ${run.id} already exists — no duplicate.`); return
+            const found = openIssues.find(i => !i.pull_request && (i.body || '').includes(marker))
+            let existing = null
+            if (found) {
+              const comments = await github.paginate(github.rest.issues.listComments,
+                { owner, repo, issue_number: found.number, per_page: 100 })
+              existing = { number: found.number, text: (found.body || '') + '\n' + comments.map(c => c.body || '').join('\n') }
             }
 
-            // App slug from the workflow file: .github/workflows/deploy-<slug>.yml.
-            // The generic per-workspace workflows (deploy-apps.yml / deploy-pocs.yml, #481)
-            // carry no app in their path — the app lives in the matrix, not the filename —
-            // so treat their "slug" as none (one issue per failing RUN, no app label).
-            const rawSlug = (run.path.match(/deploy-([a-z0-9-]+)\.yml$/) || [])[1] || null
-            const slug = (rawSlug === 'apps' || rawSlug === 'pocs') ? null : rawSlug
-
-            // Apply an app:/poc: label only if it actually exists (don't auto-create a wrong one).
-            const labels = ['type:fix', 'meta:agents']
+            // ── resolve an existing app:/poc: label (don't auto-create a wrong one) ──
+            let appLabel = null
             if (slug) {
               const all = await github.paginate(github.rest.issues.listLabelsForRepo, { owner, repo, per_page: 100 })
               const names = new Set(all.map(l => l.name))
-              const appLabel = [`app:${slug}`, `poc:${slug}`].find(n => names.has(n))
-              if (appLabel) labels.push(appLabel)
+              appLabel = [`app:${slug}`, `poc:${slug}`].find(n => names.has(n)) || null
             }
 
-            const sha7 = (run.head_sha || '').slice(0, 7)
-            const commitUrl = `https://github.com/${owner}/${repo}/commit/${run.head_sha}`
-            const title = `🚨 ${run.name} failed on ${run.head_branch} (post-merge)`
-            const body = [
-              `🔴 **@pmcp — a post-merge deploy failed: \`${run.name}\` broke on \`${run.head_branch}\`.**`,
-              '',
-              `The change is already merged, so this ticket exists so the breakage isn't lost.`,
-              '',
-              `- **Failing run:** ${run.html_url}`,
-              `- **Landed commit:** [\`${sha7}\`](${commitUrl})${run.head_commit?.message ? ' — ' + run.head_commit.message.split('\n')[0] : ''}`,
-              `- **Branch / env:** \`${run.head_branch}\``,
-              slug ? `- **App:** \`${slug}\`` : null,
-              '',
-              '## 🧪 How to verify the fix',
-              `1. Reproduce: re-run \`${run.name}\` or run the app's deploy locally and watch for the same error.`,
-              `2. Fix the cause on a branch, open a PR (\`Closes #<this>\`), and confirm the deploy goes green.`,
-              '',
-              `<sub>${HEADER.replace(/^> /, '')}</sub>`,
-              MARKER,
-            ].filter(l => l !== null).join('\n')
-
-            const issue = await github.rest.issues.create({ owner, repo, title, body, labels })
-            core.info(`Opened #${issue.data.number} for failed deploy run ${run.id}.`)
+            // ── decide + act ──
+            const d = decideReport({ run, classification, existing, appLabel })
+            if (d.action === 'skip') { core.info(d.reason); return }
+            if (d.action === 'comment') {
+              const body = d.ping ? `@pmcp — new failure on this deploy:\n\n${d.body}` : d.body
+              await github.rest.issues.createComment({ owner, repo, issue_number: d.issueNumber, body })
+              core.info(`Appended failed run ${run.id} to rolling ticket #${d.issueNumber}.`)
+              return
+            }
+            const issue = await github.rest.issues.create({ owner, repo, title: d.title, body: d.body, labels: d.labels })
+            core.info(`Opened #${issue.data.number} for failed deploy run ${run.id} (${classification.transient ? 'transient' : 'real'}).`)

--- a/scripts/deploy-detect.mjs
+++ b/scripts/deploy-detect.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * deploy-detect — decide which apps deploy-apps.yml should deploy, and to which env.
+ *
+ * Extracted from the inline `detect` bash in .github/workflows/deploy-apps.yml so the
+ * decision is a pure, unit-tested function (mirrors scripts/packages-guard.mjs). It fixes
+ * #1499: the old bash computed the changed-file set with `git diff … 2>/dev/null || true`,
+ * which laundered a *failed* diff into an empty one — indistinguishable from a legitimate
+ * "nothing changed" — so a merge that should have deployed was silently skipped while the
+ * run reported success ("green but it didn't happen").
+ *
+ * Two guarantees here:
+ *   1. `resolveChangedFiles` NEVER swallows a diff failure. On push-to-main it prefers the
+ *      merge's first-parent diff (`HEAD~1..HEAD` — the net change, robust to concurrent
+ *      pushes, unlike before..after), and if it cannot resolve ANY base it throws.
+ *   2. An EMPTY changed-file set on a triggered push/PR is treated as a compute failure,
+ *      not "deploy nothing": the workflow's own `paths:` filter guarantees ≥1 watched file
+ *      changed, so empty ⇒ the diff broke ⇒ fail loud (red run → report-failed-deploy
+ *      fires) instead of a silent green skip. (An empty *matrix* is still fine — e.g. a
+ *      workflow-only change matches no app — that's a non-empty file set with no app hit.)
+ *
+ *   CLI (used by the workflow):
+ *     EVENT=push BASE_SHA=… HEAD_SHA=… node scripts/deploy-detect.mjs
+ *       → appends `matrix=…` and `any=…` to $GITHUB_OUTPUT; exit 1 (loud) on a broken diff.
+ */
+import { execFileSync } from 'node:child_process'
+import { readdirSync, existsSync, readFileSync, appendFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+export const ZERO_SHA = '0000000000000000000000000000000000000000'
+
+export class DetectError extends Error {}
+
+// Translate a watchPath pattern into a RegExp with the SAME semantics as bash `[[ $f == $pat ]]`
+// (used by the old detect job): `*` matches any run of characters INCLUDING `/` and empty, so
+// `packages/crouton/**` matches `packages/crouton/<anything>` but not `packages/crouton-core/x`,
+// and `pnpm-lock.yaml` is an exact match. Escape every regex metachar EXCEPT `*`, then `*`→`.*`.
+export function watchPathToRegExp(pattern) {
+  const escaped = String(pattern).replace(/[.+^${}()|[\]\\?]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`)
+}
+
+export function fileMatchesAny(file, patterns = []) {
+  return patterns.some(p => p && watchPathToRegExp(p).test(file))
+}
+
+/**
+ * Compute the deploy matrix. PURE — no git, no fs. `apps` is the list of opted-in apps
+ * (each: { app, stagingUrl, productionUrl, layerPackages, requireWorkerSecrets, watchPaths }).
+ *
+ * - workflow_dispatch: the single named app, at the requested env (only the explicit
+ *   "production" choice reaches production; anything else → staging — the #318 whitelist).
+ * - push / pull_request: STAGING only (#318). A pull_request deploys ONLY the app whose OWN
+ *   paths (`apps/<app>/**`) changed (#1297 — a shared-package break is caught by the fixture
+ *   smoke + the rung-2 push deploy, not a per-PR fan-out). A push keeps the full watchPaths.
+ */
+function toEntry(a, environment) {
+  return {
+    app: a.app,
+    environment,
+    stagingUrl: a.stagingUrl || '',
+    productionUrl: a.productionUrl || '',
+    layerPackages: a.layerPackages || '',
+    requireWorkerSecrets: a.requireWorkerSecrets ?? false
+  }
+}
+
+// workflow_dispatch → the single named app at the requested env (production only for the
+// explicit choice — the #318 whitelist).
+function dispatchInclude(dispatchApp, dispatchEnv, apps) {
+  const a = apps.find(x => x.app === dispatchApp)
+  if (!a) return []
+  return [toEntry(a, dispatchEnv === 'production' ? 'production' : 'staging')]
+}
+
+// push / pull_request → STAGING only. A pull_request matches only the app's OWN paths (#1297);
+// a push matches its full watchPaths (incl. shared packages).
+function changeInclude(event, changedFiles, apps) {
+  const include = []
+  for (const a of apps) {
+    const patterns = event === 'pull_request' ? [`apps/${a.app}/**`] : (a.watchPaths || [])
+    if (changedFiles.some(f => f && fileMatchesAny(f, patterns))) include.push(toEntry(a, 'staging'))
+  }
+  return include
+}
+
+export function computeMatrix({ event, changedFiles = [], dispatchApp = '', dispatchEnv = '', apps = [] }) {
+  const include = event === 'workflow_dispatch'
+    ? dispatchInclude(dispatchApp, dispatchEnv, apps)
+    : changeInclude(event, changedFiles, apps)
+  return { include, any: include.length > 0 }
+}
+
+/**
+ * Resolve the changed-file list for a push/PR — the #1499 fix. `git` is injected so it's
+ * testable: { isResolvable(ref)->bool, diff(a,b)->string[] }. Throws DetectError rather than
+ * ever returning a silent empty list on failure.
+ */
+export function resolveChangedFiles({ event, baseSha, headSha, git }) {
+  if (event === 'pull_request') {
+    // A PR's base.sha is always a real, fetched commit — if it won't resolve, something is
+    // genuinely wrong; don't paper over it.
+    if (!git.isResolvable(baseSha)) throw new DetectError(`PR base sha not resolvable: ${baseSha || '(empty)'}`)
+    return { files: git.diff(baseSha, headSha), source: 'pr:base..head' }
+  }
+  // push-to-main: prefer the tip's first-parent diff — for a merge commit that IS the net PR
+  // change, and it doesn't depend on github.event.before (which is wrong under concurrent
+  // pushes — the #1477 cause). Fall back to before..after only if HEAD~1 is unavailable
+  // (e.g. an unexpectedly shallow checkout); if neither resolves, fail loud.
+  if (git.isResolvable('HEAD~1')) return { files: git.diff('HEAD~1', 'HEAD'), source: 'push:first-parent' }
+  if (baseSha && baseSha !== ZERO_SHA && git.isResolvable(baseSha)) {
+    return { files: git.diff(baseSha, headSha), source: 'push:before..after' }
+  }
+  throw new DetectError('cannot resolve a diff base on push (no HEAD~1, no usable before-sha)')
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+function realGit() {
+  const run = args => execFileSync('git', args, { encoding: 'utf8' })
+  return {
+    isResolvable(ref) {
+      try {
+        run(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`])
+        return true
+      } catch {
+        return false
+      }
+    },
+    diff(a, b) {
+      return run(['diff', '--name-only', a, b]).split('\n').map(s => s.trim()).filter(Boolean)
+    }
+  }
+}
+
+function loadApps(root = 'apps') {
+  if (!existsSync(root)) return []
+  const out = []
+  for (const name of readdirSync(root)) {
+    const cfgPath = `${root}/${name}/deploy.config.json`
+    if (!existsSync(cfgPath)) continue // not opted in
+    let cfg = {}
+    try {
+      cfg = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    } catch {
+      continue
+    }
+    out.push({
+      app: name,
+      stagingUrl: cfg.stagingUrl || '',
+      productionUrl: cfg.productionUrl || '',
+      layerPackages: cfg.layerPackages || '',
+      requireWorkerSecrets: cfg.secrets?.required ?? false,
+      watchPaths: Array.isArray(cfg.watchPaths) ? cfg.watchPaths : []
+    })
+  }
+  return out
+}
+
+function main() {
+  const event = process.env.EVENT || ''
+  const apps = loadApps()
+
+  let changedFiles = []
+  if (event !== 'workflow_dispatch') {
+    const { files, source } = resolveChangedFiles({
+      event,
+      baseSha: process.env.BASE_SHA || '',
+      headSha: process.env.HEAD_SHA || '',
+      git: realGit()
+    })
+    changedFiles = files
+    console.log(`Changed files (${source}):`)
+    for (const f of changedFiles) console.log(`  ${f}`)
+    // The trigger's own paths: filter guarantees a watched file changed, so an empty set can
+    // only mean the diff failed to compute — fail loud instead of a silent green no-deploy.
+    if (changedFiles.length === 0) {
+      throw new DetectError(
+        `${event} triggered deploy-apps but the changed-file set is EMPTY — the diff failed to `
+        + `compute (see #1499). Refusing to report success with no deploy.`
+      )
+    }
+  }
+
+  const { include, any } = computeMatrix({
+    event,
+    changedFiles,
+    dispatchApp: process.env.DISPATCH_APP || '',
+    dispatchEnv: process.env.DISPATCH_ENV || '',
+    apps
+  })
+  const matrix = JSON.stringify({ include })
+  const out = process.env.GITHUB_OUTPUT
+  if (out) appendFileSync(out, `matrix=${matrix}\nany=${any}\n`)
+  console.log(`Detected matrix: ${matrix}`)
+  console.log(`any=${any}`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  try {
+    main()
+  } catch (err) {
+    // ::error:: surfaces in the run summary; a non-zero exit makes the run RED so the
+    // post-merge watchdog (report-failed-deploy.yml) engages — the whole point of #1499.
+    console.error(`::error::deploy-detect: ${err.message}`)
+    process.exit(1)
+  }
+}

--- a/scripts/deploy-detect.test.mjs
+++ b/scripts/deploy-detect.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Contract for scripts/deploy-detect.mjs — the #1499 fix. Proves the detect decision:
+ *   • never launders a failed diff into a silent empty result (fail loud / fall back),
+ *   • prefers the merge's first-parent diff on push-to-main,
+ *   • reproduces the watchPath matching of the old bash `[[ $f == $pat ]]` exactly, and
+ *   • a crouton-sales-only merge always puts the consuming app (fanfare) in the matrix.
+ *
+ *   node --test scripts/deploy-detect.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  watchPathToRegExp, fileMatchesAny, computeMatrix, resolveChangedFiles, DetectError, ZERO_SHA
+} from './deploy-detect.mjs'
+
+// A stand-in for the injected git: declared-resolvable refs + canned diffs.
+const fakeGit = ({ resolvable = [], diffs = {} }) => ({
+  isResolvable: ref => resolvable.includes(ref),
+  diff: (a, b) => diffs[`${a}..${b}`] || []
+})
+
+const APPS = [
+  { app: 'fanfare', stagingUrl: 'https://kassa.pmcp.dev', productionUrl: 'https://kassa.friendlyinter.net', layerPackages: 'lp-f', requireWorkerSecrets: false, watchPaths: ['apps/fanfare/**', 'packages/crouton-sales/**', 'packages/crouton-core/**', 'pnpm-lock.yaml'] },
+  { app: 'triage', stagingUrl: 'https://triage-preview.pmcp.dev', productionUrl: '', layerPackages: 'lp-t', requireWorkerSecrets: false, watchPaths: ['apps/triage/**', 'packages/crouton-triage/**', 'pnpm-lock.yaml'] },
+  { app: 'velo', stagingUrl: 'https://velo.pmcp.dev', productionUrl: '', layerPackages: 'lp-v', requireWorkerSecrets: false, watchPaths: ['apps/velo/**', 'packages/crouton-bookings/**', 'pnpm-lock.yaml'] }
+]
+const names = r => r.include.map(e => e.app)
+
+// ── watchPath matching (must match bash `[[ $f == $pat ]]` semantics) ─────────
+test('`dir/**` matches nested files but not a sibling with a shared prefix', () => {
+  assert.equal(fileMatchesAny('packages/crouton/x.ts', ['packages/crouton/**']), true)
+  assert.equal(fileMatchesAny('packages/crouton/a/b/c.ts', ['packages/crouton/**']), true)
+  // the classic over-match trap: crouton-core must NOT match packages/crouton/**
+  assert.equal(fileMatchesAny('packages/crouton-core/x.ts', ['packages/crouton/**']), false)
+})
+
+test('an exact watchPath (pnpm-lock.yaml) is exact, not a prefix', () => {
+  assert.equal(fileMatchesAny('pnpm-lock.yaml', ['pnpm-lock.yaml']), true)
+  assert.equal(fileMatchesAny('pnpm-lock.yaml.bak', ['pnpm-lock.yaml']), false)
+  assert.equal(fileMatchesAny('a/pnpm-lock.yaml', ['pnpm-lock.yaml']), false)
+})
+
+test('watchPathToRegExp is anchored', () => {
+  assert.equal(watchPathToRegExp('apps/velo/**').test('xapps/velo/y'), false)
+})
+
+// ── computeMatrix: push (merge to main) ───────────────────────────────────────
+test('#1477 regression: a crouton-sales-only merge deploys the consuming app (fanfare)', () => {
+  const r = computeMatrix({ event: 'push', changedFiles: ['packages/crouton-sales/app/x.vue', 'packages/crouton-sales/schemas/y.json'], apps: APPS })
+  assert.deepEqual(names(r), ['fanfare'])
+  assert.equal(r.any, true)
+  assert.equal(r.include[0].environment, 'staging') // push → staging only (#318)
+  assert.equal(r.include[0].stagingUrl, 'https://kassa.pmcp.dev')
+})
+
+test('a shared-package change fans out to every consuming app', () => {
+  const r = computeMatrix({ event: 'push', changedFiles: ['pnpm-lock.yaml'], apps: APPS })
+  assert.deepEqual(names(r).sort(), ['fanfare', 'triage', 'velo'])
+})
+
+test('a workflow-only change matches no app → empty matrix (legitimately, any=false)', () => {
+  const r = computeMatrix({ event: 'push', changedFiles: ['.github/workflows/deploy-apps.yml'], apps: APPS })
+  assert.deepEqual(names(r), [])
+  assert.equal(r.any, false)
+})
+
+// ── computeMatrix: pull_request (rung split #1297) ────────────────────────────
+test('a PR deploys ONLY the app whose own paths changed, ignoring shared-package changes', () => {
+  const r = computeMatrix({
+    event: 'pull_request',
+    changedFiles: ['apps/triage/app/x.vue', 'packages/crouton-sales/y.ts'], // sales would match fanfare on a push
+    apps: APPS
+  })
+  assert.deepEqual(names(r), ['triage']) // NOT fanfare — PRs don't fan out on shared pkgs
+})
+
+// ── computeMatrix: workflow_dispatch ──────────────────────────────────────────
+test('dispatch honours production only for the explicit choice (#318 whitelist)', () => {
+  assert.equal(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'fanfare', dispatchEnv: 'production', apps: APPS }).include[0].environment, 'production')
+  assert.equal(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'fanfare', dispatchEnv: '', apps: APPS }).include[0].environment, 'staging')
+  assert.equal(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'fanfare', dispatchEnv: 'prod', apps: APPS }).include[0].environment, 'staging') // typo ≠ production
+})
+
+test('dispatch for an unknown app yields an empty matrix', () => {
+  assert.deepEqual(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'nope', apps: APPS }).include, [])
+})
+
+// ── resolveChangedFiles: the #1499 core (never a silent empty) ─────────────────
+test('push prefers the first-parent diff (HEAD~1..HEAD)', () => {
+  const git = fakeGit({ resolvable: ['HEAD~1'], diffs: { 'HEAD~1..HEAD': ['packages/crouton-sales/x.ts'] } })
+  const r = resolveChangedFiles({ event: 'push', baseSha: 'deadbeef', headSha: 'cafe', git })
+  assert.equal(r.source, 'push:first-parent')
+  assert.deepEqual(r.files, ['packages/crouton-sales/x.ts'])
+})
+
+test('push falls back to before..after only when HEAD~1 is unavailable', () => {
+  const git = fakeGit({ resolvable: ['base1'], diffs: { 'base1..head1': ['apps/velo/x.vue'] } })
+  const r = resolveChangedFiles({ event: 'push', baseSha: 'base1', headSha: 'head1', git })
+  assert.equal(r.source, 'push:before..after')
+  assert.deepEqual(r.files, ['apps/velo/x.vue'])
+})
+
+test('push throws (does NOT return empty) when no base resolves — the #1499 silent-skip guard', () => {
+  const git = fakeGit({ resolvable: [] }) // neither HEAD~1 nor the before-sha resolve
+  assert.throws(() => resolveChangedFiles({ event: 'push', baseSha: 'ghost', headSha: 'head', git }), DetectError)
+})
+
+test('push with the all-zero before-sha and no HEAD~1 throws rather than emitting empty', () => {
+  const git = fakeGit({ resolvable: [] })
+  assert.throws(() => resolveChangedFiles({ event: 'push', baseSha: ZERO_SHA, headSha: 'head', git }), DetectError)
+})
+
+test('pull_request uses base..head', () => {
+  const git = fakeGit({ resolvable: ['prbase'], diffs: { 'prbase..prhead': ['apps/triage/x.vue'] } })
+  const r = resolveChangedFiles({ event: 'pull_request', baseSha: 'prbase', headSha: 'prhead', git })
+  assert.equal(r.source, 'pr:base..head')
+  assert.deepEqual(r.files, ['apps/triage/x.vue'])
+})
+
+test('pull_request throws when the PR base sha will not resolve (no silent empty)', () => {
+  const git = fakeGit({ resolvable: [] })
+  assert.throws(() => resolveChangedFiles({ event: 'pull_request', baseSha: 'ghost', headSha: 'head', git }), DetectError)
+})

--- a/scripts/deploy-failure-report.mjs
+++ b/scripts/deploy-failure-report.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * deploy-failure-report — the decision behind the post-merge deploy watchdog
+ * (.github/workflows/report-failed-deploy.yml, #340). Pure + unit-tested (mirrors
+ * scripts/packages-guard.mjs / scripts/deploy-detect.mjs); the workflow's github-script does
+ * only the GitHub I/O (find the rolling ticket, fetch failed-job logs) and then acts on the
+ * decision returned here.
+ *
+ * Fixes the noise that produced #1617/#1548/#1535 — three separate 🔴 tickets for what was
+ * two self-healed CF flakes + one already-fixed migration (#1639):
+ *   1. Rolling dedup — one ticket per workflow[+app], commented on re-failure, not one-per-run.
+ *   2. Transient-flake classification — a CF infra blip (D1 7429, fetch-failed) is labeled
+ *      `transient-infra` and does NOT @-ping; a real regression pings loudly as before.
+ *   3. Honest attribution — a non-`push` run (e.g. workflow_dispatch) caveats that the commit
+ *      shown is the branch tip at run time, not necessarily the cause (the #1617 misattribution).
+ */
+
+// Signatures that mean "the runner/Cloudflare hiccuped", not "the code is broken". Drawn from
+// the real failing logs of #1548 (D1 overloaded 7429) and #1535 (fetch failed / connectivity).
+export const TRANSIENT_SIGNATURES = [
+  /\[code: 7429\]/,
+  /D1 DB is overloaded/i,
+  /Requests queued for too long/i,
+  /A fetch request failed/i,
+  /likely due to a connectivity issue/i,
+  /\bfetch failed\b/i,
+  /\bECONNRESET\b/,
+  /\bETIMEDOUT\b/,
+  /\bEAI_AGAIN\b/,
+  /socket hang up/i,
+  /\b50[234]\b[^\n]+(gateway|unavailable|timeout|time-out)/i
+]
+
+// Signatures of a genuine, code-caused failure. These WIN over a transient match (a run can
+// print a connectivity warning and still have died on a real error) so we never mislabel a
+// real regression as a flake. From #1620 (NOT NULL constraint) + the usual build/type errors.
+export const HARD_SIGNATURES = [
+  /constraint failed/i,
+  /SQLITE_/,
+  /error TS\d+/,
+  /Type error:/i,
+  /Cannot find module/i,
+  /Cannot resolve/i,
+  /No migrations present/i,
+  /No schema files found/i,
+  /is not defined/,
+  /SyntaxError/,
+  /Could not load/i
+]
+
+/** Classify failed-job log text. A hard signature always wins; unknown → treated as real. */
+export function classifyLogs(text = '') {
+  const s = String(text)
+  const hard = HARD_SIGNATURES.find(re => re.test(s))
+  if (hard) return { transient: false, reason: `hard-failure signature ${hard}` }
+  const soft = TRANSIENT_SIGNATURES.find(re => re.test(s))
+  if (soft) return { transient: true, reason: `transient signature ${soft}` }
+  return { transient: false, reason: null }
+}
+
+/** App/poc slug from a per-app workflow path; the generic deploy-apps/pocs workflows carry none. */
+export function slugFromPath(path = '') {
+  const raw = (String(path).match(/deploy-([a-z0-9-]+)\.yml$/) || [])[1] || null
+  return raw === 'apps' || raw === 'pocs' ? null : raw
+}
+
+// Markers: one rolling ticket per (workflow, slug); each occurrence records its run id so a
+// re-run of the SAME failed run doesn't double-log.
+export const keyMarker = (workflowName, slug) => `<!-- failed-deploy key:${workflowName}|${slug || '-'} -->`
+export const runMarker = runId => `<!-- run:${runId} -->`
+
+const shortSha = sha => String(sha || '').slice(0, 7)
+const firstLine = msg => String(msg || '').split('\n')[0]
+
+function attribution(run) {
+  const sha = shortSha(run.head_sha)
+  const url = `https://github.com/${run.repoFullName}/commit/${run.head_sha}`
+  const msg = firstLine(run.head_commit?.message)
+  const line = `- **Commit at run time:** [\`${sha}\`](${url})${msg ? ` — ${msg}` : ''}`
+  // A push deploy's head_sha IS the merge that triggered it. A workflow_dispatch (or any
+  // non-push) run's head_sha is just the branch tip when it ran — NOT necessarily the cause
+  // (the #1617 trap: a manual prod deploy blamed on an unrelated `[skip ci]` commit).
+  if (run.event === 'push') return line
+  return `${line}\n  - ⚠️ _\`${run.event}\` run — this commit is the branch tip at run time, not necessarily the cause._`
+}
+
+function occurrence(run, classification) {
+  const tag = classification.transient ? '🟡 likely transient infra' : '🔴 likely a real failure'
+  return [
+    `${tag} · [failing run](${run.html_url}) · \`${run.event}\``,
+    attribution(run),
+    classification.reason ? `- _Signal: ${classification.reason}_` : '- _Signal: unrecognised — treat as real._',
+    runMarker(run.id)
+  ].join('\n')
+}
+
+/**
+ * Decide what to do with a failed post-merge deploy run. PURE.
+ *   run: { id, name, event, path, head_sha, head_commit, html_url, head_branch, repoFullName }
+ *   classification: from classifyLogs()
+ *   existing: { number, text } for the open rolling ticket, or null. `text` = its body + all
+ *             comments joined (used to skip an already-recorded run id).
+ *   appLabel: a resolved existing `app:`/`poc:` label name, or null.
+ */
+export function decideReport({ run, classification, existing = null, appLabel = null }) {
+  const slug = slugFromPath(run.path)
+  const ping = !classification.transient
+  const labels = ['type:fix', 'meta:agents']
+  if (classification.transient) labels.push('transient-infra')
+  if (appLabel) labels.push(appLabel)
+
+  if (existing) {
+    if (String(existing.text || '').includes(runMarker(run.id))) {
+      return { action: 'skip', reason: `run ${run.id} already recorded on #${existing.number}`, ping: false }
+    }
+    return { action: 'comment', issueNumber: existing.number, ping, body: occurrence(run, classification) }
+  }
+
+  const title = `🚨 ${run.name} failed on ${run.head_branch} (post-merge)`
+  const mention = ping ? `🔴 **@pmcp — a post-merge deploy failed: \`${run.name}\` broke on \`${run.head_branch}\`.**` : `🟡 **Post-merge deploy hiccup (likely transient): \`${run.name}\` on \`${run.head_branch}\`.**`
+  const body = [
+    mention,
+    '',
+    ping
+      ? `The change is already merged, so this ticket exists so the breakage isn't lost.`
+      : `Looks like a transient CF/runner blip that usually self-heals on the next deploy — recorded here (no ping) so a *recurring* flake still shows as a pattern.`,
+    '',
+    '## Occurrences',
+    '',
+    occurrence(run, classification),
+    '',
+    '## 🧪 How to verify the fix',
+    `1. Reproduce: re-run \`${run.name}\` or run the app's deploy locally and watch for the same error.`,
+    `2. Fix the cause on a branch, open a PR (\`Closes #<this>\`), and confirm the deploy goes green.`,
+    '',
+    `<sub>🤖 **Claude Code** · agent pipeline (CI) · _post-merge deploy watchdog (#340, #1639)_</sub>`,
+    keyMarker(run.name, slug)
+  ].join('\n')
+
+  return { action: 'create', title, body, labels, ping }
+}

--- a/scripts/deploy-failure-report.test.mjs
+++ b/scripts/deploy-failure-report.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * Contract for scripts/deploy-failure-report.mjs (#1639). Proves the watchdog decision:
+ *   • classifies the real #1548 (D1 7429) / #1535 (fetch failed) logs as transient, and the
+ *     #1620 (NOT NULL constraint) log as a real failure (hard signature wins),
+ *   • dedups: an existing rolling ticket → comment (or skip an already-recorded run), else create,
+ *   • transient → no @-ping + `transient-infra` label; and
+ *   • a workflow_dispatch run caveats its commit attribution (the #1617 misattribution).
+ *
+ *   node --test scripts/deploy-failure-report.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { classifyLogs, slugFromPath, decideReport, runMarker, keyMarker } from './deploy-failure-report.mjs'
+
+const runBase = {
+  id: 999, name: 'Deploy Apps (Cloudflare Workers)', event: 'push', path: '.github/workflows/deploy-apps.yml',
+  head_sha: 'abcdef1234567890', head_commit: { message: 'fix(x): thing\n\nbody' },
+  html_url: 'https://github.com/O/R/actions/runs/999', head_branch: 'main', repoFullName: 'O/R'
+}
+
+// ── classifyLogs (against the real failure signatures) ────────────────────────
+test('#1548 D1-overload log → transient', () => {
+  const log = '✘ [ERROR] A request to the Cloudflare API (…/d1/…/query) failed.\n  D1 DB is overloaded. Requests queued for too long. [code: 7429]'
+  assert.equal(classifyLogs(log).transient, true)
+})
+
+test('#1535 fetch-failed log → transient', () => {
+  const log = '▲ [WARNING] A fetch request failed, likely due to a connectivity issue.\n✘ [ERROR] fetch failed'
+  assert.equal(classifyLogs(log).transient, true)
+})
+
+test('#1620 NOT NULL constraint log → NOT transient (real failure)', () => {
+  const log = '✘ [ERROR] NOT NULL constraint failed: __new_sales_printers.locationId: SQLITE_CONSTRAINT'
+  assert.equal(classifyLogs(log).transient, false)
+})
+
+test('a hard signature wins even when a transient one is also present', () => {
+  const log = 'A fetch request failed, likely due to a connectivity issue.\n… error TS2345: Type error: nope'
+  assert.equal(classifyLogs(log).transient, false)
+})
+
+test('an unrecognised failure is treated as real (not silently transient)', () => {
+  assert.equal(classifyLogs('some brand new error nobody has seen').transient, false)
+})
+
+// ── slugFromPath ──────────────────────────────────────────────────────────────
+test('generic deploy-apps/pocs workflows carry no slug; a per-app one does', () => {
+  assert.equal(slugFromPath('.github/workflows/deploy-apps.yml'), null)
+  assert.equal(slugFromPath('.github/workflows/deploy-pocs.yml'), null)
+  assert.equal(slugFromPath('.github/workflows/deploy-velo.yml'), 'velo')
+})
+
+// ── decideReport: dedup ───────────────────────────────────────────────────────
+test('no existing ticket → create (with the rolling key marker)', () => {
+  const d = decideReport({ run: runBase, classification: { transient: false, reason: null } })
+  assert.equal(d.action, 'create')
+  assert.match(d.body, new RegExp(keyMarker('Deploy Apps (Cloudflare Workers)', null).replace(/[()|]/g, '\\$&')))
+  assert.match(d.body, new RegExp(runMarker(999)))
+})
+
+test('an existing rolling ticket → comment the new occurrence (not a new issue)', () => {
+  const d = decideReport({ run: runBase, classification: { transient: false, reason: null }, existing: { number: 42, text: 'prior body with other run' } })
+  assert.equal(d.action, 'comment')
+  assert.equal(d.issueNumber, 42)
+  assert.match(d.body, new RegExp(runMarker(999)))
+})
+
+test('an already-recorded run id on the ticket → skip (no duplicate occurrence)', () => {
+  const existing = { number: 42, text: `body… ${runMarker(999)} …` }
+  const d = decideReport({ run: runBase, classification: { transient: false, reason: null }, existing })
+  assert.equal(d.action, 'skip')
+})
+
+// ── decideReport: transient handling ──────────────────────────────────────────
+test('transient failure → no ping + transient-infra label', () => {
+  const d = decideReport({ run: runBase, classification: { transient: true, reason: 'x' } })
+  assert.equal(d.action, 'create')
+  assert.equal(d.ping, false)
+  assert.ok(d.labels.includes('transient-infra'))
+  assert.match(d.body, /likely transient/i)
+})
+
+test('real failure → ping + no transient-infra label', () => {
+  const d = decideReport({ run: runBase, classification: { transient: false, reason: null }, appLabel: 'app:fanfare' })
+  assert.equal(d.ping, true)
+  assert.ok(!d.labels.includes('transient-infra'))
+  assert.ok(d.labels.includes('app:fanfare'))
+  assert.match(d.body, /@pmcp/)
+})
+
+// ── decideReport: honest attribution ──────────────────────────────────────────
+test('a push run states the commit plainly', () => {
+  const d = decideReport({ run: { ...runBase, event: 'push' }, classification: { transient: false, reason: null } })
+  assert.doesNotMatch(d.body, /not necessarily the cause/)
+})
+
+test('a workflow_dispatch run caveats the attribution (the #1617 trap)', () => {
+  const d = decideReport({ run: { ...runBase, event: 'workflow_dispatch' }, classification: { transient: false, reason: null } })
+  assert.match(d.body, /not necessarily the cause/)
+})


### PR DESCRIPTION
A housekeeping session — three independent, atomically-committed concerns on one branch. Review/revert by commit.

---

## 1 · Initiatives + digest rollup (#1637)

Grouped the ~30 open epics into **6 initiatives** (super-epics), and taught the daily digest to read at that altitude.

- **`.github/labels.yml`** — new `initiative` label.
- **`gather.mjs`** — detect initiatives (`label:initiative` or `^Initiative:` title); parse members from the body's Member/constituent-epics section only (∩ open epics, minus other initiatives); roll up progress; pull them out of `epics[]`.
- **`render.mjs`** — a compact "🎛 Initiatives" band (HTML + text + markdown) above the flat epic list.
- **`SKILL.md`** + **`example.data.json`** updated.

Initiatives already exist as issues: #1632 · #1633 · #1634 · #1635 · #1636 · reused #609.

## 2 · deploy-detect silent-skip fix (#1499)

A merge to `main` could be silently skipped while the run went green — the detect step's `git diff … 2>/dev/null || true` made a *failed* diff look like "nothing changed".

- **`scripts/deploy-detect.mjs`** (pure, unit-tested) — never swallows a diff failure; on push prefers the merge's **first-parent diff** (robust to the concurrent-push #1477 cause); an empty changed-file set on a triggered push/PR → **exit 1 → red run → watchdog fires**.
- **`scripts/deploy-detect.test.mjs`** — 15 cases incl. the #1477 regression.
- **`deploy-apps.yml`** detect job calls the script; happy path identical, failure path loud.

## 3 · deploy watchdog: dedup + classify (#1639)

The "🚨 Deploy Apps failed on main" tickets were noise — one per run, no flake detection, wrong commit blamed (the root of the duplicate #1617/#1548/#1535).

- **`scripts/deploy-failure-report.mjs`** (pure, unit-tested) — `classifyLogs()` (transient CF signatures vs hard-failure signatures, hard wins); `decideReport()` → one **rolling ticket** per workflow[+app] (comment on re-failure / skip a re-recorded run); transient → `transient-infra` label + **no @-ping**; non-`push` runs caveat the commit attribution.
- **`scripts/deploy-failure-report.test.mjs`** — 13 cases against the real #1548/#1535/#1620 logs.
- **`report-failed-deploy.yml`** — fetches the failed jobs' logs + finds the rolling ticket, then delegates to the script; concurrency keyed by workflow+branch.
- **`.github/labels.yml`** — new `transient-infra` label.

---

_Tests:_ `node --test scripts/deploy-detect.test.mjs scripts/deploy-failure-report.test.mjs` → **28 green**. Digest renders end-to-end. eslint + `fallow audit` clean across all changed files.

Closes #1637
Closes #1499
Closes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXyzjSq5JpurzyiyaQPQBb