### PR TITLE
feat(root): initiatives — group epics + surface them in the daily digest (#1637)

### DIFF
--- a/.claude/skills/epic-digest/SKILL.md
+++ b/.claude/skills/epic-digest/SKILL.md
@@ -48,6 +48,16 @@ Build the JSON object described in **Step 3** using these calls (all `owner: pmc
    child's labels (or the `get_sub_issues` state) to set its `status`
    (`in-progress` / `blocked` from the `status:*` label) and `state`.
    Mark the epic `blocked` if it carries `status:blocked` or any child is blocked.
+   **Initiatives (super-epics).** Among the `label:epic` results, treat an issue as an
+   **initiative** if it carries `label:initiative` **or** its title starts with `Initiative:`.
+   An initiative *groups other epics*: parse its member epic numbers from the `#NN` links in
+   its body's `## Member epics` / `## …constituent epics` section (that section only — a `#NN`
+   in a prose/"consolidation" section is not a member), keep only those that are themselves
+   gathered open epics, and roll them up into an `initiatives[]` entry (`epicsTotal`,
+   `activeCount`, `blockedCount`, `childrenTotal`/`childrenDone` summed from the members, and a
+   `members[]` list of `{number,title,url,done,total,status,blocked}`). **Remove initiatives
+   from `epics[]`** so they don't render as misleading `0/0` epics. `gather.mjs` does all this
+   deterministically; the interactive flow mirrors it.
 3. **Activity in the window** (the "since yesterday" band) — use date-filtered search,
    substituting `<cutoff>` (YYYY-MM-DD):
    - Closed: `search_issues` → `repo:FriendlyInternet/nuxt-crouton is:issue is:closed closed:>=<cutoff>`
@@ -121,7 +131,18 @@ Shape (`example.data.json` next to this skill is a complete, renderable sample):
       "testSteps": ["Open Bookings…", "Each row shows a status pill", "Filter by pending → amber only"]
     }
   ],
-  "epics": [
+  "initiatives": [                        // optional — the "🎛 Initiatives" band (super-epics grouping epics)
+    {
+      "number": 1632, "url": "https://github.com/...",
+      "title": "🎨 Visual Layout & Builder",   // the "Initiative:" prefix is stripped
+      "epicsTotal": 5, "activeCount": 2, "blockedCount": 1, "blocked": true,
+      "childrenTotal": 31, "childrenDone": 14,  // summed across member epics
+      "members": [
+        { "number": 983, "title": "...", "url": "...", "done": 7, "total": 12, "status": "blocked", "blocked": true }
+      ]
+    }
+  ],
+  "epics": [                              // regular epics only — initiatives are pulled out into `initiatives`
     {
       "number": 249, "title": "...", "url": "https://github.com/...",
       "status": "in-progress",          // in-progress | blocked | open | done
@@ -162,7 +183,9 @@ node .claude/skills/epic-digest/render.mjs digest.data.json --out-dir .         
 # → email the HTML (+ text mirror) via Resend
 ```
 - **`gather.mjs`** parses `Hypothesis` (or legacy `The bet`) / `We'll know by` from each epic body and
-  **computes** `whereWeAre` from child counts — no model in the loop.
+  **computes** `whereWeAre` from child counts — no model in the loop. It also detects **initiatives**
+  (super-epics; `label:initiative` or an `Initiative:` title), rolls their member epics up into
+  `initiatives[]`, and removes them from `epics[]` — no model in the loop.
 - **Delivery is email-only, via Resend** (#551). The job emails the rendered HTML
   (+ text mirror) when `secrets.RESEND_API_KEY`, `vars.RESEND_FROM` (shared with the
   red-team daily) and `vars.DIGEST_REPORT_EMAIL` are set; unset ⇒ the step warns and

--- a/.claude/skills/epic-digest/example.data.json
+++ b/.claude/skills/epic-digest/example.data.json
@@ -54,6 +54,26 @@
       ]
     }
   ],
+  "initiatives": [
+    {
+      "number": 1632,
+      "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/1632",
+      "title": "🎨 Visual Layout & Builder — the AI-composed, human-editable layout stack",
+      "epicsTotal": 5,
+      "activeCount": 2,
+      "blockedCount": 1,
+      "blocked": true,
+      "childrenTotal": 31,
+      "childrenDone": 14,
+      "members": [
+        { "number": 983, "title": "Graduate the Crouton Builder POC → crouton-layout package", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/983", "done": 7, "total": 12, "status": "blocked", "blocked": true },
+        { "number": 703, "title": "Lean layout engine", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/703", "done": 1, "total": 4, "status": "open", "blocked": false },
+        { "number": 868, "title": "Maquette — the semantic-zoom layout builder", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/868", "done": 0, "total": 3, "status": "open", "blocked": false },
+        { "number": 905, "title": "App-canvas on Vue Flow", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/905", "done": 6, "total": 12, "status": "open", "blocked": false },
+        { "number": 855, "title": "Mini-apps everywhere — one block, three renderers", "url": "https://github.com/FriendlyInternet/nuxt-crouton/issues/855", "done": 0, "total": 0, "status": "open", "blocked": false }
+      ]
+    }
+  ],
   "epics": [
     {
       "number": 318,

--- a/.claude/skills/epic-digest/gather.mjs
+++ b/.claude/skills/epic-digest/gather.mjs
@@ -157,11 +157,40 @@ async function subIssues(number) {
   }
 }
 
+// ── initiatives (super-epics grouping several epics) ─────────────────────────
+// An initiative is an epic that groups OTHER epics. It's detected by the
+// `initiative` label OR an `Initiative:` title prefix (the label was added to
+// .github/labels.yml but may not have synced to GitHub yet — the title prefix
+// makes this work in the meantime). Its member epics are the `#NN` links in its
+// body's "Member epics" / "constituent epics" section, intersected with the set
+// of gathered open epics (so closed/non-epic refs drop out automatically). (#1637)
+const isInitiativeEpic = (names, title) =>
+  names.includes('initiative') || /^\s*Initiative:/i.test(title || '')
+
+function parseMemberNumbers(body, self, initiativeNums, epicByNum) {
+  // Prefer the explicit member list so a #NN mentioned elsewhere in the body
+  // (e.g. a "moved out" note in a consolidation section) isn't miscounted.
+  const scoped = section(body, /^##\s.*(member epics|constituent epics|building blocks)/i)
+  const src = scoped || body
+  const seen = new Set()
+  const out = []
+  for (const m of String(src).matchAll(/#(\d+)/g)) {
+    const n = Number(m[1])
+    if (n === self || seen.has(n)) continue
+    if (initiativeNums.has(n)) continue // an initiative isn't a member of another
+    if (!epicByNum.has(n)) continue // must be a gathered OPEN epic
+    seen.add(n)
+    out.push(n)
+  }
+  return out
+}
+
 // ── gather ───────────────────────────────────────────────────────────────────
 const childNumbers = new Set()
 
 const epicItems = await search(`repo:${REPO} is:issue is:open label:epic`)
 const epics = []
+const bodyByNum = new Map()
 for (const e of epicItems) {
   const kids = await subIssues(e.number)
   let done = 0, anyBlocked = false, inProgress = 0, closedInWindow = 0
@@ -202,15 +231,58 @@ for (const e of epicItems) {
     : inProgress ? 'in-progress'
     : 'open'
 
+  bodyByNum.set(e.number, e.body || '')
   epics.push({
     number: e.number, title: e.title, url: e.html_url,
     status, blocked, total, done, readyToClose, needsPostmortem,
+    isInitiative: isInitiativeEpic(epicNames, e.title),
     theHypothesis: parseHypothesis(e.body),
     weWillKnowBy: parseKnowBy(e.body),
     whereWeAre,
     children
   })
 }
+
+// Split the gathered epics into initiatives (super-epics) and regular epics, and
+// roll each initiative's member epics up into an aggregate. Initiatives are
+// pulled OUT of the flat epic list so they don't render as misleading 0/0 epics.
+const epicByNum = new Map(epics.map((e) => [e.number, e]))
+const initiativeNums = new Set(epics.filter((e) => e.isInitiative).map((e) => e.number))
+const regularEpics = []
+const initiatives = []
+for (const e of epics) {
+  if (!e.isInitiative) {
+    delete e.isInitiative
+    regularEpics.push(e)
+    continue
+  }
+  const memberNums = parseMemberNumbers(bodyByNum.get(e.number), e.number, initiativeNums, epicByNum)
+  const members = memberNums.map((n) => epicByNum.get(n)).filter(Boolean)
+  const childrenTotal = members.reduce((s, m) => s + (m.total || 0), 0)
+  const childrenDone = members.reduce((s, m) => s + (m.done || 0), 0)
+  const blockedCount = members.filter((m) => m.blocked || m.status === 'blocked').length
+  const activeCount = members.filter(
+    (m) => m.blocked || m.status === 'blocked' || m.status === 'in-progress' || (m.done || 0) > 0
+  ).length
+  initiatives.push({
+    number: e.number,
+    url: e.url,
+    title: e.title.replace(/^\s*Initiative:\s*/i, ''),
+    epicsTotal: members.length,
+    activeCount,
+    blockedCount,
+    blocked: blockedCount > 0,
+    childrenTotal,
+    childrenDone,
+    members: members.map((m) => ({
+      number: m.number, title: m.title, url: m.url,
+      done: m.done, total: m.total, status: m.status,
+      blocked: !!(m.blocked || m.status === 'blocked')
+    }))
+  })
+}
+// Most-substantial / blocked initiatives first so the eye lands on what matters.
+initiatives.sort((a, b) => (b.blocked ? 1 : 0) - (a.blocked ? 1 : 0) || b.childrenTotal - a.childrenTotal)
 
 const [closed, opened, mergedPRs, openNonEpic] = await Promise.all([
   search(`repo:${REPO} is:issue is:closed closed:>=${cutoff}`),
@@ -248,7 +320,7 @@ const prDetailed = await Promise.all(
 )
 prDetailed.sort((a, b) => (b.testSteps.length ? 1 : 0) - (a.testSteps.length ? 1 : 0))
 const prActionables = prDetailed.slice(0, PR_ACTIONABLE_CAP)
-const completeEpics = epics.filter((e) => e.total > 0 && e.done >= e.total)
+const completeEpics = regularEpics.filter((e) => e.total > 0 && e.done >= e.total)
 const epicActionables = await Promise.all(
   completeEpics.map(async (e) => {
     const cmts = await issueComments(e.number)
@@ -275,7 +347,8 @@ const data = {
     mergedPRs: mergedPRs.map((i) => slim(i, 'pr'))
   },
   actionables,
-  epics,
+  initiatives,
+  epics: regularEpics,
   loose
 }
 

--- a/.claude/skills/epic-digest/render.mjs
+++ b/.claude/skills/epic-digest/render.mjs
@@ -90,6 +90,11 @@ const epics = (data.epics || []).slice().sort((a, b) => {
   return pct(b) - pct(a)
 })
 
+// Initiatives: super-epics that group several epics. Rendered as a compact
+// rollup band above the flat epic list — the gather step already computed the
+// aggregate + pulled them out of `epics`, so they don't double-render. (#1637)
+const initiatives = (data.initiatives || []).slice()
+
 // Loose tickets: open issues that belong to no epic (no `epic` label, no parent).
 // Grouped by type so a pile of chores reads as one block, not noise.
 const loose = (data.loose || []).slice()
@@ -205,6 +210,36 @@ function actionableCard(a) {
     ${stepsBlock}
     <div style="margin-top:18px;font-size:13px">${links.join(' &nbsp;·&nbsp; ')}</div>
   </td></tr>`
+}
+
+// Compact initiative rollup — title + aggregate progress + member epic links.
+// Not a full epicCard: an initiative is a lens, so it reads in three lines.
+const memberSep = `<span class="mut" style="color:${C.faint}"> · </span>`
+function initiativeRow(it) {
+  const blockedChip = it.blockedCount ? '&nbsp;&nbsp;' + statusChip(`${it.blockedCount} blocked`, 'orange') : ''
+  const headline =
+    `${it.activeCount}/${it.epicsTotal} epic${it.epicsTotal === 1 ? '' : 's'} active` +
+    ` · ${it.childrenDone}/${it.childrenTotal} child issue${it.childrenTotal === 1 ? '' : 's'} done`
+  const members = (it.members || [])
+    .map((m) => `<a href="${esc(m.url)}" ${linkS}>#${esc(m.number)}</a>${m.blocked ? `<span class="mut" style="color:${C.faint}"> ⛔</span>` : ''}`)
+    .join(memberSep)
+  return `
+  <tr><td class="rule" style="padding:18px 0;border-top:1px solid ${C.border}">
+    <div style="font-size:17px;font-weight:400;line-height:1.5;color:${C.ink}">
+      <a href="${esc(it.url)}" class="ink lnk" style="color:${C.ink};text-decoration:none">${esc(it.title)}</a> ${num(it.number)}${blockedChip}
+    </div>
+    <div class="mut" style="font-style:italic;color:${C.mut};font-size:13px;margin-top:6px">${headline}</div>
+    <div class="sub" style="color:${C.sub};font-size:14px;line-height:1.9;margin-top:8px">${members || '<span style="font-style:italic">no open member epics</span>'}</div>
+  </td></tr>`
+}
+function initiativesSection(items) {
+  if (!items || !items.length) return ''
+  return `
+    <tr><td style="padding:34px 0 6px">
+      ${sectionLabel('Initiatives', 'cyan')}
+      <div class="mut" style="font-style:italic;color:${C.mut};font-size:14px;margin-top:8px">${items.length} initiative${items.length === 1 ? '' : 's'} grouping the open epics.</div>
+    </td></tr>
+    ${items.map(initiativeRow).join('')}`
 }
 
 function actionablesSection(items) {
@@ -417,6 +452,8 @@ const html = `<!doctype html>
 
     ${actionablesSection(actionables)}
 
+    ${initiativesSection(initiatives)}
+
     <tr><td style="padding:34px 0 0">${sectionLabel('Since yesterday')}</td></tr>
     <tr><td style="padding:20px 0 0">
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>
@@ -489,6 +526,24 @@ const txtActionables = (items) => {
   )
 }
 
+const txtInitiatives = (items) => {
+  if (!items || !items.length) return ''
+  return (
+    `INITIATIVES (${items.length})\n\n` +
+    items
+      .map((it) => {
+        const head = `${it.title}  (#${it.number})${it.blockedCount ? `  [${it.blockedCount} blocked]` : ''}`
+        const stat = `  ${it.activeCount}/${it.epicsTotal} epics active · ${it.childrenDone}/${it.childrenTotal} child issues done`
+        const mem = (it.members || []).length
+          ? '  ' + it.members.map((m) => `#${m.number}${m.blocked ? '⛔' : ''}`).join(' · ')
+          : '  (no open member epics)'
+        return `${head}\n${stat}\n${mem}\n      ${it.url}`
+      })
+      .join('\n\n') +
+    `\n\n${'='.repeat(64)}\n\n`
+  )
+}
+
 const txtReadyToClose = (allEpics) => {
   const items = (allEpics || []).filter(isCloseable)
   if (!items.length) return ''
@@ -510,6 +565,7 @@ const txt =
   `${repo} · last ${windowHours}h · ${epics.length} open epic(s)\n` +
   `${'='.repeat(64)}\n\n` +
   txtActionables(actionables) +
+  txtInitiatives(initiatives) +
   txtReadyToClose(epics) +
   `SINCE YESTERDAY\n` +
   `  ${(activity.opened || []).length} opened · ${(activity.closed || []).length} closed · ${(activity.mergedPRs || []).length} PRs merged\n\n` +
@@ -602,6 +658,28 @@ const mdActionables = (items) => {
   )
 }
 
+const mdInitiatives = (items) => {
+  if (!items || !items.length) return ''
+  const block = items
+    .map((it) => {
+      const blocked = it.blockedCount ? ` · ⛔ ${it.blockedCount} blocked` : ''
+      const mem = (it.members || []).length
+        ? it.members.map((m) => `[#${m.number}](${m.url})${m.blocked ? ' ⛔' : ''}`).join(' · ')
+        : '_no open member epics_'
+      return (
+        `- **[${it.title}](${it.url})** — \`${it.activeCount}/${it.epicsTotal} epics active · ` +
+        `${it.childrenDone}/${it.childrenTotal} issues done\`${blocked}\n  ${mem}`
+      )
+    })
+    .join('\n')
+  return (
+    `### 🎛 Initiatives\n` +
+    `_${items.length} initiative${items.length === 1 ? '' : 's'} grouping the open epics._\n\n` +
+    block +
+    `\n\n`
+  )
+}
+
 const mdReadyToClose = (allEpics) => {
   const items = (allEpics || []).filter(isCloseable)
   if (!items.length) return ''
@@ -624,6 +702,7 @@ const md =
   `## 📊 Daily epic digest — ${prettyDate}\n` +
   `_${repo} · last ${windowHours}h · ${epics.length} open epic${epics.length === 1 ? '' : 's'}_\n\n` +
   mdActionables(actionables) +
+  mdInitiatives(initiatives) +
   mdReadyToClose(epics) +
   `**Since yesterday:** ${(activity.opened || []).length} opened · ${(activity.closed || []).length} closed · ${(activity.mergedPRs || []).length} PRs merged\n\n` +
   `<details><summary>Activity detail</summary>\n\n` +

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -191,6 +191,9 @@
   description: "Performance"
 
 # ── Meta ──
+- name: "initiative"
+  color: "0e2a63"
+  description: "Umbrella grouping several epics toward one end-goal (super-epic rollup)"
 - name: "epic"
   color: "3e4b9e"
   description: "Tracking epic with child issues"


### PR DESCRIPTION
## 👤 For humans

Grouped the ~30 open epics into **6 initiatives** (super-epics), and taught the daily digest to read at that altitude.

- **`.github/labels.yml`** — new `initiative` label (binds on the next label sync).
- **`.claude/skills/epic-digest/gather.mjs`** — detect initiatives (`label:initiative` or an `^Initiative:` title, transition-safe); parse member epics from the body's `## Member epics` / `## …constituent epics` section only (∩ open epics, minus other initiatives); roll up progress; remove them from `epics[]` so they don't render as empty `0/0`.
- **`render.mjs`** — a compact "🎛 Initiatives" band (HTML + text + markdown) above the flat "Open epics" list, unchanged below.
- **`SKILL.md`** + **`example.data.json`** updated.

The initiatives already exist as issues: #1632 · #1633 · #1634 · #1635 · #1636 · reused #609.

## 🧪 How to test

`cd .claude/skills/epic-digest && node render.mjs example.data.json --out-dir /tmp/d` → the band shows `2/5 epics active · 14/31 child issues done` above "Open epics"; parse tested against the real #1632/#1634 body structure (excludes consolidation-section refs); fallow clean.

Closes #1637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXyzjSq5JpurzyiyaQPQBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXyzjSq5JpurzyiyaQPQBb)_