### PR TITLE
fix(root): stop deploy-apps silently skipping a deploy on a broken diff (#1499)

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -98,80 +98,16 @@ jobs:
           DISPATCH_ENV: ${{ github.event.inputs.environment }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
-        run: |
-          set -euo pipefail
-          include='[]'
-
-          # Append one app (read from its deploy.config.json) to the matrix include.
-          add_app() {
-            local app="$1" env="$2"
-            local cfg="apps/$app/deploy.config.json"
-            if [ ! -f "$cfg" ]; then
-              echo "skip: apps/$app has no deploy.config.json (not opted in)"
-              return
-            fi
-            local su pu lp rq
-            su=$(jq -r '.stagingUrl // ""' "$cfg")
-            pu=$(jq -r '.productionUrl // ""' "$cfg")
-            lp=$(jq -r '.layerPackages // ""' "$cfg")
-            # secrets.required → the deploy fails loudly if WORKER_SECRETS_JSON
-            # resolves empty (the Environment-scoping trap, #1094)
-            rq=$(jq '.secrets.required // false' "$cfg")
-            include=$(printf '%s' "$include" | jq \
-              --arg a "$app" --arg e "$env" --arg su "$su" --arg pu "$pu" --arg lp "$lp" --argjson rq "$rq" \
-              '. + [{app:$a, environment:$e, stagingUrl:$su, productionUrl:$pu, layerPackages:$lp, requireWorkerSecrets:$rq}]')
-          }
-
-          if [ "$EVENT" = "workflow_dispatch" ]; then
-            # Single named app. environment honours the input; anything other than the
-            # explicit "production" choice falls back to staging (defensive whitelist).
-            env="staging"
-            [ "${DISPATCH_ENV:-staging}" = "production" ] && env="production"
-            [ -n "${DISPATCH_APP:-}" ] && add_app "$DISPATCH_APP" "$env"
-          else
-            # push / pull_request → STAGING ONLY (#318). Deploy each opted-in app whose
-            # watchPaths match a changed file.
-            if [ -z "${BASE_SHA:-}" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
-              changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
-            else
-              changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
-            fi
-            echo "Changed files:"; printf '%s\n' "$changed"
-
-            for cfg in apps/*/deploy.config.json; do
-              [ -f "$cfg" ] || continue
-              app=$(basename "$(dirname "$cfg")")
-              # Rung split (#1297): a pull_request deploys ONLY the app whose OWN paths
-              # (apps/<app>/**) changed. A shared-package change that breaks a consuming
-              # app is caught by the fixture smoke (fast, no deploy) + the rung-2 push
-              # deploy — NOT a per-PR fan-out redeploy of every consuming app, which
-              # saturated the runners and starved the changed app's own deploy (#1297).
-              # push (merge to main) keeps the full watchPaths incl. shared packages.
-              if [ "$EVENT" = "pull_request" ]; then
-                pats=("apps/$app/**")
-              else
-                mapfile -t pats < <(jq -r '.watchPaths[]? // empty' "$cfg")
-              fi
-              hit=false
-              while IFS= read -r f; do
-                [ -z "$f" ] && continue
-                for pat in "${pats[@]:-}"; do
-                  [ -z "$pat" ] && continue
-                  # In [[ ]] pattern matching '*' spans '/', so 'packages/foo/**'
-                  # matches any file under packages/foo and 'pnpm-lock.yaml' is exact.
-                  if [[ "$f" == $pat ]]; then hit=true; break; fi
-                done
-                $hit && break
-              done <<< "$changed"
-              if $hit; then add_app "$app" "staging"; fi
-            done
-          fi
-
-          matrix=$(jq -cn --argjson inc "$include" '{include:$inc}')
-          if [ "$(printf '%s' "$include" | jq 'length')" -gt 0 ]; then any=true; else any=false; fi
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-          echo "any=$any" >> "$GITHUB_OUTPUT"
-          echo "Detected matrix: $matrix"
+        # The decision lives in the pure, unit-tested scripts/deploy-detect.mjs (mirrors
+        # scripts/packages-guard.mjs). It fixes #1499: the old inline bash used
+        # `git diff … 2>/dev/null || true`, which turned a FAILED diff into an empty one —
+        # indistinguishable from "nothing changed" — so a merge that should have deployed was
+        # silently skipped while the run went green. The script never swallows a diff failure:
+        # on push it prefers the merge's first-parent diff (robust to concurrent pushes) and
+        # exits NON-ZERO (loud red → report-failed-deploy fires) if it can't compute a diff or
+        # the changed-file set comes back empty on a triggered push/PR. Contract:
+        # scripts/deploy-detect.test.mjs (`node --test`).
+        run: node scripts/deploy-detect.mjs
 
   # One deploy-app.yml call per detected app. Skipped cleanly when nothing opted-in changed.
   deploy:

--- a/scripts/deploy-detect.mjs
+++ b/scripts/deploy-detect.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * deploy-detect — decide which apps deploy-apps.yml should deploy, and to which env.
+ *
+ * Extracted from the inline `detect` bash in .github/workflows/deploy-apps.yml so the
+ * decision is a pure, unit-tested function (mirrors scripts/packages-guard.mjs). It fixes
+ * #1499: the old bash computed the changed-file set with `git diff … 2>/dev/null || true`,
+ * which laundered a *failed* diff into an empty one — indistinguishable from a legitimate
+ * "nothing changed" — so a merge that should have deployed was silently skipped while the
+ * run reported success ("green but it didn't happen").
+ *
+ * Two guarantees here:
+ *   1. `resolveChangedFiles` NEVER swallows a diff failure. On push-to-main it prefers the
+ *      merge's first-parent diff (`HEAD~1..HEAD` — the net change, robust to concurrent
+ *      pushes, unlike before..after), and if it cannot resolve ANY base it throws.
+ *   2. An EMPTY changed-file set on a triggered push/PR is treated as a compute failure,
+ *      not "deploy nothing": the workflow's own `paths:` filter guarantees ≥1 watched file
+ *      changed, so empty ⇒ the diff broke ⇒ fail loud (red run → report-failed-deploy
+ *      fires) instead of a silent green skip. (An empty *matrix* is still fine — e.g. a
+ *      workflow-only change matches no app — that's a non-empty file set with no app hit.)
+ *
+ *   CLI (used by the workflow):
+ *     EVENT=push BASE_SHA=… HEAD_SHA=… node scripts/deploy-detect.mjs
+ *       → appends `matrix=…` and `any=…` to $GITHUB_OUTPUT; exit 1 (loud) on a broken diff.
+ */
+import { execFileSync } from 'node:child_process'
+import { readdirSync, existsSync, readFileSync, appendFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+export const ZERO_SHA = '0000000000000000000000000000000000000000'
+
+export class DetectError extends Error {}
+
+// Translate a watchPath pattern into a RegExp with the SAME semantics as bash `[[ $f == $pat ]]`
+// (used by the old detect job): `*` matches any run of characters INCLUDING `/` and empty, so
+// `packages/crouton/**` matches `packages/crouton/<anything>` but not `packages/crouton-core/x`,
+// and `pnpm-lock.yaml` is an exact match. Escape every regex metachar EXCEPT `*`, then `*`→`.*`.
+export function watchPathToRegExp(pattern) {
+  const escaped = String(pattern).replace(/[.+^${}()|[\]\\?]/g, '\\$&').replace(/\*/g, '.*')
+  return new RegExp(`^${escaped}$`)
+}
+
+export function fileMatchesAny(file, patterns = []) {
+  return patterns.some(p => p && watchPathToRegExp(p).test(file))
+}
+
+/**
+ * Compute the deploy matrix. PURE — no git, no fs. `apps` is the list of opted-in apps
+ * (each: { app, stagingUrl, productionUrl, layerPackages, requireWorkerSecrets, watchPaths }).
+ *
+ * - workflow_dispatch: the single named app, at the requested env (only the explicit
+ *   "production" choice reaches production; anything else → staging — the #318 whitelist).
+ * - push / pull_request: STAGING only (#318). A pull_request deploys ONLY the app whose OWN
+ *   paths (`apps/<app>/**`) changed (#1297 — a shared-package break is caught by the fixture
+ *   smoke + the rung-2 push deploy, not a per-PR fan-out). A push keeps the full watchPaths.
+ */
+function toEntry(a, environment) {
+  return {
+    app: a.app,
+    environment,
+    stagingUrl: a.stagingUrl || '',
+    productionUrl: a.productionUrl || '',
+    layerPackages: a.layerPackages || '',
+    requireWorkerSecrets: a.requireWorkerSecrets ?? false
+  }
+}
+
+// workflow_dispatch → the single named app at the requested env (production only for the
+// explicit choice — the #318 whitelist).
+function dispatchInclude(dispatchApp, dispatchEnv, apps) {
+  const a = apps.find(x => x.app === dispatchApp)
+  if (!a) return []
+  return [toEntry(a, dispatchEnv === 'production' ? 'production' : 'staging')]
+}
+
+// push / pull_request → STAGING only. A pull_request matches only the app's OWN paths (#1297);
+// a push matches its full watchPaths (incl. shared packages).
+function changeInclude(event, changedFiles, apps) {
+  const include = []
+  for (const a of apps) {
+    const patterns = event === 'pull_request' ? [`apps/${a.app}/**`] : (a.watchPaths || [])
+    if (changedFiles.some(f => f && fileMatchesAny(f, patterns))) include.push(toEntry(a, 'staging'))
+  }
+  return include
+}
+
+export function computeMatrix({ event, changedFiles = [], dispatchApp = '', dispatchEnv = '', apps = [] }) {
+  const include = event === 'workflow_dispatch'
+    ? dispatchInclude(dispatchApp, dispatchEnv, apps)
+    : changeInclude(event, changedFiles, apps)
+  return { include, any: include.length > 0 }
+}
+
+/**
+ * Resolve the changed-file list for a push/PR — the #1499 fix. `git` is injected so it's
+ * testable: { isResolvable(ref)->bool, diff(a,b)->string[] }. Throws DetectError rather than
+ * ever returning a silent empty list on failure.
+ */
+export function resolveChangedFiles({ event, baseSha, headSha, git }) {
+  if (event === 'pull_request') {
+    // A PR's base.sha is always a real, fetched commit — if it won't resolve, something is
+    // genuinely wrong; don't paper over it.
+    if (!git.isResolvable(baseSha)) throw new DetectError(`PR base sha not resolvable: ${baseSha || '(empty)'}`)
+    return { files: git.diff(baseSha, headSha), source: 'pr:base..head' }
+  }
+  // push-to-main: prefer the tip's first-parent diff — for a merge commit that IS the net PR
+  // change, and it doesn't depend on github.event.before (which is wrong under concurrent
+  // pushes — the #1477 cause). Fall back to before..after only if HEAD~1 is unavailable
+  // (e.g. an unexpectedly shallow checkout); if neither resolves, fail loud.
+  if (git.isResolvable('HEAD~1')) return { files: git.diff('HEAD~1', 'HEAD'), source: 'push:first-parent' }
+  if (baseSha && baseSha !== ZERO_SHA && git.isResolvable(baseSha)) {
+    return { files: git.diff(baseSha, headSha), source: 'push:before..after' }
+  }
+  throw new DetectError('cannot resolve a diff base on push (no HEAD~1, no usable before-sha)')
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+function realGit() {
+  const run = args => execFileSync('git', args, { encoding: 'utf8' })
+  return {
+    isResolvable(ref) {
+      try {
+        run(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`])
+        return true
+      } catch {
+        return false
+      }
+    },
+    diff(a, b) {
+      return run(['diff', '--name-only', a, b]).split('\n').map(s => s.trim()).filter(Boolean)
+    }
+  }
+}
+
+function loadApps(root = 'apps') {
+  if (!existsSync(root)) return []
+  const out = []
+  for (const name of readdirSync(root)) {
+    const cfgPath = `${root}/${name}/deploy.config.json`
+    if (!existsSync(cfgPath)) continue // not opted in
+    let cfg = {}
+    try {
+      cfg = JSON.parse(readFileSync(cfgPath, 'utf8'))
+    } catch {
+      continue
+    }
+    out.push({
+      app: name,
+      stagingUrl: cfg.stagingUrl || '',
+      productionUrl: cfg.productionUrl || '',
+      layerPackages: cfg.layerPackages || '',
+      requireWorkerSecrets: cfg.secrets?.required ?? false,
+      watchPaths: Array.isArray(cfg.watchPaths) ? cfg.watchPaths : []
+    })
+  }
+  return out
+}
+
+function main() {
+  const event = process.env.EVENT || ''
+  const apps = loadApps()
+
+  let changedFiles = []
+  if (event !== 'workflow_dispatch') {
+    const { files, source } = resolveChangedFiles({
+      event,
+      baseSha: process.env.BASE_SHA || '',
+      headSha: process.env.HEAD_SHA || '',
+      git: realGit()
+    })
+    changedFiles = files
+    console.log(`Changed files (${source}):`)
+    for (const f of changedFiles) console.log(`  ${f}`)
+    // The trigger's own paths: filter guarantees a watched file changed, so an empty set can
+    // only mean the diff failed to compute — fail loud instead of a silent green no-deploy.
+    if (changedFiles.length === 0) {
+      throw new DetectError(
+        `${event} triggered deploy-apps but the changed-file set is EMPTY — the diff failed to `
+        + `compute (see #1499). Refusing to report success with no deploy.`
+      )
+    }
+  }
+
+  const { include, any } = computeMatrix({
+    event,
+    changedFiles,
+    dispatchApp: process.env.DISPATCH_APP || '',
+    dispatchEnv: process.env.DISPATCH_ENV || '',
+    apps
+  })
+  const matrix = JSON.stringify({ include })
+  const out = process.env.GITHUB_OUTPUT
+  if (out) appendFileSync(out, `matrix=${matrix}\nany=${any}\n`)
+  console.log(`Detected matrix: ${matrix}`)
+  console.log(`any=${any}`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  try {
+    main()
+  } catch (err) {
+    // ::error:: surfaces in the run summary; a non-zero exit makes the run RED so the
+    // post-merge watchdog (report-failed-deploy.yml) engages — the whole point of #1499.
+    console.error(`::error::deploy-detect: ${err.message}`)
+    process.exit(1)
+  }
+}

--- a/scripts/deploy-detect.test.mjs
+++ b/scripts/deploy-detect.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Contract for scripts/deploy-detect.mjs — the #1499 fix. Proves the detect decision:
+ *   • never launders a failed diff into a silent empty result (fail loud / fall back),
+ *   • prefers the merge's first-parent diff on push-to-main,
+ *   • reproduces the watchPath matching of the old bash `[[ $f == $pat ]]` exactly, and
+ *   • a crouton-sales-only merge always puts the consuming app (fanfare) in the matrix.
+ *
+ *   node --test scripts/deploy-detect.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  watchPathToRegExp, fileMatchesAny, computeMatrix, resolveChangedFiles, DetectError, ZERO_SHA
+} from './deploy-detect.mjs'
+
+// A stand-in for the injected git: declared-resolvable refs + canned diffs.
+const fakeGit = ({ resolvable = [], diffs = {} }) => ({
+  isResolvable: ref => resolvable.includes(ref),
+  diff: (a, b) => diffs[`${a}..${b}`] || []
+})
+
+const APPS = [
+  { app: 'fanfare', stagingUrl: 'https://kassa.pmcp.dev', productionUrl: 'https://kassa.friendlyinter.net', layerPackages: 'lp-f', requireWorkerSecrets: false, watchPaths: ['apps/fanfare/**', 'packages/crouton-sales/**', 'packages/crouton-core/**', 'pnpm-lock.yaml'] },
+  { app: 'triage', stagingUrl: 'https://triage-preview.pmcp.dev', productionUrl: '', layerPackages: 'lp-t', requireWorkerSecrets: false, watchPaths: ['apps/triage/**', 'packages/crouton-triage/**', 'pnpm-lock.yaml'] },
+  { app: 'velo', stagingUrl: 'https://velo.pmcp.dev', productionUrl: '', layerPackages: 'lp-v', requireWorkerSecrets: false, watchPaths: ['apps/velo/**', 'packages/crouton-bookings/**', 'pnpm-lock.yaml'] }
+]
+const names = r => r.include.map(e => e.app)
+
+// ── watchPath matching (must match bash `[[ $f == $pat ]]` semantics) ─────────
+test('`dir/**` matches nested files but not a sibling with a shared prefix', () => {
+  assert.equal(fileMatchesAny('packages/crouton/x.ts', ['packages/crouton/**']), true)
+  assert.equal(fileMatchesAny('packages/crouton/a/b/c.ts', ['packages/crouton/**']), true)
+  // the classic over-match trap: crouton-core must NOT match packages/crouton/**
+  assert.equal(fileMatchesAny('packages/crouton-core/x.ts', ['packages/crouton/**']), false)
+})
+
+test('an exact watchPath (pnpm-lock.yaml) is exact, not a prefix', () => {
+  assert.equal(fileMatchesAny('pnpm-lock.yaml', ['pnpm-lock.yaml']), true)
+  assert.equal(fileMatchesAny('pnpm-lock.yaml.bak', ['pnpm-lock.yaml']), false)
+  assert.equal(fileMatchesAny('a/pnpm-lock.yaml', ['pnpm-lock.yaml']), false)
+})
+
+test('watchPathToRegExp is anchored', () => {
+  assert.equal(watchPathToRegExp('apps/velo/**').test('xapps/velo/y'), false)
+})
+
+// ── computeMatrix: push (merge to main) ───────────────────────────────────────
+test('#1477 regression: a crouton-sales-only merge deploys the consuming app (fanfare)', () => {
+  const r = computeMatrix({ event: 'push', changedFiles: ['packages/crouton-sales/app/x.vue', 'packages/crouton-sales/schemas/y.json'], apps: APPS })
+  assert.deepEqual(names(r), ['fanfare'])
+  assert.equal(r.any, true)
+  assert.equal(r.include[0].environment, 'staging') // push → staging only (#318)
+  assert.equal(r.include[0].stagingUrl, 'https://kassa.pmcp.dev')
+})
+
+test('a shared-package change fans out to every consuming app', () => {
+  const r = computeMatrix({ event: 'push', changedFiles: ['pnpm-lock.yaml'], apps: APPS })
+  assert.deepEqual(names(r).sort(), ['fanfare', 'triage', 'velo'])
+})
+
+test('a workflow-only change matches no app → empty matrix (legitimately, any=false)', () => {
+  const r = computeMatrix({ event: 'push', changedFiles: ['.github/workflows/deploy-apps.yml'], apps: APPS })
+  assert.deepEqual(names(r), [])
+  assert.equal(r.any, false)
+})
+
+// ── computeMatrix: pull_request (rung split #1297) ────────────────────────────
+test('a PR deploys ONLY the app whose own paths changed, ignoring shared-package changes', () => {
+  const r = computeMatrix({
+    event: 'pull_request',
+    changedFiles: ['apps/triage/app/x.vue', 'packages/crouton-sales/y.ts'], // sales would match fanfare on a push
+    apps: APPS
+  })
+  assert.deepEqual(names(r), ['triage']) // NOT fanfare — PRs don't fan out on shared pkgs
+})
+
+// ── computeMatrix: workflow_dispatch ──────────────────────────────────────────
+test('dispatch honours production only for the explicit choice (#318 whitelist)', () => {
+  assert.equal(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'fanfare', dispatchEnv: 'production', apps: APPS }).include[0].environment, 'production')
+  assert.equal(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'fanfare', dispatchEnv: '', apps: APPS }).include[0].environment, 'staging')
+  assert.equal(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'fanfare', dispatchEnv: 'prod', apps: APPS }).include[0].environment, 'staging') // typo ≠ production
+})
+
+test('dispatch for an unknown app yields an empty matrix', () => {
+  assert.deepEqual(computeMatrix({ event: 'workflow_dispatch', dispatchApp: 'nope', apps: APPS }).include, [])
+})
+
+// ── resolveChangedFiles: the #1499 core (never a silent empty) ─────────────────
+test('push prefers the first-parent diff (HEAD~1..HEAD)', () => {
+  const git = fakeGit({ resolvable: ['HEAD~1'], diffs: { 'HEAD~1..HEAD': ['packages/crouton-sales/x.ts'] } })
+  const r = resolveChangedFiles({ event: 'push', baseSha: 'deadbeef', headSha: 'cafe', git })
+  assert.equal(r.source, 'push:first-parent')
+  assert.deepEqual(r.files, ['packages/crouton-sales/x.ts'])
+})
+
+test('push falls back to before..after only when HEAD~1 is unavailable', () => {
+  const git = fakeGit({ resolvable: ['base1'], diffs: { 'base1..head1': ['apps/velo/x.vue'] } })
+  const r = resolveChangedFiles({ event: 'push', baseSha: 'base1', headSha: 'head1', git })
+  assert.equal(r.source, 'push:before..after')
+  assert.deepEqual(r.files, ['apps/velo/x.vue'])
+})
+
+test('push throws (does NOT return empty) when no base resolves — the #1499 silent-skip guard', () => {
+  const git = fakeGit({ resolvable: [] }) // neither HEAD~1 nor the before-sha resolve
+  assert.throws(() => resolveChangedFiles({ event: 'push', baseSha: 'ghost', headSha: 'head', git }), DetectError)
+})
+
+test('push with the all-zero before-sha and no HEAD~1 throws rather than emitting empty', () => {
+  const git = fakeGit({ resolvable: [] })
+  assert.throws(() => resolveChangedFiles({ event: 'push', baseSha: ZERO_SHA, headSha: 'head', git }), DetectError)
+})
+
+test('pull_request uses base..head', () => {
+  const git = fakeGit({ resolvable: ['prbase'], diffs: { 'prbase..prhead': ['apps/triage/x.vue'] } })
+  const r = resolveChangedFiles({ event: 'pull_request', baseSha: 'prbase', headSha: 'prhead', git })
+  assert.equal(r.source, 'pr:base..head')
+  assert.deepEqual(r.files, ['apps/triage/x.vue'])
+})
+
+test('pull_request throws when the PR base sha will not resolve (no silent empty)', () => {
+  const git = fakeGit({ resolvable: [] })
+  assert.throws(() => resolveChangedFiles({ event: 'pull_request', baseSha: 'ghost', headSha: 'head', git }), DetectError)
+})


### PR DESCRIPTION
## 👤 For humans

A merge to `main` that should deploy to staging could be silently skipped while the run went green — so the change landed but never shipped, and nothing flagged it. The detect step computed "what changed" with a diff that swallowed its own errors (`git diff … 2>/dev/null || true`), so a *failed* diff looked identical to "nothing changed". Now a diff that can't be computed fails the run loudly (which trips the post-merge watchdog) instead of passing as a no-op.

## 🤖 For agents

- **New `scripts/deploy-detect.mjs`** (pure, unit-tested — mirrors `packages-guard.mjs`). `resolveChangedFiles()` never `|| true`-swallows: on push it prefers the merge's **first-parent diff** (`HEAD~1..HEAD`, robust to concurrent pushes — the #1477 cause), falls back to `before..after`, and throws if no base resolves. `computeMatrix()` replicates the old watchPath matching exactly.
- `main()` treats an **empty** changed-file set on a triggered push/PR as a compute failure (the workflow's `paths:` filter guarantees ≥1 watched file) → exit 1 → red run → `report-failed-deploy` fires. An empty *matrix* (workflow-only change) stays green.
- **`scripts/deploy-detect.test.mjs`** — 15 cases incl. the #1477 regression (`crouton-sales` merge → fanfare in matrix) and unresolvable-base → throw.
- **`.github/workflows/deploy-apps.yml`** detect job calls the script; happy-path behaviour identical, failure path now loud.

## 🧪 How to test

`node --test scripts/deploy-detect.test.mjs` → 15 green. CLI verified against the live repo; eslint + fallow clean.

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXyzjSq5JpurzyiyaQPQBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXyzjSq5JpurzyiyaQPQBb)_