### PR TITLE
fix(crouton-core): opaque + full-width CroutonSubBar so sticky auto-hide reads clean

### DIFF
--- a/packages/crouton-core/app/components/SubBar.vue
+++ b/packages/crouton-core/app/components/SubBar.vue
@@ -32,12 +32,21 @@ interface Props {
    * nothing to hide. No-op on the server.
    */
   autoHide?: boolean
+  /**
+   * Bleed out of a host that pads its scroll container (the standard `p-4`
+   * pane) so the bar spans the FULL width edge-to-edge — content stays inset
+   * to line up with the padded siblings. Use when the bar sits inside a padded
+   * scroll area; omit when the host has no horizontal padding (the bar is
+   * already full-width then).
+   */
+  flush?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   sticky: false,
   bordered: true,
   autoHide: false,
+  flush: false,
 })
 
 const root = ref<HTMLElement | null>(null)
@@ -74,11 +83,15 @@ onBeforeUnmount(() => cleanup())
 <template>
   <div
     ref="root"
-    class="flex items-center gap-2 px-2 py-1.5 bg-elevated/30 overflow-x-auto transition-transform duration-200 ease-out"
+    class="flex items-center gap-2 py-1.5 bg-default overflow-x-auto transition-transform duration-200 ease-out"
     :class="[
       bordered ? 'border-b border-default' : '',
       (sticky || autoHide) ? 'sticky top-0 z-10' : '',
       hidden ? '-translate-y-full' : 'translate-y-0',
+      // Full-bleed inside a `p-4` pane: cancel the host's horizontal padding,
+      // re-inset the content by the same amount so it lines up with the padded
+      // siblings below. Plain `px-2` otherwise.
+      flush ? '-mx-4 px-4' : 'px-2',
     ]"
   >
     <slot name="leading" />

--- a/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
@@ -396,7 +396,7 @@ function toggleExpand(id: string) {
              under the pane header, so they stay reachable while the orders list
              scrolls. Selects stack on a narrow pane and flow to columns when
              there's room (@container). -->
-        <CroutonSubBar sticky auto-hide :class="headerControlled ? '' : 'mt-2'">
+        <CroutonSubBar sticky auto-hide flush :class="headerControlled ? '' : 'mt-2'">
           <div class="w-full space-y-2">
             <div class="grid grid-cols-1 gap-2 @md:grid-cols-2 @2xl:grid-cols-4">
               <USelectMenu


### PR DESCRIPTION
## 👤 For humans

On the phone kassa the sticky sub-bars (orders filter, settings section tabs) looked messy: the bar was **see-through**, so content behind it bled through as you scrolled (the "Vlaamse Kermis" bleed), and the **orders** filter bar didn't reach the screen edges. Now the bar is **opaque** — content scrolls cleanly under it — and can span **full width** edge-to-edge, matching the pages editor's language bar (the reference). Auto-hide behaviour (slide away on scroll-down, reappear on scroll-up) is unchanged.

## 🤖 For agents

Reported with screenshots on `kassa.pmcp.dev`. Two root causes in the shared `CroutonSubBar` + one host-padding issue:

1. **Translucent background** — `SubBar.vue` root was `bg-elevated/30` (30% opaque); pinned/auto-hiding, content showed through. → opaque `bg-default`.
2. **Not full-width in a padded pane** — Shell wraps `OrdersTab` in `p-4`, insetting its sticky bar. → new optional **`flush`** prop (`-mx-4 px-4`) bleeds the bar out horizontally while re-insetting content to line up with the padded siblings. `OrdersTab` passes `flush`.
3. **Settings** needs no `flush` (host has no padding, already full-width); the opaque bg alone fixes its bleed.

Pages' language bar is unaffected — static bar (no sticky/auto-hide), opaque bg only makes it marginally crisper.

**Files:** `packages/crouton-core/app/components/SubBar.vue`, `packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue`. Data panel's sticky toggle is a plain div, not a `SubBar` — untouched.

Packages-approved: UI behaviour fix on the shared sub-bar per direct user feedback (crouton-core + crouton-sales), scoped minimally.

## 🧪 How to test

On the phone kassa (`kassa.pmcp.dev` after this deploys): open **Bestellingen** → expand Filters → scroll the list — the filter bar hides on scroll-down, reveals on scroll-up, opaque + edge-to-edge. Open **Instellingen** → scroll — the Algemeen/Printers/Helpers strip stays opaque (no title bleeding through).

`pnpm --filter fanfare typecheck` ✓ · `npx fallow audit` ✓ (no issues in the 2 changed files).

Closes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SfLiHQsK8U1X19RF6J5Ps)_