### PR TITLE
fix(crouton-core): reclaim CroutonSubBar space on hide + full-width settings tabs

### DIFF
--- a/packages/crouton-core/app/components/SubBar.vue
+++ b/packages/crouton-core/app/components/SubBar.vue
@@ -51,6 +51,13 @@ const props = withDefaults(defineProps<Props>(), {
 
 const root = ref<HTMLElement | null>(null)
 const hidden = ref(false)
+// Measure the bar's own height so the hidden state can RECLAIM its space. A
+// plain `translateY(-100%)` hides the bar visually, but its box still occupies
+// layout — now that the bar is opaque that reserved slot reads as an empty gap
+// (a tall, open filter bar leaves a tall gap). Collapsing it with a negative
+// margin equal to the bar's height lets the content below slide up in sync with
+// the bar sliding away, so there's no hole.
+const { height: barHeight } = useElementSize(root)
 let prevY = 0
 let cleanup: () => void = () => {}
 
@@ -83,7 +90,7 @@ onBeforeUnmount(() => cleanup())
 <template>
   <div
     ref="root"
-    class="flex items-center gap-2 py-1.5 bg-default overflow-x-auto transition-transform duration-200 ease-out"
+    class="flex items-center gap-2 py-1.5 bg-default overflow-x-auto transition-[transform,margin] duration-200 ease-out"
     :class="[
       bordered ? 'border-b border-default' : '',
       (sticky || autoHide) ? 'sticky top-0 z-10' : '',
@@ -93,6 +100,7 @@ onBeforeUnmount(() => cleanup())
       // siblings below. Plain `px-2` otherwise.
       flush ? '-mx-4 px-4' : 'px-2',
     ]"
+    :style="autoHide && hidden ? { marginBottom: `-${barHeight}px` } : undefined"
   >
     <slot name="leading" />
     <div class="min-w-0 flex-1">

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
@@ -536,10 +536,12 @@ function helperExpiry(value: string): string {
     <!-- Scroll container (tabbed): hosts BOTH the sticky, auto-hiding section
          strip and the cards, so the strip hides on scroll-down and reveals on
          scroll-up. Standalone (non-tabbed) is a plain pass-through wrapper. -->
-    <div :class="tabbed ? 'flex-1 overflow-y-auto min-h-0' : ''">
+    <div :class="tabbed ? 'flex-1 overflow-y-auto min-h-0 px-4' : ''">
       <!-- Section picker on a shared CroutonSubBar (#307), styled like the
-           pages editor's tabs — underline active, sticky + auto-hide. -->
-      <CroutonSubBar v-if="tabbed" sticky auto-hide>
+           pages editor's tabs — underline active, sticky + auto-hide. `flush`
+           bleeds it out of the container's px-4 so the strip spans full width
+           while the tabs line up with the padded cards below. -->
+      <CroutonSubBar v-if="tabbed" sticky auto-hide flush>
       <nav class="flex w-full items-center gap-0.5">
         <UButton
           v-for="s in sections"
@@ -561,7 +563,7 @@ function helperExpiry(value: string): string {
          printers (incl. receipt text), helpers (incl. PIN). Tabbed mode shows
          one at a time but keeps all mounted (v-show) so dirty state and the
          panel-wide save cover every tab. -->
-    <div class="grid grid-cols-1 gap-4 items-start" :class="tabbed ? 'px-3 pb-3 pt-3' : 'lg:grid-cols-3'">
+    <div class="grid grid-cols-1 gap-4 items-start" :class="tabbed ? 'pb-3 pt-3' : 'lg:grid-cols-3'">
       <!-- Event details (inline editable) -->
       <UCard v-show="!tabbed || activeSection === 'event'" :ui="eventCardUi">
         <template #header>


### PR DESCRIPTION
## 👤 For humans

Two follow-up mobile fixes on the sticky sub-bars (from phone feedback IMG_1517/1518):

1. **Orders — no more gap:** when the filter bar auto-hides on scroll it left an empty hole (its layout box stayed reserved, and now that the bar is opaque that hole was obvious). The list below now slides up to fill it, in sync with the bar sliding away.
2. **Settings — full width:** the section tabs (Algemeen/Printers/Helpers) now span the full width edge-to-edge, matching the pages editor's bar, instead of sitting inset.

## 🤖 For agents

- `SubBar.vue`: measure the bar (`useElementSize`); when hidden, apply `margin-bottom: -height` so the `translateY(-100%)` bar reclaims its layout box. Transition covers `transform` + `margin` so the collapse animates in sync.
- `SettingsTab.vue` (tabbed): scroll container gains `px-4`, the section `CroutonSubBar` gains `flush`, cards drop their own `px-3` — strip bleeds full-width, tabs align with the padded cards.

Verified: full-width geometry rendered at phone width (bar divider reaches both screen edges); `pnpm --filter fanfare typecheck` ✓; `npx fallow audit` ✓ (no issues in changed files).

Part of #1647 (the CroutonSubBar mobile polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016SfLiHQsK8U1X19RF6J5Ps)_