### PR TITLE
feat(root): land the Retired projects digest GC band (#1050)

### DIFF
--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -40,6 +40,7 @@ the only thing it writes.
   LLM): a cited path that **vanished** (🔴), a cited file with commits **newer than the stamp**
   (🟡 possibly-stale), or a stamp **> 90d old** (🔵 re-verify due). Report-only — a re-verified,
   re-stamped skill drops off next run (#1100 WS3). Section dropped if the checker can't run.
+- **🗑 Retired projects** — `retired/` dirs with a `.retired.json` stamp, showing age and flagging entries past 60 days for full deletion via `/retire-delete`.
 
 ## Pipeline (deterministic — no LLM, no secrets)
 

--- a/.claude/skills/housekeeping/gather.mjs
+++ b/.claude/skills/housekeeping/gather.mjs
@@ -202,6 +202,48 @@ function skillFreshness() {
   }
 }
 
+// ── Retired projects (#686) ──────────────────────────────────────────────────
+// Scan `retired/apps/` and `retired/pocs/` for subdirectories with a `.retired.json`
+// stamp file. Compute age from `archivedAt` and flag entries past 60 days for
+// full deletion. Gracefully returns [] when the `retired/` tree doesn't exist or
+// has no stamp files (WS4a may not have landed yet).
+function retiredProjects() {
+  const dirs = (p) => {
+    try {
+      return readdirSync(p, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+        .map((d) => d.name)
+    } catch {
+      return []
+    }
+  }
+  const results = []
+  for (const [base, type] of [['retired/apps', 'app'], ['retired/pocs', 'poc']]) {
+    for (const name of dirs(base)) {
+      const stampPath = `${base}/${name}/.retired.json`
+      if (!existsSync(stampPath)) continue
+      let stamp
+      try {
+        stamp = JSON.parse(readFileSync(stampPath, 'utf8'))
+      } catch {
+        continue // unparseable — skip
+      }
+      const archivedAt = stamp.archivedAt
+      if (!archivedAt) continue
+      const age = ageDays(archivedAt)
+      results.push({
+        name: stamp.name || name,
+        type: stamp.type || type,
+        archivedAt,
+        ageDays: age,
+        pastThreshold: age > 60,
+        sourceEpic: stamp.sourceEpic ?? null
+      })
+    }
+  }
+  return results.sort((a, b) => b.ageDays - a.ageDays)
+}
+
 // ── Issue / PR drift (API) ───────────────────────────────────────────────────
 const COMPONENT_RE = /^(pkg|app|worker|poc):/
 
@@ -305,6 +347,7 @@ const data = {
   labelCoverage: labelCoverage(),
   loopStation: loopStationBudget(),
   skillFreshness: skillFreshness(),
+  retiredProjects: retiredProjects(),
   ...drift
 }
 

--- a/.claude/skills/housekeeping/render.mjs
+++ b/.claude/skills/housekeeping/render.mjs
@@ -147,6 +147,19 @@ if (sf && (sf.flagged?.length || sf.malformed?.length)) {
   sections.push(['📚 Skill freshness', lines])
 }
 
+if (data.retiredProjects?.length) {
+  sections.push([
+    '\u{1F5D1} Retired projects',
+    [
+      '`retired/` dirs with a `.retired.json` stamp:',
+      ...data.retiredProjects.map((r) => {
+        const line = `- \`retired/${r.type}s/${r.name}\` — archived ${r.archivedAt} (${r.ageDays}d ago)`
+        return r.pastThreshold ? `${line} → \`/retire-delete ${r.name}\` to fully remove` : line
+      })
+    ]
+  ])
+}
+
 // Loop Station budget readout (#934, WS4) — one read-only line, always shown when
 // the inventory has produced data. Sourced from the latest committed history.jsonl
 // record (gathered, not recomputed). Omitted when WS1 hasn't run yet.

--- a/.claude/skills/housekeeping/render.mjs
+++ b/.claude/skills/housekeeping/render.mjs
@@ -148,13 +148,20 @@ if (sf && (sf.flagged?.length || sf.malformed?.length)) {
 }
 
 if (data.retiredProjects?.length) {
+  // Past-threshold entries get a direct link to the teardown-app workflow_dispatch
+  // page — the one-click "actually delete it now" trigger (#1053). teardown-app.yml
+  // only takes `app` as a free-text input, so we can't pre-fill the form via query
+  // string; the link takes the human straight to Actions with the values to type in.
+  const teardownUrl = `https://github.com/${data.repo}/actions/workflows/teardown-app.yml`
+  const retireDeleteLink = (name) =>
+    `[Retire-delete ${name}](${teardownUrl}) (run with app=${name}, scope=staging, delete_cloudflare=true)`
   sections.push([
     '\u{1F5D1} Retired projects',
     [
       '`retired/` dirs with a `.retired.json` stamp:',
       ...data.retiredProjects.map((r) => {
         const line = `- \`retired/${r.type}s/${r.name}\` — archived ${r.archivedAt} (${r.ageDays}d ago)`
-        return r.pastThreshold ? `${line} → \`/retire-delete ${r.name}\` to fully remove` : line
+        return r.pastThreshold ? `${line} → ${retireDeleteLink(r.name)}` : line
       })
     ]
   ])

--- a/.claude/skills/remove-app/SKILL.md
+++ b/.claude/skills/remove-app/SKILL.md
@@ -88,6 +88,21 @@ git rm -f .github/workflows/deploy-<app>.yml   # the per-app CI caller, if prese
 git mv pocs/<app> retired/pocs/<app>       # or git mv apps/<app> retired/apps/<app>
 git rm -f .github/workflows/deploy-<app>.yml   # the per-app CI caller, if present
 ```
+Then write a **`.retired.json`** age-stamp into the archived directory (this is
+written automatically during the archive flow):
+```bash
+cat > retired/pocs/<app>/.retired.json << 'EOF'
+{
+  "archivedAt": "<current ISO timestamp>",
+  "sourceEpic": <epic number>,
+  "sourceDir": "pocs/<app>"
+}
+EOF
+```
+Schema: `archivedAt` is the ISO-8601 date of the archive commit, `sourceEpic` is
+the epic being closed, `sourceDir` is the original path (e.g. `pocs/blog` or
+`apps/myapp`). The retirement digest band and GC trigger read this stamp.
+
 > `--archive` preserves the code as browsable reference under `retired/` while
 > still tearing down all live Cloudflare resources, branches, and issues (Steps 4+).
 > Archive != keep-deployed — the Worker/D1/KV are deleted either way.

--- a/retired/pocs/blog/.retired.json
+++ b/retired/pocs/blog/.retired.json
@@ -1,0 +1,5 @@
+{
+  "archivedAt": "2026-07-01T14:35:59+02:00",
+  "sourceEpic": 686,
+  "sourceDir": "pocs/blog"
+}

--- a/retired/pocs/thinkgraph-collab-worker/.retired.json
+++ b/retired/pocs/thinkgraph-collab-worker/.retired.json
@@ -1,0 +1,5 @@
+{
+  "archivedAt": "2026-07-01T14:35:59+02:00",
+  "sourceEpic": 686,
+  "sourceDir": "pocs/thinkgraph-collab-worker"
+}

--- a/retired/pocs/thinkgraph-worker/.retired.json
+++ b/retired/pocs/thinkgraph-worker/.retired.json
@@ -1,0 +1,5 @@
+{
+  "archivedAt": "2026-07-01T14:35:59+02:00",
+  "sourceEpic": 686,
+  "sourceDir": "pocs/thinkgraph-worker"
+}

--- a/retired/pocs/thinkgraph/.retired.json
+++ b/retired/pocs/thinkgraph/.retired.json
@@ -1,0 +1,5 @@
+{
+  "archivedAt": "2026-07-01T14:35:59+02:00",
+  "sourceEpic": 686,
+  "sourceDir": "pocs/thinkgraph"
+}

--- a/retired/pocs/three-demo/.retired.json
+++ b/retired/pocs/three-demo/.retired.json
@@ -1,0 +1,5 @@
+{
+  "archivedAt": "2026-07-01T14:35:59+02:00",
+  "sourceEpic": 686,
+  "sourceDir": "pocs/three-demo"
+}


### PR DESCRIPTION
Closes #1050

## 👤 For humans

The housekeeping digest gains a **🗑 Retired projects** band: every archived project in `retired/` is listed with its age, and anything past **60 days** gets a one-click teardown link. `retired/` stops being a place things go to be forgotten.

**This code is not new — it was written and reviewed in early July, then never landed.** Its three sub-issues (#1051 / #1052 / #1053) all merged into the working branch `epic/686-retire-via-archive`, which was never merged onward to `main`. The issues auto-closed on those merges, so the tracker read as finished while `main` had none of it. Verified before this PR: no band in the digest, no `retire-delete` trigger, no `.retired.json` stamps anywhere.

## 🤖 For agents

Recovered by cherry-picking the three feature commits from `epic/686-retire-via-archive` onto current `main` (the branch is 756 commits behind; a wholesale merge was rejected as higher-risk for no gain).

- `73893e369` → `331bbd58b` — backfill `.retired.json` age-stamps + document self-stamp in the `--archive` flow (#1051). Clean.
- `d229c0cf5` → `ba557021d` — `retiredProjects()` in `gather.mjs` + the render band + SKILL.md entry (#1052). **Conflicted** with #1100 (skill-freshness band) in all three housekeeping files.
- `8f3e4a079` → `c0ae4a8d1` — wire the `/retire-delete` trigger to `teardown-app.yml` (#1053). Clean.

### Conflict resolution

Every hunk was **additive** — #1100 and #1052 each append a new digest section; neither modifies the other. Resolved by keeping **both**, in both `gather.mjs` (the two collector functions and both keys on the emitted object) and `render.mjs` (both `sections.push` blocks). No behaviour from either feature was dropped.

### Verification

- `node --check` passes on `gather.mjs` and `render.mjs`.
- Rendered a digest from a fixture: the 🗑 band emits, past-threshold entries carry the teardown link, sub-threshold entries do not.
- All five `.retired.json` stamps present under `retired/pocs/`.
- Original commit messages and `claude[bot]` authorship preserved (no squash, per the merge policy).

Dedup-checked: recovery of existing tracked work under #1050 — no new issue minted.