### PR TITLE
docs(root): correct the stale dormancy headers on both decompose workflows

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -1,16 +1,28 @@
 name: Decompose on issue (pi.dev variant)
 
-# WS4 (#1004) of #669 — the code-writing pipeline on pi.dev. A dispatch-only,
-# default-OFF twin of `decompose-on-issue.yml` with ONE thing swapped: the agent
-# step (anthropics/claude-code-action → pi). It exists to prove the code-writing
-# flow can run on pi with the gates intact — it is NOT wired to auto-trigger and
-# cannot run until a funded provider key + `AGENT_HARNESS=pi` are set.
+# WS4 (#1004) of #669 — the code-writing pipeline on pi.dev. A twin of
+# `decompose-on-issue.yml` with ONE thing swapped: the agent step
+# (anthropics/claude-code-action → pi). It is LIVE: while `vars.AGENT_HARNESS == 'pi'`
+# (the current setting) THIS flow — not the claude one — works our `delegate` issues.
 #
-# DORMANT BY DESIGN (three locks):
-#   1. `workflow_dispatch` only — never fires on an `issues` event (no auto-trigger).
-#   2. AGENT_HARNESS gate — the job no-ops unless `harness: pi` is chosen or
-#      `vars.AGENT_HARNESS == 'pi'` is set. Default off.
-#   3. No funded key — runs error out until PI_PROVIDER_KEY has credit.
+# HOW A RUN STARTS (the `on:` block and the job `if` below are authoritative — if this
+# prose ever disagrees with them, they win and this comment is the thing that's wrong):
+#   • `delegate` label — added after creation, OR already present at creation. Only
+#     while `vars.AGENT_HARNESS == 'pi'`; otherwise `decompose-on-issue.yml` takes it
+#     and this flow yields (#1077 WS7 — one variable flips the harness back).
+#   • `delegate-pi` label — always, regardless of AGENT_HARNESS.
+#   • `delegate-hard` label — always; escalates to the METERED Claude lane (#1496).
+#   • `workflow_dispatch` — an explicit run on any issue number.
+#
+#   ⚠️ ASYMMETRY: only `delegate` has an `action == 'opened'` clause. `delegate-pi` and
+#   `delegate-hard` match `labeled` ONLY — so creating an issue with either one ALREADY
+#   applied fires nothing. Add those two as a separate step after the issue exists.
+#
+# HISTORY — this file was born dormant (dispatch-only, default-OFF, no funded key) and
+# every one of those locks has since been removed. Do NOT reintroduce that framing:
+# superseded by #1017 (`delegate-pi` trigger), #1077 (the AGENT_HARNESS=pi flip), and
+# #1421/#1423 (the funded zai/GLM-5.2 lane). Stale dormancy prose here cost a session
+# once — it reads as authoritative while sitting directly above code that refutes it.
 #
 # WHAT'S DIFFERENT FROM THE CLAUDE FLOW (the WS4 plumbing):
 #   • PUSH PATH (#1004 piece 1, the load-bearing change): unlike the reports-only
@@ -24,11 +36,11 @@ name: Decompose on issue (pi.dev variant)
 #     reads CLAUDE_EXEC_FILE, which pi doesn't emit yet (#1004 piece 3 / WS3) — the
 #     gate degrades to the conclusion-based message, PASS/FAIL is unaffected.
 #
-# WS4 plumbing is now COMPLETE (#1004) — all three pieces present, armed but dormant:
+# WS4 plumbing is now COMPLETE (#1004) — all three pieces present and LIVE:
 #   • Piece 1 — PUSH PATH: the Harness App token (below).
 #   • Piece 2 — BOT-ACTOR GUARD: the first job step (re-expresses claude-code-action's
-#     `allowed_bots`). It no-ops under `workflow_dispatch` and ARMS automatically the
-#     moment this flow is promoted to an `issues: labeled` trigger.
+#     `allowed_bots`). ARMED on every label-triggered run; it still no-ops under
+#     `workflow_dispatch`, where the actor is the human dispatcher.
 #   • Piece 3 — EXEC-LOG ADAPTER: the artifact-gate reads pi's plain-text run log
 #     (`steps.pi.outputs.exec_log`) and classifies the failure cause (billing / error /
 #     underspecified) — parity with the claude flow's structured-log "why".
@@ -36,7 +48,7 @@ name: Decompose on issue (pi.dev variant)
 # TWO LOAD-BEARING pi FACTS (verified on the mac-mini this WS):
 #   • NO TURN-CAP FLAG. `pi --help` exposes only model-cycling "Limit" options, not a
 #     claude-style `--max-turns`. The ONLY cost/safety bound is the job `timeout-minutes`
-#     (30) — do NOT assume a per-turn cap exists.
+#     (45, below) — do NOT assume a per-turn cap exists.
 #   • SINGLE-MODEL. pi runs the whole orchestrator→decomposer→worker pipeline on ONE
 #     `--model`; it cannot reproduce the Claude harness's per-role tiering (#824 — e.g.
 #     planning on Opus). Choose the one model deliberately via the `model` input.

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -3,6 +3,12 @@ name: Decompose on issue
 # Hand an issue to the Claude agent pipeline when it's opted in via the
 # `delegate` label (added at creation or any time after). The pipeline spawns
 # the orchestrator → decomposer → worker agents (see .claude/skills/task-decompose).
+#
+# ⚠️ THIS FLOW IS CURRENTLY YIELDING. The job `if` below opens with
+# `vars.AGENT_HARNESS != 'pi'`, and that repo var IS `pi` right now — so a `delegate`
+# label does NOT start this workflow; `decompose-on-issue-pidev.yml` picks the same
+# events up instead (#669 WS7 / #1077). Unset the var (or set it to anything else) and
+# claude is the default again. Check the var before concluding either flow is broken.
 on:
   issues:
     types: [opened, labeled]


### PR DESCRIPTION
Closes #1653

## 👤 For humans

The comment block at the top of `decompose-on-issue-pidev.yml` said the workflow was **dormant** and could only be started by hand. That hasn't been true since #1017/#1077 — adding the `delegate` label starts it, which is how #1652 got picked up an hour ago.

That comment is the first thing anyone reads in the file, it sits directly above the `on:` block that contradicts it, and it already cost a session: an agent read it, believed it, and told the owner his label-based hand-off was broken.

Two extra staleness bugs found while in there:
- The header claimed a `timeout-minutes` of 30; the job has said 45 for a while.
- `decompose-on-issue.yml`'s header didn't mention that the flow is currently **yielding** — its `if` starts with `vars.AGENT_HARNESS != 'pi'`, and that var *is* `pi`. So a reader would think the Claude flow handles `delegate`. It doesn't right now.

Also documented an asymmetry that's easy to get burned by: only `delegate` fires on issue *creation*. `delegate-pi` and `delegate-hard` match `labeled` only — **create an issue with either already applied and nothing happens.**

## 🤖 For agents

**Comments only. Zero behaviour change**, verified two ways:

```
$ git diff -U0 | grep -E "^[+-]" | grep -vE "^[+-]{3}|^[+-]\s*#|^[+-]\s*$"
(no output)

$ node -e "yaml.load(...)"
✅ decompose-on-issue-pidev.yml parses | on: ["workflow_dispatch","issues"]
✅ decompose-on-issue.yml       parses | on: ["issues"]
```

No `on:` block, job `if`, step, or input was touched.

**`decompose-on-issue-pidev.yml`**
- "DORMANT BY DESIGN (three locks)" → a **HOW A RUN STARTS** list covering all four entry paths, prefixed with the rule that the `on:` block and job `if` are authoritative and this prose is what's wrong if they ever disagree.
- Dormancy retained as **HISTORY** with its superseding issues (#1017 `delegate-pi` trigger, #1077 the `AGENT_HARNESS=pi` flip, #1421/#1423 the funded zai/GLM-5.2 lane) and a do-not-reintroduce note.
- Piece 2 "armed but dormant … ARMS automatically the moment this flow is promoted" → **ARMED**, with the surviving `workflow_dispatch` no-op explained.
- `timeout-minutes` (30) → (45), matching line 95.

**`decompose-on-issue.yml`**
- Header note that this flow currently yields to the pi variant, and that one variable flips it back.

Left deliberately untouched (all three are correct): the inline `PROMOTED past dispatch-only` notes above `issues:` and the bot-actor guard, and `decompose-on-issue-pidev-hosted.yml`'s *"must never grow an `issues:` trigger"* — that one is still true and load-bearing.

## 🧪 How to test

1. Open `.github/workflows/decompose-on-issue-pidev.yml` and read **only** the header block.
2. **Expect** to come away knowing the `delegate` label starts this workflow — without scrolling to the `on:` block to find out. Before this PR you'd conclude the opposite.
3. Open `decompose-on-issue.yml`'s header. **Expect** to learn it's currently yielding, so you don't debug it as broken.
4. `git diff main -- .github/workflows` → confirm every changed line begins with `#`.
