### PR TITLE
feat(crouton-auth): pairing-code grants for device claiming (#1661)

### DIFF
--- a/packages/crouton-auth/CLAUDE.md
+++ b/packages/crouton-auth/CLAUDE.md
@@ -405,6 +405,31 @@ The generic redeem endpoint fires `crouton:scoped-access:before-redeem` with `{ 
 
 Grants can't FK into domain tables — call `revokeScopedGrantsForResource` when the resource is deleted.
 
+### Device pairing codes (`server/utils/pairing-code.ts`, #1661)
+
+The **app-mints** direction of device claiming — an org owner mints a one-time code, a freshly installed till types it in and claims itself. Counterpart to #1366's device-prints-code poll (`verifyScopedGrantByResource`).
+
+```typescript
+import { mintPairingCode, redeemPairingCode } from '@crouton/auth/server/utils/pairing-code'
+
+// Owner side — show `code` once; it is never stored in plaintext.
+const { code, expiresAt } = await mintPairingCode({ organizationId: team.id, eventId })
+
+// Device side — knows only the code; the grant it finds says which org it joins.
+const result = await redeemPairingCode({ code, deviceName: 'Bar till 1' })
+if (result.ok) {
+  // result.grant IS the device; result.deviceSecret is returned ONCE — persist it.
+}
+```
+
+**A device IS its `scopedAccessGrant` — there is no `devices` table.** Redeeming consumes the transient pairing grant (`resourceId: 'pairing:<sha256(code)>'`, `maxUses: 1`, deactivated on use) and inserts the device's persistent grant (`resourceId: 'device:<uuid>'`, no expiry) plus its first token.
+
+- **resourceType `till-device`** — distinct from `print-device`, so both coexist on one org.
+- **Code shape:** 8 chars from digits + A–Z minus `I`/`O` (the glyph pairs operators mistype), rejection-sampled so the alphabet stays unbiased.
+- **TTL 15 minutes**, single-use. Hashing and the exponential lockout are the same primitives as every other grant.
+- **`redeem` reasons:** `invalid` (covers *both* unknown and wrong code — no enumeration oracle) · `expired` · `locked` · `exhausted`.
+- The lookup key is an **unsalted** SHA-256 of the code so an org-less lookup is possible; verification still runs against the salted `secretHash`, and the plaintext code never reaches the database.
+
 ### Token Server Utilities
 
 ```typescript

--- a/packages/crouton-auth/package.json
+++ b/packages/crouton-auth/package.json
@@ -43,6 +43,10 @@
       "import": "./server/utils/scoped-access.ts",
       "types": "./server/utils/scoped-access.ts"
     },
+    "./server/utils/pairing-code": {
+      "import": "./server/utils/pairing-code.ts",
+      "types": "./server/utils/pairing-code.ts"
+    },
     "./server/utils/auth": {
       "import": "./server/utils/auth.ts",
       "types": "./server/utils/auth.ts"

--- a/packages/crouton-auth/server/utils/pairing-code.ts
+++ b/packages/crouton-auth/server/utils/pairing-code.ts
@@ -1,0 +1,278 @@
+/**
+ * Pairing-code grants — the app-mints direction of device claiming (#1661).
+ *
+ * An org owner mints a short-lived, single-use pairing code; a freshly
+ * installed till device redeems it to claim itself into the org. Redemption
+ * consumes the transient pairing grant and mints the device's PERSISTENT
+ * grant plus its first scoped token.
+ *
+ * This is the counterpart to #1366's device-prints-code flow
+ * (`verifyScopedGrantByResource`), and shares its design invariant:
+ *
+ *   A DEVICE **IS** ITS `scopedAccessGrant`. There is no `devices` table.
+ *
+ * Everything security-bearing is reused from `scoped-access.ts` — salted
+ * secret hashing and the per-grant exponential lockout. This module only adds
+ * the pairing-specific shape: code generation, an org-less lookup (the device
+ * does not yet know which org it belongs to — the grant's `organizationId` is
+ * the answer), and single-use consumption.
+ */
+import { eq, and, sql } from 'drizzle-orm'
+import { scopedAccessGrant } from '../database/schema/auth'
+import {
+  createScopedToken,
+  upsertScopedGrant,
+  hashGrantSecret,
+  verifyGrantSecret,
+  GRANT_LOCKOUT_THRESHOLD,
+  lockoutDuration
+} from './scoped-access'
+
+/**
+ * Resource type for till/screen devices. Deliberately distinct from
+ * 'print-device' (#1366's routers) so the two coexist on one org.
+ */
+export const TILL_DEVICE_RESOURCE_TYPE = 'till-device'
+
+/** A pairing code is a transient credential — minutes, not hours. */
+const PAIRING_CODE_TTL_MS = 15 * 60 * 1000
+
+const PAIRING_CODE_LENGTH = 8
+
+/**
+ * Crockford-ish alphabet: digits + A–Z minus the two glyph pairs an operator
+ * reliably mistypes when reading a code off a screen (I/1 and O/0). 34 symbols
+ * over 8 characters ≈ 1.8e12 combinations, which — behind the shared per-grant
+ * lockout — is far beyond guessable.
+ */
+const CODE_ALPHABET = '0123456789ABCDEFGHJKLMNPQRSTUVWXYZ'
+
+/** Bytes ≥ this are rejected when sampling, to keep the alphabet unbiased. */
+const REJECTION_CEILING = 256 - (256 % CODE_ALPHABET.length)
+
+function generatePairingCode(): string {
+  let out = ''
+  while (out.length < PAIRING_CODE_LENGTH) {
+    const bytes = new Uint8Array(PAIRING_CODE_LENGTH)
+    crypto.getRandomValues(bytes)
+    for (const b of bytes) {
+      if (out.length === PAIRING_CODE_LENGTH) break
+      // Rejection sampling — modulo alone would over-weight the first
+      // 256 % 34 = 18 symbols.
+      if (b >= REJECTION_CEILING) continue
+      out += CODE_ALPHABET[b % CODE_ALPHABET.length]
+    }
+  }
+  return out
+}
+
+/**
+ * Deterministic, UNSALTED digest of the code, used only as the row's lookup
+ * key so a device can find its grant while presenting nothing but the code.
+ * The actual verification still runs against the salted `secretHash`, so this
+ * digest being deterministic does not weaken the credential — and critically,
+ * the plaintext code is never written to the database.
+ */
+async function codeLookupId(code: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(code))
+  return Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+const pairingResourceId = (lookupId: string) => `pairing:${lookupId}`
+
+/** Secret held by the device after claiming, so it can re-authenticate later. */
+function generateDeviceSecret(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export interface MintPairingCodeOptions {
+  /** Organization the claimed device will belong to */
+  organizationId: string
+  /** Optional event scope carried onto the device grant on redeem */
+  eventId?: string
+}
+
+/**
+ * Mint a single-use pairing code for an org.
+ *
+ * The plaintext code is returned to the caller exactly once — it is shown to
+ * the owner and never stored. Callers must not log it.
+ */
+export async function mintPairingCode(
+  options: MintPairingCodeOptions
+): Promise<{ code: string, expiresAt: Date }> {
+  const { organizationId, eventId } = options
+
+  const code = generatePairingCode()
+  const expiresAt = new Date(Date.now() + PAIRING_CODE_TTL_MS)
+
+  await upsertScopedGrant({
+    organizationId,
+    resourceType: TILL_DEVICE_RESOURCE_TYPE,
+    resourceId: pairingResourceId(await codeLookupId(code)),
+    secret: code,
+    role: 'device',
+    maxUses: 1,
+    expiresAt,
+    metadata: eventId ? { eventId } : undefined
+  })
+
+  return { code, expiresAt }
+}
+
+export interface RedeemPairingCodeOptions {
+  /** The code as typed on the device */
+  code: string
+  /** Operator-facing name for the claimed device ("Bar till 1") */
+  deviceName: string
+}
+
+/**
+ * Outcome of a claim attempt.
+ *
+ * `invalid` deliberately covers BOTH "no such code" and "wrong code" so the
+ * endpoint is not an enumeration oracle.
+ */
+export type RedeemPairingCodeResult
+  = | {
+    ok: true
+    /** First scoped token for the claimed device */
+    token: string
+    tokenExpiresAt: Date
+    /**
+     * The device's long-lived secret. Returned once, at claim time — the
+     * device persists it and presents it on later re-authentication.
+     */
+    deviceSecret: string
+    grant: {
+      id: string
+      organizationId: string
+      resourceType: string
+      resourceId: string
+      role: string
+    }
+  }
+  | { ok: false, reason: 'invalid' | 'expired' | 'locked' | 'exhausted', retryAfterMs?: number }
+
+/**
+ * Claim a device with a pairing code.
+ *
+ * Note the deliberate org-less lookup: a fresh device knows only the code, so
+ * the grant it finds is what tells it which organization it now belongs to.
+ */
+export async function redeemPairingCode(
+  options: RedeemPairingCodeOptions
+): Promise<RedeemPairingCodeResult> {
+  const { code, deviceName } = options
+
+  const db = useDB()
+  const now = new Date()
+
+  const [grant] = await db
+    .select()
+    .from(scopedAccessGrant)
+    .where(
+      and(
+        eq(scopedAccessGrant.resourceType, TILL_DEVICE_RESOURCE_TYPE),
+        eq(scopedAccessGrant.resourceId, pairingResourceId(await codeLookupId(code))),
+        eq(scopedAccessGrant.credentialType, 'pin'),
+        eq(scopedAccessGrant.isActive, true)
+      )
+    )
+    .limit(1)
+
+  // No such code — same answer a wrong code gets (see the type's note).
+  if (!grant) return { ok: false, reason: 'invalid' }
+
+  if (grant.expiresAt && grant.expiresAt <= now) {
+    return { ok: false, reason: 'expired' }
+  }
+
+  if (grant.lockedUntil && grant.lockedUntil > now) {
+    return {
+      ok: false,
+      reason: 'locked',
+      retryAfterMs: grant.lockedUntil.getTime() - now.getTime()
+    }
+  }
+
+  if (!(await verifyGrantSecret(code, grant.secretHash))) {
+    const failedAttempts = grant.failedAttempts + 1
+    const lockedUntil = failedAttempts >= GRANT_LOCKOUT_THRESHOLD
+      ? new Date(now.getTime() + lockoutDuration(failedAttempts))
+      : null
+    await db
+      .update(scopedAccessGrant)
+      .set({ failedAttempts, lockedUntil })
+      .where(eq(scopedAccessGrant.id, grant.id))
+    return lockedUntil
+      ? { ok: false, reason: 'locked', retryAfterMs: lockedUntil.getTime() - now.getTime() }
+      : { ok: false, reason: 'invalid' }
+  }
+
+  if (grant.maxUses !== null && grant.usedCount >= grant.maxUses) {
+    return { ok: false, reason: 'exhausted' }
+  }
+
+  // Consume the pairing grant. Deactivating as well as counting means a
+  // replay can't succeed even if maxUses were later widened.
+  await db
+    .update(scopedAccessGrant)
+    .set({
+      usedCount: sql`${scopedAccessGrant.usedCount} + 1`,
+      isActive: false,
+      failedAttempts: 0,
+      lockedUntil: null
+    })
+    .where(eq(scopedAccessGrant.id, grant.id))
+
+  // Mint the device's persistent grant — this row IS the device.
+  const deviceId = crypto.randomUUID()
+  const deviceResourceId = `device:${deviceId}`
+  const deviceSecret = generateDeviceSecret()
+  const deviceGrantId = crypto.randomUUID()
+
+  await db.insert(scopedAccessGrant).values({
+    id: deviceGrantId,
+    organizationId: grant.organizationId,
+    resourceType: TILL_DEVICE_RESOURCE_TYPE,
+    resourceId: deviceResourceId,
+    role: 'device',
+    credentialType: 'pin',
+    secretHash: await hashGrantSecret(deviceSecret),
+    maxUses: null,
+    expiresAt: null,
+    tokenTtl: grant.tokenTtl,
+    // Carries the pairing grant's event scope, if any, onto the device.
+    metadata: grant.metadata
+  })
+
+  const { token, expiresAt } = await createScopedToken({
+    organizationId: grant.organizationId,
+    resourceType: TILL_DEVICE_RESOURCE_TYPE,
+    resourceId: deviceResourceId,
+    displayName: deviceName,
+    role: 'device',
+    expiresIn: grant.tokenTtl
+  })
+
+  return {
+    ok: true,
+    token,
+    tokenExpiresAt: expiresAt,
+    deviceSecret,
+    grant: {
+      id: deviceGrantId,
+      organizationId: grant.organizationId,
+      resourceType: TILL_DEVICE_RESOURCE_TYPE,
+      resourceId: deviceResourceId,
+      role: 'device'
+    }
+  }
+}

--- a/packages/crouton-auth/server/utils/scoped-access.ts
+++ b/packages/crouton-auth/server/utils/scoped-access.ts
@@ -485,8 +485,13 @@ export async function extendScopedToken(
  * PINs are low-entropy, so the hash is NOT the security boundary here —
  * the per-grant lockout in verifyAndRedeemGrant is. SHA-256 keeps this
  * cheap on Workers; the salt only prevents trivial cross-grant comparison.
+ *
+ * Exported for sibling grant modules (e.g. pairing-code.ts) that need the same
+ * hashing/lockout primitives. Not part of the package's public API — consumers
+ * use upsertScopedGrant / verifyAndRedeemGrant instead.
+ * @internal
  */
-async function hashGrantSecret(secret: string, saltHex?: string): Promise<string> {
+export async function hashGrantSecret(secret: string, saltHex?: string): Promise<string> {
   const salt = saltHex ?? Array.from(crypto.getRandomValues(new Uint8Array(16)))
     .map(b => b.toString(16).padStart(2, '0'))
     .join('')
@@ -498,20 +503,32 @@ async function hashGrantSecret(secret: string, saltHex?: string): Promise<string
   return `${salt}:${hash}`
 }
 
-async function verifyGrantSecret(secret: string, stored: string): Promise<boolean> {
+/**
+ * Exported for sibling grant modules — see hashGrantSecret.
+ * @internal
+ */
+export async function verifyGrantSecret(secret: string, stored: string): Promise<boolean> {
   const [salt] = stored.split(':')
   if (!salt) return false
   return (await hashGrantSecret(secret, salt)) === stored
 }
 
-/** Lockout policy: after this many consecutive failures, redemption locks */
-const GRANT_LOCKOUT_THRESHOLD = 5
+/**
+ * Lockout policy: after this many consecutive failures, redemption locks.
+ * Exported for sibling grant modules — see hashGrantSecret.
+ * @internal
+ */
+export const GRANT_LOCKOUT_THRESHOLD = 5
 /** Base lockout duration; doubles with each failure past the threshold */
 const GRANT_LOCKOUT_BASE_MS = 60 * 1000
 /** Lockout never exceeds this */
 const GRANT_LOCKOUT_MAX_MS = 60 * 60 * 1000
 
-function lockoutDuration(failedAttempts: number): number {
+/**
+ * Exported for sibling grant modules — see hashGrantSecret.
+ * @internal
+ */
+export function lockoutDuration(failedAttempts: number): number {
   const past = failedAttempts - GRANT_LOCKOUT_THRESHOLD
   return Math.min(GRANT_LOCKOUT_BASE_MS * 2 ** Math.max(past, 0), GRANT_LOCKOUT_MAX_MS)
 }

--- a/packages/crouton-auth/tests/unit/server/pairing-code.test.ts
+++ b/packages/crouton-auth/tests/unit/server/pairing-code.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Pairing-code grant tests (#1661 — WS2 of epic #801)
+ *
+ * The owner mints a short-lived, SINGLE-USE pairing code; a freshly-installed
+ * till device redeems it to claim itself into the org. Redemption consumes the
+ * transient pairing grant and mints the PERSISTENT device grant + its token.
+ *
+ * Design invariant (from #1366, re-affirmed on #1661): a device IS its
+ * scopedAccessGrant. There is NO `devices` table — do not add one.
+ *
+ * Built on the existing scoped-access primitives (hashed secret + per-grant
+ * brute-force lockout); this file only pins the pairing-specific behaviour.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+let lastInsertedValues: Record<string, unknown> | null = null
+let selectResults: unknown[] = []
+
+const createMockDb = () => ({
+  insert: vi.fn(() => ({
+    values: vi.fn(async (data) => {
+      lastInsertedValues = data
+      return { rowsAffected: 1 }
+    })
+  })),
+  select: vi.fn(() => ({
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn(async () => selectResults)
+  })),
+  update: vi.fn(() => ({
+    set: vi.fn(function (this: unknown) {
+      return this
+    }),
+    where: vi.fn(async () => ({ rowsAffected: 1 }))
+  })),
+  delete: vi.fn(() => ({
+    where: vi.fn(async () => ({ rowsAffected: 0 }))
+  }))
+})
+
+let mockDb = createMockDb()
+
+const realSubtle = globalThis.crypto.subtle
+vi.stubGlobal('useDB', () => mockDb)
+vi.stubGlobal('crypto', {
+  randomUUID: vi.fn().mockReturnValue('test-uuid-1234'),
+  getRandomValues: vi.fn((arr: Uint8Array) => {
+    for (let i = 0; i < arr.length; i++) arr[i] = Math.floor(Math.random() * 256)
+    return arr
+  }),
+  subtle: realSubtle
+})
+
+// Import after mocks
+import { mintPairingCode, redeemPairingCode } from '../../../server/utils/pairing-code'
+
+const ORG = 'org-123'
+const EVENT = 'event-456'
+
+beforeEach(() => {
+  mockDb = createMockDb()
+  lastInsertedValues = null
+  selectResults = []
+  vi.clearAllMocks()
+})
+
+describe('mintPairingCode', () => {
+  it('returns a code and an expiry, and never returns the stored hash', async () => {
+    const result = await mintPairingCode({ organizationId: ORG })
+
+    expect(result.code).toBeTruthy()
+    expect(result.expiresAt).toBeInstanceOf(Date)
+    // The plaintext code is returned to the owner exactly once; what lands in
+    // the DB is a hash, never the code itself.
+    expect(JSON.stringify(lastInsertedValues)).not.toContain(result.code)
+    expect(lastInsertedValues?.secretHash).toBeTruthy()
+  })
+
+  it('mints a human-transcribable code (short, unambiguous charset)', async () => {
+    // An operator reads this off a screen and types it on a till.
+    const { code } = await mintPairingCode({ organizationId: ORG })
+    expect(code).toMatch(/^[0-9A-HJ-NP-Z]{8}$/) // excludes I and O — the glyphs mistyped as 1 and 0
+  })
+
+  it('is single-use and short-lived by construction', async () => {
+    await mintPairingCode({ organizationId: ORG })
+
+    expect(lastInsertedValues?.maxUses).toBe(1)
+    const ttlMs = (lastInsertedValues?.expiresAt as Date).getTime() - Date.now()
+    expect(ttlMs).toBeGreaterThan(0)
+    expect(ttlMs).toBeLessThanOrEqual(15 * 60 * 1000)
+  })
+
+  it('scopes the grant to the till-device resource type, coexisting with print-device', async () => {
+    await mintPairingCode({ organizationId: ORG })
+    expect(lastInsertedValues?.resourceType).toBe('till-device')
+    expect(lastInsertedValues?.organizationId).toBe(ORG)
+  })
+
+  it('carries the optional event scope into the grant', async () => {
+    await mintPairingCode({ organizationId: ORG, eventId: EVENT })
+    expect(JSON.stringify(lastInsertedValues?.metadata)).toContain(EVENT)
+  })
+})
+
+describe('redeemPairingCode', () => {
+  it('turns a valid code into a persistent device grant and a token', async () => {
+    const { code } = await mintPairingCode({ organizationId: ORG })
+    selectResults = [pairingGrantRecordFor(code)]
+
+    const result = await redeemPairingCode({ code, deviceName: 'Bar till 1' })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.token).toBeTruthy()
+    // The device's own persistent grant — NOT the transient pairing grant.
+    expect(result.grant.resourceType).toBe('till-device')
+    expect(result.grant.organizationId).toBe(ORG)
+    expect(result.grant.id).not.toBe('pairing-grant-id')
+  })
+
+  it('rejects a second redeem of the same code (single-use)', async () => {
+    const { code } = await mintPairingCode({ organizationId: ORG })
+    // First redeem consumed it: usedCount has caught up with maxUses.
+    selectResults = [pairingGrantRecordFor(code, { usedCount: 1, maxUses: 1 })]
+
+    const result = await redeemPairingCode({ code, deviceName: 'Bar till 2' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('exhausted')
+  })
+
+  it('rejects an expired code', async () => {
+    const { code } = await mintPairingCode({ organizationId: ORG })
+    selectResults = [
+      pairingGrantRecordFor(code, { expiresAt: new Date(Date.now() - 60_000) })
+    ]
+
+    const result = await redeemPairingCode({ code, deviceName: 'Late till' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('expired')
+  })
+
+  it('locks out after repeated wrong codes', async () => {
+    const { code } = await mintPairingCode({ organizationId: ORG })
+    selectResults = [pairingGrantRecordFor(code, { failedAttempts: 5 })]
+
+    const result = await redeemPairingCode({ code: 'WRONGCOD', deviceName: 'Attacker' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('locked')
+  })
+
+  it('does not distinguish an unknown code from a wrong one', async () => {
+    selectResults = [] // no such grant
+    const result = await redeemPairingCode({ code: 'NOSUCHCD', deviceName: 'Probe' })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    // Same reason a wrong-but-existing code yields — no enumeration oracle.
+    expect(result.reason).toBe('invalid')
+  })
+})
+
+/**
+ * Build a select-able pairing-grant row whose secretHash really matches `code`,
+ * by reusing the hash the mint path just wrote.
+ */
+function pairingGrantRecordFor(code: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pairing-grant-id',
+    organizationId: ORG,
+    resourceType: 'till-device',
+    resourceId: `pairing:${code}`,
+    credentialType: 'pin',
+    secretHash: lastInsertedValues?.secretHash,
+    role: 'device',
+    maxUses: 1,
+    usedCount: 0,
+    failedAttempts: 0,
+    lockedUntil: null,
+    expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+    tokenTtl: 8 * 60 * 60 * 1000,
+    isActive: true,
+    metadata: null,
+    ...overrides
+  }
+}


### PR DESCRIPTION
Closes #1661

## 👤 For humans

An org owner mints a **one-time pairing code**; a freshly installed till types it in and claims itself into the org. The code is 8 characters, readable off a screen, expires in 15 minutes, and works exactly once.

This is WS2 of the self-serve onboarding epic (#803 → #801) — the piece that makes #804's installer "ready to pair" step mean something.

## 🤖 For agents

New `packages/crouton-auth/server/utils/pairing-code.ts`:

- `mintPairingCode({ organizationId, eventId? }) → { code, expiresAt }`
- `redeemPairingCode({ code, deviceName }) → { ok, token, deviceSecret, grant } | { ok: false, reason }`

**Reuses rather than reimplements.** Salted hashing and the per-grant exponential lockout come from `scoped-access.ts`, which now exports `hashGrantSecret`, `verifyGrantSecret`, `GRANT_LOCKOUT_THRESHOLD` and `lockoutDuration` as `@internal`. That diff is purely additive — visibility and JSDoc only, no behaviour change.

### Design decisions

- **`resourceType: till-device`** — distinct from #1366's `print-device`, so both coexist on one org.
- **No `devices` table.** A device IS its `scopedAccessGrant`, per #1366's shipped decision. #803's body asks for a table but predates that; the docs-trust-map rule says shipped code wins.
- **Org-less lookup.** A fresh device knows only the code, so the row is keyed by an *unsalted* sha256 of it. Verification still runs against the salted `secretHash`, and the plaintext code never reaches the database (asserted in the tests).
- **Consumption is belt-and-braces**: redeem bumps `usedCount` **and** sets `isActive: false`, so a replay fails even if `maxUses` were later widened.
- **`invalid` covers both unknown and wrong codes** — the endpoint is not an enumeration oracle. `expired`, `locked` and `exhausted` are distinguished.
- **Code alphabet** excludes `I` and `O` (mistyped as 1 and 0), rejection-sampled so the 34-symbol alphabet stays unbiased.

## 🧪 How to test

```bash
npx vitest run --root packages/crouton-auth
```

10 new cases in `tests/unit/server/pairing-code.test.ts`, written **before** the implementation per the #774 test-first gate and signed off by the owner:

- mint returns a code + expiry, stores only a hash, never the plaintext
- code matches the transcribable charset
- grant is single-use and expires within 15 min
- scoped to `till-device`; optional event scope carried through
- valid code → persistent device grant + token (not the transient pairing grant)
- second redeem → `exhausted` · expired → `expired` · repeated wrong → `locked` · unknown → `invalid`

Full suite green: **289 passed**, no pre-existing test disturbed. Lint adds nothing beyond the 6 errors already present on `main` in that file.

Packages gate: the `crouton-auth` edit was approved by the owner for this issue; the session-scoped approval file has been removed.

Note on the branch name: the original `1661-pairing-code-grant` branch was reset by a concurrent session, orphaning the commit. It was recovered intact onto this branch; the stale branch carried no unique work.