### PR TITLE
chore(root): run mac-mini pi CI on the Claude subscription (#1669)

### DIFF
--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -84,17 +84,20 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # ── The agent: pi.dev, REPORTS-ONLY, scoped to the model key only ──────────────
-      # env carries ONLY the provider key — no GH_TOKEN/GITHUB_TOKEN. CI pins
-      # `--provider anthropic` with a FUNDED API key (PI_PROVIDER_KEY) — NOT a Claude
-      # subscription (subscription OAuth must never back unattended CI — Anthropic terms;
-      # the box's interactive `pi-claude-cli`/subscription path stays interactive-only).
+      # env carries NO GH_TOKEN/GITHUB_TOKEN (reports-only) and NO provider key —
+      # this runs on the mac-mini (`AGENT_RUNNER=mac-mini`) where `claude` is logged
+      # in, so `--provider pi-claude-cli` drives the Claude SUBSCRIPTION directly, no
+      # metered key. This REVERSES the old #652/#823 "subscription must never back CI"
+      # constraint on the owner's instruction that Anthropic now permits it (#1669;
+      # source pending on that issue). NB the GitHub-hosted spike
+      # (decompose-on-issue-pidev-hosted.yml) CANNOT use this — no `claude` login on
+      # ubuntu-latest — and stays on the metered key.
       # Invocation + skills confirmed on the mac-mini (#888): the `.pi/skills` symlink
       # bridge does NOT load — pi's discovery ignores it — so skills are passed via the
       # explicit `--skill .claude/skills` flag (our SKILL.md format is drop-in portable).
       - id: pi
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.PI_PROVIDER_KEY }}
-          PI_MODEL: ${{ inputs.model }}
+          PI_MODEL: ${{ inputs.model || 'claude-haiku-4-5' }}
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent
@@ -122,7 +125,7 @@ jobs:
           echo "exec=$LOG" >> "$GITHUB_OUTPUT"
           START=$(date +%s)
           # Confirmed on the mac-mini (#888): pin provider + load skills via --skill.
-          pi --print --provider anthropic --model "$PI_MODEL" --skill .claude/skills "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
+          pi --print --provider pi-claude-cli --model "$PI_MODEL" --skill .claude/skills "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
           RC=${PIPESTATUS[0]}
           END=$(date +%s)
           echo "wall=$((END-START))" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -153,11 +153,13 @@ jobs:
 
       # ── The agent: pi.dev (replaces claude-code-action) ──────────────────────────
       # GH_TOKEN = the App token → pi's `gh`/git operations (sub-issues, epic branch,
-      # the worker PR) act as the Harness App and cascade. ANTHROPIC_API_KEY = the
-      # funded metered key (NOT a subscription — subscription OAuth must not back CI).
+      # the worker PR) act as the Harness App and cascade. NO ANTHROPIC_API_KEY: this
+      # runs on the mac-mini (`AGENT_RUNNER=mac-mini`) where `claude` is logged in, so
+      # `--provider pi-claude-cli` drives the Claude SUBSCRIPTION directly (no metered
+      # key). REVERSES the old #652/#823 "subscription must not back CI" rule on the
+      # owner's instruction that Anthropic now permits it (#1669; source pending there).
       - id: pi
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.PI_PROVIDER_KEY }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PI_MODEL: ${{ inputs.model || 'claude-sonnet-5' }}
@@ -193,7 +195,7 @@ jobs:
           # runs `true` as its own pipeline, clobbering PIPESTATUS[0] to 0 and masking the
           # failure as success. Verified empirically, #1299.)
           set +e
-          pi --print --provider anthropic --model "$PI_MODEL" --skill .claude/skills \
+          pi --print --provider pi-claude-cli --model "$PI_MODEL" --skill .claude/skills \
             "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
           RC=${PIPESTATUS[0]}
           set -e

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Headless CI profile (#1019/#1004) — only pipeline-critical + telemetry extensions. pi merges this project file OVER ~/.pi/agent/settings.json, and `packages` (an array) REPLACES the global list, so CI loads exactly these 8 — notably WITHOUT pi-ask-user / pi-interactive-shell, so a headless run can't stall-and-ask (the #839 failure). pi-ralph-wiggum gives the persistence loop. In CI, ANTHROPIC_API_KEY activates the 'anthropic' provider; locally, pi-claude-cli reads auth.json.",
-  "defaultProvider": "anthropic",
+  "$comment": "Headless CI profile (#1019/#1004) — only pipeline-critical + telemetry extensions. pi merges this project file OVER ~/.pi/agent/settings.json, and `packages` (an array) REPLACES the global list, so CI loads exactly these 8 — notably WITHOUT pi-ask-user / pi-interactive-shell, so a headless run can't stall-and-ask (the #839 failure). pi-ralph-wiggum gives the persistence loop. defaultProvider is 'pi-claude-cli' — on the mac-mini runner (AGENT_RUNNER=mac-mini) headless runs drive the Claude SUBSCRIPTION via the logged-in `claude` CLI, no metered key. This REVERSES #652/#823's 'subscription must not back CI' rule on the owner's instruction that Anthropic now permits it (#1669; source pending there). WARNING: pi-claude-cli only works where `claude` is logged in — a GitHub-hosted run (ubuntu-latest, e.g. decompose-on-issue-pidev-hosted.yml) has no such login and must pass its own --provider/key.",
+  "defaultProvider": "pi-claude-cli",
   "defaultThinkingLevel": "medium",
   "quietStartup": true,
   "enableInstallTelemetry": false,


### PR DESCRIPTION
Part of #1669 (WS1 + WS2). Reverses the #652/#823 "subscription must never back CI" constraint.

## ⚠️ Premise pending source — do not merge until attached
This proceeds on @pmcp's instruction that Anthropic now permits **subscription auth for unattended automation**. Per AGENTS.md the reversal is logged append-only on #652 / #823. **Attach the supporting source on #1669 before merging.** If it doesn't actually cover automation, revert — it's pure workflow config, a clean `git revert`.

## 👤 For humans
The two pi.dev agent workflows that run **on the Mac mini** (the a11y sweep and issue decomposition) now use your **Claude subscription** instead of a metered API key. The subscription is already logged in on that box, so those runs stop being billed per-token. Your interactive sessions were already flipped separately (machine-local `~/.pi/agent/settings.json`).

## 🤖 For agents — what changed
- `a11y-daily-pidev.yml`, `decompose-on-issue-pidev.yml`: dropped `ANTHROPIC_API_KEY: PI_PROVIDER_KEY`; `--provider anthropic` → `--provider pi-claude-cli` (drives the mini's `claude` login = subscription). a11y default model → `claude-haiku-4-5`; decompose stays `claude-sonnet-5`.
- `.pi/settings.json`: `defaultProvider` `anthropic` → `pi-claude-cli`, with a warning it only works where `claude` is logged in.

## Deliberately NOT in this PR
- **`decompose-on-issue-pidev-hosted.yml`** — runs on `ubuntu-latest` (no `claude` login), physically can't use the subscription; stays metered.
- **WS3 — the live `claude-code-action` paths** (`resume-on-comment`, `decompose-on-issue`, and the `a11y`/`red-team`/`frontend-review` PR gates) — where most metered spend is. Blocked on a secret only @pmcp can mint:
  ```bash
  # on the mac-mini:
  claude setup-token
  gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo FriendlyInternet/nuxt-crouton
  ```
  Then a follow-up PR swaps `anthropic_api_key: secrets.ANTHROPIC_API_KEY` → `claude_code_oauth_token: secrets.CLAUDE_CODE_OAUTH_TOKEN` on those workflows.

## 🧪 How to test
1. Dispatch **a11y-daily-pidev** (harness=pi) on the mini → report produced; check the Anthropic **API** dashboard shows `$0` for that window (drew on the subscription quota).
2. `/delegate` a throwaway issue → decompose runs on `pi-claude-cli`, PR produced, artifact-gate green, `$0` API spend.
3. Confirm the hosted spike is unchanged (still metered).
