### PR TITLE
feat(fanfare): generic venue-till installer + release bundle (#804)

### DIFF
--- a/.github/workflows/release-venue-bundle.yml
+++ b/.github/workflows/release-venue-bundle.yml
@@ -1,0 +1,132 @@
+# Publish the venue (node-server) bundle as a release asset (#804).
+#
+# The generic installer (`apps/fanfare/deploy/install.sh`) turns a bare Linux
+# box into a running till by *downloading* this tarball — it does NOT clone and
+# build. Building Nuxt on-site needs multiple GB of heap (the Pi rig sets
+# --max-old-space-size=6144), which a 4GB Pi cannot do without swapping for
+# many minutes. Shipping a prebuilt bundle is what makes "bare box → till in
+# one command" actually true.
+#
+# CI's `build-fanfare` job already proves this preset builds on every PR; this
+# workflow is the same build, kept and published.
+name: Release venue bundle
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create/update (e.g. venue-2026.08.03)."
+        required: true
+        type: string
+      prerelease:
+        description: "Mark the release as a prerelease."
+        required: false
+        default: true
+        type: boolean
+  push:
+    tags:
+      - 'venue-*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-venue-bundle-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  bundle:
+    name: Build + publish venue bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build fanfare's workspace dependencies
+        # Dist-consumed, so they must be built before the app (mirrors ci.yml).
+        run: pnpm --filter "fanfare^..." build
+
+      - name: Prepare Nuxt
+        run: npx nuxt prepare
+        working-directory: apps/fanfare
+
+      - name: Build fanfare (node-server)
+        run: npx nuxt build
+        working-directory: apps/fanfare
+        env:
+          NITRO_PRESET: node-server
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          # Build-time prerender needs a secret present; value is irrelevant.
+          BETTER_AUTH_SECRET: ci-placeholder
+
+      - name: Assemble the bundle
+        id: bundle
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          STAGE="$(mktemp -d)/fanfare-venue"
+          mkdir -p "$STAGE"
+
+          # The runnable server, plus the deploy assets the installer wires up
+          # (systemd unit, health check, network config, env example).
+          cp -R apps/fanfare/.output "$STAGE/output"
+          cp -R apps/fanfare/deploy "$STAGE/deploy"
+
+          # Stamp provenance so a box can report exactly what it runs.
+          cat > "$STAGE/BUNDLE.json" <<JSON
+          {
+            "tag": "$TAG",
+            "commit": "${{ github.sha }}",
+            "builtAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "preset": "node-server",
+            "node": "20"
+          }
+          JSON
+
+          TARBALL="fanfare-venue.tar.gz"
+          tar -czf "$TARBALL" -C "$(dirname "$STAGE")" fanfare-venue
+          sha256sum "$TARBALL" > "$TARBALL.sha256"
+
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          ls -lh "$TARBALL"
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.bundle.outputs.tag }}"
+          TARBALL="${{ steps.bundle.outputs.tarball }}"
+          PRERELEASE=""
+          if [ "${{ github.event.inputs.prerelease || 'true' }}" = "true" ]; then
+            PRERELEASE="--prerelease"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "$TARBALL" "$TARBALL.sha256" --clobber
+          else
+            gh release create "$TAG" "$TARBALL" "$TARBALL.sha256" \
+              --title "Venue bundle $TAG" \
+              --notes "Prebuilt node-server bundle for the venue till installer (#804).
+
+Install on a bare Linux box:
+
+\`\`\`bash
+curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/apps/fanfare/deploy/install.sh | sudo bash -s -- --release $TAG
+\`\`\`
+
+Built from \`${{ github.sha }}\`." \
+              $PRERELEASE
+          fi

--- a/apps/fanfare/deploy/README.md
+++ b/apps/fanfare/deploy/README.md
@@ -1,0 +1,102 @@
+# Venue till installers
+
+Two ways to get a till running. Pick by what the box is.
+
+| | `install.sh` (#804) | `pi/setup.sh` (#798) |
+|---|---|---|
+| **Target** | any Linux box with systemd | the bench Pi rig |
+| **Needs a repo on the box?** | no | **yes** — runs from a checkout |
+| **Builds on-site?** | no — downloads a prebuilt bundle | yes (needs ~6GB heap) |
+| **Binds to an org?** | yes — pairing code | no — hand-seeded |
+| **Use when** | provisioning a real venue | hacking on the Pi rig itself |
+
+`install.sh` is the one an operator runs. `pi/` stays for the developer rig and
+still owns the network/mDNS/printer-route specifics (`configure-network.sh`,
+`avahi-alias`) that a generic installer deliberately doesn't touch.
+
+## Install a till
+
+**On the target box:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/FriendlyInternet/nuxt-crouton/main/apps/fanfare/deploy/install.sh \
+  | sudo bash -s -- --release latest
+```
+
+It will prompt for a pairing code. Mint one first **in the app**, as a team member:
+
+```
+POST /api/crouton-sales/teams/<team>/devices/pairing-codes  →  { code, expiresAt }
+```
+
+The code is 8 characters (no `I` or `O`), single-use, and valid for 15 minutes.
+
+That code is the **only** thing anyone types on the box. Everything else — which
+organization, which event, the device's token and its own secret — comes back
+from the claim and is written to `/etc/fanfare/device.env` (root-only, `0600`).
+
+### Preview without touching anything
+
+```bash
+bash install.sh --dry-run --release latest --code ABCD2345 --name "Bar till 1"
+```
+
+Runs anywhere, including a laptop with no systemd. Prints every action it would
+take and exits.
+
+### Options
+
+| Flag | Meaning |
+|---|---|
+| `--release <tag>` | bundle to install (default: latest `venue-*` release) |
+| `--api-url <url>` | origin that accepts the claim (default: `https://kassa.friendlyinter.net`) |
+| `--code <code>` | pairing code, instead of being prompted |
+| `--name <name>` | device name in the org's device list (default: hostname) |
+| `--reclaim` | re-pair a box that already has an identity |
+| `--skip-claim` | install and wire only; pair later |
+| `--dry-run` | preview; touch nothing |
+
+Env equivalents: `FANFARE_API_URL`, `FANFARE_PAIRING_CODE`, `FANFARE_DEVICE_NAME`,
+`FANFARE_INSTALL_DIR`, `FANFARE_PORT`, `FANFARE_USER`, `FANFARE_PRINTER_HOSTS`.
+
+## After it runs
+
+```bash
+systemctl status fanfare
+journalctl -u fanfare -f
+```
+
+The till listens on `:3000` and restarts on failure and on boot — surviving a
+power cut is the point.
+
+The installer ends with a reachability report: the local app, the cloud origin,
+and (when `FANFARE_PRINTER_HOSTS="192.168.1.72 192.168.1.73"` is set) each
+printer's `:9100`. **Those checks report, they never fail the install** — a till
+with an unplugged printer should still boot so it can be fixed on site.
+
+## Upgrading
+
+Re-run the same command. The bundle is replaced, the device identity is left
+alone (`--reclaim` to re-pair), and the previous build stays at
+`/opt/fanfare/output.old` for a manual rollback.
+
+## Publishing a bundle
+
+The installer downloads what `.github/workflows/release-venue-bundle.yml`
+publishes. Cut one from the Actions tab (**Release venue bundle** →
+*Run workflow* → tag e.g. `venue-2026.08.03`), or push a `venue-*` tag.
+
+It builds fanfare with `NITRO_PRESET=node-server` — the same build CI already
+proves on every PR — then attaches `fanfare-venue.tar.gz` plus a `.sha256` the
+installer verifies.
+
+## Layout on the box
+
+```
+/opt/fanfare/output/          the Nitro server bundle
+/opt/fanfare/output.old/      previous bundle (rollback)
+/opt/fanfare/BUNDLE.json      tag + commit + build time
+/etc/fanfare/fanfare.env      port, auth secret            (0600)
+/etc/fanfare/device.env       org, event, token, secret    (0600)
+/etc/systemd/system/fanfare.service
+```

--- a/apps/fanfare/deploy/install.sh
+++ b/apps/fanfare/deploy/install.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# Generic venue-till installer (#804) — bare Linux box → running, org-bound till.
+#
+# The device-agnostic generalisation of the Pi rig (#798, `deploy/pi/setup.sh`),
+# which assumed a checked-out repo and built in place. This one assumes NOTHING
+# on the box: it downloads a prebuilt node-server bundle, installs a systemd
+# unit, claims the device against the org with a one-time pairing code (#1662),
+# and verifies it can actually reach what it needs.
+#
+# Design notes:
+#   * NO build on-site. Nuxt needs multiple GB of heap; a 4GB Pi would swap for
+#     minutes. The bundle is built by CI (`release-venue-bundle.yml`).
+#   * The pairing code is the ONLY thing an operator types. Everything the
+#     device needs afterwards (org, event, token, its own secret) comes back
+#     from the claim — no config file to hand-edit, no engineer, no SSH.
+#   * Idempotent. Re-running upgrades the bundle and leaves an existing device
+#     identity alone unless --reclaim is passed.
+#
+# Usage (on the target box):
+#   curl -fsSL <raw-url>/install.sh | sudo bash -s -- --release venue-2026.08.03
+#
+#   --release <tag>     bundle release tag to install (default: latest)
+#   --api-url <url>     origin that mints/accepts pairing codes
+#   --code <code>       pairing code (otherwise prompted for)
+#   --name <name>       device name shown in the org's device list
+#   --reclaim           re-run the claim even if this box already has an identity
+#   --skip-claim        install + wire only; claim later with --reclaim
+#   --dry-run           print what would happen; touch nothing
+set -euo pipefail
+
+REPO="${FANFARE_REPO:-FriendlyInternet/nuxt-crouton}"
+API_URL="${FANFARE_API_URL:-https://kassa.friendlyinter.net}"
+RELEASE="latest"
+PAIRING_CODE="${FANFARE_PAIRING_CODE:-}"
+DEVICE_NAME="${FANFARE_DEVICE_NAME:-}"
+RECLAIM=0
+SKIP_CLAIM=0
+DRY_RUN=0
+
+INSTALL_DIR="${FANFARE_INSTALL_DIR:-/opt/fanfare}"
+ETC_DIR="/etc/fanfare"
+ENV_FILE="$ETC_DIR/fanfare.env"
+DEVICE_FILE="$ETC_DIR/device.env"
+SERVICE_NAME="fanfare"
+RUN_USER="${FANFARE_USER:-fanfare}"
+PORT="${FANFARE_PORT:-3000}"
+
+log()  { echo "[install] $*"; }
+warn() { echo "[install] WARN: $*" >&2; }
+die()  { echo "[install] ERROR: $*" >&2; exit 1; }
+run()  { if [ "$DRY_RUN" = 1 ]; then echo "  would run: $*"; else "$@"; fi }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release)    RELEASE="${2:?--release needs a value}"; shift 2 ;;
+    --api-url)    API_URL="${2:?--api-url needs a value}"; shift 2 ;;
+    --code)       PAIRING_CODE="${2:?--code needs a value}"; shift 2 ;;
+    --name)       DEVICE_NAME="${2:?--name needs a value}"; shift 2 ;;
+    --reclaim)    RECLAIM=1; shift ;;
+    --skip-claim) SKIP_CLAIM=1; shift ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    -h|--help)    sed -n '2,30p' "$0"; exit 0 ;;
+    *)            die "unknown option: $1 (try --help)" ;;
+  esac
+done
+
+# ── 0. Preflight ─────────────────────────────────────────────────────────────
+# Fail fast and specifically: a half-installed box is worse than no box.
+# Under --dry-run these are advisory — the point of a dry run is to preview the
+# plan from anywhere (a laptop, CI), not only from a box that could install.
+require() {
+  local what="$1" msg="$2"
+  if command -v "$what" >/dev/null 2>&1; then return 0; fi
+  if [ "$DRY_RUN" = 1 ]; then warn "$msg (dry-run: continuing)"; return 0; fi
+  die "$msg"
+}
+if [ "$DRY_RUN" != 1 ] && [ "$(id -u)" != 0 ]; then
+  die "must run as root (use sudo)"
+fi
+require systemctl "systemd is required (this installer wires a service)"
+require curl "curl is required"
+require tar  "tar is required"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|aarch64|armv7l) : ;;
+  *) warn "untested architecture: $ARCH (continuing)" ;;
+esac
+log "host: $(uname -s) $ARCH"
+
+# ── 1. Node runtime ──────────────────────────────────────────────────────────
+# The bundle is a Nitro node-server build, so a modern Node is the one real
+# dependency. We install it rather than asking the operator to.
+NODE_BIN="$(command -v node || true)"
+NODE_MAJOR=0
+[ -n "$NODE_BIN" ] && NODE_MAJOR="$("$NODE_BIN" -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+
+if [ "$NODE_MAJOR" -lt 20 ]; then
+  log "installing Node.js 20 (found: ${NODE_BIN:-none} ${NODE_MAJOR:-})"
+  if command -v apt-get >/dev/null 2>&1; then
+    run bash -c 'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -'
+    run apt-get install -y nodejs
+  elif command -v dnf >/dev/null 2>&1; then
+    run dnf install -y nodejs
+  else
+    die "no supported package manager; install Node.js >= 20 manually, then re-run"
+  fi
+  NODE_BIN="$(command -v node || echo /usr/bin/node)"
+else
+  log "node: $NODE_BIN ($("$NODE_BIN" -v))"
+fi
+
+# ── 2. Service user + directories ────────────────────────────────────────────
+if ! id -u "$RUN_USER" >/dev/null 2>&1; then
+  log "creating service user: $RUN_USER"
+  run useradd --system --home-dir "$INSTALL_DIR" --shell /usr/sbin/nologin "$RUN_USER"
+fi
+run mkdir -p "$INSTALL_DIR" "$ETC_DIR"
+run chmod 750 "$ETC_DIR"
+
+# ── 3. Fetch + unpack the bundle ─────────────────────────────────────────────
+# Resolve the tag first so the installed version is always recorded, even when
+# the operator asked for "latest".
+if [ "$RELEASE" = "latest" ]; then
+  log "resolving latest venue release..."
+  RELEASE="$(curl -fsSL "https://api.github.com/repos/$REPO/releases" \
+    | grep -o '"tag_name": *"venue-[^"]*"' | head -1 | sed 's/.*"venue-/venue-/;s/"$//' || true)"
+  [ -n "$RELEASE" ] || die "could not resolve a venue-* release; pass --release <tag>"
+fi
+TARBALL="fanfare-venue.tar.gz"
+URL="https://github.com/$REPO/releases/download/$RELEASE/$TARBALL"
+log "bundle: $RELEASE"
+
+if [ "$DRY_RUN" = 1 ]; then
+  echo "  would download: $URL"
+else
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  curl -fsSL "$URL" -o "$TMP/$TARBALL" || die "download failed: $URL"
+
+  # Verify when the checksum is published; never fail the install if it is not
+  # (older releases predate it) — but say so loudly.
+  if curl -fsSL "$URL.sha256" -o "$TMP/$TARBALL.sha256" 2>/dev/null; then
+    ( cd "$TMP" && sha256sum -c "$TARBALL.sha256" >/dev/null ) \
+      || die "checksum mismatch — refusing to install"
+    log "checksum ok"
+  else
+    warn "no published checksum for $RELEASE — skipping verification"
+  fi
+
+  tar -xzf "$TMP/$TARBALL" -C "$TMP"
+  # Replace atomically-ish: keep the old tree until the new one is in place.
+  rm -rf "$INSTALL_DIR/output.new"
+  cp -R "$TMP/fanfare-venue/output" "$INSTALL_DIR/output.new"
+  rm -rf "$INSTALL_DIR/output.old"
+  [ -d "$INSTALL_DIR/output" ] && mv "$INSTALL_DIR/output" "$INSTALL_DIR/output.old"
+  mv "$INSTALL_DIR/output.new" "$INSTALL_DIR/output"
+  cp -f "$TMP/fanfare-venue/BUNDLE.json" "$INSTALL_DIR/BUNDLE.json" 2>/dev/null || true
+  chown -R "$RUN_USER:$RUN_USER" "$INSTALL_DIR"
+  log "installed to $INSTALL_DIR"
+fi
+
+# ── 4. Claim the device ──────────────────────────────────────────────────────
+# The one interactive step. Everything the till needs to be part of an org
+# comes back from this call (#1662) — there is no config to hand-edit.
+claim_device() {
+  if [ -z "$PAIRING_CODE" ]; then
+    if [ -t 0 ]; then
+      printf '[install] pairing code (from the app, 8 characters): '
+      read -r PAIRING_CODE
+    else
+      die "no pairing code: pass --code <code> (stdin is not a terminal)"
+    fi
+  fi
+  PAIRING_CODE="$(echo "$PAIRING_CODE" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')"
+  echo "$PAIRING_CODE" | grep -qE '^[0-9A-HJ-NP-Z]{8}$' \
+    || die "that does not look like a pairing code (8 chars, no I or O)"
+
+  [ -n "$DEVICE_NAME" ] || DEVICE_NAME="$(hostname)"
+
+  log "claiming as \"$DEVICE_NAME\" against $API_URL ..."
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "  would POST $API_URL/api/crouton-sales/devices/claim"
+    return 0
+  fi
+
+  local body http
+  body="$(curl -fsS -w '\n%{http_code}' -X POST \
+    -H 'content-type: application/json' \
+    -d "{\"code\":\"$PAIRING_CODE\",\"deviceName\":\"$DEVICE_NAME\"}" \
+    "$API_URL/api/crouton-sales/devices/claim" 2>/dev/null || true)"
+  http="$(echo "$body" | tail -1)"
+  body="$(echo "$body" | sed '$d')"
+
+  case "$http" in
+    200) : ;;
+    401) die "the pairing code was rejected — mint a fresh one in the app" ;;
+    410) die "that pairing code is used up or expired — mint a fresh one" ;;
+    429) die "too many attempts; this code is locked for a while — wait, then retry" ;;
+    *)   die "claim failed (HTTP ${http:-no response}) against $API_URL" ;;
+  esac
+
+  # Persist the identity. 0600 root-owned: deviceSecret is a credential.
+  local dev org evt tok sec
+  dev="$(echo "$body" | "$NODE_BIN" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).deviceId||""))')"
+  org="$(echo "$body" | "$NODE_BIN" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).orgId||""))')"
+  evt="$(echo "$body" | "$NODE_BIN" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).eventId||""))')"
+  tok="$(echo "$body" | "$NODE_BIN" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).token||""))')"
+  sec="$(echo "$body" | "$NODE_BIN" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).deviceSecret||""))')"
+  [ -n "$dev" ] || die "claim returned no device id — refusing to write a partial identity"
+
+  umask 077
+  cat > "$DEVICE_FILE" <<EOF
+# Written by install.sh at claim time (#804). Do not edit by hand —
+# re-run the installer with --reclaim to replace this identity.
+FANFARE_DEVICE_ID=$dev
+FANFARE_ORG_ID=$org
+FANFARE_EVENT_ID=$evt
+FANFARE_DEVICE_TOKEN=$tok
+FANFARE_DEVICE_SECRET=$sec
+FANFARE_API_URL=$API_URL
+EOF
+  chmod 600 "$DEVICE_FILE"
+  log "claimed: device=$dev org=$org event=${evt:-<none yet>}"
+}
+
+if [ "$SKIP_CLAIM" = 1 ]; then
+  log "skipping claim (--skip-claim)"
+elif [ -f "$DEVICE_FILE" ] && [ "$RECLAIM" != 1 ]; then
+  log "already claimed (use --reclaim to re-pair); leaving $DEVICE_FILE alone"
+else
+  claim_device
+fi
+
+# ── 5. Base env ──────────────────────────────────────────────────────────────
+if [ ! -f "$ENV_FILE" ]; then
+  log "writing $ENV_FILE"
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "  would write $ENV_FILE"
+  else
+    umask 077
+    cat > "$ENV_FILE" <<EOF
+# Base runtime env for the venue till. Device identity lives in device.env.
+NITRO_PORT=$PORT
+NITRO_HOST=0.0.0.0
+NODE_ENV=production
+# Set a real value before going live — sessions are signed with this.
+BETTER_AUTH_SECRET=$(head -c 32 /dev/urandom | base64 | tr -d '\n/+=' | head -c 32)
+BETTER_AUTH_URL=http://localhost:$PORT
+EOF
+    chmod 600 "$ENV_FILE"
+  fi
+else
+  log "keeping existing $ENV_FILE"
+fi
+
+# ── 6. systemd unit ──────────────────────────────────────────────────────────
+UNIT="/etc/systemd/system/$SERVICE_NAME.service"
+log "writing $UNIT"
+if [ "$DRY_RUN" = 1 ]; then
+  echo "  would write $UNIT, then: systemctl enable --now $SERVICE_NAME"
+else
+  cat > "$UNIT" <<EOF
+[Unit]
+Description=Fanfare venue till (local-first POS)
+Documentation=https://github.com/$REPO
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$RUN_USER
+WorkingDirectory=$INSTALL_DIR
+EnvironmentFile=$ENV_FILE
+# Optional: absent until the device is claimed.
+EnvironmentFile=-$DEVICE_FILE
+ExecStart=$NODE_BIN $INSTALL_DIR/output/server/index.mjs
+Restart=always
+RestartSec=3
+# The till must come back by itself after a power cut — that is the whole point.
+StandardOutput=journal
+StandardError=journal
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable "$SERVICE_NAME" >/dev/null 2>&1 || true
+  systemctl restart "$SERVICE_NAME"
+fi
+
+# ── 7. Reachability check ────────────────────────────────────────────────────
+# "It installed" is not "it works". Report, never fail the install — a till
+# with an unplugged printer should still boot and be fixable on site.
+log "checking reachability..."
+if [ "$DRY_RUN" = 1 ]; then
+  echo "  would check: local app, $API_URL, printers on the LAN"
+else
+  for _ in $(seq 1 20); do
+    curl -fsS -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null && break
+    sleep 1
+  done
+  if curl -fsS -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null; then
+    log "  ✅ till responds on http://127.0.0.1:$PORT"
+  else
+    warn "  ❌ till did not respond on :$PORT — check: journalctl -u $SERVICE_NAME -n 50"
+  fi
+
+  if curl -fsS -o /dev/null --max-time 8 "$API_URL" 2>/dev/null; then
+    log "  ✅ cloud reachable: $API_URL"
+  else
+    warn "  ⚠️  cloud unreachable: $API_URL (the till still runs offline; sync resumes later)"
+  fi
+
+  # Thermal printers listen on :9100. Probe any configured hosts.
+  if [ -n "${FANFARE_PRINTER_HOSTS:-}" ]; then
+    for host in $FANFARE_PRINTER_HOSTS; do
+      if timeout 3 bash -c ">/dev/tcp/$host/9100" 2>/dev/null; then
+        log "  ✅ printer reachable: $host:9100"
+      else
+        warn "  ❌ printer unreachable: $host:9100"
+      fi
+    done
+  else
+    log "  (no FANFARE_PRINTER_HOSTS set — skipping printer probe)"
+  fi
+fi
+
+log ""
+log "done — $SERVICE_NAME is installed and enabled."
+log "  status : systemctl status $SERVICE_NAME"
+log "  logs   : journalctl -u $SERVICE_NAME -f"
+# `|| true`: `hostname -I` is Linux-only, and under `set -e` a failing command
+# substitution in an assignment aborts the script — which would truncate this
+# summary on the very last line.
+HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+log "  till   : http://${HOST_IP:-<this-box>}:$PORT"
+[ -f "$DEVICE_FILE" ] && log "  device : $(grep FANFARE_DEVICE_ID "$DEVICE_FILE" 2>/dev/null | cut -d= -f2)" || true


### PR DESCRIPTION
Closes #804

## 👤 For humans

One command turns a bare Linux box into a running till bound to an organization:

```bash
curl -fsSL .../install.sh | sudo bash -s -- --release latest
```

The operator types exactly **one** thing — a pairing code from the app. No engineer, no SSH, no config file to hand-edit. Everything else (which org, which event, the device token and its own secret) comes back from the claim.

This is WS3 of the onboarding epic (#801). It was unblocked by WS2 (#803): its acceptance is *"a fresh box reaches **ready to pair**"*, which now has a real endpoint to talk to.

## 🤖 For agents

| File | Purpose |
|---|---|
| `apps/fanfare/deploy/install.sh` | the installer — Node 20 if missing, download bundle, service user, claim via #1662, systemd unit, reachability report |
| `.github/workflows/release-venue-bundle.yml` | publishes the bundle it consumes |
| `apps/fanfare/deploy/README.md` | operator guide + the split from the #798 Pi rig |

### The one real decision (owner, 2026-08-03)

**Download a prebuilt bundle; do not clone and build on-site.** Nuxt needs multiple GB of heap — the Pi rig sets `--max-old-space-size=6144` — so a 4GB box would swap for minutes, and "one command" would be a lie. CI already builds this exact `node-server` preset on every PR and throws it away; the new workflow keeps it, tars it with a `BUNDLE.json` provenance stamp, and attaches a `.sha256` the installer verifies.

Considered & rejected: *clone + build on-box* → ❌ unusable on a 4GB Pi; *container image* → ❌ adds a runtime dependency and complicates the LAN printer socket + mDNS the rig relies on.

### Properties worth keeping

- **Idempotent** — re-running upgrades the bundle, keeps the device identity (`--reclaim` to re-pair), leaves the previous build at `output.old` for rollback.
- **Credentials** land in `/etc/fanfare/device.env`, root-only `0600`; a partial claim is refused rather than half-written.
- **Reachability checks report, never fail the install** — a till with an unplugged printer should still boot so it can be fixed on site.
- **`--dry-run` previews the whole plan from any machine** (preflight is advisory there), so this is reviewable without a target box.
- **`pi/` is untouched.** It still owns the network/mDNS/printer-route specifics a generic installer deliberately must not touch; the README states which to use when.

## 🧪 How to test

No target box needed — the dry run is the review surface:

```bash
bash apps/fanfare/deploy/install.sh --dry-run --release latest \
  --code ABCD2345 --name "Bar till 1"
```

Prints every action it would take, exits 0, touches nothing. Also verified:

- a code containing `I`/`O` is rejected (matches #1661's charset)
- unknown flags are rejected
- `bash -n` parses clean

**On a real box**, end to end: mint a code (`POST teams/<team>/devices/pairing-codes`) → run the installer → the till appears in `GET teams/<team>/devices` → `systemctl status fanfare` is active → reboot → it comes back.

⚠️ **Not yet exercised against a real box or a real release** — no `venue-*` release exists until this merges and the workflow is run once. The claim path itself is covered by #1662's unit tests.

Running it caught a genuine bug worth noting: `HOST_IP="$(hostname -I)"` aborted the script under `set -e` on hosts without that flag, truncating the final summary. Fixed with `|| true`.