### PR TITLE
chore(root): move the 12 claude-code-action workflows onto the Claude subscription (#1669) [DRAFT — gated on ToS source]

### DIFF
--- a/.github/workflows/a11y-daily.yml
+++ b/.github/workflows/a11y-daily.yml
@@ -52,7 +52,7 @@ jobs:
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
       - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # bypassPermissions REQUIRED (#834): headless CI denies un-allowlisted tools, so the
           # deep sweep couldn't write its report, update the standing issue, or file a11y issues.

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -71,7 +71,7 @@ jobs:
         # decider: no verdict ⇒ inconclusive pass; a 🔴 finding in the verdict ⇒ fail.
         continue-on-error: true
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # --allowedTools REQUIRED (#834): the prompt has the top-level agent *act as* the
           # subagent and call Bash/Write directly; headless CI denies un-allowlisted tools, so

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,7 +45,7 @@ jobs:
       # bounds who can invoke, and the action keeps WebSearch/WebFetch disallowed.
       - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-sonnet-5 --max-turns 100 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           show_full_output: true
 

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -73,13 +73,15 @@ jobs:
         run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
-      # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
-      # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
-      # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
+      # AUTH: uses the subscription CLAUDE_CODE_OAUTH_TOKEN (not a metered API key).
+      # This REVERSES the old "OAuth is interactive-only, never in CI" rule (#652/#823)
+      # on the owner's instruction that Anthropic now permits subscription auth for
+      # unattended automation (#1669; supporting source pending on that issue — if it
+      # does not cover automation, revert). Runs on the mac-mini runner.
       - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         id: claude
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: "/task-decompose #${{ github.event.issue.number }}"
           claude_args: "--model claude-sonnet-5 --max-turns 30"
           show_full_output: true

--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -132,7 +132,7 @@ jobs:
       - if: steps.gate.outputs.proceed == 'true'
         uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           claude_args: "--model claude-sonnet-5 --max-turns 30"
           show_full_output: true

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -58,7 +58,7 @@ jobs:
         # decider: no verdict ⇒ inconclusive pass; a 🔴 finding in the verdict ⇒ fail.
         continue-on-error: true
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # --allowedTools is REQUIRED, not optional (#834). This prompt has the top-level
           # action agent *act as* the subagent and call Bash/Write DIRECTLY (it does not spawn

--- a/.github/workflows/gate-smoke.yml
+++ b/.github/workflows/gate-smoke.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         continue-on-error: true
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           claude_args: "--model claude-sonnet-5 --max-turns 40 --allowedTools Bash,Write,Edit,Read,Grep,Glob"
           prompt: |

--- a/.github/workflows/loop-station-advisor.yml
+++ b/.github/workflows/loop-station-advisor.yml
@@ -55,7 +55,7 @@ jobs:
         # the whole point of this workflow is that actionable findings reach a human (#1037).
         continue-on-error: true
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # bypassPermissions REQUIRED (#834/#1036): this prompt has the top-level agent
           # create/update issues via tool calls directly; headless CI denies un-allowlisted

--- a/.github/workflows/red-team-daily.yml
+++ b/.github/workflows/red-team-daily.yml
@@ -55,7 +55,7 @@ jobs:
       # Pinned to the same SHA as the repo's other claude-code-action workflows — bump together.
       - uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # bypassPermissions REQUIRED (#834): headless CI denies un-allowlisted tools, so the
           # deep sweep couldn't write its report, update the standing issue, or file security

--- a/.github/workflows/red-team.yml
+++ b/.github/workflows/red-team.yml
@@ -59,7 +59,7 @@ jobs:
         # no verdict ⇒ inconclusive pass; a high/critical in the verdict ⇒ fail.
         continue-on-error: true
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # --allowedTools REQUIRED (#834): the prompt has the top-level agent *act as* the
           # subagent and call Bash/Write directly; headless CI denies un-allowlisted tools, so

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -104,14 +104,16 @@ jobs:
           echo "── collected answer payload ──"; cat .resume-answer.md
 
       # Pinned to the same SHA as claude.yml — keep these in sync when bumping.
-      # AUTH: this is headless/unattended, so it MUST use an API key. Do NOT swap in a
-      # subscription CLAUDE_CODE_OAUTH_TOKEN — subscription OAuth is for interactive
-      # Claude Code use only, not CI automation (Anthropic Legal & Compliance terms).
+      # AUTH: uses the subscription CLAUDE_CODE_OAUTH_TOKEN (not a metered API key).
+      # This REVERSES the old "OAuth is interactive-only, never in CI" rule (#652/#823)
+      # on the owner's instruction that Anthropic now permits subscription auth for
+      # unattended automation (#1669; supporting source pending on that issue — if it
+      # does not cover automation, revert). Runs on the mac-mini runner.
       - id: agent
         if: steps.state.outputs.open == 'true'
         uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Resume the task-decomposition pipeline for issue #${{ github.event.issue.number }}.
             The owner has replied to a blocking question. Their answer may be in the medium the

--- a/.github/workflows/simplify-review.yml
+++ b/.github/workflows/simplify-review.yml
@@ -57,7 +57,7 @@ jobs:
         # fails regardless.
         continue-on-error: true
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           # --allowedTools is REQUIRED (#834): the prompt has the top-level agent *act as* the
           # subagent and call Bash/Write DIRECTLY (no sub-agent spawn to auto-grant frontmatter


### PR DESCRIPTION
WS3 of #1669 — rebased onto current `main` after discovering the original branch was 443 commits stale. (#1670, the pi-lane half, was **closed** — it would have regressed the owner-approved GLM Coding Plan lane; the pi lanes stay on GLM.)

## ⛔ DRAFT — two gates before merge
1. **`CLAUDE_CODE_OAUTH_TOKEN` secret** — set ✅ (`claude setup-token`). Merging without it 401s all 12.
2. **Attach Anthropic's automation-permitting terms to #1669.** This PR **deletes in-code Legal/Compliance guardrails** (the `# Do NOT swap in a subscription CLAUDE_CODE_OAUTH_TOKEN … Anthropic Legal & Compliance terms` comments in `resume-on-comment.yml` + `decompose-on-issue.yml`) that a prior session deliberately placed reaffirming #652. If the source doesn't cover unattended automation, **revert** — it's pure workflow config.

## 👤 For humans
Your cheap lanes already run on the flat-rate GLM Coding Plan ($0 marginal). The only genuinely metered-Claude spend left is these 12 `claude-code-action` paths (PR gates, resume-on-comment, decompose, red-team, simplify…). This points them at your flat subscription → last metered bucket → ~$0.

## 🤖 What changed
- `anthropic_api_key: secrets.ANTHROPIC_API_KEY` → `claude_code_oauth_token: secrets.CLAUDE_CODE_OAUTH_TOKEN` in **12** workflows: fix-ci-on-failure, a11y-daily, red-team, resume-on-comment, frontend-review, red-team-daily, decompose-on-issue, a11y, claude, gate-smoke, **simplify-review** (new since the old branch), loop-station-advisor.
- Rewrote the 2 guardrail comments to reflect the #1669 reversal.

## Deliberately untouched
- **GLM (zai) pi lanes** (`a11y-daily-pidev`, `decompose-on-issue-pidev`, `-hosted`) — stay on GLM; `delegate-hard` still escalates to metered Claude (a separate decision if you want that on the subscription too).
- **Raw-API scripts** `sync-changelogs.yml`, `loop-station-inventory.yml` — call the API directly; the OAuth token can't back raw API, so they stay metered.

## 🧪 How to test (after undraft)
1. Open a trivial PR → a11y/frontend-review/simplify gates run green; `$0` API spend for that window.
2. Comment on a blocked issue → resume-on-comment runs on the subscription.