### PR TITLE
feat(crouton-sales): bulk product-import endpoint + the missing parser implementation (#1656)

### DIFF
--- a/packages/crouton-sales/app/utils/parse-product-paste.ts
+++ b/packages/crouton-sales/app/utils/parse-product-paste.ts
@@ -9,9 +9,12 @@
  * server re-validation) lean on this. The server NEVER trusts the client's parse — it
  * re-runs this — so this module is the single source of truth for the parse contract.
  *
- * STATUS: test-first contract committed FAILING (#774). Implementation lands only after
- * the test cases are signed off. This stub carries the types the test compiles against
- * and throws so every test is red.
+ * STATUS: signed off 2026-08-03 (#1655) — implemented against the committed contract in
+ * `test/parse-product-paste.test.ts`. The sign-off resolved the epic's one ambiguity in
+ * favour of the How-to-test reading: a clean row that happens to introduce a new
+ * category/location is `new`, and the creation surfaces once in `relationsToCreate` (one
+ * banner) rather than shouting `warn-creates-relation` on all 30 rows. That status stays
+ * in the union, reserved and unemitted, so the UI can switch without a type change.
  */
 
 export type Delimiter = 'tab' | 'semicolon' | 'comma'
@@ -92,6 +95,213 @@ export interface ParseResult {
  *  - relationsToCreate: deduped unknown category/location titles from importable-by-default rows (new + warn-creates-relation)
  *  - resilience: a malformed row degrades to one error row; it never aborts the batch
  */
-export function parseProductPaste(_input: string, _options?: ParseOptions): ParseResult {
-  throw new Error('parseProductPaste: not implemented — test-first contract pending sign-off (#1655)')
+/** Column header → field, matched trimmed + case-insensitive. EN + NL. */
+const HEADER_ALIASES: Record<string, ImportableField> = {
+  'name': 'title',
+  'product name': 'title',
+  'naam': 'title',
+  'titel': 'title',
+  'title': 'title',
+  'price': 'price',
+  'prijs': 'price',
+  'category': 'categoryTitle',
+  'categorie': 'categoryTitle',
+  'location': 'locationTitle',
+  'prep location': 'locationTitle',
+  'locatie': 'locationTitle',
+  'description': 'description',
+  'omschrijving': 'description',
+  'active': 'isActive',
+  'is active': 'isActive',
+  'actief': 'isActive',
+  'requires remark': 'requiresRemark',
+  'opmerking vereist': 'requiresRemark',
+  'remark prompt': 'remarkPrompt',
+  'opmerking prompt': 'remarkPrompt',
+}
+
+const TRUTHY = new Set(['ja', 'yes', 'true', '1', 'x'])
+const FALSY = new Set(['nee', 'no', 'false', '0'])
+
+/** Normalized key for trimmed, case-insensitive matching of titles and headers. */
+function norm(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function detectDelimiter(lines: string[]): Delimiter {
+  if (lines.some(l => l.includes('\t'))) return 'tab'
+  if (lines.some(l => l.includes(';'))) return 'semicolon'
+  return 'comma'
+}
+
+const SPLIT_ON: Record<Delimiter, string> = { tab: '\t', semicolon: ';', comma: ',' }
+
+/**
+ * `3` · `3.50` · `3,50` · `€ 3,50` · `€3.50` → number. Anything else → null.
+ * The comma is a DECIMAL separator here (nl locale), never a thousands separator —
+ * this parser only ever sees single-cell prices, so there is no ambiguity to resolve.
+ */
+function parsePrice(raw: string): number | null {
+  const cleaned = raw.replace(/[€$\s]/g, '').replace(',', '.')
+  if (!cleaned) return null
+  if (!/^-?\d+(\.\d+)?$/.test(cleaned)) return null
+  const n = Number(cleaned)
+  return Number.isFinite(n) ? n : null
+}
+
+function parseBoolean(raw: string): boolean | undefined {
+  const v = norm(raw)
+  if (TRUTHY.has(v)) return true
+  if (FALSY.has(v)) return false
+  return undefined
+}
+
+/** Split into a rectangular grid, padding ragged rows so columns stay aligned. */
+function buildTable(input: string): { table: string[][], delimiter: Delimiter, width: number } {
+  const lines = (input ?? '').split(/\r?\n/).filter(l => l.trim() !== '')
+  const delimiter = detectDelimiter(lines)
+  const table = lines.map(l => l.split(SPLIT_ON[delimiter]))
+  const width = Math.max(0, ...table.map(r => r.length))
+  for (const row of table) while (row.length < width) row.push('')
+  return { table, delimiter, width }
+}
+
+/**
+ * How many trailing columns are empty in EVERY row, header included — a spreadsheet
+ * habitually pastes a few. A column blank in some rows but filled in others is real
+ * data and is kept.
+ */
+function countTrailingEmptyColumns(table: string[][], width: number): number {
+  let effective = width
+  while (effective > 0 && table.every(r => (r[effective - 1] ?? '').trim() === '')) effective--
+  return width - effective
+}
+
+function mapHeaders(cells: string[]): HeaderMapping[] {
+  return cells.map(name => ({ name: name.trim(), field: HEADER_ALIASES[norm(name)] ?? null }))
+}
+
+/**
+ * Which fields are plain text vs booleans. A lookup rather than a switch: adding a
+ * column becomes a one-line table entry instead of another branch in a growing
+ * `switch` (`price` stays special — it is the only one that reports parse failure).
+ */
+const TEXT_FIELDS = new Set<ImportableField>([
+  'title', 'categoryTitle', 'locationTitle', 'description', 'remarkPrompt',
+])
+const BOOLEAN_FIELDS = new Set<ImportableField>(['isActive', 'requiresRemark'])
+
+/** Read one row's cells into fields. Reports whether a price column was present/parseable. */
+function readRowFields(
+  cells: string[],
+  headers: HeaderMapping[],
+  row: ParsedProductRow,
+): { priceSeen: boolean, priceBad: boolean } {
+  let priceSeen = false
+  let priceBad = false
+  headers.forEach((header, c) => {
+    const field = header.field
+    if (!field) return
+    const raw = (cells[c] ?? '').trim()
+    if (field === 'price') {
+      priceSeen = true
+      const n = parsePrice(raw)
+      if (n === null) priceBad = true
+      else row.price = n
+    } else if (TEXT_FIELDS.has(field)) {
+      if (raw) (row as unknown as Record<string, unknown>)[field] = raw
+    } else if (BOOLEAN_FIELDS.has(field)) {
+      const b = parseBoolean(raw)
+      if (b !== undefined) (row as unknown as Record<string, unknown>)[field] = b
+    }
+  })
+  return { priceSeen, priceBad }
+}
+
+/**
+ * Status precedence: error > warn-duplicate > new. A bad row is RECORDED, never thrown —
+ * one mangled line must not cost the other 29.
+ */
+function classifyRow(
+  row: ParsedProductRow,
+  price: { priceSeen: boolean, priceBad: boolean },
+  existingProducts: Set<string>,
+): void {
+  if (!row.title) {
+    row.status = 'error'
+    row.error = 'Missing product name'
+    return
+  }
+  if (!price.priceSeen) {
+    row.status = 'error'
+    row.error = 'Missing price column'
+    return
+  }
+  if (price.priceBad || row.price === undefined) {
+    row.status = 'error'
+    row.error = 'Unreadable price'
+    return
+  }
+  if (existingProducts.has(norm(row.title))) {
+    row.status = 'warn-duplicate'
+    row.duplicateOf = row.title
+    row.create = false
+    return
+  }
+  row.status = 'new'
+  row.create = true
+}
+
+/**
+ * Accumulate the category/location titles this import would have to create. Keyed
+ * `kind:normalizedTitle` so `Bar` and `bar` collapse to one; the FIRST spelling wins.
+ * Only rows that will actually be imported justify creating a relation.
+ */
+function collectRelations(
+  row: ParsedProductRow,
+  known: { categories: Set<string>, locations: Set<string> },
+  into: Map<string, RelationToCreate>,
+): void {
+  if (row.status !== 'new') return
+  const pairs: Array<[RelationToCreate['kind'], string | undefined, Set<string>]> = [
+    ['category', row.categoryTitle, known.categories],
+    ['location', row.locationTitle, known.locations],
+  ]
+  for (const [kind, title, existing] of pairs) {
+    if (!title || existing.has(norm(title))) continue
+    const key = `${kind}:${norm(title)}`
+    if (!into.has(key)) into.set(key, { kind, title })
+  }
+}
+
+export function parseProductPaste(input: string, options: ParseOptions = {}): ParseResult {
+  const { table, delimiter, width } = buildTable(input)
+  const droppedTrailingColumns = countTrailingEmptyColumns(table, width)
+  const effectiveWidth = width - droppedTrailingColumns
+  const headers = mapHeaders((table[0] ?? []).slice(0, effectiveWidth))
+
+  const existingProducts = new Set((options.existingProductTitles ?? []).map(norm))
+  const known = {
+    categories: new Set((options.existingCategoryTitles ?? []).map(norm)),
+    locations: new Set((options.existingLocationTitles ?? []).map(norm)),
+  }
+
+  const rows: ParsedProductRow[] = []
+  const relations = new Map<string, RelationToCreate>()
+
+  for (let i = 1; i < table.length; i++) {
+    const row: ParsedProductRow = { rowIndex: i, status: 'new' }
+    const price = readRowFields(table[i]!.slice(0, effectiveWidth), headers, row)
+    classifyRow(row, price, existingProducts)
+    collectRelations(row, known, relations)
+    rows.push(row)
+  }
+
+  return {
+    delimiter,
+    headers,
+    droppedTrailingColumns,
+    rows,
+    relationsToCreate: [...relations.values()],
+  }
 }

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/products/import.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/products/import.post.ts
@@ -1,0 +1,140 @@
+/**
+ * Bulk paste-import of products (#1656, epic #1652).
+ *
+ * Receives the batch the user confirmed in the import modal (#1657) and writes it:
+ * missing categories/locations first, then the products, all scoped to this event.
+ *
+ * THE LOAD-BEARING RULE: the client's parse is treated as a *hint*, never as truth.
+ * The raw pasted text is re-run through the same pure parser the modal used
+ * (`parseProductPaste`, #1655) and the result of THAT is what gets written — so a
+ * tampered, stale, or hand-rolled payload cannot smuggle in a row the parser would
+ * have rejected, nor a field this import is not allowed to set.
+ *
+ * `id`, `eventId`, `teamId`, `options`, `hasOptions` and `multipleOptionsAllowed` are
+ * never read off the payload: the first three come from the route + session, and the
+ * option fields are deliberately out of scope for a flat paste (epic decision).
+ *
+ * The branchy part is the pure, unit-tested `server/utils/plan-product-import.ts`
+ * (same split as `order-filters.ts` / `my-orders-shape.ts`); this handler is the
+ * fetch → plan → insert delegate.
+ */
+import { desc, eq } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { requireTeamEvent } from '../../../../../../../utils/team-event'
+import { parseProductPaste } from '../../../../../../../../app/utils/parse-product-paste'
+import {
+  planProductImport,
+  buildProductValues,
+  indexByTitle,
+  readImportRequest,
+  nextOrderAfter,
+  norm,
+  type TitleRow,
+} from '../../../../../../../utils/plan-product-import'
+import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
+import { salesCategories } from '~~/layers/sales/collections/categories/server/database/schema'
+import { salesLocations } from '~~/layers/sales/collections/locations/server/database/schema'
+
+/**
+ * Insert freshly-minted relation rows (if any) and fold their ids into the lookup the
+ * products resolve against, so a product can point at a category created moments ago.
+ */
+async function insertAndIndex(
+  db: ReturnType<typeof useDB>,
+  table: typeof salesCategories | typeof salesLocations,
+  rows: Array<{ id: string, title: string }>,
+  index: Map<string, string>,
+): Promise<void> {
+  if (!rows.length) return
+  await db.insert(table).values(rows as never)
+  for (const row of rows) index.set(norm(row.title), row.id)
+}
+
+/**
+ * Body: `{ paste: string, createDuplicateRowIndexes?: number[] }` — the raw clipboard text
+ * (re-parsed here; it is the source of truth) plus the 1-based row indexes the user ticked
+ * to create despite a duplicate warning. Normalized by `readImportRequest`.
+ */
+export default defineEventHandler(async (event) => {
+  const { team, user, db, eventId } = await requireTeamEvent(event)
+
+  const { paste, optIn } = readImportRequest(await readBody(event))
+  if (!paste) {
+    throw createError({ status: 400, statusText: 'A non-empty paste is required' })
+  }
+
+  // Current state of the event, so the re-parse flags duplicates and unknown relations
+  // against what is really in the DB right now — not against the snapshot the browser
+  // held when the user hit paste.
+  const [existingProducts, existingCategories, existingLocations] = await Promise.all([
+    db.select({ id: salesProducts.id, title: salesProducts.title })
+      .from(salesProducts).where(eq(salesProducts.eventId, eventId)),
+    db.select({ id: salesCategories.id, title: salesCategories.title })
+      .from(salesCategories).where(eq(salesCategories.eventId, eventId)),
+    db.select({ id: salesLocations.id, title: salesLocations.title })
+      .from(salesLocations).where(eq(salesLocations.eventId, eventId)),
+  ]) as [TitleRow[], TitleRow[], TitleRow[]]
+
+  const parsed = parseProductPaste(paste, {
+    existingProductTitles: existingProducts.map(p => p.title),
+    existingCategoryTitles: existingCategories.map(c => c.title),
+    existingLocationTitles: existingLocations.map(l => l.title),
+  })
+
+  const plan = planProductImport({
+    rows: parsed.rows,
+    relationsToCreate: parsed.relationsToCreate,
+    optIn,
+    existingCategories,
+    existingLocations,
+  })
+
+  const now = new Date()
+  const stamp = { teamId: team.id, owner: user.id, createdBy: user.id, updatedBy: user.id }
+
+  // 1. Relations first, so every product has an id to point at.
+  const newCategories = plan.newCategoryTitles.map(title => ({
+    id: nanoid(), eventId, title, displayOrder: 0, ...stamp, createdAt: now, updatedAt: now,
+  }))
+  const newLocations = plan.newLocationTitles.map(title => ({
+    id: nanoid(), eventId, title, ...stamp, createdAt: now, updatedAt: now,
+  }))
+
+  const categoryIds = indexByTitle(existingCategories)
+  const locationIds = indexByTitle(existingLocations)
+
+  await insertAndIndex(db, salesCategories, newCategories, categoryIds)
+  await insertAndIndex(db, salesLocations, newLocations, locationIds)
+
+  // 2. Products, appended after the event's current highest `order`.
+  const highest = await db
+    .select({ maxOrder: salesProducts.order })
+    .from(salesProducts)
+    .where(eq(salesProducts.eventId, eventId))
+    .orderBy(desc(salesProducts.order))
+    .limit(1)
+
+  const productRows = buildProductValues(
+    plan.toCreate,
+    { categories: categoryIds, locations: locationIds },
+    {
+      eventId,
+      stamp,
+      now,
+      startOrder: nextOrderAfter(highest as Array<{ maxOrder: number | null }>),
+      newId: nanoid,
+    },
+  )
+
+  if (productRows.length) {
+    await db.insert(salesProducts).values(productRows)
+  }
+
+  return {
+    created: productRows.length,
+    skipped: plan.skipped,
+    errors: plan.errors,
+    createdCategories: newCategories.map(c => c.title),
+    createdLocations: newLocations.map(l => l.title),
+  }
+})

--- a/packages/crouton-sales/server/utils/plan-product-import.ts
+++ b/packages/crouton-sales/server/utils/plan-product-import.ts
@@ -1,0 +1,126 @@
+/**
+ * @crouton-package crouton-sales
+ * @description Pure planning for the product paste-import (#1656, epic #1652).
+ *
+ * Decides WHAT the import will write — which rows survive, which are reported as errors,
+ * which duplicates are skipped, and which categories/locations have to be created first —
+ * without touching the DB, the clock, or an id generator. The endpoint stays a thin
+ * fetch → plan → insert delegate.
+ *
+ * Same split as `order-filters.ts` / `my-orders-shape.ts` / `delete-event-orders.ts`:
+ * the branchy part is pure and unit-tested (`test/plan-product-import.test.ts`), so the
+ * handler carries no logic worth testing through Nitro.
+ */
+import type { ParsedProductRow, RelationToCreate } from '../../app/utils/parse-product-paste'
+
+export interface TitleRow { id: string, title: string }
+export interface ImportError { rowIndex: number, message: string }
+
+export interface ImportPlan {
+  /** Rows that will become products. */
+  toCreate: ParsedProductRow[]
+  /** Rows the parser rejected, reported back to the modal. */
+  errors: ImportError[]
+  /** Count of duplicate rows the user did not opt into. */
+  skipped: number
+  /** Category titles that don't exist on this event yet, in first-seen spelling. */
+  newCategoryTitles: string[]
+  /** Location titles that don't exist on this event yet, in first-seen spelling. */
+  newLocationTitles: string[]
+}
+
+/** Trimmed, case-insensitive key — the same normalization the parser uses. */
+export const norm = (v: string) => v.trim().toLowerCase()
+
+/**
+ * Normalize the untrusted request body. Returns an empty `paste` when the field is
+ * missing/blank/not-a-string, so the handler's only job is to turn that into a 400.
+ * Non-integer row indexes are dropped rather than trusted.
+ */
+export function readImportRequest(body: unknown): { paste: string, optIn: Set<number> } {
+  const b = (body ?? {}) as { paste?: unknown, createDuplicateRowIndexes?: unknown }
+  const paste = typeof b.paste === 'string' && b.paste.trim() ? b.paste : ''
+  const raw = Array.isArray(b.createDuplicateRowIndexes) ? b.createDuplicateRowIndexes : []
+  return { paste, optIn: new Set(raw.filter((n: unknown): n is number => Number.isInteger(n))) }
+}
+
+/** Append after the event's current highest `order`; an empty event starts at 0. */
+export function nextOrderAfter(rows: Array<{ maxOrder: number | null }>): number {
+  return (rows[0]?.maxOrder ?? -1) + 1
+}
+
+/** Map every known title → id, so products can resolve their relations by name. */
+export function indexByTitle(rows: TitleRow[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const r of rows) map.set(norm(r.title), r.id)
+  return map
+}
+
+/**
+ * A row the parser rejected is reported and dropped — it must never abort the batch for
+ * the good rows. A duplicate is only written when the user explicitly ticked that row.
+ */
+export function planProductImport(input: {
+  rows: ParsedProductRow[]
+  relationsToCreate: RelationToCreate[]
+  optIn: Set<number>
+  existingCategories: TitleRow[]
+  existingLocations: TitleRow[]
+}): ImportPlan {
+  const errors: ImportError[] = []
+  const toCreate: ParsedProductRow[] = []
+  let skipped = 0
+
+  for (const row of input.rows) {
+    if (row.status === 'error') errors.push({ rowIndex: row.rowIndex, message: row.error ?? 'Invalid row' })
+    else if (row.status === 'warn-duplicate' && !input.optIn.has(row.rowIndex)) skipped++
+    else toCreate.push(row)
+  }
+
+  // Derived from the re-parse's relation list, filtered against what the DB really has —
+  // never from the client's own `relationsToCreate`, which a payload could inflate.
+  const knownCategories = indexByTitle(input.existingCategories)
+  const knownLocations = indexByTitle(input.existingLocations)
+  const newCategoryTitles = input.relationsToCreate
+    .filter(r => r.kind === 'category' && !knownCategories.has(norm(r.title)))
+    .map(r => r.title)
+  const newLocationTitles = input.relationsToCreate
+    .filter(r => r.kind === 'location' && !knownLocations.has(norm(r.title)))
+    .map(r => r.title)
+
+  return { toCreate, errors, skipped, newCategoryTitles, newLocationTitles }
+}
+
+/**
+ * Turn planned rows into insertable product values. `order` continues after the event's
+ * current highest so an import lands at the end of the list instead of colliding with
+ * existing positions. Ids and timestamps are injected so this stays pure.
+ */
+export function buildProductValues(
+  toCreate: ParsedProductRow[],
+  ids: { categories: Map<string, string>, locations: Map<string, string> },
+  ctx: {
+    eventId: string
+    stamp: { teamId: string, owner: string, createdBy: string, updatedBy: string }
+    now: Date
+    startOrder: number
+    newId: () => string
+  },
+) {
+  return toCreate.map((row, i) => ({
+    id: ctx.newId(),
+    ...ctx.stamp,
+    order: ctx.startOrder + i,
+    eventId: ctx.eventId,
+    categoryId: row.categoryTitle ? (ids.categories.get(norm(row.categoryTitle)) ?? null) : null,
+    locationId: row.locationTitle ? (ids.locations.get(norm(row.locationTitle)) ?? null) : null,
+    title: row.title as string,
+    description: row.description ?? null,
+    price: row.price as number,
+    isActive: row.isActive ?? true,
+    requiresRemark: row.requiresRemark ?? false,
+    remarkPrompt: row.remarkPrompt ?? null,
+    createdAt: ctx.now,
+    updatedAt: ctx.now,
+  }))
+}

--- a/packages/crouton-sales/test/plan-product-import.test.ts
+++ b/packages/crouton-sales/test/plan-product-import.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest'
+import { parseProductPaste } from '../app/utils/parse-product-paste'
+import { planProductImport, buildProductValues, indexByTitle, readImportRequest, nextOrderAfter } from '../server/utils/plan-product-import'
+
+/**
+ * Pure planning for the bulk product import (#1656, epic #1652).
+ *
+ * These assert the SERVER's decisions, which are deliberately not the client's: the
+ * endpoint re-parses the raw paste and plans from that, so a stale or tampered payload
+ * can't smuggle a row past the rules. The parser's own contract lives in
+ * `parse-product-paste.test.ts`; here we feed it real pasted text and check what the
+ * import would write.
+ */
+
+/** The epic's messy Armonia fixture: 4 good rows, 1 nameless, 1 with an unreadable price. */
+const messyPaste = [
+  'Name\tPrice\tCategory\tLocation',
+  'Pils\t3\tDrank\tBar',
+  'Leffe blond\t4\tDrank\tbar',
+  'Gin\t8,00\tDrank\tBar',
+  'Fles cava\t€ 18\tDrank\tBar',
+  '\t5\tDrank\tBar',
+  'Kriek\tabc\tDrank\tBar',
+].join('\n')
+
+const plan = (paste: string, opts: {
+  optIn?: number[]
+  products?: string[]
+  categories?: { id: string, title: string }[]
+  locations?: { id: string, title: string }[]
+} = {}) => {
+  const parsed = parseProductPaste(paste, {
+    existingProductTitles: opts.products ?? [],
+    existingCategoryTitles: (opts.categories ?? []).map(c => c.title),
+    existingLocationTitles: (opts.locations ?? []).map(l => l.title),
+  })
+  return planProductImport({
+    rows: parsed.rows,
+    relationsToCreate: parsed.relationsToCreate,
+    optIn: new Set(opts.optIn ?? []),
+    existingCategories: opts.categories ?? [],
+    existingLocations: opts.locations ?? [],
+  })
+}
+
+describe('planProductImport — the messy fixture', () => {
+  it('imports the 4 good rows and reports the 2 bad ones', () => {
+    const p = plan(messyPaste)
+    expect(p.toCreate.map(r => r.title)).toEqual(['Pils', 'Leffe blond', 'Gin', 'Fles cava'])
+    expect(p.errors).toEqual([
+      { rowIndex: 5, message: 'Missing product name' },
+      { rowIndex: 6, message: 'Unreadable price' },
+    ])
+    expect(p.skipped).toBe(0)
+  })
+
+  it('creates each missing relation once, case-insensitively (Bar == bar)', () => {
+    const p = plan(messyPaste)
+    expect(p.newCategoryTitles).toEqual(['Drank'])
+    expect(p.newLocationTitles).toEqual(['Bar'])
+  })
+
+  it('creates nothing when the relations already exist', () => {
+    const p = plan(messyPaste, {
+      categories: [{ id: 'c1', title: 'Drank' }],
+      locations: [{ id: 'l1', title: 'bar' }], // different casing on purpose
+    })
+    expect(p.newCategoryTitles).toEqual([])
+    expect(p.newLocationTitles).toEqual([])
+  })
+})
+
+describe('planProductImport — duplicates', () => {
+  it('skips a duplicate by default and writes nothing for it', () => {
+    const p = plan(messyPaste, { products: ['Pils'] })
+    expect(p.skipped).toBe(1)
+    expect(p.toCreate.map(r => r.title)).not.toContain('Pils')
+  })
+
+  it('writes a duplicate the user explicitly opted into', () => {
+    const p = plan(messyPaste, { products: ['Pils'], optIn: [1] })
+    expect(p.skipped).toBe(0)
+    expect(p.toCreate.map(r => r.title)).toContain('Pils')
+  })
+
+  it('an opt-in for a DIFFERENT row does not rescue this one', () => {
+    const p = plan(messyPaste, { products: ['Pils'], optIn: [99] })
+    expect(p.skipped).toBe(1)
+    expect(p.toCreate.map(r => r.title)).not.toContain('Pils')
+  })
+
+  it('re-importing the same paste is a no-op — every row already exists', () => {
+    const p = plan(messyPaste, { products: ['Pils', 'Leffe blond', 'Gin', 'Fles cava'] })
+    expect(p.toCreate).toHaveLength(0)
+    expect(p.skipped).toBe(4)
+  })
+
+  it('a duplicate does not drag its relations into the create-list', () => {
+    const p = plan('Name\tPrice\tCategory\nPils\t3\tNieuw', { products: ['Pils'] })
+    expect(p.newCategoryTitles).toEqual([])
+  })
+})
+
+describe('buildProductValues', () => {
+  const ctx = {
+    eventId: 'e1',
+    stamp: { teamId: 't1', owner: 'u1', createdBy: 'u1', updatedBy: 'u1' },
+    now: new Date('2026-08-03T10:00:00Z'),
+    startOrder: 7,
+    newId: (() => { let n = 0; return () => `id${++n}` })(),
+  }
+
+  it('resolves relations by title and continues the order sequence', () => {
+    const p = plan(messyPaste)
+    const values = buildProductValues(p.toCreate, {
+      categories: indexByTitle([{ id: 'cat-drank', title: 'Drank' }]),
+      locations: indexByTitle([{ id: 'loc-bar', title: 'Bar' }]),
+    }, ctx)
+
+    expect(values.map(v => v.order)).toEqual([7, 8, 9, 10])
+    expect(values.every(v => v.categoryId === 'cat-drank')).toBe(true)
+    // 'bar' on the Leffe row must resolve to the same location as 'Bar'.
+    expect(values.every(v => v.locationId === 'loc-bar')).toBe(true)
+    expect(values.map(v => v.price)).toEqual([3, 4, 8, 18])
+    expect(values.every(v => v.eventId === 'e1' && v.teamId === 't1')).toBe(true)
+  })
+
+  it('leaves an unresolvable relation null rather than inventing an id', () => {
+    const p = plan('Name\tPrice\tCategory\nPils\t3\tGhost')
+    const values = buildProductValues(p.toCreate, {
+      categories: new Map(), locations: new Map(),
+    }, ctx)
+    expect(values[0]!.categoryId).toBeNull()
+    expect(values[0]!.locationId).toBeNull()
+  })
+
+  it('applies the schema defaults for the flags a flat paste omits', () => {
+    const p = plan('Name\tPrice\nPils\t3')
+    const [v] = buildProductValues(p.toCreate, { categories: new Map(), locations: new Map() }, ctx)
+    expect(v).toMatchObject({ isActive: true, requiresRemark: false, remarkPrompt: null, description: null })
+  })
+
+  it('honours explicit Active / Requires Remark columns', () => {
+    const p = plan('Name\tPrice\tActive\tRequires Remark\nPils\t3\tnee\tja')
+    const [v] = buildProductValues(p.toCreate, { categories: new Map(), locations: new Map() }, ctx)
+    expect(v).toMatchObject({ isActive: false, requiresRemark: true })
+  })
+})
+
+describe('readImportRequest — untrusted body normalization', () => {
+  it('accepts a real paste and opt-in list', () => {
+    const r = readImportRequest({ paste: 'Name\tPrice', createDuplicateRowIndexes: [1, 3] })
+    expect(r.paste).toBe('Name\tPrice')
+    expect([...r.optIn]).toEqual([1, 3])
+  })
+  for (const [label, body] of [
+    ['missing body', undefined],
+    ['no paste field', {}],
+    ['blank paste', { paste: '   ' }],
+    ['non-string paste', { paste: 42 }],
+  ] as const) {
+    it(`yields an empty paste for ${label} (handler turns it into a 400)`, () => {
+      expect(readImportRequest(body).paste).toBe('')
+    })
+  }
+  it('drops non-integer opt-in entries rather than trusting them', () => {
+    const r = readImportRequest({ paste: 'x', createDuplicateRowIndexes: [1, '2', 3.5, null, NaN] })
+    expect([...r.optIn]).toEqual([1])
+  })
+  it('tolerates a non-array opt-in field', () => {
+    expect([...readImportRequest({ paste: 'x', createDuplicateRowIndexes: 'all' }).optIn]).toEqual([])
+  })
+})
+
+describe('nextOrderAfter', () => {
+  it('starts an empty event at 0', () => expect(nextOrderAfter([])).toBe(0))
+  it('appends after the highest existing order', () => expect(nextOrderAfter([{ maxOrder: 12 }])).toBe(13))
+  it('treats a null order as unset', () => expect(nextOrderAfter([{ maxOrder: null }])).toBe(0))
+})


### PR DESCRIPTION
Closes #1656

Packages-approved: epic #1652 owner-approved the `packages/crouton-sales` scope. Local unlock used and removed; the override file was never committed.

## 👤 For humans

Two things, because the first was missing.

**The parser had never been implemented.** PR #1659 merged the signed-off test contract with a throwing stub — that's the point of the test-first gate — but the follow-up run that writes the code hit the GLM plan quota and produced nothing. So `#1655` closed with 35 red tests on the epic branch and a parser that threw on every call. This PR writes it: 35/35 green, no test touched.

**Then the endpoint itself** (#1656): takes the batch confirmed in the modal and writes it, creating any missing categories and locations first. It re-checks everything itself rather than trusting the browser, and returns a `{ created, skipped, errors }` tally.

## 🤖 For agents

### The load-bearing rule

The client's parse is a **hint, never truth**. The raw pasted text is re-run through `parseProductPaste` server-side and the result of *that* is what gets written. A tampered, stale, or hand-rolled payload therefore cannot:
- smuggle in a row the parser would have rejected,
- set `id` / `eventId` / `teamId` (route + session), or `options` / `hasOptions` / `multipleOptionsAllowed` (out of scope for a flat paste, per the epic),
- inflate `relationsToCreate` to conjure category/location rows — the create-list is derived from the re-parse and filtered against what the DB actually has,
- claim a row isn't a duplicate — duplication is re-checked against the event's **current** rows, not the browser's snapshot.

### Shape

`POST /api/crouton-sales/teams/:id/events/:eventId/products/import` — team-scoped via `requireTeamEvent`, every write scoped to the path `eventId`. Relations are created first so products can resolve their ids; products append after the event's current highest `order` rather than colliding with existing positions. An invalid row is reported and dropped, never fatal for the batch.

### Why a separate `plan-product-import.ts`

The branchy part is pure and unit-tested; the handler is a thin fetch → plan → insert delegate. Same split the package already uses for `order-filters.ts` / `my-orders-shape.ts` / `delete-event-orders.ts`.

It's also what keeps the fallow gate green. `fallow audit` weights CRAP by real coverage, and an endpoint has none — so an untested handler must stay genuinely small, not merely tidy. Extracting the logic took it from 13 cyclomatic (CRITICAL, CRAP 182) to a delegate, and split the parser's growing `switch` into a lookup table. Final: **✓ No issues in 4 changed files**. Nothing was suppressed with `fallow-ignore`.

### Verification

| Check | Result |
|---|---|
| `packages/crouton-sales` tests | **143/143** (35 parser contract + 22 new planner + 86 existing) |
| `pnpm --filter fanfare typecheck` | **0 errors in crouton-sales** |
| `npx fallow audit` | **clean, 4 changed files** |

One pre-existing failure is unrelated and **not** from this PR: `crouton-core/.../theme.patch.ts` fails typecheck locally against a stale `crouton-themes` dist predating the "accept all preset slugs" fix (#1387). That file is byte-identical to `origin/main`, and main's CI is green.

Not verified here: the endpoint against a live DB — it has no integration test, and the modal that calls it is #1657. See How to test.

## 🧪 How to test

1. Boot fanfare, open an event workspace, and note the event's current products.
2. `POST` to `/api/crouton-sales/teams/<team>/events/<eventId>/products/import` with:
   ```json
   { "paste": "Name\tPrice\tCategory\tLocation\nPils\t3\tDrank\tBar\nLeffe blond\t4\tDrank\tbar\nGin\t8,00\tDrank\tBar\nFles cava\t€ 18\tDrank\tBar\n\t5\tDrank\tBar\nKriek\tabc\tDrank\tBar" }
   ```
3. **Expect** `{ created: 4, skipped: 0, errors: [ {rowIndex:5,"Missing product name"}, {rowIndex:6,"Unreadable price"} ], createdCategories: ["Drank"], createdLocations: ["Bar"] }` — and on the event, exactly **one** `Drank` and **one** `Bar` (`bar` on the Leffe row resolved to the same location).
4. Repeat the identical call. **Expect** `{ created: 0, skipped: 4 }` and no new rows.
5. Repeat again with `"createDuplicateRowIndexes": [1]`. **Expect** `created: 1` — a second `Pils`.
6. Send `{ "paste": "   " }` → **expect** 400.
7. Send a paste for an event belonging to another team → **expect** 404 from `requireTeamEvent`.
