### PR TITLE
fix(crouton-sales): repair the device-pairing imports that broke main (#1662)

### DIFF
--- a/packages/crouton-sales/server/api/crouton-sales/devices/claim.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/devices/claim.post.ts
@@ -33,7 +33,8 @@ export default defineEventHandler(async (event) => {
 
   if (!result.ok) {
     if (result.retryAfterSeconds) {
-      setHeader(event, 'Retry-After', String(result.retryAfterSeconds))
+      // h3 types Retry-After as numeric seconds — do not stringify it.
+      setHeader(event, 'Retry-After', result.retryAfterSeconds)
     }
     throw createError({
       status: result.status,

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/devices/[deviceId].delete.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/devices/[deviceId].delete.ts
@@ -7,7 +7,7 @@
  * does not exist (404), so this is not a cross-team probe.
  */
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
-import { revokeTeamDevice } from '../../../../utils/device-pairing'
+import { revokeTeamDevice } from '../../../../../utils/device-pairing'
 
 export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/devices/index.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/devices/index.get.ts
@@ -7,7 +7,7 @@
  * older `/print-devices` endpoint stays as-is for the routers-only view.
  */
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
-import { listTeamDevices } from '../../../../utils/device-pairing'
+import { listTeamDevices } from '../../../../../utils/device-pairing'
 
 export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)

--- a/packages/crouton-sales/server/utils/device-pairing.ts
+++ b/packages/crouton-sales/server/utils/device-pairing.ts
@@ -152,7 +152,15 @@ export async function listTeamDevices(organizationId: string): Promise<TeamDevic
     )
     .limit(500)
 
-  return rows.map(r => ({
+  // `useDB()` is an untyped global here, so the row shape must be stated —
+  // otherwise `r` is an implicit any and typecheck fails in consuming apps.
+  const selected = rows as Array<{
+    deviceId: string
+    resourceType: string
+    claimedAt: Date | null
+  }>
+
+  return selected.map(r => ({
     deviceId: r.deviceId,
     type: r.resourceType,
     claimedAt: r.claimedAt ?? null


### PR DESCRIPTION
## 👤 For humans

**`main` has been red since 10:30 today.** Three mistakes in the device-pairing endpoints I added in #1668 broke the fanfare typecheck and both fanfare builds. This fixes them. No behaviour changes.

PR #1671 (the installer) is **not** broken — its red checks are inherited from `main` and should clear once this lands.

## 🤖 For agents

| Bug | Detail |
|---|---|
| import path off by one | `teams/[id]/devices/{index.get,[deviceId].delete}.ts` used `../../../../utils/device-pairing`. From `server/api/crouton-sales/teams/[id]/devices/` it is **five** levels up to `server/`, not four. Broke Rollup in both presets, plus TS2307. |
| `Retry-After` stringified | h3 types that header as numeric seconds (TS2345) |
| implicit `any` | `listTeamDevices` mapped an untyped `useDB()` row (TS7006) |

## 🔍 Why it reached `main` — the part worth fixing beyond this PR

PR #1668 was **stacked on `feat/1661-pairing-code`**, but `ci.yml` triggers on `pull_request: branches: [main]`. So **no checks ran on it at all** — `Type Check Apps` and both `Build fanfare` jobs never executed.

The failure mode is that **"no failing checks" is indistinguishable from "no checks"** in the PR UI, and it was reported as verified on that basis. The 94 unit tests that did run come from a package-level vitest runner and never exercise the app typecheck or the Nitro build — which is exactly where all three bugs lived.

This is a structural gap, not only an individual slip: **any** stacked PR in this repo merges with zero CI. Worth its own `workflow` issue — either run `ci.yml` on all PR bases, or refuse to merge a PR that ran zero checks. Happy to open it.

## 🧪 How to test

Verified locally with the three checks that actually failed:

```bash
cd apps/fanfare && npx nuxt typecheck                      # clean
NITRO_PRESET=node-server BETTER_AUTH_SECRET=x npx nuxt build   # Build complete
npx vitest run --root packages/crouton-sales               # 94 passed
```

CI on this PR targets `main`, so this time the full suite actually runs.

Packages-approved: owner approved in an interactive session (2026-08-03) after the same break was independently diagnosed from a red fanfare staging deploy on main. Scope: crouton-sales device-pairing import depths + the two type fixes riding along.
