### PR TITLE
chore(root): move the pi lanes onto the Claude subscription too (#1669)

### DIFF
--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -41,16 +41,16 @@ on:
         type: choice
         options: ["off", "pi"]
       model:
-        description: "Model for pi. Default glm-5.2 (flat-rate GLM Coding Plan — beat the Haiku baseline on fidelity at $0 marginal, #1409). For provider=anthropic use e.g. claude-haiku-4-5-20251001."
+        description: "Model for pi. Default claude-haiku-4-5 on the Claude SUBSCRIPTION (provider=pi-claude-cli). glm-5.2 available via provider=zai if you want the GLM plan."
         required: false
-        default: "glm-5.2"
+        default: "claude-haiku-4-5"
         type: string
       provider:
-        description: "pi provider. Default zai = GLM Coding Plan via the runner box's pi auth store (#1409, self-hosted runner only); anthropic = funded PI_PROVIDER_KEY (metered baseline lane)."
+        description: "pi provider. Default pi-claude-cli = Claude SUBSCRIPTION via the mini's `claude` login (#1669 — everything on the subscription). zai = GLM Coding Plan; anthropic = metered PI_PROVIDER_KEY."
         required: false
-        default: "zai"
+        default: "pi-claude-cli"
         type: choice
-        options: ["zai", "anthropic"]
+        options: ["pi-claude-cli", "zai", "anthropic"]
 
 concurrency:
   group: a11y-daily-pidev
@@ -89,21 +89,19 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      # ── The agent: pi.dev, REPORTS-ONLY, scoped to the model key only ──────────────
-      # env carries ONLY the provider key — no GH_TOKEN/GITHUB_TOKEN. Two provider lanes:
-      # `anthropic` (default) uses a FUNDED API key (PI_PROVIDER_KEY) — NOT a Claude
-      # subscription (subscription OAuth must never back unattended CI — Anthropic terms;
-      # the box's interactive `pi-claude-cli`/subscription path stays interactive-only).
-      # `zai` (#1409) uses the GLM Coding Plan via pi's auth store on the runner box —
-      # z.ai's plan officially whitelists pi, and the flat-rate key is model-scoped.
+      # ── The agent: pi.dev, REPORTS-ONLY ────────────────────────────────────────────
+      # env carries NO GH_TOKEN/GITHUB_TOKEN (reports-only) and NO metered key. Provider
+      # lanes: `pi-claude-cli` (DEFAULT, #1669) = Claude SUBSCRIPTION via the mini's
+      # `claude` login — this REVERSES the old "OAuth must not back CI" rule on the owner's
+      # instruction Anthropic now permits it. `zai` = GLM Coding Plan (flat-rate); `anthropic`
+      # = metered PI_PROVIDER_KEY. Only `pi-claude-cli`/`zai` work on the mac-mini runner.
       # Invocation + skills confirmed on the mac-mini (#888): the `.pi/skills` symlink
       # bridge does NOT load — pi's discovery ignores it — so skills are passed via the
       # explicit `--skill .claude/skills` flag (our SKILL.md format is drop-in portable).
       - id: pi
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.PI_PROVIDER_KEY }}
-          PI_MODEL: ${{ inputs.model }}
-          PI_PROVIDER: ${{ inputs.provider || 'zai' }}
+          PI_MODEL: ${{ inputs.model || 'claude-haiku-4-5' }}
+          PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -72,16 +72,16 @@ on:
         type: choice
         options: ["off", "pi"]
       model:
-        description: "Model for pi. Default glm-5.2 — passed the #1421 autonomous code-writing eval (PR-producing, no #1019 stall) at $0 marginal on the flat-rate GLM Coding Plan. For provider=anthropic use claude-sonnet-5 (the metered baseline; Haiku only for trivial/reports, #1019)."
+        description: "Model for pi. Default claude-sonnet-5 on the Claude SUBSCRIPTION (provider=pi-claude-cli). glm-5.2 available via provider=zai if you want the GLM plan."
         required: false
-        default: "glm-5.2"
+        default: "claude-sonnet-5"
         type: string
       provider:
-        description: "pi provider. Default zai = GLM Coding Plan via the runner box's pi auth store (#1421 eval passed, owner-approved flip; self-hosted runner only); anthropic = funded PI_PROVIDER_KEY (metered baseline lane)."
+        description: "pi provider. Default pi-claude-cli = Claude SUBSCRIPTION via the mini's `claude` login (#1669 — everything on the subscription). zai = GLM Coding Plan; anthropic = metered PI_PROVIDER_KEY."
         required: false
-        default: "zai"
+        default: "pi-claude-cli"
         type: choice
-        options: ["zai", "anthropic"]
+        options: ["pi-claude-cli", "zai", "anthropic"]
   # PROMOTED past dispatch-only (#1017): a human applying the `delegate-pi` label starts a pi
   # run. We fire on EVERY labeled event but the job `if` gates to the exact `delegate-pi` label,
   # so a worker later adding `status:in-progress` does NOT re-fire (the claude flow's #535 lesson).
@@ -176,14 +176,13 @@ jobs:
       # funded metered key (NOT a subscription — subscription OAuth must not back CI).
       - id: pi
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.PI_PROVIDER_KEY }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          # delegate-hard escalates this one leaf to the metered Claude lane (#1496); the
-          # label check is falsy on dispatch/other-label runs so they keep the zai/glm-5.2
-          # default. Opus stays a deliberate manual dispatch — never wired to a label.
-          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-sonnet-5') || 'glm-5.2' }}
-          PI_PROVIDER: ${{ inputs.provider || (github.event.label.name == 'delegate-hard' && 'anthropic') || 'zai' }}
+          # Everything on the Claude SUBSCRIPTION (#1669). delegate-hard still escalates,
+          # but now by MODEL (sonnet → opus) on the same subscription provider — no metered
+          # lane. NO ANTHROPIC_API_KEY: pi-claude-cli uses the mini's `claude` login.
+          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
+          PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
         run: |
           set -uo pipefail

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Headless CI profile (#1019/#1004) — only pipeline-critical + telemetry extensions. pi merges this project file OVER ~/.pi/agent/settings.json, and `packages` (an array) REPLACES the global list, so CI loads exactly these 8 — notably WITHOUT pi-ask-user / pi-interactive-shell, so a headless run can't stall-and-ask (the #839 failure). pi-ralph-wiggum gives the persistence loop. In CI, ANTHROPIC_API_KEY activates the 'anthropic' provider; locally, pi-claude-cli reads auth.json.",
-  "defaultProvider": "anthropic",
+  "$comment": "Headless CI profile (#1019/#1004) — only pipeline-critical + telemetry extensions. pi merges this project file OVER ~/.pi/agent/settings.json, and `packages` (an array) REPLACES the global list, so CI loads exactly these 8 — notably WITHOUT pi-ask-user / pi-interactive-shell, so a headless run can't stall-and-ask (the #839 failure). pi-ralph-wiggum gives the persistence loop. defaultProvider is 'pi-claude-cli' — on the mac-mini runner headless runs drive the Claude SUBSCRIPTION via the logged-in `claude` CLI (#1669, everything-on-the-subscription). WARNING: only works where `claude` is logged in — a GitHub-hosted run (ubuntu-latest) has none and must pass its own --provider/key.",
+  "defaultProvider": "pi-claude-cli",
   "defaultThinkingLevel": "medium",
   "quietStartup": true,
   "enableInstallTelemetry": false,


### PR DESCRIPTION
Completes "everything on the Claude subscription" — the piece I wrongly left out (and wrongly closed #1670 over).

## 👤 For humans
The pi lanes were still running on the **paid GLM Coding Plan** (z.ai) — a separate subscription. This moves them to the **Claude subscription** you already pay for. GLM/metered remain as opt-in dispatch choices, but nothing defaults to them anymore.

## 🤖 What changed
- `a11y-daily-pidev` + `decompose-on-issue-pidev`: default provider `zai` → `pi-claude-cli`, default model → Claude (haiku / sonnet), dropped the metered-key env.
- `delegate-hard` escalation: was → metered `anthropic`; now → `claude-opus-4-6` on the **same subscription** (escalate by model, not by paying).
- `.pi/settings.json` default → `pi-claude-cli`.

## The only things NOT on the subscription now (hard technical limits, not choices)
- `sync-changelogs.yml`, `loop-station-inventory.yml` — call the Anthropic **API directly** (not the CLI/action); the OAuth token can't back raw API. Would need rewriting to route through the CLI.
- `decompose-on-issue-pidev-hosted.yml` — runs on `ubuntu-latest`, no `claude` login there.

## ⚠️ Note
This puts the pi lanes on the **same 5-hour subscription quota** as interactive + the 12 claude-code-action workflows. That's the shared-quota tradeoff you accepted ("everything on the subscription for now"). If interactive work starts getting throttled, the escape hatch is putting some lanes back on GLM (one dispatch input).

## 🧪 Test after merge
Dispatch `a11y-daily-pidev` (harness=pi) → runs on `pi-claude-cli`, no GLM/metered spend.