### PR TITLE
fix(root): make the venue-bundle workflow parseable (#804)

### DIFF
--- a/.github/workflows/release-venue-bundle.yml
+++ b/.github/workflows/release-venue-bundle.yml
@@ -114,19 +114,29 @@ jobs:
             PRERELEASE="--prerelease"
           fi
 
+          # Build the notes in a FILE, not as an inline multi-line argument.
+          # The previous version's continuation lines sat at column 0, which
+          # ends the YAML block scalar — the whole workflow then failed to
+          # parse, so GitHub never registered workflow_dispatch (no "Run
+          # workflow" button) and logged a failed run on every push.
+          # Everything here must stay indented inside this block.
+          {
+            echo "Prebuilt node-server bundle for the venue till installer (#804)."
+            echo
+            echo "Install on a bare Linux box:"
+            echo
+            echo '```bash'
+            echo "curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/apps/fanfare/deploy/install.sh | sudo bash -s -- --release $TAG"
+            echo '```'
+            echo
+            echo "Built from commit ${{ github.sha }}."
+          } > release-notes.md
+
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" "$TARBALL" "$TARBALL.sha256" --clobber
           else
             gh release create "$TAG" "$TARBALL" "$TARBALL.sha256" \
               --title "Venue bundle $TAG" \
-              --notes "Prebuilt node-server bundle for the venue till installer (#804).
-
-Install on a bare Linux box:
-
-\`\`\`bash
-curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/apps/fanfare/deploy/install.sh | sudo bash -s -- --release $TAG
-\`\`\`
-
-Built from \`${{ github.sha }}\`." \
+              --notes-file release-notes.md \
               $PRERELEASE
           fi


### PR DESCRIPTION
Follow-up to #1671.

## 👤 For humans

**The Release venue bundle workflow cannot be run today.** There is no "Run workflow" button in the Actions UI, and every push since it landed has logged a failed run. The file does not parse, so GitHub never registered its triggers.

This fixes it. Merge, and the button appears.

## 🤖 For agents

The release notes were passed as an inline multi-line `--notes` argument whose continuation lines sat at **column 0**. In YAML that terminates the `run: |` block scalar, so the parser hit:

```
Implicit keys need to be on a single line at line 126
```

…and the whole workflow was invalid.

GitHub surfaces this badly: the only signal is *"This run likely failed because of a workflow file issue"* on a run that **should never have triggered at all** (a branch push, when the file declares `push: tags: [venue-*]`). An unparseable workflow has no usable triggers — which is exactly why `workflow_dispatch` never appeared in the UI.

Notes now go to `release-notes.md` inside the block, every line indented, passed via `--notes-file`.

## 🧪 How to test

```bash
node -e "const Y=require(yaml);Y.parse(require(fs).readFileSync(.github/workflows/release-venue-bundle.yml,utf8))"
```

Result: parses · triggers `workflow_dispatch, push` · inputs `tag, prerelease` · 1 job, 9 steps.

I swept all **60** workflows the same way — this was the only broken one.

After merge: Actions → **Release venue bundle** → **Run workflow** → tag e.g. `venue-2026.08.03`.

## 🔍 Why it got through

My pre-push check for this file grepped for a `name:` line and reported it "readable". That is not validation. A real `YAML.parse` — which takes one line and would have caught it instantly — is now what I used, and is what the how-to-test above pins.