### PR TITLE
fix(root): ship the arm64 native addon in the venue bundle (#1680)

### DIFF
--- a/.github/workflows/release-venue-bundle.yml
+++ b/.github/workflows/release-venue-bundle.yml
@@ -70,6 +70,53 @@ jobs:
           # Build-time prerender needs a secret present; value is irrelevant.
           BETTER_AUTH_SECRET: ci-placeholder
 
+      - name: Add the arm64 native addon (#1680)
+        # libsql ships its native addon as per-platform optional packages, so a
+        # build on this x64 runner installs ONLY linux-x64-gnu. A Raspberry Pi —
+        # the canonical venue till — would then die at boot on
+        # "Cannot find module '@libsql/linux-arm64-gnu'".
+        # Ship both so one tarball runs anywhere and install.sh stays dumb.
+        run: |
+          set -euo pipefail
+          OUT="apps/fanfare/.output/server/node_modules/@libsql"
+          # Derive the version from the x64 package that was actually installed,
+          # so the two architectures can never drift apart.
+          VERSION="$(node -p "require('./$OUT/linux-x64-gnu/package.json').version")"
+          echo "libsql native addon version: $VERSION"
+
+          TMP="$(mktemp -d)"
+          ( cd "$TMP" && npm pack "@libsql/linux-arm64-gnu@$VERSION" >/dev/null )
+          tar -xzf "$TMP"/*.tgz -C "$TMP"
+          mkdir -p "$OUT/linux-arm64-gnu"
+          cp -R "$TMP/package/." "$OUT/linux-arm64-gnu/"
+
+          echo "platform packages now bundled:"
+          ls -1 "$OUT"
+          # Prove the arm64 binary really is arm64 — a same-arch copy would
+          # silently reintroduce the bug this step exists to fix.
+          file "$OUT/linux-arm64-gnu/index.node"
+          file "$OUT/linux-arm64-gnu/index.node" | grep -q -i "aarch64\|arm64" \
+            || { echo "::error::bundled arm64 addon is not an aarch64 binary"; exit 1; }
+
+      - name: Smoke the bundle (it must actually boot)
+        # The bug in #1680 shipped green: nothing in this pipeline ever STARTED
+        # the artifact. Booting it here is what turns "it built" into "it runs".
+        run: |
+          set -euo pipefail
+          cd apps/fanfare/.output
+          BETTER_AUTH_SECRET=smoke NITRO_PORT=3999 node server/index.mjs & PID=$!
+          for _ in $(seq 1 30); do
+            if curl -fsS -o /dev/null "http://127.0.0.1:3999/" 2>/dev/null; then
+              echo "bundle booted and served a response"
+              kill $PID 2>/dev/null || true
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::the built bundle did not serve a response within 30s"
+          kill $PID 2>/dev/null || true
+          exit 1
+
       - name: Assemble the bundle
         id: bundle
         run: |


### PR DESCRIPTION
Closes #1680

## 👤 For humans

The bundle published yesterday only ran on **x86-64**. On a Raspberry Pi — the actual venue till this epic exists for — it died at boot:

```
Error: Cannot find module '@libsql/linux-arm64-gnu'
```

Now one tarball runs on both, and **CI boots the bundle before publishing it**.

## 🤖 For agents

`libsql` ships its native addon as per-platform optional packages, so a build on the x64 runner installed only `@libsql/linux-x64-gnu`.

**Two new steps, before assembling the tarball:**

1. **Add the arm64 addon.** Fetches `@libsql/linux-arm64-gnu` at the version derived from the *installed* x64 package, so the two can never drift, and copies it into the output. Then asserts via `file` that the result really is aarch64 — a same-arch copy would silently reintroduce the exact bug this step exists to prevent.
2. **Smoke the bundle.** Boots `server/index.mjs` and waits for a response. This is the important one: **#1680 shipped green because nothing in the pipeline ever started the artifact.** A build that succeeds is not a bundle that runs, and this workflow now knows the difference.

Rejected: per-arch tarballs on an arm64 runner (needs a runner we have not wired; two artifacts to keep in sync for ~5MB) and `npm install` on the box (adds npm + network as a runtime dependency, against the download-and-run design).

## 🧪 How to test

Verified locally against the real published version:

```bash
npm pack @libsql/linux-arm64-gnu@0.5.29
tar -xzf ./*.tgz && file package/index.node
# → ELF 64-bit LSB shared object, ARM aarch64 ✅
```

Workflow re-parsed with `YAML.parse` — 11 steps, triggers intact.

After merge, cut a fresh release and confirm:

```bash
gh release download <tag> --pattern "fanfare-venue.tar.gz"
tar -xzf fanfare-venue.tar.gz
ls fanfare-venue/output/server/node_modules/@libsql/   # expect BOTH linux-* packages
```

## ⚠️ What this does not prove

**Actual boot on a Pi.** That needs arm64 hardware. This change guarantees the correct binary ships and that the bundle boots in CI on x64. The Pi run remains the real acceptance test, and the mac-mini fleet cannot stand in for it (arm64, but macOS not Linux).