### PR TITLE
fix(root): discover the @libsql path instead of hardcoding it (#1680)

### DIFF
--- a/.github/workflows/release-venue-bundle.yml
+++ b/.github/workflows/release-venue-bundle.yml
@@ -78,10 +78,35 @@ jobs:
         # Ship both so one tarball runs anywhere and install.sh stays dumb.
         run: |
           set -euo pipefail
-          OUT="apps/fanfare/.output/server/node_modules/@libsql"
-          # Derive the version from the x64 package that was actually installed,
-          # so the two architectures can never drift apart.
-          VERSION="$(node -p "require('./$OUT/linux-x64-gnu/package.json').version")"
+          ROOT="apps/fanfare/.output"
+
+          # DISCOVER the directory rather than hardcode it: where Nitro traces
+          # @libsql to inside .output is not guaranteed to be one fixed path,
+          # and a wrong guess here fails the whole release (it did once).
+          OUT="$(find "$ROOT" -type d -name '@libsql' -print -quit 2>/dev/null || true)"
+
+          if [ -z "$OUT" ]; then
+            echo "::notice::no @libsql in $ROOT — this build does not carry the native addon, nothing to patch"
+            exit 0
+          fi
+          echo "found @libsql at: $OUT"
+          ls -1 "$OUT"
+
+          if [ -d "$OUT/linux-arm64-gnu" ]; then
+            echo "arm64 addon already present — nothing to do"
+            exit 0
+          fi
+
+          # Derive the version from the x64 package that was actually installed
+          # so the two architectures can never drift apart. Read the file
+          # directly — `require()` of a relative path from `node -e` resolves
+          # against the eval module, not reliably against the workdir.
+          X64_PKG="$OUT/linux-x64-gnu/package.json"
+          if [ ! -f "$X64_PKG" ]; then
+            echo "::error::expected $X64_PKG; @libsql contains:"; ls -1 "$OUT"
+            exit 1
+          fi
+          VERSION="$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).version" "$X64_PKG")"
           echo "libsql native addon version: $VERSION"
 
           TMP="$(mktemp -d)"


### PR DESCRIPTION
Follow-up to #1681 — that merged before this fix landed, so the release workflow on `main` is currently broken.

## 👤 For humans

The arm64 step I added in #1681 **fails the release run**:

```
Error: Cannot find module
  ./apps/fanfare/.output/server/node_modules/@libsql/linux-x64-gnu/package.json
```

Merge this and the workflow runs again.

## 🤖 For agents

Two faults, both mine:

1. **Hardcoded path.** I took it from one observed artifact. Where Nitro traces `@libsql` inside `.output` is not guaranteed, and a wrong guess kills the entire release. It now **discovers** the directory with `find`, and skips cleanly (`::notice`, exit 0) when a build carries no native addon at all.
2. **`require()` from `node -p`.** `require(./relative/path)` resolves against the eval module, not dependably against the workdir. Now reads the file via `fs` with the path passed as `argv`.

Also hardened: exits early when the arm64 package is already present (idempotent), and on a missing x64 package prints the actual `@libsql` contents *before* failing — so the next run diagnoses itself instead of costing another round trip.

## 🧪 How to test

I executed the step logic against the real published bundle rather than reading it:

```
discovered  sim/.output/server/node_modules/@libsql
version     0.5.29
after       client core hrana-client isomorphic-ws linux-arm64-gnu linux-x64-gnu
guard       ELF 64-bit ... ARM aarch64 → passes
re-run      exits early
```

Workflow re-parsed with `YAML.parse`: 11 steps.

After merge: Actions → **Release venue bundle** → Run workflow → a new tag (e.g. `venue-2026.08.03b`). The new smoke step will boot the bundle before publishing, so a broken artifact fails the run instead of shipping.