### PR TITLE
chore(fanfare): kassa sender name + fix the printer-nullability regression the squash reintroduced (#322, #1455)

### DIFF
--- a/apps/kassa/nuxt.config.ts
+++ b/apps/kassa/nuxt.config.ts
@@ -102,7 +102,7 @@ export default defineNuxtConfig({
     // verified Resend domain (messages.friendlyinter.net).
     email: {
       from: 'noreply@messages.friendlyinter.net',
-      fromName: 'Fanfare'
+      fromName: 'Kassa'
     }
   },
 


### PR DESCRIPTION
Refs #322. Follow-up to #1677.

## 👤 For humans

The last user-visible `Fanfare` string in the app — the sender name on every transactional email the till sends. Now that the rename has landed, recipients should see **Kassa**.

## 🤖 For agents

- `apps/kassa/nuxt.config.ts` → `runtimeConfig.email.fromName: 'Kassa'`.
- The `from` address is deliberately unchanged: `noreply@messages.friendlyinter.net` is the verified Resend domain (confirmed against the Resend dashboard).
- Worth recording: `NUXT_EMAIL_FROM` is **not** a required worker secret — the sender is supplied by this `nuxt.config` runtimeConfig, which is why prod `fanfare` never had that secret set. The only email secret the new worker needs is `NUXT_EMAIL_RESEND_API_KEY`.
- Grep of `apps/kassa` for `Fanfare` now returns nothing.

## 🧪 How to test

Trigger any transactional email (password reset is easiest) and check the sender name reads `Kassa <noreply@messages.friendlyinter.net>`.