### PR TITLE
fix(root): warn when a PR's Closes targets an epic, and document Refs

### DIFF
--- a/.claude/skills/github-tasks/SKILL.md
+++ b/.claude/skills/github-tasks/SKILL.md
@@ -113,7 +113,16 @@ So an issue closes by **either** path — `Closes #NN` on a merged PR, **or** a 
 
 ### Closing a child? Always check the parent (REQUIRED — do it the moment the PR merges *or the task is answered*)
 
-A merged PR auto-closes the issues in its `Closes #NN` lines — but **a parent epic has no `Closes` line of its own, so it never auto-closes**, and a fully-delivered epic left open is the most common stale-tracking bug. So **the instant you close an issue — or a PR merges that auto-closes one — walk up the tree, unprompted.** Don't wait to be asked and don't defer it to a later task: closing the leaf is not "done" until you've checked the branch above it. Closing the epic travels *with* the merge that closes its last child — same logical step, not a follow-up someone has to remember.
+A merged PR auto-closes the issues in its `Closes #NN` lines — but **a parent epic has no `Closes` line of its own, so it never auto-closes**, and a fully-delivered epic left open is the most common stale-tracking bug.
+
+> **⚠️ An epic-integration PR uses `Refs #NN`, never `Closes #NN` (#1690).** That "an epic has
+> no `Closes` line" is an *assumption this whole flow rests on*, not something GitHub enforces —
+> and epic #1652 broke it: its integration PR wrote `Closes #1652`, so merging closed the epic
+> instantly, skipping the `/close-epic` gate (step 4) and landing the postmortem *after* the
+> close it was meant to precede. Write `Refs #NN` on the epic→`main` PR and close via
+> `/close-epic`. **Sub-issue PRs keep `Closes #NN`** — the resume merge-on-approval step
+> identifies the gate PR by exactly that string (#1663), so don't "fix" those too. CI warns on
+> a closing keyword aimed at an `epic`-labelled issue (`warn-closes-blocked.yml`). So **the instant you close an issue — or a PR merges that auto-closes one — walk up the tree, unprompted.** Don't wait to be asked and don't defer it to a later task: closing the leaf is not "done" until you've checked the branch above it. Closing the epic travels *with* the merge that closes its last child — same logical step, not a follow-up someone has to remember.
 
 1. Resolve the parent: `mcp__github__issue_read` (`method: get`) → `parent_issue_url`, or read the epic's `get_sub_issues`.
 2. If the issue has a parent, check whether **all** of the parent's children are now `closed` (`get_sub_issues` → every child's `state`).

--- a/.github/workflows/warn-closes-blocked.yml
+++ b/.github/workflows/warn-closes-blocked.yml
@@ -1,8 +1,17 @@
-name: Warn on Closes of a blocked issue
+name: Warn on a risky Closes
 
+# Two shapes of `Closes #NN` that fire the moment a PR merges and defeat a gate:
+#
 # (#1253, Fix B) A root-cause-fix PR that writes `Closes #<retest issue>` auto-closes a
 # `status:blocked` issue out from under the owner's pending reply — the #1233/#1234 race,
 # where the resume then ran against a closed, superseded issue.
+#
+# (#1690) An epic-integration PR that writes `Closes #<epic>` closes the epic on merge,
+# skipping the `/close-epic` gate that exists so the postmortem runs first (#856/#403).
+# Epic #1652 closed exactly this way and its retro landed after the close it was meant
+# to precede. NOTE the asymmetry: a SUB-ISSUE PR should keep `Closes #NN` — the resume
+# merge-on-approval step identifies the gate PR by it (#1663). Only the epic-level PR
+# switches to `Refs`.
 #
 # WARNING ONLY — deliberately NOT a required check. Closing a blocked issue via `Closes`
 # is the NORMAL flow for sign-off gate PRs: resume-on-comment's merge-on-approval step
@@ -40,17 +49,28 @@ jobs:
             const nums = [...new Set([...body.matchAll(re)].map(m => Number(m[1])))]
             if (!nums.length) { core.info('No closing references in the PR body.'); return }
 
+            const has = (issue, name) => (issue.labels || [])
+              .some(l => (typeof l === 'string' ? l : l.name) === name)
+
             const blocked = []
+            const epics = []
             for (const issue_number of nums) {
               try {
                 const issue = (await github.rest.issues.get({ ...context.repo, issue_number })).data
                 if (issue.pull_request) continue // a PR reference, not an issue
-                const isBlocked = (issue.labels || [])
-                  .some(l => (typeof l === 'string' ? l : l.name) === 'status:blocked')
-                if (issue.state === 'open' && isBlocked) blocked.push(issue_number)
+                if (issue.state !== 'open') continue
+                if (has(issue, 'status:blocked')) blocked.push(issue_number)
+                // #1690: an EPIC must not be auto-closed by its own integration PR —
+                // that fires the moment the PR merges and silently walks past the
+                // postmortem gate (`/close-epic`, gated on status:ready-to-close, #856).
+                // Epic #1652 closed this way; its retro had to be posted after the close
+                // it was meant to precede.
+                if (has(issue, 'epic')) epics.push(issue_number)
               } catch (e) { core.warning(`could not check #${issue_number}: ${e.message}`) }
             }
-            if (!blocked.length) { core.info('No open status:blocked issues referenced.'); return }
+            if (!blocked.length && !epics.length) {
+              core.info('No open status:blocked or epic issues referenced.'); return
+            }
 
             // Warn once per PR — dedupe on the marker so `edited` events don't re-post.
             const marker = '<!-- warn-closes-blocked -->'
@@ -60,10 +80,28 @@ jobs:
               core.info('Already warned on this PR.'); return
             }
 
-            const list = blocked.map(n => `#${n}`).join(', ')
-            const plural = blocked.length > 1
+            const fmt = ns => ns.map(n => `#${n}`).join(', ')
+            const sections = []
+
+            if (blocked.length) {
+              const list = fmt(blocked)
+              const plural = blocked.length > 1
+              sections.push(
+                `🚫 **On merge this PR auto-closes ${list} — but ${plural ? 'they are' : 'it is'} \`status:blocked\` (awaiting an owner reply).**\n\n`
+                + `**Fix:** if this is a root-cause fix rather than the blocked work itself, use \`Refs ${list}\` instead of \`Closes\` — so merging doesn't close ${plural ? 'them' : 'it'} out from under the pending reply (the #1233 race).`)
+            }
+
+            if (epics.length) {
+              const list = fmt(epics)
+              const plural = epics.length > 1
+              sections.push(
+                `🚫 **On merge this PR auto-closes the epic${plural ? 's' : ''} ${list} — skipping the postmortem gate.**\n\n`
+                + `An epic is meant to close via \`/close-epic\`, which is gated on \`status:ready-to-close\` so the retro runs first (#856/#403). A closing keyword fires on merge and walks straight past that.\n\n`
+                + `**Fix:** use \`Refs ${list}\` in this PR body. After merging, post the verify rollup + postmortem, then comment \`/close-epic\` on the epic.\n\n`
+                + `_Sub-issue PRs are different — they should keep \`Closes #NN\`; the resume merge-on-approval step keys on it (#1663)._`)
+            }
+
             await github.rest.issues.createComment({ ...context.repo, issue_number: pr.number,
-              body: `${marker}\n🚫 **On merge this PR auto-closes ${list} — but ${plural ? 'they are' : 'it is'} \`status:blocked\` (awaiting an owner reply).**\n\n`
-                + `**Fix:** if this is a root-cause fix rather than the blocked work itself, use \`Refs ${list}\` instead of \`Closes\` — so merging doesn't close ${plural ? 'them' : 'it'} out from under the pending reply (the #1233 race).\n\n`
-                + `<sub>🤖 agent pipeline (CI) · closes-a-blocked-issue check (#1253) · warning only, not a required check</sub>` })
-            core.warning(`PR #${pr.number} Closes blocked issue(s): ${list}`)
+              body: `${marker}\n${sections.join('\n\n---\n\n')}\n\n`
+                + `<sub>🤖 agent pipeline (CI) · risky-\`Closes\` check (#1253/#1690) · warning only, not a required check</sub>` })
+            core.warning(`PR #${pr.number} risky Closes — blocked: ${fmt(blocked) || 'none'} · epics: ${fmt(epics) || 'none'}`)


### PR DESCRIPTION
Closes #1690

## 👤 For humans

An epic is meant to close via `/close-epic`, which is gated on `status:ready-to-close` so the postmortem runs first. `Closes #NN` in an epic's integration PR fires the moment it merges and walks straight past that gate.

Epic #1652 closed exactly that way this morning. Its retro was posted **after** the close it was supposed to precede, and nothing warned — the gate was built (#856) and a single conventional keyword defeated it.

## 🤖 For agents

### The interesting part: this was already an assumption, just not a rule

`github-tasks` states, as the premise of the whole walk-up step:

> *"a parent epic has no `Closes` line of its own, so it never auto-closes"*

That is an **assumption GitHub does not enforce**, written as though it were a fact. PR #1682 wrote `Closes #1652` and the assumption quietly failed. This PR turns it into a stated rule plus a warning.

### The asymmetry that matters

**Sub-issue PRs must keep `Closes #NN`.** The resume merge-on-approval step identifies the gate PR by that exact string (#1663 — fixed earlier today). A blanket "strip closing keywords" would undo that fix and re-break every sign-off gate.

Only the **epic-level** PR switches to `Refs`. This is spelled out in three places — the workflow header, the warning comment itself, and the skill — because a bare "use Refs" invites the next agent to over-apply it.

### Changes

- `warn-closes-blocked.yml` → renamed **"Warn on a risky Closes"**. It already caught closing keywords aimed at `status:blocked` issues (#1253); it now also catches them aimed at `epic`-labelled ones. One comment, one section per problem found.
- `github-tasks` skill → the rule is explicit at the walk-up step, with the #1652 incident as its evidence.

Warning only, **deliberately not a required check**: a small epic may legitimately close inline, and a hard fail would be its own trap.

### Verification

The step's script was executed against stubbed GitHub APIs — 7 branches, all passing:

| # | Case | Expected | Result |
|---|---|---|---|
| A | `Closes` an `epic` issue | warns, and keeps the sub-issue caveat | ✅ |
| B | `Closes` a `status:blocked` issue | warns (no #1253 regression) | ✅ |
| C | both at once | **one** comment, two sections | ✅ |
| D | `Closes` an ordinary open issue | silent | ✅ |
| E | `Refs` an epic (the fix) | silent | ✅ |
| F | re-run with the marker present | deduped | ✅ |
| G | epic already closed | silent | ✅ |

Not verified: a live PR event end-to-end — see How to test.

## 🧪 How to test

1. Open a PR into `main` whose body says `Closes #<any open epic-labelled issue>`.
2. **Expect** a warning comment explaining the postmortem gate and telling you to use `Refs` — plus the note that sub-issue PRs keep `Closes`.
3. Edit the body to `Refs #NN`. **Expect** no second comment (the marker dedupes; the original stays as a record).
4. Regression #1253: a PR closing a `status:blocked` issue still warns.
5. Regression #1663: a sub-issue PR with `Closes #NN` into an `epic/*` branch still merges on `lgtm`.
