### PR TITLE
feat(root): reachability probe for issue-sanity-check

### DIFF
--- a/.claude/skills/issue-sanity-check/SKILL.md
+++ b/.claude/skills/issue-sanity-check/SKILL.md
@@ -36,6 +36,17 @@ Read the issue, then ask each — answer with one line of evidence (a link, a pa
    config flip that gets 90% of the value? (KISS — CLAUDE.md core principle.)
 6. **Net-negative?** — does it add surface/complexity we'll regret, contradict a current
    pattern, or block something more valuable? Sometimes the right move is to close it.
+7. **Target reachable?** — do the files the issue *names* actually render or execute? Run
+   `node scripts/check-issue-targets.mjs <issue-number>`. An issue can name dead code, and
+   building exactly to spec then ships something nobody can reach **while satisfying every
+   acceptance criterion** — #1657 specified an Import button in `ProductsTab.vue`, a component
+   mounted in no template.
+   > ⚠️ **Flag, never drop.** Zero references is a *hypothesis* (the #1149 deletion protocol,
+   > in reverse): this repo mounts things dynamically — directory scanners, the
+   > `croutonBlocks`/`croutonLayoutBlocks` registries, `@nuxt/kit` resolver paths. The probe
+   > already excuses file-routed paths (`server/api/**`, `app/pages/**`, auto-imported
+   > `utils`/`composables`) and registry entries, but verify before acting. The right verdict
+   > is **🔁 Reshape** — "build it, somewhere reachable; confirm where" — not 🛑.
 
 ## The verdict (REQUIRED output)
 
@@ -48,7 +59,7 @@ End with exactly one of:
   recommend closing `not_planned` / merging into the duplicate — **ask the owner before
   closing**, don't unilaterally bin their issue.
 
-Keep it tight — six one-line checks and a verdict, not an essay. The value is the *pause*, not
+Keep it tight — seven one-line checks and a verdict, not an essay. The value is the *pause*, not
 a long report.
 
 ## Recording it

--- a/scripts/check-issue-targets.mjs
+++ b/scripts/check-issue-targets.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * #1689 — reachability probe for `issue-sanity-check`.
+ *
+ * An issue can name a target file that is dead code. Building exactly to spec then ships
+ * something nobody can reach, while satisfying every acceptance criterion. That happened on
+ * #1657: it specified an Import button in `ProductsTab.vue`, a component mounted in no
+ * template. It was caught by reading the package docs, not by any gate.
+ *
+ * This answers one question per named path: **is anything going to render/execute this?**
+ *
+ * IT REPORTS A HYPOTHESIS, NEVER A VERDICT (the #1149 deletion protocol, in reverse).
+ * Zero static references does not prove death — this repo mounts things dynamically via
+ * directory scanners, `croutonBlocks`/`croutonLayoutBlocks` registries, and @nuxt/kit
+ * resolver paths. So an unreachable finding is a *reshape* prompt for a human, never a drop.
+ *
+ *   node scripts/check-issue-targets.mjs 1657          # probe an issue's named paths
+ *   node scripts/check-issue-targets.mjs path/to/a.vue # probe paths directly
+ *   node --test scripts/check-issue-targets.test.mjs
+ */
+import { execFileSync } from 'node:child_process'
+
+/** Roots whose files are worth probing. Anything else in a body is prose, not a target. */
+const REPO_ROOTS = ['packages/', 'apps/', 'pocs/', 'workers/', 'scripts/', 'e2e/', 'fixtures/']
+
+/**
+ * Paths that are reachable *by convention* — the file IS its own registration, so a
+ * zero-reference result means nothing. Probing these only produces false positives.
+ */
+const FILE_ROUTED = [
+  /(^|\/)server\/api\//,
+  /(^|\/)server\/routes\//,
+  /(^|\/)server\/plugins\//,
+  /(^|\/)server\/middleware\//,
+  /(^|\/)server\/utils\//, // Nitro auto-import
+  /(^|\/)app\/pages\//,
+  /(^|\/)app\/middleware\//,
+  /(^|\/)app\/plugins\//,
+  /(^|\/)app\/composables\//, // Nuxt auto-import
+  /(^|\/)app\/utils\//, // Nuxt auto-import
+  /(^|\/)app\.config\.ts$/,
+  /(^|\/)nuxt\.config\.ts$/,
+  /(^|\/)crouton\.config\.js$/,
+]
+
+/** Extract repo-relative paths from free text (an issue body). */
+export function extractPaths(text) {
+  if (!text) return []
+  const re = /\b((?:packages|apps|pocs|workers|scripts|e2e|fixtures)\/[\w@./[\]-]+\.(?:vue|ts|mjs|js|json))\b/g
+  const found = [...String(text).matchAll(re)].map(m => m[1])
+  return [...new Set(found)].filter(p => REPO_ROOTS.some(r => p.startsWith(r)))
+}
+
+/** What kind of target is this, and is it reachable purely by convention? */
+export function classifyTarget(path) {
+  if (FILE_ROUTED.some(re => re.test(path))) {
+    return { kind: 'convention', symbol: basename(path) }
+  }
+  if (path.endsWith('.vue')) return { kind: 'component', symbol: basename(path) }
+  if (/\.(ts|mjs|js)$/.test(path)) return { kind: 'module', symbol: basename(path) }
+  return { kind: 'other', symbol: basename(path) }
+}
+
+function basename(path) {
+  return path.split('/').pop().replace(/\.(vue|ts|mjs|js|json)$/, '')
+}
+
+/**
+ * Decide one target's status from the references a caller found.
+ *
+ * `references` = [{ file, line }] — hits for the target's symbol ANYWHERE except the target
+ * file itself. The caller does the searching so this stays pure and testable.
+ */
+export function assessTarget({ path, references = [] }) {
+  const { kind, symbol } = classifyTarget(path)
+  if (kind === 'convention') {
+    return { path, symbol, kind, status: 'convention', evidence: 'file-based routing / auto-import — the file is its own registration' }
+  }
+
+  const outside = references.filter(r => r.file !== path)
+  const code = outside.filter(r => !/\.(md|mdc|txt)$/.test(r.file))
+  const registry = code.filter(r => /app\.config\.ts$|\.manifest\.ts$/.test(r.file))
+
+  if (registry.length) {
+    return { path, symbol, kind, status: 'registry', evidence: `registered in ${registry.map(r => r.file).join(', ')}` }
+  }
+  if (code.length) {
+    return { path, symbol, kind, status: 'reachable', evidence: `referenced in ${code.length} file(s), e.g. ${code[0].file}` }
+  }
+  const docsOnly = outside.length > 0
+  return {
+    path,
+    symbol,
+    kind,
+    status: 'unreachable',
+    evidence: docsOnly
+      ? `only mentioned in prose (${outside.map(r => r.file).join(', ')}) — no code references it`
+      : 'no references anywhere outside the file itself',
+  }
+}
+
+/** Render the sanity-check line(s). Unreachable targets are a RESHAPE prompt, never a drop. */
+export function formatReport(assessments) {
+  const bad = assessments.filter(a => a.status === 'unreachable')
+  if (!assessments.length) return '7. **Target reachable?** — n/a (the issue names no repo paths).'
+  if (!bad.length) {
+    return `7. **Target reachable?** — ✅ all ${assessments.length} named path(s) are reachable.`
+  }
+  const lines = bad.map(a => `   - \`${a.path}\` — ${a.evidence}`)
+  return [
+    `7. **Target reachable?** — 🔁 **${bad.length} of ${assessments.length} named path(s) appear unreachable:**`,
+    ...lines,
+    '',
+    '   Building here may ship something nobody can reach. **Confirm where it should live before building.**',
+    '   ⚠️ Zero references is a hypothesis, not proof — this repo mounts things dynamically',
+    '   (directory scanners, `croutonBlocks` registries, `@nuxt/kit` resolver paths). Verify, then reshape.',
+  ].join('\n')
+}
+
+/**
+ * What counts as *using* a target — deliberately not a bare symbol grep.
+ *
+ * A plain `git grep ProductsTab` "finds" it in two files that merely mention it in a code
+ * COMMENT, and reports the deadest component in the package as reachable. (Verified: that
+ * false negative is exactly what the first version of this script did.) So:
+ *
+ *  - a component is used when a TAG bears its name — `<SalesEventWorkspaceProductsTab`,
+ *    `<ProductsTab`, or the kebab form — with any auto-import prefix in front;
+ *  - a module is used when it is IMPORTED, not merely named.
+ */
+export function referenceQuery(kind, symbol) {
+  const kebab = symbol.replace(/([a-z\d])([A-Z])/g, '$1-$2').toLowerCase()
+  if (kind === 'component') {
+    // The trailing class MUST allow end-of-line: a multi-line tag
+    // (`<SalesEventWorkspaceProductImportPreview\n  :rows="…"`) has nothing after the
+    // name on its own line, and requiring a character there flagged live components.
+    return `<([A-Za-z0-9]*${symbol}|[a-z0-9-]*${kebab})([[:space:]/>]|$)`
+  }
+  return `(from|import|require)[^\\n]*${symbol}`
+}
+
+/**
+ * Registries mount by NAME, not by tag — `croutonBlocks`/`croutonLayoutBlocks` entries in an
+ * `app.config.ts`, and package manifests. A tag grep misses those entirely, so they get a
+ * plain name search scoped to just those files.
+ */
+export const REGISTRY_GLOBS = ['*app.config.ts', '*.manifest.ts']
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function sh(cmd, args) {
+  try { return execFileSync(cmd, args, { encoding: 'utf8' }) }
+  catch (e) { return e.stdout ?? '' }
+}
+
+const EXCLUDE = [':!*/dist/*', ':!*/node_modules/*', ':!*/.nuxt/*']
+
+/** Grep the repo for real usage of a target, excluding build output. */
+function findReferences(path) {
+  const { kind, symbol } = classifyTarget(path)
+  const lines = out => out.split('\n').filter(Boolean).map(file => ({ file }))
+
+  // 1. Real usage — a tag for a component, an import for a module.
+  const used = lines(sh('git', ['grep', '-l', '-E', referenceQuery(kind, symbol), '--', ...EXCLUDE]))
+  // 2. Registry mounts, which are names in a config rather than tags in a template.
+  const registered = lines(sh('git', ['grep', '-l', '-F', symbol, '--', ...REGISTRY_GLOBS, ...EXCLUDE]))
+
+  const seen = new Set()
+  return [...used, ...registered].filter(r => !seen.has(r.file) && seen.add(r.file))
+}
+
+function main(argv) {
+  const args = argv.slice(2)
+  if (!args.length) {
+    console.error('usage: check-issue-targets.mjs <issue-number | path...>')
+    process.exit(2)
+  }
+  let paths = args.filter(a => a.includes('/'))
+  if (!paths.length && /^\d+$/.test(args[0])) {
+    const body = sh('gh', ['issue', 'view', args[0], '--json', 'body', '--jq', '.body'])
+    paths = extractPaths(body)
+  }
+  const assessments = paths.map(path => assessTarget({ path, references: findReferences(path) }))
+  console.log(formatReport(assessments))
+  // Exit 0 always — this informs a human verdict, it does not gate anything.
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main(process.argv)

--- a/scripts/check-issue-targets.test.mjs
+++ b/scripts/check-issue-targets.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * #1689 contract — the reachability probe for `issue-sanity-check`.
+ *
+ * The case that minted it: #1657 named `ProductsTab.vue`, a component mounted in no template.
+ * Building exactly to spec would have shipped an unclickable button while satisfying every
+ * acceptance criterion.
+ *
+ *   node --test scripts/check-issue-targets.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { extractPaths, classifyTarget, assessTarget, formatReport, referenceQuery, REGISTRY_GLOBS } from './check-issue-targets.mjs'
+
+const TAB = 'packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue'
+const ENDPOINT = 'packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/products/import.post.ts'
+const BLOCK = 'packages/crouton-sales/app/components/Blocks/OrdersRender.vue'
+
+test('extractPaths pulls repo paths out of an issue body and ignores prose', () => {
+  const body = [
+    'Add the button to `' + TAB + '` and also edit',
+    'packages/crouton-sales/app/components/Client/OrderInterface.vue.',
+    'See https://example.com/not/a/path.html and the "products/import" endpoint.',
+  ].join('\n')
+  const paths = extractPaths(body)
+  assert.ok(paths.includes(TAB))
+  assert.ok(paths.includes('packages/crouton-sales/app/components/Client/OrderInterface.vue'))
+  assert.equal(paths.length, 2)
+})
+
+test('extractPaths dedupes a path named several times', () => {
+  assert.deepEqual(extractPaths(`${TAB} and again ${TAB}`), [TAB])
+})
+
+test('extractPaths returns nothing for a body with no paths', () => {
+  assert.deepEqual(extractPaths('Make the import faster, please.'), [])
+  assert.deepEqual(extractPaths(''), [])
+  assert.deepEqual(extractPaths(undefined), [])
+})
+
+test('file-routed targets are reachable by convention — never probed', () => {
+  for (const p of [
+    ENDPOINT,
+    'apps/fanfare/app/pages/admin/[team]/sales.vue',
+    'packages/crouton-sales/server/utils/plan-product-import.ts',
+    'packages/crouton-sales/app/composables/usePosOrder.ts',
+    'packages/crouton-sales/app/app.config.ts',
+  ]) {
+    assert.equal(classifyTarget(p).kind, 'convention', p)
+    assert.equal(assessTarget({ path: p, references: [] }).status, 'convention', p)
+  }
+})
+
+test('a component with no references anywhere is flagged unreachable (the #1657 case)', () => {
+  const a = assessTarget({ path: TAB, references: [] })
+  assert.equal(a.status, 'unreachable')
+  assert.match(a.evidence, /no references/)
+})
+
+test('a component mentioned ONLY in prose is still unreachable — docs are not a mount', () => {
+  const a = assessTarget({
+    path: TAB,
+    references: [{ file: 'packages/crouton-sales/CLAUDE.md' }, { file: TAB }],
+  })
+  assert.equal(a.status, 'unreachable')
+  assert.match(a.evidence, /only mentioned in prose/)
+})
+
+test('a component referenced from real code is reachable', () => {
+  const a = assessTarget({
+    path: TAB,
+    references: [{ file: 'packages/crouton-sales/app/components/EventWorkspace/Shell.vue' }],
+  })
+  assert.equal(a.status, 'reachable')
+})
+
+test('a registry-mounted block is reachable, not a false positive', () => {
+  const a = assessTarget({
+    path: BLOCK,
+    references: [{ file: 'packages/crouton-sales/app/app.config.ts' }],
+  })
+  assert.equal(a.status, 'registry')
+  assert.match(a.evidence, /registered in/)
+})
+
+test('a self-reference does not count as being reachable', () => {
+  assert.equal(assessTarget({ path: TAB, references: [{ file: TAB }] }).status, 'unreachable')
+})
+
+test('formatReport frames an unreachable target as reshape, with the dynamic-mount caveat', () => {
+  const out = formatReport([assessTarget({ path: TAB, references: [] })])
+  assert.match(out, /🔁/)
+  assert.match(out, /Confirm where it should live before building/)
+  assert.match(out, /hypothesis, not proof/)
+  assert.doesNotMatch(out, /🛑/) // never a drop
+})
+
+test('formatReport passes cleanly when everything is reachable', () => {
+  const out = formatReport([
+    assessTarget({ path: ENDPOINT, references: [] }),
+    assessTarget({ path: TAB, references: [{ file: 'x/Shell.vue' }] }),
+  ])
+  assert.match(out, /✅ all 2 named path\(s\)/)
+})
+
+test('formatReport says n/a when the issue names no paths', () => {
+  assert.match(formatReport([]), /n\/a/)
+})
+
+// ── referenceQuery: the two false positives found by running this against the real repo ──
+
+test('component query matches a MULTI-LINE tag (nothing after the name on its line)', () => {
+  const q = new RegExp(referenceQuery('component', 'ProductImportPreview').replace(/\[\[:space:\]/g, '[\\s'))
+  // The real mount in ProductImportModal.vue — attributes are on the following lines.
+  assert.ok(q.test('            <SalesEventWorkspaceProductImportPreview'))
+  assert.ok(q.test('  <SalesEventWorkspaceProductImportPreview :rows="rows"'))
+  assert.ok(q.test('  <ProductImportPreview/>'))
+})
+
+test('component query matches the kebab tag form too', () => {
+  const q = new RegExp(referenceQuery('component', 'ProductsTab').replace(/\[\[:space:\]/g, '[\\s'))
+  assert.ok(q.test('  <sales-event-workspace-products-tab :event="e" />'))
+})
+
+test('component query does NOT match a bare mention in a code comment', () => {
+  const q = new RegExp(referenceQuery('component', 'ProductsTab').replace(/\[\[:space:\]/g, '[\\s'))
+  // Both of these exist verbatim in the repo and made the first version report the
+  // deadest component in the package as reachable.
+  assert.equal(q.test('// ProductsTab). Always the render source so editable paths match.'), false)
+  assert.equal(q.test('`ProductsTab.vue` renders products as a drag-reorderable list'), false)
+})
+
+test('module query requires an import, not a mention', () => {
+  const q = new RegExp(referenceQuery('module', 'plan-product-import'))
+  assert.ok(q.test("import { planProductImport } from '../utils/plan-product-import'"))
+  assert.equal(q.test('// see plan-product-import for the pure planning'), false)
+})
+
+test('registry globs are scoped to config/manifest files only', () => {
+  assert.deepEqual(REGISTRY_GLOBS, ['*app.config.ts', '*.manifest.ts'])
+})


### PR DESCRIPTION
Closes #1689

## 👤 For humans

An issue can name a file that renders nowhere. Build exactly to spec and you ship something nobody can reach — **while ticking every acceptance box**.

That happened on #1657: it specified an Import button in `ProductsTab.vue`, a component mounted in no template. It was caught by reading the package docs, not by any gate. Check 7 of the sanity-check now asks *"will anything actually run this?"* before you build.

```
$ node scripts/check-issue-targets.mjs packages/crouton-sales/app/components/EventWorkspace/ProductsTab.vue
7. **Target reachable?** — 🔁 1 of 1 named path(s) appear unreachable:
   - `…/ProductsTab.vue` — no references anywhere outside the file itself
```

## 🤖 For agents

`scripts/check-issue-targets.mjs` — pure core (`extractPaths` / `classifyTarget` / `assessTarget` / `referenceQuery` / `formatReport`) plus a thin `git grep` CLI, mirroring `packages-guard.mjs`. Tests via `node --test`.

**It reports a hypothesis, never a verdict** — the #1149 deletion protocol in reverse. Output is a **🔁 Reshape** prompt carrying the dynamic-mount caveat; it structurally cannot emit 🛑. File-routed paths are excused by convention (`server/api`, `server/routes`, plugins, middleware, `app/pages`, auto-imported `utils`/`composables`) because the file *is* its own registration — probing those only manufactures false positives.

### The part worth reading: two false positives, found by running it, not by testing it

Both were caught only because I pointed the finished script at the real repo. The unit tests were green through both.

1. **A bare symbol grep reported the deadest component in the package as reachable.** `git grep ProductsTab` hits two files that mention it in *code comments*. Usage now means a **tag** for a component and an **import** for a module.
2. **Fixing that then flagged live components.** The tag pattern required a character *after* the name, but a multi-line tag ends the line there:
   ```vue
   <SalesEventWorkspaceProductImportPreview
     :rows="rows"
   ```
   The trailing class now allows end-of-line. Separately, registry mounts (`croutonBlocks` entries in an `app.config.ts`) are **names, not tags**, so they get a second name-scoped grep — otherwise every block would be flagged.

Each has a regression test asserting the exact strings that fooled it.

### Verification

Unit: **17 tests**, `node --test scripts/check-issue-targets.test.mjs`.

Against real repo files:

| File | Should | Result |
|---|---|---|
| `ProductsTab.vue` — mounted nowhere | flag | 🔁 |
| `ProductImportPreview.vue` — mounted in the modal | pass | ✅ |
| `Shell.vue` — mounted in pages | pass | ✅ |
| `Blocks/OrdersRender.vue` — registry-mounted | pass | ✅ |
| `server/utils/plan-product-import.ts` — auto-imported | pass | ✅ |

`npx fallow audit` clean on all 3 changed files.

**Known limits (accepted):** it greps text, so a component referenced only through a computed/dynamic name is invisible — which is exactly why the output is advisory. It probes only paths *named in the issue body*; an issue that names no files gets `n/a`.

## 🧪 How to test

1. `node scripts/check-issue-targets.mjs 1657` → **expect** `ProductsTab.vue` flagged 🔁, with the dynamic-mount caveat and no 🛑.
2. `node scripts/check-issue-targets.mjs 1656` → **expect** ✅; its target is a `server/api/**` route, reachable by convention.
3. `node scripts/check-issue-targets.mjs packages/crouton-sales/app/components/Blocks/OrdersRender.vue` → **expect** ✅ (registry-mounted, not a false positive).
4. `node --test scripts/check-issue-targets.test.mjs` → 17 pass.
