### PR TITLE
fix(root): hold a wave whose epic branch is red

### DIFF
--- a/.github/workflows/schedule-waves.yml
+++ b/.github/workflows/schedule-waves.yml
@@ -16,15 +16,31 @@ name: Wave scheduler
 # bot-actor guard via its `allowed_bots` allow-list (see decompose-on-issue.yml). Retires the human
 # PAT. Needs Actions secrets HARNESS_APP_ID + HARNESS_APP_PRIVATE_KEY, and the App granted Issues: write.
 
+# GREEN-BRANCH GATE (#1688): "blocker closed" is not the same as "the blocker works". On
+# epic #1652, #1655 merged a DELIBERATELY failing test contract (correct — that is the
+# test-first gate) and the run that writes the implementation then died on a provider quota.
+# #1655 closed, wave 2 released, and the epic branch carried 35 red tests and a throwing
+# parser for ~an hour. So a release now also checks the epic branch is not red.
+#
+# It must never STRAND a wave, so: only an outright `failure` holds (pending/unknown still
+# release — see scripts/wave-gate.mjs), and the `workflow_run` trigger below re-runs the scan
+# when CI finishes on an `epic/*` branch, releasing anything that was held. A held wave
+# therefore resolves itself with no human action.
+
 on:
   issues:
     types: [closed]
   pull_request:
     types: [closed]
+  # Retry path: CI finishing on an epic branch is what un-holds a wave held above.
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 permissions:
   contents: read
   issues: read
+  checks: read
 
 jobs:
   release:
@@ -41,12 +57,106 @@ jobs:
         with:
           app-id: ${{ secrets.HARNESS_APP_ID }}
           private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+      # Needed so the script can `require` the unit-tested gate decision (scripts/wave-gate.mjs).
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - uses: actions/github-script@v7
         with:
           # All calls use the App token so the addLabels event is actored as nuxt-harness[bot].
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo
+            const gate = await import(`${process.env.GITHUB_WORKSPACE}/scripts/wave-gate.mjs`)
+
+            /** Collapse an epic branch's CI into success | failure | pending | unknown. */
+            async function branchStatus(ref) {
+              if (!ref) return 'unknown'
+              try {
+                const runs = await github.paginate(github.rest.checks.listForRef,
+                  { owner, repo, ref, per_page: 100 })
+                return gate.summarizeChecks(runs)
+              } catch (e) {
+                // Never let a status lookup stall the chain — an unreadable ref is `unknown`,
+                // which releases.
+                core.warning(`check lookup failed for ${ref}: ${e.message}`)
+                return 'unknown'
+              }
+            }
+
+            /** The `epic/*` branch a closed issue's PR landed on, or null. */
+            async function epicBranchOf(issue_number) {
+              try {
+                const tl = await github.paginate(github.rest.issues.listEventsForTimeline,
+                  { owner, repo, issue_number, per_page: 100 })
+                const prs = [...new Set(tl
+                  .filter(e => e.event === 'cross-referenced' && e.source?.issue?.pull_request)
+                  .map(e => e.source.issue.number))]
+                for (const n of prs) {
+                  const pr = (await github.rest.pulls.get({ owner, repo, pull_number: n })).data
+                  if (pr.merged_at && /^epic\//.test(pr.base.ref)) return pr.base.ref
+                }
+              } catch (e) { core.warning(`epic-branch lookup failed for #${issue_number}: ${e.message}`) }
+              return null
+            }
+
+            /**
+             * Release every open dependent whose blockers are all closed — gated on its epic
+             * branch not being red. Shared by the issues-closed path and the CI-green retry.
+             */
+            async function releaseReady({ onlyBlockedBy = null, branch = null } = {}) {
+              const q = `repo:${owner}/${repo} is:issue is:open in:body "Blocked-by:"`
+              const found = await github.paginate(github.rest.search.issuesAndPullRequests, { q, per_page: 100 })
+
+              for (const it of found) {
+                const blockers = gate.parseBlockers(it.body)
+                if (!blockers.length) continue
+                if (onlyBlockedBy && !blockers.includes(onlyBlockedBy)) continue
+
+                const blockerStates = []
+                for (const b of blockers) {
+                  const bi = await github.rest.issues.get({ owner, repo, issue_number: b })
+                  blockerStates.push(bi.data.state)
+                }
+
+                // Which branch does this work land on? On the retry path we already know.
+                const ref = branch ?? await epicBranchOf(blockers[blockers.length - 1])
+                const status = ref ? await branchStatus(ref) : 'unknown'
+
+                const decision = gate.shouldRelease({ blockerStates, labels: it.labels, branchStatus: status })
+                if (!decision.release) {
+                  core.info(`#${it.number}: ${decision.reason}`)
+                  if (decision.reason === 'branch-red') {
+                    const comments = await github.paginate(github.rest.issues.listComments,
+                      { owner, repo, issue_number: it.number, per_page: 100 })
+                    if (!comments.some(c => (c.body || '').includes(gate.HOLD_MARKER))) {
+                      await github.rest.issues.createComment({ owner, repo, issue_number: it.number,
+                        body: gate.formatHoldComment({ issueNumber: it.number, branch: ref, doneNumber: onlyBlockedBy ?? blockers[blockers.length - 1] }) })
+                    }
+                  }
+                  continue
+                }
+
+                await github.rest.issues.addLabels({ owner, repo, issue_number: it.number, labels: ['delegate'] })
+                await github.rest.issues.createComment({ owner, repo, issue_number: it.number,
+                  body: gate.formatReleaseComment({ doneNumber: onlyBlockedBy ?? blockers[blockers.length - 1], branchStatus: status }) })
+                core.info(`Released #${it.number} (${decision.reason})`)
+              }
+            }
+
+            // CI finished on an epic branch → re-scan, releasing anything held for a red branch.
+            if (context.eventName === 'workflow_run') {
+              const wr = context.payload.workflow_run
+              if (!/^epic\//.test(wr.head_branch || '')) {
+                core.info(`CI finished on '${wr.head_branch}' (not an epic branch) — nothing to retry.`); return
+              }
+              if (wr.conclusion !== 'success') {
+                core.info(`CI on ${wr.head_branch} concluded '${wr.conclusion}' — still not releasable.`); return
+              }
+              core.info(`CI green on ${wr.head_branch} — retrying held waves.`)
+              await releaseReady({ branch: wr.head_branch })
+              return
+            }
 
             // 1) What just completed?
             // On a merged PR: sub-PRs merge into the EPIC branch, so GitHub does NOT
@@ -96,35 +206,7 @@ jobs:
             if (!done) return
             core.info(`Completed workstream: #${done}`)
 
-            // 2) Candidate dependents: open issues with a Blocked-by line.
-            const q = `repo:${owner}/${repo} is:issue is:open in:body "Blocked-by:"`
-            const found = await github.paginate(github.rest.search.issuesAndPullRequests, { q, per_page: 100 })
-            const reLine = /Blocked-by:\s*([#\d,\s]+)/i
-
-            for (const it of found) {
-              const mm = (it.body || '').match(reLine)
-              if (!mm) continue
-              const blockers = [...new Set((mm[1].match(/\d+/g) || []).map(Number))]
-              if (!blockers.includes(done)) continue
-
-              // Idempotency: already dispatched / in-flight?
-              const names = it.labels.map(l => (typeof l === 'string' ? l : l.name))
-              if (names.includes('delegate') || names.includes('status:in-progress')) {
-                core.info(`#${it.number} already dispatched — skip.`); continue
-              }
-
-              // 3) Fan-in: ALL blockers closed?
-              let allClosed = true
-              for (const b of blockers) {
-                const bi = await github.rest.issues.get({ owner, repo, issue_number: b })
-                if (bi.data.state !== 'closed') { allClosed = false; break }
-              }
-              if (!allClosed) { core.info(`#${it.number} still has open blockers — wait.`); continue }
-
-              // 4) Release: apply `delegate` (as the PAT user → human-actor trigger).
-              await github.rest.issues.addLabels({ owner, repo, issue_number: it.number, labels: ['delegate'] })
-              await github.rest.issues.createComment({ owner, repo, issue_number: it.number,
-                body: `🟢 **Unblocked — starting this workstream now.** Its last blocker (#${done}) just closed.\n\n`
-                  + `<sub>🤖 wave scheduler (#283) · applied \`delegate\`</sub>` })
-              core.info(`Released #${it.number}`)
-            }
+            // 2–4) Candidate dependents blocked by THIS issue: fan-in (all blockers closed),
+            // idempotency (not already dispatched) and the green-branch gate all live in
+            // releaseReady() above, shared with the CI-green retry path.
+            await releaseReady({ onlyBlockedBy: done })

--- a/scripts/wave-gate.mjs
+++ b/scripts/wave-gate.mjs
@@ -1,0 +1,88 @@
+/**
+ * #1688 — the wave scheduler's green-branch gate.
+ *
+ * `schedule-waves.yml` releases a dependent workstream when all its `Blocked-by:` issues are
+ * closed. "Closed" is not the same as "works": on epic #1652, #1655's job was to land a
+ * DELIBERATELY FAILING test contract (that is what the test-first gate is for), and the
+ * follow-up run that writes the implementation died on a provider quota. #1655 closed anyway,
+ * wave 2 released, and the epic branch carried 35 red tests and a throwing parser for about an
+ * hour. Nothing surfaced it — it was caught only because wave 2 went to call the parser.
+ *
+ * So the release also asks: **is the branch this work lands on actually green?**
+ *
+ * The decision lives here, pure and unit-tested, because the workflow it gates is the thing
+ * that releases every workstream in the repo — a bug here stalls or mis-starts all of them.
+ *
+ *   node --test scripts/wave-gate.test.mjs
+ */
+
+/** Dedupe marker so a held wave is explained once, not on every re-check. */
+export const HOLD_MARKER = '<!-- wave-gate:held -->'
+
+/** `Blocked-by: #454` / `Blocked-by: #275, #276` → [454] / [275, 276]. */
+export function parseBlockers(body) {
+  const m = String(body || '').match(/Blocked-by:\s*([#\d,\s]+)/i)
+  if (!m) return []
+  return [...new Set((m[1].match(/\d+/g) || []).map(Number))]
+}
+
+/** Already dispatched or being worked — never re-release. */
+export function isDispatched(labels = []) {
+  const names = labels.map(l => (typeof l === 'string' ? l : l.name))
+  return names.includes('delegate') || names.includes('status:in-progress')
+}
+
+/**
+ * Collapse a branch's check runs into one verdict.
+ *
+ * `queued`/`in_progress` ⇒ `pending`: CI that has not finished is NOT evidence of green, and
+ * releasing on it would reintroduce the very race this gate exists to stop. An empty list is
+ * `unknown` — no CI configured for that ref, which must not hard-block the chain.
+ */
+export function summarizeChecks(checkRuns = []) {
+  if (!checkRuns.length) return 'unknown'
+  const relevant = checkRuns.filter(r => !/^(skipped|neutral)$/.test(r.conclusion ?? ''))
+  if (!relevant.length) return 'unknown'
+  if (relevant.some(r => r.status !== 'completed')) return 'pending'
+  const bad = new Set(['failure', 'timed_out', 'action_required', 'cancelled'])
+  return relevant.some(r => bad.has(r.conclusion)) ? 'failure' : 'success'
+}
+
+/**
+ * Should this dependent be released?
+ *
+ * `branchStatus` is `summarizeChecks` over the epic branch head, or `unknown` when the work
+ * did not land on an `epic/*` branch at all (nothing to gate on).
+ *
+ * Deliberate asymmetry: only an outright `failure` holds. `pending` and `unknown` release.
+ * A gate that waits for green would deadlock the chain on any repo without CI for that ref,
+ * and this workflow has no timer to rescue it — the failure mode we are fixing is a SILENT
+ * bad release, not a slow one.
+ */
+export function shouldRelease({ blockerStates = [], labels = [], branchStatus = 'unknown' } = {}) {
+  if (isDispatched(labels)) return { release: false, reason: 'already-dispatched' }
+  if (!blockerStates.length) return { release: false, reason: 'no-blockers' }
+  if (blockerStates.some(s => s !== 'closed')) return { release: false, reason: 'blockers-open' }
+  if (branchStatus === 'failure') return { release: false, reason: 'branch-red' }
+  return { release: true, reason: branchStatus === 'success' ? 'green' : `ungated-${branchStatus}` }
+}
+
+/** The comment posted when a wave is held because its branch is red. */
+export function formatHoldComment({ issueNumber, branch, doneNumber }) {
+  return `${HOLD_MARKER}\n`
+    + `⏸️ **Not starting this workstream yet — \`${branch}\` is red.**\n\n`
+    + `Its last blocker (#${doneNumber}) closed, so the dependency chain is satisfied — but the branch it builds on currently fails CI. `
+    + `Starting here would build on top of code that does not work (epic #1652: a merged test contract whose implementation never landed left 35 red tests, and wave 2 released onto a throwing stub).\n\n`
+    + `**This releases itself** as soon as CI goes green on \`${branch}\` — no action needed. `
+    + `If the branch is red for an unrelated reason, apply \`delegate\` by hand to override.\n\n`
+    + `<sub>🤖 wave scheduler · green-branch gate (#1688/#283)</sub>`
+}
+
+/** The comment posted on a normal release. */
+export function formatReleaseComment({ doneNumber, branchStatus }) {
+  const suffix = branchStatus === 'success'
+    ? ' Its branch is green.'
+    : ''
+  return `🟢 **Unblocked — starting this workstream now.** Its last blocker (#${doneNumber}) just closed.${suffix}\n\n`
+    + `<sub>🤖 wave scheduler (#283) · applied \`delegate\`</sub>`
+}

--- a/scripts/wave-gate.test.mjs
+++ b/scripts/wave-gate.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * #1688 contract — the wave scheduler's green-branch gate.
+ *
+ * The incident it encodes: on epic #1652, #1655 merged a deliberately FAILING test contract
+ * (correct — that is the test-first gate), its implementation run then died on a provider
+ * quota, and the wave scheduler released wave 2 onto a branch with 35 red tests and a
+ * throwing parser.
+ *
+ *   node --test scripts/wave-gate.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseBlockers,
+  isDispatched,
+  summarizeChecks,
+  shouldRelease,
+  formatHoldComment,
+  formatReleaseComment,
+  HOLD_MARKER,
+} from './wave-gate.mjs'
+
+test('parseBlockers reads one and many blockers', () => {
+  assert.deepEqual(parseBlockers('Blocked-by: #454'), [454])
+  assert.deepEqual(parseBlockers('Blocked-by: #275, #276'), [275, 276])
+  assert.deepEqual(parseBlockers('body\n\nBlocked-by: #1655, #1656\n'), [1655, 1656])
+})
+
+test('parseBlockers dedupes and tolerates no line', () => {
+  assert.deepEqual(parseBlockers('Blocked-by: #5, #5'), [5])
+  assert.deepEqual(parseBlockers('no dependency line here'), [])
+  assert.deepEqual(parseBlockers(''), [])
+  assert.deepEqual(parseBlockers(undefined), [])
+})
+
+test('isDispatched catches both in-flight labels, in either shape', () => {
+  assert.equal(isDispatched(['delegate']), true)
+  assert.equal(isDispatched([{ name: 'status:in-progress' }]), true)
+  assert.equal(isDispatched([{ name: 'type:feat' }]), false)
+  assert.equal(isDispatched([]), false)
+})
+
+// ── summarizeChecks ──────────────────────────────────────────────────────────
+
+test('all completed + successful → success', () => {
+  assert.equal(summarizeChecks([
+    { status: 'completed', conclusion: 'success' },
+    { status: 'completed', conclusion: 'success' },
+  ]), 'success')
+})
+
+test('any failure → failure (the #1652 case)', () => {
+  assert.equal(summarizeChecks([
+    { status: 'completed', conclusion: 'success' },
+    { status: 'completed', conclusion: 'failure' },
+  ]), 'failure')
+})
+
+test('timed_out / cancelled / action_required all count as failure', () => {
+  for (const conclusion of ['timed_out', 'cancelled', 'action_required']) {
+    assert.equal(summarizeChecks([{ status: 'completed', conclusion }]), 'failure', conclusion)
+  }
+})
+
+test('unfinished CI is pending, never success — releasing on it reopens the race', () => {
+  assert.equal(summarizeChecks([
+    { status: 'completed', conclusion: 'success' },
+    { status: 'in_progress', conclusion: null },
+  ]), 'pending')
+  assert.equal(summarizeChecks([{ status: 'queued', conclusion: null }]), 'pending')
+})
+
+test('skipped and neutral runs are ignored, not treated as green', () => {
+  assert.equal(summarizeChecks([{ status: 'completed', conclusion: 'skipped' }]), 'unknown')
+  assert.equal(summarizeChecks([
+    { status: 'completed', conclusion: 'skipped' },
+    { status: 'completed', conclusion: 'failure' },
+  ]), 'failure')
+})
+
+test('no checks at all → unknown (must not hard-block a repo with no CI for that ref)', () => {
+  assert.equal(summarizeChecks([]), 'unknown')
+})
+
+// ── shouldRelease ────────────────────────────────────────────────────────────
+
+const CLOSED = ['closed', 'closed']
+
+test('THE #1652 CASE: blockers closed but branch red → held', () => {
+  const d = shouldRelease({ blockerStates: ['closed'], branchStatus: 'failure' })
+  assert.equal(d.release, false)
+  assert.equal(d.reason, 'branch-red')
+})
+
+test('blockers closed and branch green → released', () => {
+  const d = shouldRelease({ blockerStates: CLOSED, branchStatus: 'success' })
+  assert.equal(d.release, true)
+  assert.equal(d.reason, 'green')
+})
+
+test('an open blocker holds regardless of branch colour', () => {
+  assert.equal(shouldRelease({ blockerStates: ['closed', 'open'], branchStatus: 'success' }).reason, 'blockers-open')
+})
+
+test('an already-dispatched issue is never re-released', () => {
+  const d = shouldRelease({ blockerStates: CLOSED, labels: ['delegate'], branchStatus: 'success' })
+  assert.equal(d.release, false)
+  assert.equal(d.reason, 'already-dispatched')
+})
+
+test('pending and unknown still RELEASE — the gate stops silent-bad, not slow', () => {
+  // Deliberate: holding on pending/unknown would deadlock any chain whose ref has no CI,
+  // and this workflow has no timer to rescue it.
+  assert.equal(shouldRelease({ blockerStates: CLOSED, branchStatus: 'pending' }).release, true)
+  assert.equal(shouldRelease({ blockerStates: CLOSED, branchStatus: 'unknown' }).release, true)
+  assert.equal(shouldRelease({ blockerStates: CLOSED, branchStatus: 'unknown' }).reason, 'ungated-unknown')
+})
+
+test('no blockers → nothing to release', () => {
+  assert.equal(shouldRelease({ blockerStates: [], branchStatus: 'success' }).reason, 'no-blockers')
+})
+
+test('defaults are safe when called with nothing', () => {
+  assert.equal(shouldRelease().release, false)
+})
+
+// ── comments ─────────────────────────────────────────────────────────────────
+
+test('the hold comment is deduped, self-resolving and overridable', () => {
+  const c = formatHoldComment({ issueNumber: 1656, branch: 'epic/1652-sales-paste-import', doneNumber: 1655 })
+  assert.ok(c.startsWith(HOLD_MARKER))
+  assert.match(c, /epic\/1652-sales-paste-import` is red/)
+  assert.match(c, /releases itself/)       // no human action needed in the normal case
+  assert.match(c, /apply `delegate` by hand to override/) // but an escape hatch exists
+})
+
+test('the release comment names the blocker and only claims green when it is', () => {
+  assert.match(formatReleaseComment({ doneNumber: 1655, branchStatus: 'success' }), /Its branch is green/)
+  assert.doesNotMatch(formatReleaseComment({ doneNumber: 1655, branchStatus: 'unknown' }), /green/)
+})


### PR DESCRIPTION
Closes #1688

## 👤 For humans

The wave scheduler released a workstream as soon as its blockers **closed**. But "closed" is not "works".

On epic #1652, #1655's job was to land a **deliberately failing** test contract — that is exactly what the test-first gate is for. The follow-up run that writes the implementation then died on a provider quota. #1655 closed anyway, wave 2 released, and the epic branch sat with **35 red tests and a parser that threw on every call** for about an hour. Nothing flagged it; it surfaced only because wave 2 went to call the parser and found a stub.

A release now also asks whether the branch is red. **A held wave releases itself the moment CI goes green** — nobody has to remember it.

## 🤖 For agents

### Why the decision is a separate module

This workflow releases *every* workstream in the repo. A bug here stalls or mis-starts all of them, so `scripts/wave-gate.mjs` holds the decision as pure functions with 18 unit tests, and the workflow imports it (hence the added `checkout` and `checks: read`).

### Two deliberate asymmetries

Both exist so the fix doesn't trade a silent-bad release for a silent stall:

1. **Only `failure` holds.** `pending` and `unknown` still release. A gate that waited for green would deadlock any chain whose ref has no CI, and this workflow has no timer to rescue it. `queued`/`in_progress` map to `pending`, never to green — releasing on unfinished CI would reopen the race.
2. **A `workflow_run` trigger on CI completion for `epic/*` re-runs the scan**, so a held wave un-holds itself. The hold comment is deduped on a marker, says plainly that it self-resolves, and documents the manual `delegate` override for a branch that's red for unrelated reasons.

`skipped`/`neutral` runs are ignored rather than counted as green.

### Safe degradation

If the Harness App lacks `Checks: read`, the lookup throws, is caught, and returns `unknown` — i.e. **exactly today's behaviour**, not a stall. The gate can only ever be as strict as its permissions allow, never stricter than its ability to recover.

### Refactor note

`releaseReady()` is now shared by the issues-closed path and the CI-green retry; the old inline fan-in + idempotency loop collapses into it. Behaviour there is unchanged and covered by scenarios 5–7 below.

### Verification

**18 unit tests** on the decision (`node --test scripts/wave-gate.test.mjs`).

Plus the workflow's **own inline script executed against stubs** — 8 scenarios, all passing:

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | `workflow_run` on a non-epic branch | ignored | ✅ |
| 2 | `workflow_run`, epic branch, CI red | no release | ✅ |
| 3 | `workflow_run`, epic branch, CI green | releases the held wave | ✅ |
| 4 | **the #1652 case** — blocker closed, branch red | held **and explained** | ✅ |
| 5 | blocker closed, branch green | released | ✅ |
| 6 | one blocker still open | held (no regression) | ✅ |
| 7 | already `delegate`-labelled | not re-released (no regression) | ✅ |
| 8 | no CI for the ref | **still releases** — never strands | ✅ |

`npx fallow audit` clean on all 3 changed files.

**Not verified:** a live `workflow_run` round-trip on a real epic branch — see How to test.

## 🧪 How to test

1. On a scratch `epic/*` branch, merge a sub-PR that lands a failing test, so its issue closes while the branch is red.
2. **Expect** the dependent wave to stay unlabelled, with a comment saying the branch is red and that it will start itself when CI goes green.
   **Before this PR:** it gets `delegate` immediately and builds on the broken code.
3. Push a fix so CI goes green on that branch. **Expect** the wave to release on its own, with no human action.
4. Regression: a dependent with a still-open second blocker stays held.
5. Regression: an already-`delegate`d issue is not labelled twice.
