### PR TITLE
feat(root): event-driven pi pipeline — context-on-issue + label handoff + loop-guards (#1685 WS2/WS3/WS4)

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -158,17 +158,25 @@ conventions (`frontend-review`), a11y (`/a11y`), or visual taste (`/ui-proposal`
   **already hold its result** — read it, confirm the PR/comment actually exists, and only then
   report. If the spawn didn't deliver, you are **not done**: spawn again (and wait), or do the
   work yourself. There is no fire-and-forget.
-- **Hand off by SPAWNING, never by LABELING (the #457 root cause).** To get a child issue
-  worked you **spawn** it with the `Agent` tool (a `task-decomposer` or `task-worker`) in
-  THIS run and wait for its result. **NEVER apply the `delegate` label to a sub-issue to
-  "dispatch" it.** `delegate` is the *human* entry trigger only: applied from inside a run
-  you are `claude[bot]`, so it re-enters `decompose-on-issue.yml` as a **bot actor** → the
-  bot-actor guard rejects that child run → it produces nothing; worse, a sub-issue dispatched
-  that way runs `/task-decompose` on *itself as a fresh epic off `main`*, where the real
-  epic's scaffold doesn't exist. (This is exactly how the #457 deploy stalled: the
-  orchestrator applied `delegate` to #456/#457 instead of spawning workers — both child runs
-  were bot-rejected, no PR, no deploy.) There is no label-based hand-off: spawn the agent, or
-  do the leaf's work yourself in this run.
+- **Hand off by SPAWNING, never by LABELING — UNLESS you are in event-driven mode (#1685 WS3).**
+  In the **default (in-process / claude) mode** you get a child worked by **spawning** it with the
+  `Agent` tool (a `task-decomposer` or `task-worker`) in THIS run and waiting for its result.
+  **NEVER apply the `delegate` label to a sub-issue to "dispatch" it here:** applied from inside a
+  claude run you are `claude[bot]`, so it re-enters `decompose-on-issue.yml` as a **disallowed bot
+  actor** → the bot-actor guard rejects that child run → it produces nothing; worse, a sub-issue
+  dispatched that way runs `/task-decompose` on *itself as a fresh epic off `main`*, where the real
+  epic's scaffold doesn't exist. (This is exactly how the #457 deploy stalled: the orchestrator
+  applied `delegate` to #456/#457 instead of spawning workers — both child runs were bot-rejected,
+  no PR, no deploy.)
+  **The one sanctioned exception — event-driven mode (`PIPELINE_MODE=event-driven`, the pi harness):**
+  pi-claude-cli can't drive an in-process `Agent` tree, so there the decomposer hands off by
+  **labeling** (`work-this` / `delegate-pi`) **via the Harness App token** (`GH_TOKEN`) and STOPS —
+  a fresh single-use run works each child. That path is safe because the App token is actored as
+  `nuxt-harness[bot]` — the **one allowed bot** whose adds cascade and pass the guard — so #457 stays
+  dead for every *other* bot. Labels MUST go through the App-token `gh` (not the MCP tool, which uses
+  the human PAT and won't cascade). The invariants that keep it from looping are the pure, unit-tested
+  `scripts/pipeline-loop-guard.mjs` (bot-actor · exact-label · depth cap) — see `task-decomposer.md`
+  → “Event-driven mode”. Outside that one mode, the rule is unchanged: spawn, or do the leaf yourself.
 - **A directly-dispatched child resolves to its parent's epic branch — never a new epic off
   `main`.** When `/task-decompose` is invoked on an issue that is itself a **sub-issue** (its
   `parent_issue_url` is set / it carries a parent epic), do **NOT** mint a fresh

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -29,6 +29,22 @@ Repo: `FriendlyInternet/nuxt-crouton`. Honour the `github-tasks` skill for every
 pipeline is building on — pass it straight through to any child decomposer **and** to the
 worker you spawn, so everything branches off it (not `main`). See the task-decompose skill.
 
+### Two hand-off modes (pick by `PIPELINE_MODE`)
+
+Run `echo "$PIPELINE_MODE"` (Bash) **once at the start**. It selects how you hand a child off:
+
+- **Unset / anything but `event-driven` → IN-PROCESS mode (default, the claude harness).**
+  You hand off by **spawning** a child decomposer or a worker via the `Agent` tool and waiting
+  for it (Steps 3–4 as written). This is the proven flow; nothing below changes it.
+- **`event-driven` → LABEL mode (the pi harness, #1685 WS3).** pi-claude-cli can't drive an
+  in-process `Agent` tree, so instead of spawning you **write the WS2 context block onto each
+  child and apply a trigger label via the Harness App token**, then **STOP** — a fresh single-use
+  workflow run picks each child up. See **“Event-driven mode”** below; it overrides Steps 3–4.
+
+When context (`depth`/`epic`/`epic_branch`) isn't in your prompt (a fresh single-use run has no
+Agent prompt), read it off the issue's WS2 block:
+`gh issue view <n> --json body -q .body | node scripts/pipeline-context.mjs read` → `{ epic, depth, epic_branch }`.
+
 ## Step 1 — Read & understand
 
 `mcp__github__issue_read` (method `get`) on `issue_number`. If the issue already has
@@ -97,18 +113,72 @@ Spawn one `task-worker` via the `Agent` tool:
 
 Report: "issue #N is leaf-sized (or at depth cap) → worker spawned in worktree". Stop.
 
+## Event-driven mode (`PIPELINE_MODE=event-driven`) — LABEL, don't spawn (#1685 WS3)
+
+When `PIPELINE_MODE` is `event-driven`, **replace Steps 3 and 4** with the label hand-off below.
+Everything else — Step 1 (read), Step 2 (LEAF TEST), the caps — is unchanged. You **never** call
+the `Agent` tool in this mode; a fresh workflow run works each child.
+
+**The load-bearing rule: apply labels with the App-token `gh`, NOT the MCP GitHub tool.**
+The workflow put the Harness App token in `GH_TOKEN`. A label applied via `gh issue edit … --add-label`
+is actored as **`nuxt-harness[bot]`** — the one allowed bot — so the downstream run passes the
+bot-actor guard **and** the add *cascades* (re-triggers the workflow). A label applied via the
+`mcp__github__*` tools uses the human PAT: it may not cascade the trigger and muddies provenance.
+So: **labels → `Bash` + `gh` (App token); issue bodies/creates → either, but the WS2 block must be present.**
+
+Read `depth` from the issue's WS2 block first (`gh issue view <this> --json body -q .body | node scripts/pipeline-context.mjs read`);
+treat a missing `depth` as 0.
+
+**If this issue is a leaf (or `depth >= MAX_DEPTH`):**
+1. Ensure its body carries the WS2 block (epic, this depth, epic_branch) — upsert with
+   `node scripts/pipeline-context.mjs write epic=<e> depth=<d> epic_branch=<b>` piped through the body,
+   then `gh issue edit <this> --body-file -`.
+2. `gh issue edit <this> --add-label work-this` (App token). The single-use `work-issue-pidev`
+   worker picks it up and opens the PR. **Do not** also add `status:in-progress` — the worker
+   manages its own status, and an extra label here is noise (the exact-label gate ignores it, #535).
+3. Report "issue #N labelled `work-this` (event-driven leaf) → worker run will implement it". **Stop.**
+
+**If this issue still needs splitting (not a leaf, `depth < MAX_DEPTH`):**
+1. Derive 2–6 children exactly as Step 3 (coherent concerns, full two-audience body,
+   `## 🧪 How to test`, correct `type:*`/`pkg:*`/`app:*` labels, the `Dedup-checked: sub-issue of
+   #<this>` line). **Each child's body MUST include the WS2 block** for `depth = <this depth> + 1`,
+   same `epic`/`epic_branch` — build it with `node scripts/pipeline-context.mjs write epic=<e>
+   depth=<d+1> epic_branch=<b>` before creating. Link it under this issue with `sub_issue_write`.
+2. For **each** child, apply its trigger label via the App-token `gh` — pick with the LEAF TEST at
+   the child's depth (`d+1`):
+   - child is leaf-sized **or** `d+1 >= MAX_DEPTH` → `gh issue edit <child> --add-label work-this`
+   - child still needs splitting → `gh issue edit <child> --add-label delegate-pi` (a fresh
+     `decompose-on-issue-pidev` run recurses on it, in event-driven mode again).
+   This is the recursion, done across runs instead of in-process. The depth cap is what
+   guarantees termination: a `delegate-pi` chain always converges to `work-this` at `MAX_DEPTH`
+   (`scripts/pipeline-loop-guard.mjs` → `labelForChild` is the tested decision this mirrors).
+3. **Dependency order still holds.** If a child must land before a sibling, label only the
+   foundation child now; leave the dependents unlabelled and note them in a comment — an idempotent
+   re-dispatch (`delegate-pi` on this issue again) labels them once the foundation has merged.
+4. Report the children created + which labels were applied. **Stop** — no `Agent` spawn.
+
 ## Guardrails
 
 - **Never exceed MAX_DEPTH or MAX_CHILDREN.** These are not suggestions.
 - Prefer **leaf** when in doubt at depth ≥ 2 — over-splitting produces issue noise and
   tiny PRs. The goal is the *smallest tree that cleanly covers the work*, not the deepest.
-- You do not write feature code. Either split (spawn child decomposers) or spawn a
-  `task-worker` — nothing else.
-- **Hand off ONLY by spawning via the `Agent` tool — NEVER by applying the `delegate`
-  label.** Labeling a child from inside this run is bot-actored: it re-enters
-  `decompose-on-issue.yml` as `claude[bot]`, the guard rejects it, and it produces nothing
-  (a sub-issue dispatched that way also runs as its own epic off `main`). The #457 deploy
-  stalled exactly this way. Spawn the worker (Step 4), wait for it, and verify its PR exists.
+- You do not write feature code. You either **split** or **hand off a leaf** — nothing else. *How*
+  you do each depends on the mode: in-process ⇒ spawn a child decomposer / a `task-worker` via
+  `Agent`; event-driven ⇒ label the child `delegate-pi` / `work-this` via the App token (see above).
+- **Hand-off depends on the mode (read `PIPELINE_MODE`).**
+  - **IN-PROCESS mode (default):** hand off ONLY by **spawning** via the `Agent` tool — **NEVER**
+    by applying a `delegate`/`work-this` label. Labeling a child from inside a *claude* run is
+    actored as `claude[bot]`: it re-enters `decompose-on-issue.yml` as a disallowed bot, the guard
+    rejects it, and it produces nothing (a sub-issue dispatched that way also runs as its own epic
+    off `main`). The #457 deploy stalled exactly this way. Spawn the worker (Step 4), wait, verify
+    its PR exists.
+  - **EVENT-DRIVEN mode (`PIPELINE_MODE=event-driven`, #1685 WS3):** the ban is LIFTED, but only
+    for the **App-token** path. The workflow runs you as `nuxt-harness[bot]` (the one *allowed*
+    bot — the bot-actor guard passes it and its label-adds cascade), so here you hand off by
+    **labeling via `gh` with the App token** (`work-this` / `delegate-pi`) and STOP — never by
+    spawning. This is the deliberate reversal the App token (#1004/#626) unblocked; #457 stays
+    dead because the guard still rejects every *other* bot. Do **not** apply labels via the MCP
+    tool (human PAT — won't cascade). See “Event-driven mode” above.
 - Label every issue you create. Stick to the existing taxonomy (unknown label = error).
 
 ## Asking the human (async — never block)

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -27,6 +27,24 @@ If you are handed a free-text task instead of an issue number, STOP — the
 `/task-decompose` skill is responsible for creating the epic first. Ask for the epic
 number.
 
+### Hand-off mode (`PIPELINE_MODE`) — spawn vs label (#1685 WS3)
+
+Run `echo "$PIPELINE_MODE"` (Bash) once at the start. It changes only **how you hand a child
+off** in steps 2 & 8 — the slicing, the epic branch, the foundation checkpoint are identical:
+
+- **Unset / not `event-driven` → IN-PROCESS (default, claude harness):** spawn a `task-decomposer`
+  per child via the `Agent` tool and wait (steps 2 & 8 as written).
+- **`event-driven` → LABEL (pi harness):** pi-claude-cli can't drive an in-process `Agent` tree,
+  so you **do not spawn**. Instead, for each top-level child: write the WS2 pipeline block
+  (`node scripts/pipeline-context.mjs write epic=<epic> depth=1 epic_branch=<branch>` piped through
+  the child body → `gh issue edit <child> --body-file -`), then apply its trigger label **via the
+  App-token `gh`** (`GH_TOKEN` is the Harness App, so the add is `nuxt-harness[bot]`-actored →
+  passes the bot-actor guard and cascades) — `delegate-pi` normally, or `work-this` if the child is
+  already a ready leaf. Then **STOP**; a fresh `decompose-on-issue-pidev` run works each child.
+  Apply labels through `gh`, **never** the `mcp__github__*` tools (human PAT — won't cascade). This
+  is the same reversal `task-decomposer.md` documents; the loop-guards that keep it safe are the
+  unit-tested `scripts/pipeline-loop-guard.mjs`.
+
 ## Step 0 — Package-fit check (reuse before building) (#292)
 
 **Before** you slice the epic (step 4), check whether an existing `@fyit/crouton-*` package
@@ -215,11 +233,15 @@ just what you tell workers and how the approval propagates.
 - Label every issue (exactly one `type:*`, plus the component label). Applying a label
   that doesn't exist errors — stick to the taxonomy in `.github/labels.yml`.
 - Never push code or open PRs yourself.
-- **Never apply the `delegate` label to a child to "dispatch" it.** Hand a child off ONLY by
-  spawning a `task-decomposer`/`task-worker` via the `Agent` tool (steps 2 & 8), synchronously,
-  and verifying its PR/comment exists. Labeling from inside the run is bot-actored → the
-  guard rejects it → nothing happens (and the child runs as its own epic off `main`). This was
-  the #457 deploy stall.
+- **Hand-off mode (`PIPELINE_MODE`).** In the default **in-process** mode, hand a child off ONLY
+  by spawning a `task-decomposer`/`task-worker` via the `Agent` tool (steps 2 & 8), synchronously,
+  and verifying its PR/comment exists — **never** by applying a `delegate`/`work-this` label
+  (labeling from inside a *claude* run is bot-actored → the guard rejects it → nothing happens, and
+  the child runs as its own epic off `main`; the #457 deploy stall). **The one exception is
+  event-driven mode** (`PIPELINE_MODE=event-driven`, the pi harness): there you hand off by
+  **labeling `delegate-pi`/`work-this` via the App-token `gh`** and stopping — safe because the App
+  is `nuxt-harness[bot]`, the one allowed bot (see the mode note above). #457 stays dead for every
+  other bot.
 - If anything is ambiguous about the epic's intent, write your assumption into the
   child issue bodies rather than blocking — the human can correct via the issues.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,22 @@ jobs:
       - name: Check TypeScript types (attw)
         run: pnpm check:attw
 
+  # The pure `scripts/*.mjs` helpers (deploy-detect, packages-guard, harness-stages,
+  # pipeline-context, pipeline-loop-guard, …) carry `node --test` contracts next to them. This
+  # job runs them so those contracts actually GATE — most load-bearingly the #1685 WS4 loop-guard
+  # (bot-actor · exact-label · depth cap), which must hold before the decomposer emits labels.
+  # No pnpm install: the tests use only Node core + the local .mjs modules.
+  scripts-tests:
+    name: Scripts unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Run scripts/*.test.mjs
+        run: node --test scripts/*.test.mjs
+
   fallow-audit:
     # Rung 1 of the check ladder (#632): the codebase-intelligence gate (#1145).
     # `fallow audit` is diff-scoped — it judges only the changed code

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -112,26 +112,6 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      # ── BOT-ACTOR GUARD (#1004 piece 2) — re-expresses claude-code-action's `allowed_bots` ──
-      # The claude flow passes `allowed_bots: "nuxt-harness[bot]"`; pi has no such built-in, so we
-      # assert it ourselves as the FIRST step (fail fast, before minting any token). DORMANT under
-      # `workflow_dispatch` — the actor is the human dispatcher, so the `if` skips it. It ARMS the
-      # moment this flow is promoted to an `issues: labeled` trigger: only the Harness App's
-      # label-add (`nuxt-harness[bot]`) may drive the pipeline; any OTHER bot actor — e.g.
-      # `claude[bot]`/`github-actions[bot]` re-firing from a worker's own `status:in-progress`
-      # label change — is rejected here, breaking the bot re-fire loop (#457/#535). Humans pass.
-      - name: Bot-actor guard
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        env:
-          ACTOR: ${{ github.actor }}
-        run: |
-          ALLOWED="nuxt-harness[bot]"
-          if [[ "$ACTOR" == *"[bot]" && "$ACTOR" != "$ALLOWED" ]]; then
-            echo "::error::Bot-actor guard: '$ACTOR' may not drive the pi pipeline (only $ALLOWED). Refusing to run."
-            exit 1
-          fi
-          echo "Bot-actor guard OK (actor: $ACTOR)."
-
       # ── PUSH PATH (#1004 piece 1) — mint a Harness App token so pi's pushes CASCADE ──
       # Same app as automerge-epic-subpr.yml. A GITHUB_TOKEN push would NOT re-trigger
       # downstream workflows (#572); an App-installation token does.
@@ -146,6 +126,24 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}   # writes the App token into the git remote → pushes cascade
+
+      # ── BOT-ACTOR GUARD (#1004 piece 2) — re-expresses claude-code-action's `allowed_bots` ──
+      # The claude flow passes `allowed_bots: "nuxt-harness[bot]"`; pi has no such built-in, so we
+      # assert it ourselves before pi runs. DORMANT under `workflow_dispatch` — the actor is the
+      # human dispatcher, so the `if` skips it. On the `issues: labeled` path only the Harness App's
+      # label-add (`nuxt-harness[bot]`) may drive the pipeline; any OTHER bot actor — e.g.
+      # `claude[bot]`/`github-actions[bot]` re-firing from a worker's own `status:in-progress`
+      # label change — is rejected here, breaking the bot re-fire loop (#457/#535). Humans pass.
+      # This matters MORE now (#1685 WS3): the decomposer itself applies `delegate-pi`/`work-this`
+      # via the App token, so those cascading label-adds re-enter this flow as `nuxt-harness[bot]` —
+      # allowed — while every other bot actor is still refused. The decision is the pure, unit-tested
+      # `botActorAllowed` (WS4); this step is I/O only, so the SHIPPED guard IS the tested function.
+      # Contract: scripts/pipeline-loop-guard.test.mjs. (After checkout so the script is available.)
+      - name: Bot-actor guard
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        env:
+          ACTOR: ${{ github.actor }}
+        run: node scripts/pipeline-loop-guard.mjs bot-guard "$ACTOR"
 
       - uses: pnpm/action-setup@v4
         with:
@@ -184,6 +182,12 @@ jobs:
           PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
+          # WS3 (#1696), approach A — event-driven, label handoff. This flag tells the
+          # task-decomposer to hand each child off by LABELING it via the App token (already in
+          # GH_TOKEN) and STOP — not by spawning an in-process `Agent` tree (which pi-claude-cli
+          # can't drive). The claude flow (`decompose-on-issue.yml`) does NOT set this, so it keeps
+          # the proven in-process spawn. See .claude/agents/task-decomposer.md → "Event-driven mode".
+          PIPELINE_MODE: event-driven
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -113,26 +113,6 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      # ── BOT-ACTOR GUARD (#1004 piece 2) — re-expresses claude-code-action's `allowed_bots` ──
-      # The claude flow passes `allowed_bots: "nuxt-harness[bot]"`; pi has no such built-in, so we
-      # assert it ourselves as the FIRST step (fail fast, before minting any token). DORMANT under
-      # `workflow_dispatch` — the actor is the human dispatcher, so the `if` skips it. It ARMS the
-      # moment this flow is promoted to an `issues: labeled` trigger: only the Harness App's
-      # label-add (`nuxt-harness[bot]`) may drive the pipeline; any OTHER bot actor — e.g.
-      # `claude[bot]`/`github-actions[bot]` re-firing from a worker's own `status:in-progress`
-      # label change — is rejected here, breaking the bot re-fire loop (#457/#535). Humans pass.
-      - name: Bot-actor guard
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        env:
-          ACTOR: ${{ github.actor }}
-        run: |
-          ALLOWED="nuxt-harness[bot]"
-          if [[ "$ACTOR" == *"[bot]" && "$ACTOR" != "$ALLOWED" ]]; then
-            echo "::error::Bot-actor guard: '$ACTOR' may not drive the pi pipeline (only $ALLOWED). Refusing to run."
-            exit 1
-          fi
-          echo "Bot-actor guard OK (actor: $ACTOR)."
-
       # ── PUSH PATH (#1004 piece 1) — mint a Harness App token so pi's pushes CASCADE ──
       # Same app as automerge-epic-subpr.yml. A GITHUB_TOKEN push would NOT re-trigger
       # downstream workflows (#572); an App-installation token does.
@@ -147,6 +127,43 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}   # writes the App token into the git remote → pushes cascade
+
+      # ── BOT-ACTOR GUARD (#1004 piece 2) — re-expresses claude-code-action's `allowed_bots` ──
+      # The claude flow passes `allowed_bots: "nuxt-harness[bot]"`; pi has no such built-in, so we
+      # assert it ourselves before pi runs. DORMANT under `workflow_dispatch` — the actor is the
+      # human dispatcher, so the `if` skips it. On the `issues: labeled` path only the Harness App's
+      # label-add (`nuxt-harness[bot]`) may drive the pipeline; any OTHER bot actor — e.g.
+      # `claude[bot]`/`github-actions[bot]` re-firing from a worker's own `status:in-progress`
+      # label change — is rejected here, breaking the bot re-fire loop (#457/#535). Humans pass.
+      # The decision is the pure, unit-tested `botActorAllowed` (WS4 of #1685); this step is I/O
+      # only — so the SHIPPED guard IS the tested function. Contract: scripts/pipeline-loop-guard.test.mjs.
+      # (Placed after checkout so the script is available; the token minted above is unused if we exit.)
+      - name: Bot-actor guard
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        env:
+          ACTOR: ${{ github.actor }}
+        run: node scripts/pipeline-loop-guard.mjs bot-guard "$ACTOR"
+
+      # ── WS2 pipeline context (#1695) — read epic_branch/depth/epic OFF the issue body ──
+      # The single-use worker has no Agent-prompt channel; the parent wrote the context into a
+      # `<!-- pipeline: epic=.. depth=.. epic_branch=.. -->` block on the issue. Fetch the body via
+      # github-script (the API — these self-hosted runners don't guarantee the `gh` CLI at step
+      # level) so it works for BOTH the label trigger and a manual dispatch (where the body isn't in
+      # the event payload), write it to a file, then parse with the tested helper — exposing
+      # epic_branch as a step output so the pi prompt branches deterministically, not by grepping.
+      - name: Fetch issue body
+        id: body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
+            const { data } = await github.rest.issues.get({ ...context.repo, issue_number })
+            require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/issue-body.txt`, data.body || '')
+      - id: ctx
+        run: |
+          EPIC_BRANCH="$(node scripts/pipeline-context.mjs read epic_branch < "$RUNNER_TEMP/issue-body.txt")"
+          echo "epic_branch=${EPIC_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "pipeline context: epic_branch='${EPIC_BRANCH:-<none → main>}'"
 
       - uses: pnpm/action-setup@v4
         with:
@@ -185,6 +202,8 @@ jobs:
           PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
+          # WS2 (#1695): the integration branch parsed off the issue's pipeline block (empty → main).
+          EPIC_BRANCH: ${{ steps.ctx.outputs.epic_branch }}
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent
@@ -208,7 +227,15 @@ jobs:
           # SINGLE-USE WORKER (#1686): implement this ONE leaf — no decompose, no sub-issues,
           # no subagents. printf (single-quoted format, %s for ISSUE) — never backticks (they'd
           # command-substitute inside the shell).
-          printf 'IMPLEMENT this ONE leaf issue end-to-end. Do NOT decompose it, do NOT create sub-issues, do NOT spawn subagents — it is already a leaf. Read issue #%s (gh issue view %s). If its body has a "pipeline: epic_branch=<name>" line, branch off that integration branch and target the PR there; otherwise branch off main. Make the change, run pnpm typecheck, commit via the /commit skill, and open ONE pull request whose body FIRST line is literally "Closes #%s". Then STOP (never merge). If you are genuinely blocked, hold: post a top-level comment plus add the status:blocked label. Producing no PR and no hold is a FAILED run.\n' "$ISSUE" "$ISSUE" "$ISSUE" >> "$PROMPT_FILE"
+          # The integration branch is parsed OFF the issue's WS2 pipeline block by the `ctx` step
+          # (#1695) and passed in as EPIC_BRANCH — the worker no longer greps the body itself. When
+          # empty, branch off main. printf uses %s for every value (single-quoted format) — never
+          # backticks (they'd command-substitute in the shell).
+          BRANCH_INSTR="branch off main and target the PR at main"
+          if [ -n "${EPIC_BRANCH:-}" ]; then
+            BRANCH_INSTR="branch off the integration branch '${EPIC_BRANCH}' and target the PR THERE (not main)"
+          fi
+          printf 'IMPLEMENT this ONE leaf issue end-to-end. Do NOT decompose it, do NOT create sub-issues, do NOT spawn subagents — it is already a leaf. Read issue #%s (gh issue view %s), then %s. Make the change, run pnpm typecheck, commit via the /commit skill, and open ONE pull request whose body FIRST line is literally "Closes #%s". Then STOP (never merge). If you are genuinely blocked, hold: post a top-level comment plus add the status:blocked label. Producing no PR and no hold is a FAILED run.\n' "$ISSUE" "$ISSUE" "$BRANCH_INSTR" "$ISSUE" >> "$PROMPT_FILE"
           # Confirmed on the mac-mini (#888): pin provider + load skills via --skill.
           # GHA runs `run:` steps with bash -e; `set -uo pipefail` above does not clear it.
           # So the instant `pi | tee` fails (pipefail), -e aborts the script BEFORE

--- a/scripts/pipeline-context.mjs
+++ b/scripts/pipeline-context.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// pipeline-context.mjs — WS2 of epic #1685 (#1695): carry the pipeline's
+// { epic, depth, epic_branch } context ON the issue, so a fresh single-use run can read it.
+//
+// WHY this exists. The old in-process pipeline passed `{ epic, depth, epic_branch }` to a
+// child decomposer/worker via the `Agent` spawn prompt. The event-driven redesign (#1685)
+// has no such channel: `decompose-on-issue-pidev.yml` labels a child and STOPS; a brand-new
+// workflow run picks the child up with zero memory of the parent. So the context must live
+// on the issue body itself, in a machine-readable block that BOTH the decomposer
+// (`decompose-on-issue-pidev`) and the worker (`work-issue-pidev`) parse.
+//
+// THE FORMAT (canonical — this file is the one place it's defined, per #1695 acceptance):
+//
+//   <!-- pipeline: epic=1685 depth=2 epic_branch=epic/1685-single-use-pipeline -->
+//
+//   • An HTML comment, so it renders invisibly in the issue body.
+//   • `key=value` tokens, space-separated, in a single line. Keys: epic (int), depth (int),
+//     epic_branch (branch name; may contain `/` and `-`, never a space).
+//   • Any subset of keys may be present; absent keys parse to null.
+//   • Back-compat (#1686): WS1's worker read a bare `pipeline: epic_branch=<name>` line (no
+//     HTML-comment wrapper). `parsePipelineBlock` still reads that legacy shape so already-
+//     labelled issues keep working; `formatPipelineBlock` always emits the wrapped form.
+//
+// This module is PURE + unit-tested (pipeline-context.test.mjs). The workflows shell out to
+// the CLI at the bottom for the values they need (e.g. `... read epic_branch < body.txt`).
+
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+// The wrapped, canonical block: `<!-- pipeline: k=v k=v ... -->`. Tolerant of extra inner
+// whitespace. The legacy fallback below matches the bare `pipeline: ...` line WS1 emitted.
+const BLOCK_RE = /<!--\s*pipeline:\s*([^>]*?)\s*-->/i
+const LEGACY_RE = /^[ \t]*pipeline:\s*(.+?)\s*$/im
+
+// Keys we understand. Anything else in the block is ignored (forward-compatible).
+const INT_KEYS = new Set(['epic', 'depth'])
+const STR_KEYS = new Set(['epic_branch'])
+
+/** Parse the `k=v k=v` token string into a typed object. Unknown keys are dropped. */
+function parseTokens(tokenStr) {
+  const out = { epic: null, depth: null, epic_branch: null }
+  if (!tokenStr) return out
+  for (const tok of tokenStr.trim().split(/\s+/)) {
+    const eq = tok.indexOf('=')
+    if (eq < 1) continue
+    const key = tok.slice(0, eq)
+    const raw = tok.slice(eq + 1)
+    if (INT_KEYS.has(key)) {
+      const n = Number.parseInt(raw, 10)
+      out[key] = Number.isFinite(n) ? n : null
+    } else if (STR_KEYS.has(key)) {
+      out[key] = raw || null
+    }
+  }
+  return out
+}
+
+/**
+ * Read the pipeline block out of an issue body.
+ * Returns `{ epic, depth, epic_branch }` (each null when absent).
+ * Prefers the wrapped `<!-- pipeline: ... -->` form; falls back to the legacy bare line.
+ */
+export function parsePipelineBlock(body) {
+  if (!body || typeof body !== 'string') return { epic: null, depth: null, epic_branch: null }
+  const wrapped = body.match(BLOCK_RE)
+  if (wrapped) return parseTokens(wrapped[1])
+  const legacy = body.match(LEGACY_RE)
+  if (legacy) return parseTokens(legacy[1])
+  return { epic: null, depth: null, epic_branch: null }
+}
+
+/**
+ * Render the canonical wrapped block for the given context. Only the keys with a
+ * non-null/defined value are emitted, in a stable order (epic, depth, epic_branch).
+ * Returns null if nothing is worth writing (so callers can skip an empty block).
+ */
+export function formatPipelineBlock({ epic, depth, epic_branch } = {}) {
+  const toks = []
+  if (epic !== null && epic !== undefined && `${epic}` !== '') toks.push(`epic=${epic}`)
+  if (depth !== null && depth !== undefined && `${depth}` !== '') toks.push(`depth=${depth}`)
+  if (epic_branch) toks.push(`epic_branch=${epic_branch}`)
+  if (toks.length === 0) return null
+  return `<!-- pipeline: ${toks.join(' ')} -->`
+}
+
+/**
+ * Upsert the pipeline block into an issue body, idempotently. If a block (wrapped OR legacy)
+ * already exists it is REPLACED in place; otherwise the block is appended after a blank line.
+ * Passing the same context twice yields byte-identical output (idempotent — #1695 acceptance).
+ * If the merged context is empty, the body is returned unchanged (any existing block removed).
+ */
+export function writePipelineBlock(body, context = {}) {
+  const base = typeof body === 'string' ? body : ''
+  // Merge onto whatever is already there so a partial update (e.g. only depth) preserves the
+  // other keys. `null`/`undefined` in `context` mean "not supplied → keep the base value" (never
+  // "clear it") — so both the function contract (undefined) and the CLI write path (parseTokens
+  // yields null for absent keys) do a true partial update instead of nulling siblings.
+  const merged = { ...parsePipelineBlock(base), ...stripEmpty(context) }
+  const block = formatPipelineBlock(merged)
+
+  const hasWrapped = BLOCK_RE.test(base)
+  const hasLegacy = !hasWrapped && LEGACY_RE.test(base)
+
+  if (block === null) {
+    // Nothing to write — drop any existing block so the body doesn't keep a stale one.
+    if (hasWrapped) return base.replace(BLOCK_RE, '').replace(/\n{3,}/g, '\n\n').trimEnd()
+    if (hasLegacy) return base.replace(LEGACY_RE, '').replace(/\n{3,}/g, '\n\n').trimEnd()
+    return base
+  }
+  if (hasWrapped) return base.replace(BLOCK_RE, block)
+  if (hasLegacy) return base.replace(LEGACY_RE, block)
+  const sep = base.trim() === '' ? '' : `${base.replace(/\s+$/, '')}\n\n`
+  return `${sep}${block}`
+}
+
+function stripEmpty(obj) {
+  const out = {}
+  for (const [k, v] of Object.entries(obj)) if (v !== undefined && v !== null) out[k] = v
+  return out
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────────
+// Reads an issue body from stdin (or a file arg after the command), for the workflows.
+//   node scripts/pipeline-context.mjs read [<field>]   < body.txt
+//     • no field → prints JSON `{ epic, depth, epic_branch }`
+//     • field    → prints just that value (empty string when absent) — for `epic_branch=$(...)`
+//   node scripts/pipeline-context.mjs write epic=.. depth=.. epic_branch=..  < body.txt
+//     • prints the body with the block upserted
+function readStdin() {
+  try { return readFileSync(0, 'utf8') } catch { return '' }
+}
+
+function main(argv) {
+  const [cmd, ...rest] = argv
+  if (cmd === 'read') {
+    const ctx = parsePipelineBlock(readStdin())
+    const field = rest[0]
+    if (field) {
+      const v = ctx[field]
+      process.stdout.write(v === null || v === undefined ? '' : String(v))
+    } else {
+      process.stdout.write(JSON.stringify(ctx))
+    }
+    return
+  }
+  if (cmd === 'write') {
+    const ctx = parseTokens(rest.join(' '))
+    process.stdout.write(writePipelineBlock(readStdin(), ctx))
+    return
+  }
+  console.error('usage: node scripts/pipeline-context.mjs read [<field>] | write <k=v ...>   (body on stdin)')
+  process.exit(2)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main(process.argv.slice(2))
+}

--- a/scripts/pipeline-context.test.mjs
+++ b/scripts/pipeline-context.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * #1695 contract — the pipeline-context block that carries { epic, depth, epic_branch }
+ * ON an issue so a fresh single-use run (WS1's worker, WS3's decomposer) can read it.
+ *
+ * The case that minted it: the event-driven redesign (#1685) has no Agent-prompt channel to
+ * pass context to a child — the child is picked up by a brand-new workflow run. The block on
+ * the body IS that channel; it must parse/write idempotently and stay back-compatible with
+ * WS1's bare `pipeline: epic_branch=<name>` line.
+ *
+ *   node --test scripts/pipeline-context.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parsePipelineBlock, formatPipelineBlock, writePipelineBlock } from './pipeline-context.mjs'
+
+const BRANCH = 'epic/1685-single-use-pipeline'
+
+test('parse reads a full wrapped block', () => {
+  const body = `Some issue text.\n\n<!-- pipeline: epic=1685 depth=2 epic_branch=${BRANCH} -->`
+  assert.deepEqual(parsePipelineBlock(body), { epic: 1685, depth: 2, epic_branch: BRANCH })
+})
+
+test('parse tolerates extra whitespace and key order', () => {
+  const body = `<!--   pipeline:   epic_branch=${BRANCH}    epic=42   depth=0   -->`
+  assert.deepEqual(parsePipelineBlock(body), { epic: 42, depth: 0, epic_branch: BRANCH })
+})
+
+test('parse returns nulls for a subset / absent keys', () => {
+  assert.deepEqual(parsePipelineBlock('<!-- pipeline: epic_branch=main -->'),
+    { epic: null, depth: null, epic_branch: 'main' })
+  assert.deepEqual(parsePipelineBlock('no block here'),
+    { epic: null, depth: null, epic_branch: null })
+  assert.deepEqual(parsePipelineBlock(''), { epic: null, depth: null, epic_branch: null })
+  assert.deepEqual(parsePipelineBlock(undefined), { epic: null, depth: null, epic_branch: null })
+})
+
+test('parse reads the legacy bare `pipeline:` line WS1 emitted (back-compat)', () => {
+  const body = `Implement this leaf.\npipeline: epic_branch=${BRANCH}\nmore text`
+  assert.equal(parsePipelineBlock(body).epic_branch, BRANCH)
+})
+
+test('parse ignores unknown keys and bad ints', () => {
+  assert.deepEqual(parsePipelineBlock('<!-- pipeline: epic=notanint depth=3 wave=2 -->'),
+    { epic: null, depth: 3, epic_branch: null })
+})
+
+test('depth=0 is preserved, not dropped as falsy', () => {
+  assert.equal(parsePipelineBlock('<!-- pipeline: depth=0 -->').depth, 0)
+})
+
+test('format emits only present keys in a stable order', () => {
+  assert.equal(formatPipelineBlock({ epic: 1685, depth: 2, epic_branch: BRANCH }),
+    `<!-- pipeline: epic=1685 depth=2 epic_branch=${BRANCH} -->`)
+  assert.equal(formatPipelineBlock({ epic_branch: BRANCH }),
+    `<!-- pipeline: epic_branch=${BRANCH} -->`)
+  assert.equal(formatPipelineBlock({ depth: 0 }), '<!-- pipeline: depth=0 -->')
+  assert.equal(formatPipelineBlock({}), null)
+})
+
+test('write appends a block to a body that has none', () => {
+  const out = writePipelineBlock('Issue body.', { epic: 1685, depth: 1, epic_branch: BRANCH })
+  assert.match(out, /^Issue body\.\n\n<!-- pipeline: epic=1685 depth=1 epic_branch=/)
+  assert.deepEqual(parsePipelineBlock(out), { epic: 1685, depth: 1, epic_branch: BRANCH })
+})
+
+test('write is idempotent — same context twice is byte-identical', () => {
+  const ctx = { epic: 1685, depth: 2, epic_branch: BRANCH }
+  const once = writePipelineBlock('Body', ctx)
+  const twice = writePipelineBlock(once, ctx)
+  assert.equal(twice, once)
+})
+
+test('write replaces an existing block in place (no duplication)', () => {
+  const start = writePipelineBlock('Body', { epic: 1, depth: 0, epic_branch: 'main' })
+  const updated = writePipelineBlock(start, { depth: 1, epic_branch: BRANCH })
+  // epic preserved from the merge, depth+branch updated, still exactly one block.
+  assert.deepEqual(parsePipelineBlock(updated), { epic: 1, depth: 1, epic_branch: BRANCH })
+  assert.equal((updated.match(/<!-- pipeline:/g) || []).length, 1)
+})
+
+test('write upgrades a legacy bare line to the wrapped block', () => {
+  const legacy = `Do the thing.\npipeline: epic_branch=${BRANCH}`
+  const out = writePipelineBlock(legacy, { epic: 1685, depth: 3 })
+  assert.match(out, /<!-- pipeline: epic=1685 depth=3 epic_branch=/)
+  assert.doesNotMatch(out, /^pipeline:/m) // legacy line is gone
+  assert.equal((out.match(/pipeline:/g) || []).length, 1)
+})
+
+test('write with empty context leaves a body without a block unchanged', () => {
+  assert.equal(writePipelineBlock('Just text.', {}), 'Just text.')
+})
+
+test('a partial update with explicit nulls preserves siblings (the CLI write path)', () => {
+  // parseTokens yields null for absent keys; `write depth=1` must NOT wipe epic/epic_branch.
+  const start = writePipelineBlock('Body', { epic: 1685, depth: 0, epic_branch: BRANCH })
+  const updated = writePipelineBlock(start, { epic: null, depth: 1, epic_branch: null })
+  assert.deepEqual(parsePipelineBlock(updated), { epic: 1685, depth: 1, epic_branch: BRANCH })
+})

--- a/scripts/pipeline-loop-guard.mjs
+++ b/scripts/pipeline-loop-guard.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// pipeline-loop-guard.mjs — WS4 of epic #1685: the loop-guards that make the event-driven,
+// label-handoff pipeline (WS3) safe to turn on. Pure + unit-tested (pipeline-loop-guard.test.mjs)
+// so the invariants that broke at #457 can't silently regress when the decomposer starts
+// emitting labels.
+//
+// THE THREE INVARIANTS (each has a function here; the workflows / the decomposer wire to them):
+//
+//  1. BOT-ACTOR GUARD (#457/#1004) — a label applied from INSIDE a run must be actored by the
+//     Harness App (`nuxt-harness[bot]`, an allowed + cascading bot). Any OTHER `*[bot]` actor —
+//     `claude[bot]`, `github-actions[bot]` — is REJECTED, so a worker's own label change can't
+//     re-drive the pipeline as a masquerading bot. Humans always pass (they ARE the entry point).
+//     `work-issue-pidev.yml` / `decompose-on-issue-pidev.yml` call the `bot-guard` CLI below.
+//
+//  2. EXACT-LABEL GATING (#535) — a job fires ONLY on the exact trigger label freshly applied
+//     (`work-this` for the worker, `delegate-pi`/`delegate-hard` for the decomposer), never on a
+//     worker's incidental `status:in-progress` add. This mirrors each workflow's job `if:` so the
+//     re-fire loop is closed. (`jobShouldFire` is the executable spec of that `if:`.)
+//
+//  3. DEPTH / FAN-OUT CAPS (#249) — enforced ACROSS runs, not by an in-process counter: `depth`
+//     is read from the WS2 pipeline block (#1695) on the issue. At `depth >= MAX_DEPTH` the
+//     decomposer must LABEL the issue a leaf (`work-this`), never split again — otherwise a
+//     `delegate-pi` child could beget a `delegate-pi` child forever. `MAX_CHILDREN` bounds one
+//     split. `withinCaps` is the decision the decomposer's label choice maps to.
+//
+// These MUST stay in lockstep with the caps in `.claude/agents/task-decomposer.md` and the job
+// `if:` blocks in the two `*-pidev.yml` workflows. This file is the single tested source.
+
+import { pathToFileURL } from 'node:url'
+
+export const ALLOWED_BOT = 'nuxt-harness[bot]'
+export const MAX_DEPTH = 3
+export const MAX_CHILDREN = 6
+// The labels that legitimately DRIVE a fresh pipeline run (a human or the App may apply them).
+export const WORKER_TRIGGER = 'work-this'
+export const DECOMPOSE_TRIGGERS = ['delegate-pi', 'delegate-hard']
+
+/**
+ * INVARIANT 1 — may `actor` drive the pipeline?
+ * A human (no `[bot]` suffix) always may. A bot may ONLY if it is the allowed Harness App.
+ * This is the #457 loop-break: `claude[bot]`/`github-actions[bot]` re-firing off a worker's
+ * own label change is refused.
+ */
+export function botActorAllowed(actor, allowed = ALLOWED_BOT) {
+  if (!actor || typeof actor !== 'string') return false
+  if (!actor.endsWith('[bot]')) return true // a human
+  return actor === allowed
+}
+
+/**
+ * INVARIANT 2 — should the job fire for this event? Executable mirror of the workflow `if:`.
+ *   { eventName, action, labelName, trigger }
+ * `trigger` is a single label or an array of labels the workflow fires on. `workflow_dispatch`
+ * always fires (a human explicitly asked). An `issues`/`labeled` event fires ONLY when the
+ * freshly-applied label is exactly one of the triggers — so `status:in-progress` (added by a
+ * worker mid-run) does NOT re-fire.
+ */
+export function jobShouldFire({ eventName, action, labelName, trigger } = {}) {
+  if (eventName === 'workflow_dispatch') return true
+  if (eventName !== 'issues' || action !== 'labeled') return false
+  const triggers = Array.isArray(trigger) ? trigger : [trigger]
+  return triggers.includes(labelName)
+}
+
+/**
+ * INVARIANT 3 — given the current depth (from the WS2 block) and a proposed split size, what
+ * should the decomposer do? Returns `{ action, reason }` where action is:
+ *   • 'leaf'  → label the issue `work-this` (build it; do not split). Forced at the depth cap.
+ *   • 'split' → create children and label each. Only when below the depth cap.
+ * `childCount` (optional) is validated against MAX_CHILDREN when splitting.
+ */
+export function decideSplit({ depth = 0, isLeaf = false, childCount = 0,
+  maxDepth = MAX_DEPTH, maxChildren = MAX_CHILDREN } = {}) {
+  const d = Number.isFinite(depth) ? depth : 0
+  if (d >= maxDepth) return { action: 'leaf', reason: `depth ${d} >= MAX_DEPTH ${maxDepth} — forced leaf` }
+  if (isLeaf) return { action: 'leaf', reason: 'passes the LEAF TEST' }
+  if (childCount > maxChildren) {
+    return { action: 'split', reason: `over MAX_CHILDREN (${childCount} > ${maxChildren}) — slices too thin, merge` , overCap: true }
+  }
+  return { action: 'split', reason: `depth ${d} < ${maxDepth} — split` }
+}
+
+/** The label a child should receive given its own leaf-ness and depth. */
+export function labelForChild({ depth = 0, isLeaf = false, maxDepth = MAX_DEPTH } = {}) {
+  return decideSplit({ depth, isLeaf, maxDepth }).action === 'leaf' ? WORKER_TRIGGER : 'delegate-pi'
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────────
+//   node scripts/pipeline-loop-guard.mjs bot-guard <actor> [<allowed>]
+//     → exit 0 if allowed, exit 1 (with an ::error::) if a disallowed bot. Used as the
+//       workflow's Bot-actor guard step so the SHIPPED guard is the unit-tested function.
+function main(argv) {
+  const [cmd, ...rest] = argv
+  if (cmd === 'bot-guard') {
+    const actor = rest[0]
+    const allowed = rest[1] || ALLOWED_BOT
+    if (botActorAllowed(actor, allowed)) {
+      console.log(`Bot-actor guard OK (actor: ${actor}).`)
+      return
+    }
+    console.log(`::error::Bot-actor guard: '${actor}' may not drive the pi pipeline (only ${allowed}). Refusing to run.`)
+    process.exit(1)
+  }
+  console.error('usage: node scripts/pipeline-loop-guard.mjs bot-guard <actor> [<allowed>]')
+  process.exit(2)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main(process.argv.slice(2))
+}

--- a/scripts/pipeline-loop-guard.test.mjs
+++ b/scripts/pipeline-loop-guard.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * #1685 WS4 contract — the loop-guards that make the event-driven label handoff (WS3) safe.
+ *
+ * The case that minted them: #457. A label applied from inside a run was actored as
+ * `claude[bot]`; the bot-actor guard (had it existed) would have rejected it, and children ran
+ * off `main`. These tests pin the three invariants BEFORE the decomposer starts emitting labels,
+ * so the re-fire loop cannot come back silently.
+ *
+ *   node --test scripts/pipeline-loop-guard.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  botActorAllowed, jobShouldFire, decideSplit, labelForChild,
+  ALLOWED_BOT, MAX_DEPTH, MAX_CHILDREN, WORKER_TRIGGER,
+} from './pipeline-loop-guard.mjs'
+
+// ── Invariant 1: bot-actor guard (#457) ───────────────────────────────────────────
+test('a human always drives the pipeline', () => {
+  assert.equal(botActorAllowed('pmcp'), true)
+  assert.equal(botActorAllowed('maarten'), true)
+})
+
+test('the Harness App (nuxt-harness[bot]) is the one allowed bot', () => {
+  assert.equal(botActorAllowed(ALLOWED_BOT), true)
+})
+
+test('any OTHER bot is rejected — the #457 re-fire loop', () => {
+  assert.equal(botActorAllowed('claude[bot]'), false)
+  assert.equal(botActorAllowed('github-actions[bot]'), false)
+  assert.equal(botActorAllowed('dependabot[bot]'), false)
+})
+
+test('a missing/empty actor is rejected (fail closed)', () => {
+  assert.equal(botActorAllowed(''), false)
+  assert.equal(botActorAllowed(undefined), false)
+  assert.equal(botActorAllowed(null), false)
+})
+
+// ── Invariant 2: exact-label gating (#535) ─────────────────────────────────────────
+test('the worker job fires on an exact work-this label, not on status:in-progress', () => {
+  const fire = (labelName) => jobShouldFire({ eventName: 'issues', action: 'labeled', labelName, trigger: WORKER_TRIGGER })
+  assert.equal(fire('work-this'), true)
+  // The re-fire loop that #535 closed: a worker adding its own status label must NOT re-trigger.
+  assert.equal(fire('status:in-progress'), false)
+  assert.equal(fire('delegate-pi'), false)
+})
+
+test('the decompose job fires on delegate-pi / delegate-hard only', () => {
+  const fire = (labelName) => jobShouldFire({ eventName: 'issues', action: 'labeled', labelName, trigger: ['delegate-pi', 'delegate-hard'] })
+  assert.equal(fire('delegate-pi'), true)
+  assert.equal(fire('delegate-hard'), true)
+  assert.equal(fire('work-this'), false)
+  assert.equal(fire('status:in-progress'), false)
+})
+
+test('workflow_dispatch always fires; an unlabeled issue event never does', () => {
+  assert.equal(jobShouldFire({ eventName: 'workflow_dispatch' }), true)
+  assert.equal(jobShouldFire({ eventName: 'issues', action: 'opened', labelName: 'work-this', trigger: WORKER_TRIGGER }), false)
+  assert.equal(jobShouldFire({ eventName: 'issues', action: 'unlabeled', labelName: 'work-this', trigger: WORKER_TRIGGER }), false)
+})
+
+// ── Invariant 3: depth / fan-out caps across runs (#249) ───────────────────────────
+test('at the depth cap the decomposer is forced to a leaf (no infinite delegate-pi chain)', () => {
+  assert.equal(decideSplit({ depth: MAX_DEPTH, isLeaf: false }).action, 'leaf')
+  assert.equal(decideSplit({ depth: MAX_DEPTH + 1, isLeaf: false }).action, 'leaf')
+})
+
+test('below the cap a non-leaf splits, a leaf builds', () => {
+  assert.equal(decideSplit({ depth: 0, isLeaf: false }).action, 'split')
+  assert.equal(decideSplit({ depth: 1, isLeaf: true }).action, 'leaf')
+})
+
+test('a non-finite depth is treated as 0, not NaN-through', () => {
+  assert.equal(decideSplit({ depth: NaN, isLeaf: false }).action, 'split')
+})
+
+test('MAX_CHILDREN over-cap is flagged', () => {
+  const d = decideSplit({ depth: 0, isLeaf: false, childCount: MAX_CHILDREN + 1 })
+  assert.equal(d.overCap, true)
+})
+
+// ── The label a child gets — the WS3 handoff decision ──────────────────────────────
+test('labelForChild routes leaves to work-this and splits to delegate-pi', () => {
+  assert.equal(labelForChild({ depth: 1, isLeaf: true }), 'work-this')
+  assert.equal(labelForChild({ depth: 1, isLeaf: false }), 'delegate-pi')
+  // Depth cap forces work-this even for a would-be split.
+  assert.equal(labelForChild({ depth: MAX_DEPTH, isLeaf: false }), 'work-this')
+})


### PR DESCRIPTION
Closes #1695
Closes #1696
Refs #1685

## 👤 For humans

Continues epic #1685 (single-use, event-driven code-writing pipeline). WS1 (the single-use worker) is already live; this lands the next three workstreams so the pi decomposer can hand work off by **labeling** issues instead of spawning an in-process agent tree (which `pi-claude-cli` can't drive).

Three pieces, one coherent change:

- **WS2 (#1695) — context on the issue.** A fresh single-use run has no memory of its parent, so the parent leaves the context ON the issue: a canonical invisible `<!-- pipeline: epic=.. depth=.. epic_branch=.. -->` block + a small helper to read/write it. The worker now reads its integration branch off that block.
- **WS3 (#1696) — spawn → label (approach A, pi-only).** When the pi workflow sets `PIPELINE_MODE=event-driven`, the orchestrator/decomposer write the block onto each child and apply `work-this`/`delegate-pi` via the **Harness App token**, then stop — a fresh run works each child. The default (claude) path still spawns in-process, unchanged. This deliberately reverses the old "never label" ban (#457), now safe because the App token is the one allowed bot.
- **WS4 — the loop-guards, folded in first.** Before the decomposer starts emitting labels, the guards that stop the #457 loop are pinned by a unit-tested pure module and a new CI job that runs it: bot-actor (only `nuxt-harness[bot]` drives), exact-label gating (a worker's `status:in-progress` can't re-fire, #535), and the depth cap (a `delegate-pi` chain always converges to `work-this`).

## 🤖 For agents

**New helpers (pure + `node --test`):**
- `scripts/pipeline-context.mjs` (+ test) — parse/format/idempotent-upsert of the pipeline block; `read [field]` / `write <k=v..>` CLI (body on stdin). The one place the block format is documented.
- `scripts/pipeline-loop-guard.mjs` (+ test) — `botActorAllowed` / `jobShouldFire` / `decideSplit` / `labelForChild` + a `bot-guard <actor>` CLI. The single tested source for the loop invariants.

**Workflows:**
- `work-issue-pidev.yml` — bot-guard now runs `pipeline-loop-guard.mjs bot-guard` (shipped guard = tested function); new github-script fetch-body + `ctx` step parses `epic_branch` → into the pi prompt (worker no longer greps the body).
- `decompose-on-issue-pidev.yml` — same bot-guard rewire; pi step gains `PIPELINE_MODE=event-driven`.
- `ci.yml` — new `scripts-tests` job runs `node --test scripts/*.test.mjs`, so these (and the 6 pre-existing) contracts finally gate.

**Agent docs:** `task-decomposer.md` + `task-orchestrator.md` gain an "Event-driven mode" branch (label via App-token `gh`, never the MCP tool — human PAT won't cascade); `agents/CLAUDE.md`'s shared "hand off by spawning, never labeling" invariant now carries the one sanctioned exception.

## 🧪 How to test

- **Helpers (local):** `node --test scripts/pipeline-context.test.mjs scripts/pipeline-loop-guard.test.mjs` → all green (25 cases). CI's new `scripts-tests` job runs the whole `scripts/*.test.mjs` set (101 cases).
- **Bot-guard CLI:** `node scripts/pipeline-loop-guard.mjs bot-guard "claude[bot]"` exits 1; `... "nuxt-harness[bot]"` and `... "pmcp"` exit 0.
- **Context CLI:** `printf 'x\n\n<!-- pipeline: epic=1 depth=0 epic_branch=epic/1-x -->' | node scripts/pipeline-context.mjs write depth=2` → block updated to `depth=2`, epic/epic_branch preserved.
- **End-to-end (WS5, follow-up):** a `delegate-pi` test issue on the mac-mini → children get `work-this`/`delegate-pi` via `nuxt-harness[bot]` → independent single-use runs → PR(s). WS5 (#1685) is the cutover/e2e proof and is intentionally NOT in this PR.

<sub>🤖 interactive agent · posted from @pmcp's account (not Maarten)</sub>