### PR TITLE
fix: stop the post-login spinner on kassa (#1703)

### DIFF
--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -1,58 +1,55 @@
 <script setup lang="ts">
-// Root redirect: send users straight to the sales events page for their team.
-// Auth is client-driven (nanostore), so we resolve the team reactively and
-// redirect once it's known; signed-out users go to login.
-definePageMeta({ layout: false })
+// Root dispatcher: send users straight to the sales events page for their team.
+//
+// The redirect lives in ROUTE MIDDLEWARE, not a watchEffect (#1703). A
+// watchEffect re-runs on every reactive change and re-issues navigateTo, which
+// cancels its own in-flight navigation — and since the team middleware calls
+// setActive (which used to re-emit better-auth's $sessionSignal), each redirect
+// attempt retriggered the effect that started it. The router never settled and
+// the page sat on its spinner until a manual reload.
+//
+// Route middleware runs once per navigation, on the server as well as the
+// client, can await its data, and returns a single navigateTo. It cannot
+// restart itself.
+definePageMeta({
+  layout: false,
+  middleware: [
+    async () => {
+      const auth = tryUse(() => useAuth())
+      const team = tryUse(() => useTeam())
 
-const auth = tryUseAuth()
-const team = tryUseTeam()
-const session = tryUseSession()
+      if (!auth?.loggedIn?.value) {
+        return navigateTo('/auth/login')
+      }
 
-function tryUseAuth() {
-  try { return useAuth() } catch { return null }
-}
-function tryUseTeam() {
-  try { return useTeam() } catch { return null }
-}
-function tryUseSession() {
-  try { return useSession() } catch { return null }
+      let slug = resolveSlug(team)
+
+      // On a cold load `team-context.global.ts` has already populated the team
+      // list during SSR, so this rarely runs. It matters after a client-side
+      // login, where nothing has fetched yet.
+      if (!slug && team && import.meta.client) {
+        await team.refreshTeams().catch(() => {})
+        slug = resolveSlug(team)
+      }
+
+      // No slug: fall through and render the team-less message below. Never spin.
+      if (slug) {
+        return navigateTo(`/admin/${slug}/sales/events`, { replace: true })
+      }
+    }
+  ]
+})
+
+function tryUse<T>(fn: () => T): T | null {
+  try { return fn() } catch { return null }
 }
 
-const loggedIn = computed(() => auth?.loggedIn?.value ?? false)
-const isPending = computed(() => session?.isPending?.value ?? false)
-const teamSlug = computed(() => {
+function resolveSlug(team: ReturnType<typeof useTeam> | null): string | null {
   const t = team?.currentTeam?.value ?? team?.teams?.value?.[0]
   return t?.slug ?? null
-})
+}
 
-// The auth modal's after-login refreshTeams() is fire-and-forget and can race
-// the session cookie (seen on iOS Safari: teams stay empty → this page used to
-// spin forever). Re-fetch here once auth resolves; if the account really has
-// no team, say so instead of spinning.
-const teamsRefreshed = ref(false)
-const refreshingTeams = ref(false)
-
-const noTeam = computed(() =>
-  !isPending.value && loggedIn.value && teamsRefreshed.value && !refreshingTeams.value && !teamSlug.value
-)
-
-watchEffect(() => {
-  // Wait until auth has resolved (avoids a premature login bounce on hydration)
-  if (isPending.value) return
-  if (!loggedIn.value) {
-    navigateTo('/auth/login')
-    return
-  }
-  if (teamSlug.value) {
-    navigateTo(`/admin/${teamSlug.value}/sales/events`)
-    return
-  }
-  if (!teamsRefreshed.value && team && import.meta.client) {
-    teamsRefreshed.value = true
-    refreshingTeams.value = true
-    team.refreshTeams().finally(() => { refreshingTeams.value = false })
-  }
-})
+const auth = tryUse(() => useAuth())
 
 async function signOut() {
   await auth?.logout?.()
@@ -61,8 +58,14 @@ async function signOut() {
 </script>
 
 <template>
+  <!--
+    Reaching this template means the middleware ran and found no team — the
+    account genuinely belongs to none. That is a terminal, actionable state, not
+    a loading state, so there is deliberately no spinner here: if this page
+    renders at all, waiting cannot help.
+  -->
   <div class="min-h-screen flex items-center justify-center bg-(--ui-bg)">
-    <div v-if="noTeam" class="text-center space-y-3 px-6">
+    <div class="text-center space-y-3 px-6">
       <UIcon name="i-lucide-users" class="size-8 text-(--ui-text-dimmed)" />
       <p class="text-(--ui-text-muted)">
         Geen team gevonden voor dit account. Vraag een uitnodiging aan je teambeheerder.
@@ -71,10 +74,5 @@ async function signOut() {
         Uitloggen
       </UButton>
     </div>
-    <UIcon
-      v-else
-      name="i-lucide-loader-2"
-      class="size-6 animate-spin text-(--ui-text-dimmed)"
-    />
   </div>
 </template>

--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -15,44 +15,43 @@ definePageMeta({
   layout: false,
   middleware: [
     async () => {
-      const auth = tryUse(() => useAuth())
-      const team = tryUse(() => useTeam())
+      const { loggedIn } = useAuth()
+      if (!loggedIn.value) return navigateTo('/auth/login')
 
-      if (!auth?.loggedIn?.value) {
-        return navigateTo('/auth/login')
-      }
+      const slug = await resolveTeamSlug(useTeam())
+      // No slug: fall through and render the team-less message. Never spin.
+      if (!slug) return
 
-      let slug = resolveSlug(team)
-
-      // On a cold load `team-context.global.ts` has already populated the team
-      // list during SSR, so this rarely runs. It matters after a client-side
-      // login, where nothing has fetched yet.
-      if (!slug && team && import.meta.client) {
-        await team.refreshTeams().catch(() => {})
-        slug = resolveSlug(team)
-      }
-
-      // No slug: fall through and render the team-less message below. Never spin.
-      if (slug) {
-        return navigateTo(`/admin/${slug}/sales/events`, { replace: true })
-      }
+      return navigateTo(`/admin/${slug}/sales/events`, { replace: true })
     }
   ]
 })
 
-function tryUse<T>(fn: () => T): T | null {
-  try { return fn() } catch { return null }
+/**
+ * The team this account should land in.
+ *
+ * On a cold load `team-context.global.ts` (a global middleware, so it always
+ * runs first) has already populated the team list during SSR, so the refresh
+ * below rarely fires. It matters after a client-side login, where nothing has
+ * fetched yet.
+ */
+async function resolveTeamSlug(team: ReturnType<typeof useTeam>): Promise<string | null> {
+  const pick = () => {
+    const active = team.currentTeam.value ?? team.teams.value[0]
+    return active?.slug ?? null
+  }
+
+  const known = pick()
+  if (known || import.meta.server) return known
+
+  await team.refreshTeams().catch(() => {})
+  return pick()
 }
 
-function resolveSlug(team: ReturnType<typeof useTeam> | null): string | null {
-  const t = team?.currentTeam?.value ?? team?.teams?.value?.[0]
-  return t?.slug ?? null
-}
-
-const auth = tryUse(() => useAuth())
+const { logout } = useAuth()
 
 async function signOut() {
-  await auth?.logout?.()
+  await logout()
   navigateTo('/auth/login')
 }
 </script>

--- a/packages/crouton-auth/app/components/Auth/RouteModal.vue
+++ b/packages/crouton-auth/app/components/Auth/RouteModal.vue
@@ -82,7 +82,19 @@ const modalTitle = computed(() => {
   }
 })
 
-// Close modal, restore URL, refresh teams, then navigate
+// Close modal, restore URL, load the team list, then navigate.
+//
+// This is the ONLY thing that moves the user after a successful sign-in, so it
+// has to be deterministic (#1703). Two things used to make it not be:
+//
+//  1. `refreshTeams()` was fire-and-forget, so we navigated with an empty team
+//     list and left the destination page to race the fetch. Now awaited — the
+//     landing route middleware can resolve a team synchronously.
+//  2. `navigateTo(redirectTo)` was a silent no-op whenever `redirectTo` matched
+//     the router's current route, which is EVERY plain login: the router plugin
+//     cancels the navigation to /auth/login and only pushState's the URL, so
+//     vue-router still thinks it is at '/'. `force: true` bypasses that
+//     same-route dedupe so the guard chain actually re-runs.
 async function handleSuccess() {
   const redirectTo = state.value.redirectTo
   state.value.open = false
@@ -92,9 +104,18 @@ async function handleSuccess() {
   if (import.meta.client) {
     window.history.replaceState(null, '', redirectTo)
   }
-  // Refresh teams list now that we're authenticated (nanostore doesn't auto-populate)
-  useTeam().refreshTeams()
-  await navigateTo(redirectTo, { replace: true })
+  // Populate the team list before navigating — a failure here must not strand
+  // the user on the modal, the destination can still recover.
+  await useTeam().refreshTeams().catch(() => {})
+
+  // `force` lives on the route LOCATION (vue-router's RouteLocationOptions),
+  // not on navigateTo's options. Resolve first so a redirectTo carrying a query
+  // or hash survives the round-trip.
+  const target = useRouter().resolve(redirectTo)
+  await navigateTo(
+    { path: target.path, query: target.query, hash: target.hash, force: true },
+    { replace: true }
+  )
 }
 
 // ── OAuth / passkey providers (shared across login & register) ────────────────

--- a/packages/crouton-auth/app/composables/useSession.ts
+++ b/packages/crouton-auth/app/composables/useSession.ts
@@ -572,6 +572,20 @@ export function useSession() {
     if (authClient) {
       await authClient.signOut()
     }
+
+    // Everything below this line is keyed to WHO is signed in, so logout has to
+    // tear all of it down. kassa is a shared till: the next person signs in on
+    // the same tab with no page reload, and without this they inherit the
+    // previous user's state.
+    //
+    //  - the in-flight promises: otherwise the next login can join the previous
+    //    user's still-pending fetch and adopt whatever it resolves to.
+    //  - the repair latch: otherwise a second user with a legacy org-less
+    //    session never gets the one repair attempt, and lands on "no team found".
+    inFlightSession = null
+    inFlightActiveOrg = null
+    ctx.triedDefaultOrgState.value = false
+
     ctx.sessionState.value = null
     ctx.userState.value = null
     ctx.activeOrgState.value = null

--- a/packages/crouton-auth/app/composables/useSession.ts
+++ b/packages/crouton-auth/app/composables/useSession.ts
@@ -46,7 +46,20 @@ interface SessionContext {
   isPendingState: Ref<boolean>
   errorState: Ref<Error | null>
   isListening: Ref<boolean>
+  triedDefaultOrgState: Ref<boolean>
 }
+
+// Client-side single-flight guards (#1703). Login drives three concurrent
+// resolution paths — useAuth.login()'s own refresh, the $sessionSignal
+// listener, and the initial fetch — which used to fire duplicate requests and
+// clobber each other's results.
+//
+// Deliberately gated on `!import.meta.server`, never touched during SSR: module
+// scope on the server is shared across concurrent requests, so caching a promise
+// there would leak one visitor's session fetch into another's. On the client one
+// module instance == one browser tab, and `callOnce` already dedupes SSR.
+let inFlightSession: Promise<void> | null = null
+let inFlightActiveOrg: Promise<void> | null = null
 
 // Shared state using useState (works in components, middleware, plugins)
 function createSessionState() {
@@ -60,6 +73,11 @@ function createSessionState() {
   // Track if we've set up the signal listener (once per app)
   const isListening = useState('crouton-auth-listening', () => false)
 
+  // Whether we've already attempted to repair a session that arrived with no
+  // active organization (#1703). One attempt per client lifecycle: an account
+  // that genuinely has no team must not retry forever.
+  const triedDefaultOrgState = useState('crouton-auth-tried-default-org', () => false)
+
   return {
     sessionState,
     userState,
@@ -67,7 +85,8 @@ function createSessionState() {
     userProfileState,
     isPendingState,
     errorState,
-    isListening
+    isListening,
+    triedDefaultOrgState
   }
 }
 
@@ -122,36 +141,80 @@ async function fetchSessionOnClient(ctx: SessionContext): Promise<void> {
   }
 }
 
-// Fetch session from Better Auth
+// Fetch session from Better Auth.
+//
+// `isPending` is a RESOLVED-LATCH, not an in-flight flag (#1703): it starts
+// true and goes false the first time the session resolves, then never returns
+// to true. Every consumer already reads it that way — the auth/guest/team-context
+// middleware, crouton-admin's guards, AuthGuard.vue, and the app landing pages
+// all use it as "do we know who the user is yet?". Flipping it back to true on
+// every background revalidation re-armed all of them at once, which is what let
+// a background refetch restart an in-flight navigation.
 async function fetchSession(ctx: SessionContext): Promise<void> {
   const { debug, sessionState, userState, isPendingState, errorState } = ctx
+
+  // Single-flight on the client: concurrent callers share one request.
+  if (!import.meta.server && inFlightSession) {
+    if (debug) {
+      console.log('[@crouton/auth] useSession: joining in-flight session fetch')
+    }
+    return inFlightSession
+  }
 
   if (debug) {
     console.log('[@crouton/auth] useSession: fetching session...')
   }
 
-  isPendingState.value = true
   errorState.value = null
 
-  try {
-    if (import.meta.server) {
-      await fetchSessionOnServer(ctx)
-    } else {
-      await fetchSessionOnClient(ctx)
+  const run = (async () => {
+    try {
+      if (import.meta.server) {
+        await fetchSessionOnServer(ctx)
+      } else {
+        await fetchSessionOnClient(ctx)
+      }
+    } catch (err) {
+      console.error('[@crouton/auth] useSession: fetch failed', err)
+      errorState.value = err instanceof Error ? err : new Error('Session fetch failed')
+      sessionState.value = null
+      userState.value = null
+    } finally {
+      isPendingState.value = false
     }
-  } catch (err) {
-    console.error('[@crouton/auth] useSession: fetch failed', err)
-    errorState.value = err instanceof Error ? err : new Error('Session fetch failed')
-    sessionState.value = null
-    userState.value = null
+  })()
+
+  if (import.meta.server) return run
+
+  inFlightSession = run
+  try {
+    await run
   } finally {
-    isPendingState.value = false
+    inFlightSession = null
   }
 }
 
 // Fetch active organization
-// If no active org is set (400 error), try to find and set one automatically
+// If no active org is set, try to find and set one automatically.
+//
+// NOTE: better-auth answers `getFullOrganization` with HTTP 200 and `data: null`
+// when no org is active — not an error — so the `!data` branch below is the
+// normal path for an org-less session, not an exceptional one.
 async function fetchActiveOrg(ctx: SessionContext): Promise<void> {
+  if (!import.meta.server && inFlightActiveOrg) return inFlightActiveOrg
+
+  const run = fetchActiveOrgImpl(ctx)
+  if (import.meta.server) return run
+
+  inFlightActiveOrg = run
+  try {
+    await run
+  } finally {
+    inFlightActiveOrg = null
+  }
+}
+
+async function fetchActiveOrgImpl(ctx: SessionContext): Promise<void> {
   const { authClient, debug, headers, userState, activeOrgState } = ctx
 
   // Don't fetch org data if user is not authenticated (prevents 401 console errors)
@@ -188,13 +251,32 @@ async function fetchActiveOrg(ctx: SessionContext): Promise<void> {
   }
 }
 
-// Try to find and set a default organization (for personal/single-tenant modes)
+// Try to find and set a default organization.
+//
+// This is a client-side REPAIR for a session that arrived without an active
+// organization. Since #1703 the server sets one on `session.create.before`, so
+// this should now only fire for sessions created before that fix (they keep a
+// null org for up to their 7-day lifetime).
+//
+// Two hard rules here, both learned from the kassa forever-spinner:
+//   1. `setActive` MUST pass `disableSignal` — better-auth re-emits
+//      `$sessionSignal` on /organization/set-active, and this function is
+//      reached FROM that signal's handler, so without it we re-enter ourselves.
+//   2. It runs at most once per client lifecycle — an account that genuinely
+//      has no team must not retry on every signal.
 async function trySetDefaultOrg(ctx: SessionContext): Promise<void> {
-  const { authClient, debug, headers, userState, activeOrgState } = ctx
+  const { authClient, debug, headers, userState, activeOrgState, triedDefaultOrgState } = ctx
 
   // Don't try to set org if user is not authenticated (prevents 401 console errors)
   if (!userState.value) return
   if (!authClient?.organization) return
+  if (triedDefaultOrgState.value) {
+    if (debug) {
+      console.log('[@crouton/auth] useSession: default-org repair already attempted, skipping')
+    }
+    return
+  }
+  triedDefaultOrgState.value = true
 
   try {
     // List user's organizations
@@ -207,10 +289,14 @@ async function trySetDefaultOrg(ctx: SessionContext): Promise<void> {
     }
 
     if (orgs && orgs.length > 0) {
-      // Set the first org as active
+      // Set the first org as active.
+      // `disableSignal` is better-auth's own opt-out (see rule 1 above): without
+      // it, this write re-emits $sessionSignal and re-enters the handler that
+      // called us.
       const firstOrg = orgs[0]!
       await authClient.organization.setActive({
-        organizationId: firstOrg.id
+        organizationId: firstOrg.id,
+        fetchOptions: { disableSignal: true }
       })
 
       if (debug) {

--- a/packages/crouton-auth/app/composables/useTeam.ts
+++ b/packages/crouton-auth/app/composables/useTeam.ts
@@ -134,11 +134,16 @@ export function useTeam() {
   // Also get activeOrgRaw which includes members array for role checking
   const { activeOrganization: sessionActiveOrg, activeOrgRaw } = useSession()
 
-  // For organizations list, use atom with API fallback
-  const organizationsAtom = authClient?.useListOrganizations
-  const organizationsData = computed(() => organizationsAtom?.value?.data ?? null)
-
-  // Fallback: fetch teams via API when nanostore atom doesn't auto-populate
+  // The organizations list comes from useState, NOT from better-auth's
+  // `useListOrganizations` nanostore (#1703). We use better-auth's *vanilla*
+  // client, so that export is a raw nanostore rather than a Vue ref — and
+  // nothing ever subscribes to it, so it is never mounted and its `.value`
+  // stays `undefined` forever. Reading it produced a computed with no reactive
+  // dependencies that silently cached its first evaluation.
+  //
+  // This state is populated by `refreshTeams()` below and, crucially, by
+  // `team-context.global.ts` during SSR — which is why a full page load
+  // resolves the team when a client-side transition sometimes did not.
   const fallbackTeams = useState<Team[]>('crouton-auth-fallback-teams', () => [])
 
   // Use session's active org instead of nanostore (which doesn't auto-populate)
@@ -153,13 +158,8 @@ export function useTeam() {
   // activeOrgData is already a Team type from useSession
   const currentTeam = computed<Team | null>(() => activeOrgData.value)
 
-  // Computed: all user's teams (atom first, then fallback)
-  const teams = computed<Team[]>(() => {
-    if (organizationsData.value && organizationsData.value.length > 0) {
-      return organizationsData.value.map(mapOrganizationToTeam)
-    }
-    return fallbackTeams.value
-  })
+  // Computed: all user's teams
+  const teams = computed<Team[]>(() => fallbackTeams.value)
 
   // Fetch teams via API as fallback when nanostore atom stays pending
   async function refreshTeams(): Promise<void> {

--- a/packages/crouton-auth/server/lib/auth.ts
+++ b/packages/crouton-auth/server/lib/auth.ts
@@ -20,6 +20,7 @@ import { i18n } from '@better-auth/i18n'
 import { passkey } from '@better-auth/passkey'
 import { sql } from 'drizzle-orm'
 import { useNitroApp } from 'nitropack/runtime'
+import { resolveInitialOrgId } from './session-org'
 import type { BetterAuthOptions } from 'better-auth'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import type {
@@ -378,9 +379,15 @@ function buildSessionConfig(sessionConfig?: SessionConfig): BetterAuthOptions['s
  * 2. Make the user the owner of their personal organization
  * 3. Set the personal organization as active for new sessions
  *
+ * **Always (no `teams` config required, #1703):**
+ * Every new session gets an `activeOrganizationId` via `session.create.before`
+ * — falling back to the user's first membership. Previously this whole block
+ * was skipped unless `defaultTeamSlug` or `autoCreateOnSignup` was set, which
+ * meant no app in the repo ever got it and every session started org-less.
+ *
  * @param config - @crouton/auth configuration
  * @param db - Drizzle database instance
- * @returns Database hooks configuration or undefined if no auto-creation enabled
+ * @returns Database hooks configuration
  */
 function buildDatabaseHooks(
   config: CroutonAuthConfig,
@@ -389,11 +396,6 @@ function buildDatabaseHooks(
   const teams = config.teams ?? {}
   const hasDefaultTeam = !!teams.defaultTeamSlug
   const hasAutoCreate = !!teams.autoCreateOnSignup
-
-  // No hooks needed if neither auto-creation feature is enabled
-  if (!hasDefaultTeam && !hasAutoCreate) {
-    return undefined
-  }
 
   const appName = config.appName ?? 'Default Workspace'
 
@@ -437,35 +439,28 @@ function buildDatabaseHooks(
     },
     session: {
       create: {
-        after: async (session) => {
-          // Priority: personal workspace > default team
-          // This ensures users land in their own workspace first if both are enabled
-          if (hasAutoCreate) {
-            const personalOrgId = await getUserPersonalOrgId(db, session.userId)
-            if (personalOrgId) {
-              await setSessionActiveOrg(db, session.id, personalOrgId)
+        // MUST be `before`, not `after` (#1703). better-auth runs `create.after`
+        // through queueAfterTransactionHook — deferred — so the in-memory session
+        // handed to setSessionCookie would still carry activeOrganizationId: null,
+        // and the cookie cache (buildSessionConfig, maxAge 300) would then serve
+        // that null for up to five minutes. `before` merges its returned `data`
+        // into the record actually created, so it lands in the cookie too.
+        before: async (session) => {
+          const orgId = await resolveInitialOrgId(db, session.userId, teams)
 
-              if (config.debug) {
-                console.log(`[crouton/auth] Session ${session.id} set to personal org ${personalOrgId}`)
-              }
-              return
-            } else if (config.debug) {
-              console.warn(`[crouton/auth] No personal org found for user ${session.userId}`)
+          if (!orgId) {
+            if (config.debug) {
+              console.warn(`[crouton/auth] No organization to activate for user ${session.userId}`)
             }
+            // Leave the field alone rather than writing an explicit null.
+            return
           }
 
-          // Fall back to default team
-          if (hasDefaultTeam) {
-            // Get the org ID by slug
-            const defaultOrg = await getOrgBySlug(db, teams.defaultTeamSlug!)
-            if (defaultOrg) {
-              await setSessionActiveOrg(db, session.id, defaultOrg.id)
-
-              if (config.debug) {
-                console.log(`[crouton/auth] Session ${session.id} set to default org (slug: ${teams.defaultTeamSlug})`)
-              }
-            }
+          if (config.debug) {
+            console.log(`[crouton/auth] New session for ${session.userId} starts in org ${orgId}`)
           }
+
+          return { data: { ...session, activeOrganizationId: orgId } }
         }
       }
     }
@@ -567,25 +562,6 @@ async function addUserToDefaultOrg(
   }
 }
 
-/**
- * Set the active organization for a session
- *
- * Updates the session record to set the active organization.
- *
- * @param db - Drizzle database instance
- * @param sessionId - Session ID to update
- * @param orgId - Organization ID to set as active
- */
-async function setSessionActiveOrg(
-  db: DrizzleD1Database<Record<string, unknown>>,
-  sessionId: string,
-  orgId: string
-): Promise<void> {
-  await db.run(sql`
-    UPDATE session SET activeOrganizationId = ${orgId} WHERE id = ${sessionId}
-  `)
-}
-
 // ============================================================================
 // Personal Mode: Helper Functions
 // ============================================================================
@@ -638,34 +614,6 @@ async function createPersonalOrg(
   console.log(`[crouton/auth] Created personal organization "${orgName}" for user (personal mode)`)
 
   return orgId
-}
-
-/**
- * Get the user's personal organization ID
- *
- * In personal mode, each user has exactly one organization where they are the owner.
- * Uses the ownerId column for efficient lookup (Task 6.2).
- *
- * @param db - Drizzle database instance
- * @param userId - User ID to find personal org for
- * @returns Organization ID or null if not found
- */
-async function getUserPersonalOrgId(
-  db: DrizzleD1Database<Record<string, unknown>>,
-  userId: string
-): Promise<string | null> {
-  // Find personal organization by ownerId (Task 6.2 - indexed column)
-  const result = await db.all(sql`
-    SELECT id FROM organization
-    WHERE personal = 1 AND ownerId = ${userId}
-    LIMIT 1
-  `)
-
-  if (result.length === 0) {
-    return null
-  }
-
-  return (result[0] as { id: string }).id
 }
 
 // ============================================================================

--- a/packages/crouton-auth/server/lib/auth.ts
+++ b/packages/crouton-auth/server/lib/auth.ts
@@ -20,7 +20,7 @@ import { i18n } from '@better-auth/i18n'
 import { passkey } from '@better-auth/passkey'
 import { sql } from 'drizzle-orm'
 import { useNitroApp } from 'nitropack/runtime'
-import { resolveInitialOrgId } from './session-org'
+import { resolveInitialOrgId, getOrgBySlug } from './session-org'
 import type { BetterAuthOptions } from 'better-auth'
 import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import type {
@@ -385,6 +385,12 @@ function buildSessionConfig(sessionConfig?: SessionConfig): BetterAuthOptions['s
  * was skipped unless `defaultTeamSlug` or `autoCreateOnSignup` was set, which
  * meant no app in the repo ever got it and every session started org-less.
  *
+ * Side effect of always registering: `user.create.after` now fires for apps
+ * with no `teams` config too, so they start emitting the
+ * `crouton:operation` / `auth:user:registered` event on signup where they
+ * previously emitted nothing. Its two team-creation branches still no-op
+ * without the flags, so the only new behaviour is that event.
+ *
  * @param config - @crouton/auth configuration
  * @param db - Drizzle database instance
  * @returns Database hooks configuration
@@ -467,27 +473,6 @@ function buildDatabaseHooks(
   }
 }
 
-/**
- * Get organization by slug
- *
- * @param db - Drizzle database instance
- * @param slug - Organization slug to find
- * @returns Organization object or null if not found
- */
-async function getOrgBySlug(
-  db: DrizzleD1Database<Record<string, unknown>>,
-  slug: string
-): Promise<{ id: string, name: string, slug: string } | null> {
-  const result = await db.all(sql`
-    SELECT id, name, slug FROM organization WHERE slug = ${slug}
-  `)
-
-  if (result.length === 0) {
-    return null
-  }
-
-  return result[0] as { id: string, name: string, slug: string }
-}
 
 /**
  * Ensure the default organization exists (lazy creation)

--- a/packages/crouton-auth/server/lib/session-org.ts
+++ b/packages/crouton-auth/server/lib/session-org.ts
@@ -28,6 +28,24 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1'
 import type { TeamsConfig } from '../../types/config'
 
 /**
+ * Look up an organization by slug.
+ *
+ * Lives here rather than in `auth.ts` so there is exactly one copy of this
+ * query: `auth.ts` already imports this module, so the dependency runs
+ * leaf-ward and importing it back the other way would be circular.
+ */
+export async function getOrgBySlug(
+  db: DrizzleD1Database<Record<string, unknown>>,
+  slug: string
+): Promise<{ id: string, name: string, slug: string } | null> {
+  const result = await db.all(sql`
+    SELECT id, name, slug FROM organization WHERE slug = ${slug}
+  `)
+
+  return (result[0] as { id: string, name: string, slug: string } | undefined) ?? null
+}
+
+/**
  * Resolve which organization a brand-new session should start in.
  *
  * Order of preference:
@@ -60,11 +78,8 @@ export async function resolveInitialOrgId(
   }
 
   if (teams.defaultTeamSlug) {
-    const defaultOrg = await db.all(sql`
-      SELECT id FROM organization WHERE slug = ${teams.defaultTeamSlug} LIMIT 1
-    `)
-    const id = (defaultOrg[0] as { id?: string } | undefined)?.id
-    if (id) return id
+    const defaultOrg = await getOrgBySlug(db, teams.defaultTeamSlug)
+    if (defaultOrg) return defaultOrg.id
   }
 
   // Deterministic tiebreak — see (3) above.

--- a/packages/crouton-auth/server/lib/session-org.ts
+++ b/packages/crouton-auth/server/lib/session-org.ts
@@ -1,0 +1,81 @@
+/**
+ * Initial active organization for a newly created session
+ *
+ * Extracted from `auth.ts` so it can be unit-tested against a plain
+ * `{ all, run }` fake, without standing up better-auth + drizzle.
+ *
+ * ## Why this is a `session.create.BEFORE` concern (#1703)
+ *
+ * The previous implementation lived in `databaseHooks.session.create.after` and
+ * wrote the org with a raw `UPDATE`. That can never work: better-auth runs
+ * `create.after` through `queueAfterTransactionHook` (deferred), so the
+ * in-memory session handed to `setSessionCookie` still carries
+ * `activeOrganizationId: null` — and with the cookie cache enabled
+ * (`buildSessionConfig`, maxAge 300) that stale null is then served for up to
+ * five minutes.
+ *
+ * `create.before` is the correct hook: whatever it returns as `{ data }` is
+ * merged into the record that is actually created, so it lands in the session
+ * row *and* in the cookie.
+ *
+ * The client used to paper over this at runtime — `useSession`'s
+ * `$sessionSignal` handler would notice the null org and call `setActive`,
+ * which re-emits `$sessionSignal` and re-enters itself. That re-entrancy is
+ * what stranded kassa logins on an infinite spinner.
+ */
+import { sql } from 'drizzle-orm'
+import type { DrizzleD1Database } from 'drizzle-orm/d1'
+import type { TeamsConfig } from '../../types/config'
+
+/**
+ * Resolve which organization a brand-new session should start in.
+ *
+ * Order of preference:
+ * 1. The user's personal workspace — only when `autoCreateOnSignup` is on.
+ * 2. The configured default team — only when `defaultTeamSlug` is set.
+ * 3. **The user's first membership.** This is the case that matters for apps
+ *    with no `teams` config at all (kassa, velo, triage): they have real
+ *    memberships, they just never told crouton which one to prefer. Ordered by
+ *    `member.createdAt` then `organization.id` so a user in several teams lands
+ *    in the same place on every login instead of wherever SQLite felt like.
+ * 4. `null` — a genuinely team-less account. The UI is responsible for saying
+ *    so; it must not spin.
+ *
+ * Never throws: a resolution failure must not take down sign-in. The caller
+ * treats `null` as "leave `activeOrganizationId` alone".
+ */
+export async function resolveInitialOrgId(
+  db: DrizzleD1Database<Record<string, unknown>>,
+  userId: string,
+  teams: TeamsConfig = {}
+): Promise<string | null> {
+  if (teams.autoCreateOnSignup) {
+    const personal = await db.all(sql`
+      SELECT id FROM organization
+      WHERE personal = 1 AND ownerId = ${userId}
+      LIMIT 1
+    `)
+    const id = (personal[0] as { id?: string } | undefined)?.id
+    if (id) return id
+  }
+
+  if (teams.defaultTeamSlug) {
+    const defaultOrg = await db.all(sql`
+      SELECT id FROM organization WHERE slug = ${teams.defaultTeamSlug} LIMIT 1
+    `)
+    const id = (defaultOrg[0] as { id?: string } | undefined)?.id
+    if (id) return id
+  }
+
+  // Deterministic tiebreak — see (3) above.
+  const memberships = await db.all(sql`
+    SELECT m.organizationId AS organizationId
+    FROM member m
+    JOIN organization o ON o.id = m.organizationId
+    WHERE m.userId = ${userId}
+    ORDER BY m.createdAt ASC, o.id ASC
+    LIMIT 1
+  `)
+
+  return (memberships[0] as { organizationId?: string } | undefined)?.organizationId ?? null
+}

--- a/packages/crouton-auth/tests/unit/composables/useSession.signal.test.ts
+++ b/packages/crouton-auth/tests/unit/composables/useSession.signal.test.ts
@@ -194,3 +194,76 @@ describe('useSession — isPending is a resolved-latch, not an in-flight flag (#
     expect(mockAuthClient.getSession).toHaveBeenCalledTimes(1)
   })
 })
+
+/**
+ * kassa is a shared till: staff sign out and the next person signs in on the
+ * SAME tab, with no page reload. Any cache keyed to "the current identity" must
+ * therefore be torn down by `clear()`, or the second user inherits the first
+ * user's state. Both caches added for #1703 are per-identity.
+ */
+describe('useSession — logout invalidates per-identity caches (#1703)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.keys(mockUseStateValues).forEach(k => delete mockUseStateValues[k])
+    reemit = null
+    reemits = 0
+
+    mockAuthClient.signOut.mockResolvedValue({})
+    mockAuthClient.getSession.mockResolvedValue({
+      data: {
+        session: { id: 'session-1', userId: 'user-1', activeOrganizationId: null },
+        user: { id: 'user-1', email: 'staff-a@example.com' }
+      },
+      error: null
+    })
+    mockAuthClient.organization.getFullOrganization.mockResolvedValue({ data: null, error: null })
+    mockAuthClient.organization.list.mockResolvedValue({ data: [ORG], error: null })
+    mockAuthClient.organization.setActive.mockResolvedValue({ data: ORG, error: null })
+  })
+
+  it('lets the next user get the default-org repair after a logout', async () => {
+    const { refresh, clear } = useSession()
+
+    // Staff A: legacy org-less session, gets the one repair attempt.
+    await refresh()
+    await flush()
+    expect(mockAuthClient.organization.list).toHaveBeenCalledTimes(1)
+
+    await clear()
+    await flush()
+
+    // Staff B on the same tab, also org-less — must NOT inherit A's latch.
+    mockAuthClient.organization.list.mockClear()
+    await refresh()
+    await flush()
+
+    expect(mockAuthClient.organization.list).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let a post-logout fetch join the previous user\'s in-flight request', async () => {
+    const { refresh, clear } = useSession()
+
+    // Staff A's fetch hangs (slow till wifi) and is still pending at logout.
+    let releaseA: (v: unknown) => void = () => {}
+    mockAuthClient.getSession.mockImplementationOnce(
+      () => new Promise((resolve) => { releaseA = resolve })
+    )
+
+    const pendingA = refresh()
+    await flush()
+
+    await clear()
+
+    // Staff B signs in before A's request comes back. B must issue their own
+    // fetch, not adopt whatever A's stale promise resolves to.
+    const callsBefore = mockAuthClient.getSession.mock.calls.length
+    const pendingB = refresh()
+    await flush()
+
+    expect(mockAuthClient.getSession.mock.calls.length).toBe(callsBefore + 1)
+
+    releaseA({ data: null, error: null })
+    await pendingA
+    await pendingB
+  })
+})

--- a/packages/crouton-auth/tests/unit/composables/useSession.signal.test.ts
+++ b/packages/crouton-auth/tests/unit/composables/useSession.signal.test.ts
@@ -1,0 +1,196 @@
+/**
+ * useSession — $sessionSignal re-entrancy and pending-latch contract (#1703)
+ *
+ * These tests pin the behaviour behind the kassa "forever spinner": the
+ * `$sessionSignal` handler performs a WRITE (`organization.setActive`) from
+ * inside a READ handler, and better-auth re-emits `$sessionSignal` on
+ * set-active (verified in better-auth 1.5.5:
+ * `dist/plugins/organization/client.mjs:79-84` matches
+ * `/organization/set-active` → `signal: "$sessionSignal"`).
+ *
+ * That re-entrancy keeps `isPending` flapping, which keeps re-arming the only
+ * effect that can redirect the user after login.
+ *
+ * NOTE on the driver: `import.meta` is module-scoped, so a test file cannot flip
+ * `import.meta.client` inside `useSession.ts` — the `$sessionSignal` listener is
+ * therefore never registered under vitest. We drive the identical code path
+ * through the public `refresh()` instead: the real signal handler runs
+ * `await fetchSession(ctx); await fetchActiveOrg(ctx)` (useSession.ts:304-308) and
+ * `refresh()` runs exactly that same pair (useSession.ts:481-482). Re-entrancy is
+ * modelled by having the mocked `setActive` re-invoke `refresh()`, which is what
+ * better-auth's re-emitted signal does in production.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, computed } from 'vue'
+
+import { useSession } from '../../../app/composables/useSession'
+
+const ORG = { id: 'org-1', name: 'Test 1', slug: 'test1', createdAt: '2024-01-01T00:00:00.000Z' }
+
+// How many times the mocked better-auth client will re-emit $sessionSignal in
+// response to a set-active that did NOT opt out via `disableSignal`. Bounded so
+// a genuinely re-entrant implementation fails the assertion instead of hanging
+// the suite.
+const MAX_REEMITS = 3
+
+// Stands in for better-auth's re-emitted `$sessionSignal`: the handler it would
+// re-enter does the same fetchSession+fetchActiveOrg pair that `refresh()` does.
+let reemit: (() => Promise<void>) | null = null
+let reemits = 0
+
+const mockAuthClient = {
+  getSession: vi.fn(),
+  signOut: vi.fn(),
+  organization: {
+    getFullOrganization: vi.fn(),
+    list: vi.fn(),
+    setActive: vi.fn()
+  },
+  $store: { listen: vi.fn() }
+}
+
+const mockUseStateValues: Record<string, ReturnType<typeof ref>> = {}
+
+vi.stubGlobal('useNuxtApp', () => ({ $authClient: mockAuthClient }))
+vi.stubGlobal('useAuthClientSafe', () => mockAuthClient)
+vi.stubGlobal('useRuntimeConfig', () => ({
+  public: { crouton: { auth: { debug: false } } }
+}))
+vi.stubGlobal('useRequestHeaders', () => ({}))
+vi.stubGlobal('useState', (key: string, init?: () => unknown) => {
+  if (!mockUseStateValues[key]) {
+    mockUseStateValues[key] = ref(init ? init() : null)
+  }
+  return mockUseStateValues[key]
+})
+vi.stubGlobal('callOnce', vi.fn())
+vi.stubGlobal('ref', ref)
+vi.stubGlobal('computed', computed)
+vi.stubGlobal('$fetch', vi.fn().mockResolvedValue(null))
+vi.stubGlobal('useI18n', () => {
+  throw new Error('i18n not available in this test')
+})
+
+Object.defineProperty(import.meta, 'server', { value: false, writable: true, configurable: true })
+
+/** Let queued microtasks (the composable's async chains) settle. */
+async function flush(times = 12) {
+  for (let i = 0; i < times; i++) await Promise.resolve()
+}
+
+describe('useSession — $sessionSignal re-entrancy (#1703)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.keys(mockUseStateValues).forEach(k => delete mockUseStateValues[k])
+    reemit = null
+    reemits = 0
+
+    // The kassa condition: a session with NO active organization.
+    mockAuthClient.getSession.mockResolvedValue({
+      data: {
+        session: { id: 'session-1', userId: 'user-1', activeOrganizationId: null },
+        user: { id: 'user-1', email: 'review@example.com' }
+      },
+      error: null
+    })
+
+    // better-auth returns 200 with `data: null` when there is no active org —
+    // NOT an error (dist/plugins/organization/routes/crud-org.mjs:321-322).
+    mockAuthClient.organization.getFullOrganization.mockResolvedValue({ data: null, error: null })
+    mockAuthClient.organization.list.mockResolvedValue({ data: [ORG], error: null })
+
+    // Faithful model of better-auth: set-active re-emits $sessionSignal unless
+    // the caller opts out with fetchOptions.disableSignal.
+    mockAuthClient.organization.setActive.mockImplementation(async (arg: any) => {
+      if (!arg?.fetchOptions?.disableSignal && reemits < MAX_REEMITS && reemit) {
+        reemits++
+        await reemit()
+      }
+      return { data: ORG, error: null }
+    })
+  })
+
+  it('calls setActive with fetchOptions.disableSignal so it cannot re-enter its own handler', async () => {
+    const { refresh } = useSession()
+    reemit = refresh
+
+    await refresh()
+    await flush()
+
+    expect(mockAuthClient.organization.setActive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchOptions: expect.objectContaining({ disableSignal: true })
+      })
+    )
+  })
+
+  it('does not re-enter when set-active re-emits the signal — setActive runs once', async () => {
+    const { refresh } = useSession()
+    reemit = refresh
+
+    await refresh()
+    await flush()
+
+    expect(mockAuthClient.organization.setActive).toHaveBeenCalledTimes(1)
+  })
+
+  it('attempts the default-org repair at most once per client lifecycle', async () => {
+    const { refresh } = useSession()
+    // No re-emission here — three independent signals, each with a session that
+    // never gains an org.
+    reemit = null
+
+    await refresh()
+    await flush()
+    await refresh()
+    await flush()
+    await refresh()
+    await flush()
+
+    expect(mockAuthClient.organization.list).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useSession — isPending is a resolved-latch, not an in-flight flag (#1703)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.keys(mockUseStateValues).forEach(k => delete mockUseStateValues[k])
+    reemit = null
+    reemits = 0
+
+    mockAuthClient.getSession.mockResolvedValue({
+      data: {
+        session: { id: 'session-1', userId: 'user-1', activeOrganizationId: 'org-1' },
+        user: { id: 'user-1', email: 'review@example.com' }
+      },
+      error: null
+    })
+    mockAuthClient.organization.getFullOrganization.mockResolvedValue({ data: ORG, error: null })
+    mockAuthClient.organization.list.mockResolvedValue({ data: [ORG], error: null })
+    mockAuthClient.organization.setActive.mockResolvedValue({ data: ORG, error: null })
+  })
+
+  it('never returns to true once the session has resolved', async () => {
+    const { refresh, isPending } = useSession()
+
+    await refresh()
+    await flush()
+    expect(isPending.value).toBe(false)
+
+    // A background revalidation must NOT re-arm every consumer that treats
+    // isPending as "session not resolved yet" (8 of them across the packages).
+    const second = refresh()
+    expect(isPending.value).toBe(false)
+    await second
+  })
+
+  it('deduplicates concurrent session fetches into a single request', async () => {
+    const { refresh } = useSession()
+    mockAuthClient.getSession.mockClear()
+
+    await Promise.all([refresh(), refresh()])
+    await flush()
+
+    expect(mockAuthClient.getSession).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/crouton-auth/tests/unit/composables/useTeam.test.ts
+++ b/packages/crouton-auth/tests/unit/composables/useTeam.test.ts
@@ -766,4 +766,48 @@ describe('useTeam', () => {
       expect(currentTeam.value?.isDefault).toBe(false)
     })
   })
+
+  describe('teams source (#1703)', () => {
+    // `useListOrganizations` is a raw nanostore from better-auth's vanilla
+    // client, and nothing in the app ever subscribes to it — so it is never
+    // mounted and its `.value` stays `undefined` in production. `teams` is
+    // therefore ALWAYS `fallbackTeams` (the reactive, SSR-populated useState).
+    //
+    // This pins that we deliberately read the reactive source, so deleting the
+    // dead `organizationsData` branch in useTeam.ts is provably behaviour-
+    // preserving. It is also why the `it.todo`s above could never be made to
+    // pass by mocking harder.
+    it('reads fallbackTeams even when the organizations atom exposes other data', () => {
+      const original = mockAuthClient.useListOrganizations
+
+      // An atom that *does* expose data — the state that can never occur in
+      // production, and that we must not prefer over the reactive source.
+      mockAuthClient.useListOrganizations = {
+        value: {
+          data: [{ id: 'stale-org', name: 'Stale Org', slug: 'stale', createdAt: '2024-01-01T00:00:00Z' }]
+        }
+      } as unknown as typeof original
+
+      try {
+        const fallback = useState<Team[]>('crouton-auth-fallback-teams', () => [])
+        fallback.value = [{
+          id: 'org-1',
+          name: 'Test 1',
+          slug: 'test1',
+          logo: null,
+          metadata: {},
+          personal: false,
+          isDefault: false,
+          createdAt: new Date('2024-01-01T00:00:00Z'),
+          updatedAt: new Date('2024-01-01T00:00:00Z')
+        } as Team]
+
+        const { teams } = useTeam()
+        expect(teams.value).toHaveLength(1)
+        expect(teams.value[0]?.slug).toBe('test1')
+      } finally {
+        mockAuthClient.useListOrganizations = original
+      }
+    })
+  })
 })

--- a/packages/crouton-auth/tests/unit/server/session-org.test.ts
+++ b/packages/crouton-auth/tests/unit/server/session-org.test.ts
@@ -1,0 +1,95 @@
+/**
+ * resolveInitialOrgId — which organization a brand-new session starts in (#1703)
+ *
+ * WHY THIS EXISTS
+ * The `session.create.after` hook this replaces could never have worked:
+ * better-auth runs `create.after` through `queueAfterTransactionHook`
+ * (deferred) and the old hook mutated the row with raw SQL, so the in-memory
+ * session handed to `setSessionCookie` still carried
+ * `activeOrganizationId: null` — and better-auth's cookie cache
+ * (server/lib/auth.ts:345-348, maxAge 300) then served that null for up to five
+ * minutes. The correct hook is `session.create.before`, whose returned
+ * `{ data }` is merged into the record actually created.
+ *
+ * The resolver is extracted into its own module so it can be tested against a
+ * plain `{ all, run }` fake, sidestepping the drizzle/better-auth mocking wall
+ * that `server/lib/auth.ts` imposes.
+ *
+ * Resolution order: personal org (when autoCreateOnSignup) → default-team org
+ * (when defaultTeamSlug) → FIRST MEMBERSHIP (new — this is what fixes kassa,
+ * velo and triage, none of which set a `teams` config) → null.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+import { resolveInitialOrgId } from '../../../server/lib/session-org'
+
+/** Rough text of a drizzle `sql` template, for structural assertions. */
+function sqlText(query: unknown): string {
+  return JSON.stringify(query ?? '').toLowerCase()
+}
+
+/** Fake drizzle db that answers `all()` from a queue of canned result sets. */
+function fakeDb(results: unknown[][]) {
+  const queries: unknown[] = []
+  const queue = [...results]
+  return {
+    queries,
+    db: {
+      all: vi.fn(async (query: unknown) => {
+        queries.push(query)
+        return queue.shift() ?? []
+      }),
+      run: vi.fn(async () => undefined)
+    } as never
+  }
+}
+
+describe('resolveInitialOrgId (#1703)', () => {
+  it('returns the personal org when autoCreateOnSignup is enabled', async () => {
+    const { db } = fakeDb([[{ id: 'org-personal' }]])
+
+    const orgId = await resolveInitialOrgId(db, 'user-1', { autoCreateOnSignup: true })
+
+    expect(orgId).toBe('org-personal')
+  })
+
+  it('returns the default-team org when defaultTeamSlug is set', async () => {
+    const { db } = fakeDb([[{ id: 'org-default', name: 'Acme', slug: 'acme' }]])
+
+    const orgId = await resolveInitialOrgId(db, 'user-1', { defaultTeamSlug: 'acme' })
+
+    expect(orgId).toBe('org-default')
+  })
+
+  it('falls back to the first membership when no teams config is set', async () => {
+    // The kassa / velo / triage case: no `teams` block at all. Today this
+    // returns null, which is exactly why a fresh session starts org-less and
+    // the client has to repair it.
+    const { db } = fakeDb([[{ organizationId: 'org-1' }]])
+
+    const orgId = await resolveInitialOrgId(db, 'user-1', {})
+
+    expect(orgId).toBe('org-1')
+  })
+
+  it('returns null when the user has no memberships at all', async () => {
+    const { db } = fakeDb([[]])
+
+    const orgId = await resolveInitialOrgId(db, 'user-1', {})
+
+    expect(orgId).toBeNull()
+  })
+
+  it('orders memberships deterministically so the choice is stable across logins', async () => {
+    const { db, queries } = fakeDb([[
+      { organizationId: 'org-a' },
+      { organizationId: 'org-b' }
+    ]])
+
+    const orgId = await resolveInitialOrgId(db, 'user-1', {})
+
+    expect(orgId).toBe('org-a')
+    // A user in two teams must not land somewhere different each login.
+    expect(sqlText(queries.at(-1))).toContain('order by')
+  })
+})


### PR DESCRIPTION
Closes #1703

Packages-approved: the root cause is in `packages/crouton-auth` (better-auth session hook + the client-side org resolution). Owner approved the package scope up front; the app-level guard alone would only have papered over it.

## 👤 For humans

Logging in to kassa sometimes dumped you on a spinner that never resolved — only a reload got you in.

The cause: a new session was created without an active team, so the app tried to repair that in the browser. But the repair *wrote* to the session, and writing to the session fired the same "session changed" event that triggered the repair. One sign-in set your active team three times over, and every round restarted the redirect that was already in progress — so the navigation never finished.

Now a session simply starts in the right team, decided once on the server.

**Measured on one machine, one login, before and after:**

| auth call | before | after |
|---|---|---|
| `organization/list` | 4 | 1 |
| `organization/set-active` | **3** | **0** |
| `organization/get-full-organization` | 5 | 2 |

Ten consecutive logins land cleanly with no spinner.

## 🤖 For agents

Test-first (#774 gate): the failing contract landed in `6e9530e9` and was signed off before any production code.

**Root causes, in order of how much they mattered**

1. **`server/lib/auth.ts` — `session.create.after` → `session.create.before`.** better-auth runs `create.after` through `queueAfterTransactionHook` (deferred), so the in-memory session handed to `setSessionCookie` still carried `activeOrganizationId: null`, and the cookie cache (`maxAge: 300`) served that null for five minutes. `before` merges its returned `data` into the record actually created. Also lifted the early return that skipped the whole hook block unless `defaultTeamSlug` or `autoCreateOnSignup` was set — kassa, velo and triage set neither, so **no app in the repo ever got it**.
2. **`app/composables/useSession.ts` — `setActive` now passes `fetchOptions.disableSignal`.** better-auth re-emits `$sessionSignal` on `/organization/set-active` (`dist/plugins/organization/client.mjs:79-84`), and `trySetDefaultOrg` is reached *from* that handler, so it re-entered itself. Plus single-flight `fetchSession`/`fetchActiveOrg`, `isPending` latched to "resolved", and the repair limited to one attempt per client lifecycle.
3. **`app/components/Auth/RouteModal.vue`** — `await refreshTeams()` (was fire-and-forget) and force the post-login navigation. `navigateTo(redirectTo)` was a silent no-op on every plain login: the router plugin cancels the `/auth/login` navigation and only `pushState`s the URL, so vue-router still believed it was at `/`.
4. **`apps/kassa/app/pages/index.vue`** — the `watchEffect` dispatcher became page route middleware. Route middleware runs once per navigation, on SSR too, and cannot restart itself.

**Supporting changes**

- `server/lib/session-org.ts` (new) — `resolveInitialOrgId()`: personal org → default-team org → **first membership** → null, deterministically ordered so a multi-team user lands consistently. Also now owns `getOrgBySlug` (deduped out of `auth.ts`).
- `app/composables/useTeam.ts` — dropped the `organizationsData` computed. It read better-auth's *vanilla* `useListOrganizations` nanostore, which nothing subscribes to, so it is never mounted and `.value` is `undefined` forever — a computed with no reactive dependencies. `teams` is now plainly `fallbackTeams`.
- `clear()` resets the in-flight promises and the repair latch — kassa is a shared till, staff rotate logins in one tab with no reload.

**Semantic change to be aware of:** `isPending` no longer returns to `true` on background revalidation. All 8 consumers across crouton-auth, crouton-admin, crouton-core and kassa already read it as a "session resolved yet?" latch — but velo and triage share this package.

**Evidence.** The fix was reverted on the same running app and the identical probe re-run; the reverted numbers reproduce the staging capture in #1703 exactly (3× `set-active`, 5× `get-full-organization`). A session created after the change carries `activeOrganizationId` at insert time.

**Gates:** 292 unit tests pass · `pnpm typecheck` clean across kassa/velo/triage · `npx fallow audit` reports no issues in the changed files.

## ⚠️ Only new sessions

The server fix does not retro-fix live sessions — existing ones keep `activeOrganizationId = NULL` for the rest of their 7-day life, so the client repair path still runs for them (once now, with `disableSignal`, instead of storming). Worth watching for a week post-deploy rather than assuming it's gone.

## 🧪 How to test

1. Open https://kassa.pmcp.dev/ signed out, with DevTools open and Network filtered to `organization`.
2. Sign in from the root URL.
3. **Expect:** you land straight on `/admin/<team>/sales/events`, with **0** `set-active` calls and **1** `get-full-organization`. No spinner at any point.
4. The bug was intermittent — repeat a few times in fresh incognito windows rather than trusting one pass.
5. Regressions to spot-check: a `?redirect=` deep link still lands where you asked (#1323); logging out returns you to the login form; reloading `/` while signed in goes straight through.

Not covered by automated tests: `RouteModal.vue` — this package has no component-test harness, so that change is verified by the manual matrix only.

## Follow-ups (deliberately not widened into this PR)

1. `useAuth.ts:107-128 refreshWithOrgRetry` is now dead weight — and it is a `setTimeout` sleep.
2. crouton-auth imports `better-auth/client` (vanilla) rather than `better-auth/client/vue`, which is *why* the nanostore atoms were never reactive.
3. Latent TDZ `ReferenceError` at `team-context.global.ts:40-50`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
