### PR TITLE
fix(root): event-driven pi decompose that actually works — inline entry + plan-then-apply (#1696)

### DIFF
--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -113,49 +113,34 @@ Spawn one `task-worker` via the `Agent` tool:
 
 Report: "issue #N is leaf-sized (or at depth cap) → worker spawned in worktree". Stop.
 
-## Event-driven mode (`PIPELINE_MODE=event-driven`) — LABEL, don't spawn (#1685 WS3)
+## Event-driven mode (`PIPELINE_MODE=event-driven`) — pi PLANS, code APPLIES (#1685 WS3 / #1696)
 
-When `PIPELINE_MODE` is `event-driven`, **replace Steps 3 and 4** with the label hand-off below.
-Everything else — Step 1 (read), Step 2 (LEAF TEST), the caps — is unchanged. You **never** call
-the `Agent` tool in this mode; a fresh workflow run works each child.
+When `PIPELINE_MODE` is `event-driven` (the **pi** harness), the mechanism is **not** this agent
+calling the `Agent` tool or `gh` — it is driven by **`decompose-on-issue-pidev.yml`**, and your job
+shrinks to **pure reasoning + writing a plan file**. This is deliberate: pi cannot drive an
+in-process `Agent` tree (it no-op'd, #1381/#1706), *and* pi hand-building `gh issue create` with rich
+bodies breaks on shell quoting (`$(cat <<EOF)`, #1001) and then fabricates success. So:
 
-**The load-bearing rule: apply labels with the App-token `gh`, NOT the MCP GitHub tool.**
-The workflow put the Harness App token in `GH_TOKEN`. A label applied via `gh issue edit … --add-label`
-is actored as **`nuxt-harness[bot]`** — the one allowed bot — so the downstream run passes the
-bot-actor guard **and** the add *cascades* (re-triggers the workflow). A label applied via the
-`mcp__github__*` tools uses the human PAT: it may not cascade the trigger and muddies provenance.
-So: **labels → `Bash` + `gh` (App token); issue bodies/creates → either, but the WS2 block must be present.**
+- **You do NOT spawn, and you do NOT run any `gh`/`git`/issue-mutating command.**
+- **Read** the target issue and apply the **LEAF TEST** (Step 2) — reading (`gh issue view`) is fine.
+- **Write `decompose-plan.json`** in the working directory (use your file-writing tool, *not* a shell
+  heredoc), as JSON:
+  - leaf → `{ "leaf": true }`
+  - split → `{ "leaf": false, "children": [ { "title", "body" (markdown, no pipeline block / no
+    Dedup line — the apply step adds them), "labels": ["type:*","<component>"], "needsSplit": <bool> } … ] }`
+    — 2–6 children, `needsSplit:true` for a child that itself needs further decomposition.
+- Then **STOP**. Writing a correct `decompose-plan.json` is the entire deliverable.
 
-Read `depth` from the issue's WS2 block first (`gh issue view <this> --json body -q .body | node scripts/pipeline-context.mjs read`);
-treat a missing `depth` as 0.
+The deterministic **apply step** (`scripts/apply-decompose-plan.mjs`) turns the plan into real
+issues — resolve/create the epic branch, inject the WS2 block at `depth+1`, sanitize labels against
+`.github/labels.yml`, `gh issue create --body-file` (execFile array-args → no shell-quoting bug),
+link via the sub-issues API, and label each `work-this` (leaf) / `delegate-pi` (needs-split) via the
+App token so it cascades. The depth cap (`labelForChild` in `scripts/pipeline-loop-guard.mjs`) forces
+`work-this` at `MAX_DEPTH`, so a `delegate-pi` chain always terminates. Because **code** creates the
+issues, there is nothing for pi to fabricate — they exist or the step fails loudly.
 
-**If this issue is a leaf (or `depth >= MAX_DEPTH`):**
-1. Ensure its body carries the WS2 block (epic, this depth, epic_branch) — upsert with
-   `node scripts/pipeline-context.mjs write epic=<e> depth=<d> epic_branch=<b>` piped through the body,
-   then `gh issue edit <this> --body-file -`.
-2. `gh issue edit <this> --add-label work-this` (App token). The single-use `work-issue-pidev`
-   worker picks it up and opens the PR. **Do not** also add `status:in-progress` — the worker
-   manages its own status, and an extra label here is noise (the exact-label gate ignores it, #535).
-3. Report "issue #N labelled `work-this` (event-driven leaf) → worker run will implement it". **Stop.**
-
-**If this issue still needs splitting (not a leaf, `depth < MAX_DEPTH`):**
-1. Derive 2–6 children exactly as Step 3 (coherent concerns, full two-audience body,
-   `## 🧪 How to test`, correct `type:*`/`pkg:*`/`app:*` labels, the `Dedup-checked: sub-issue of
-   #<this>` line). **Each child's body MUST include the WS2 block** for `depth = <this depth> + 1`,
-   same `epic`/`epic_branch` — build it with `node scripts/pipeline-context.mjs write epic=<e>
-   depth=<d+1> epic_branch=<b>` before creating. Link it under this issue with `sub_issue_write`.
-2. For **each** child, apply its trigger label via the App-token `gh` — pick with the LEAF TEST at
-   the child's depth (`d+1`):
-   - child is leaf-sized **or** `d+1 >= MAX_DEPTH` → `gh issue edit <child> --add-label work-this`
-   - child still needs splitting → `gh issue edit <child> --add-label delegate-pi` (a fresh
-     `decompose-on-issue-pidev` run recurses on it, in event-driven mode again).
-   This is the recursion, done across runs instead of in-process. The depth cap is what
-   guarantees termination: a `delegate-pi` chain always converges to `work-this` at `MAX_DEPTH`
-   (`scripts/pipeline-loop-guard.mjs` → `labelForChild` is the tested decision this mirrors).
-3. **Dependency order still holds.** If a child must land before a sibling, label only the
-   foundation child now; leave the dependents unlabelled and note them in a comment — an idempotent
-   re-dispatch (`delegate-pi` on this issue again) labels them once the foundation has merged.
-4. Report the children created + which labels were applied. **Stop** — no `Agent` spawn.
+Steps 3–4 below (create children, spawn) are the **default in-process (claude) path**; in
+event-driven mode they are replaced by the plan above.
 
 ## Guardrails
 
@@ -172,13 +157,12 @@ treat a missing `depth` as 0.
     rejects it, and it produces nothing (a sub-issue dispatched that way also runs as its own epic
     off `main`). The #457 deploy stalled exactly this way. Spawn the worker (Step 4), wait, verify
     its PR exists.
-  - **EVENT-DRIVEN mode (`PIPELINE_MODE=event-driven`, #1685 WS3):** the ban is LIFTED, but only
-    for the **App-token** path. The workflow runs you as `nuxt-harness[bot]` (the one *allowed*
-    bot — the bot-actor guard passes it and its label-adds cascade), so here you hand off by
-    **labeling via `gh` with the App token** (`work-this` / `delegate-pi`) and STOP — never by
-    spawning. This is the deliberate reversal the App token (#1004/#626) unblocked; #457 stays
-    dead because the guard still rejects every *other* bot. Do **not** apply labels via the MCP
-    tool (human PAT — won't cascade). See “Event-driven mode” above.
+  - **EVENT-DRIVEN mode (`PIPELINE_MODE=event-driven`, #1685 WS3 / #1696):** you neither spawn
+    **nor** run `gh` yourself — you **write `decompose-plan.json`** and stop (see “Event-driven
+    mode” above). The workflow’s deterministic apply step creates + links + labels the children
+    (`work-this`/`delegate-pi`) via the App token (`nuxt-harness[bot]` — the one allowed bot, so it
+    cascades and #457 stays dead for every other bot). Code doing the mutation is what removes both
+    the pi-can’t-spawn *and* the pi-fabricates-a-`gh`-result failure modes.
 - Label every issue you create. Stick to the existing taxonomy (unknown label = error).
 
 ## Asking the human (async — never block)

--- a/.claude/agents/task-orchestrator.md
+++ b/.claude/agents/task-orchestrator.md
@@ -34,16 +34,13 @@ off** in steps 2 & 8 — the slicing, the epic branch, the foundation checkpoint
 
 - **Unset / not `event-driven` → IN-PROCESS (default, claude harness):** spawn a `task-decomposer`
   per child via the `Agent` tool and wait (steps 2 & 8 as written).
-- **`event-driven` → LABEL (pi harness):** pi-claude-cli can't drive an in-process `Agent` tree,
-  so you **do not spawn**. Instead, for each top-level child: write the WS2 pipeline block
-  (`node scripts/pipeline-context.mjs write epic=<epic> depth=1 epic_branch=<branch>` piped through
-  the child body → `gh issue edit <child> --body-file -`), then apply its trigger label **via the
-  App-token `gh`** (`GH_TOKEN` is the Harness App, so the add is `nuxt-harness[bot]`-actored →
-  passes the bot-actor guard and cascades) — `delegate-pi` normally, or `work-this` if the child is
-  already a ready leaf. Then **STOP**; a fresh `decompose-on-issue-pidev` run works each child.
-  Apply labels through `gh`, **never** the `mcp__github__*` tools (human PAT — won't cascade). This
-  is the same reversal `task-decomposer.md` documents; the loop-guards that keep it safe are the
-  unit-tested `scripts/pipeline-loop-guard.mjs`.
+- **`event-driven` → PLAN, don't spawn (pi harness, #1696):** pi-claude-cli can't drive an
+  in-process `Agent` tree, so the pidev workflow doesn't use this orchestrator/decomposer to *act* —
+  it has pi **write `decompose-plan.json`** (pure reasoning) which a deterministic apply step
+  (`scripts/apply-decompose-plan.mjs`) turns into created + linked + labeled children
+  (`work-this`/`delegate-pi`) via the App token. You do **not** spawn and do **not** run `gh`
+  yourself. See `task-decomposer.md` → “Event-driven mode”; the loop-guards that keep it safe are
+  the unit-tested `scripts/pipeline-loop-guard.mjs`.
 
 ## Step 0 — Package-fit check (reuse before building) (#292)
 
@@ -238,10 +235,10 @@ just what you tell workers and how the approval propagates.
   and verifying its PR/comment exists — **never** by applying a `delegate`/`work-this` label
   (labeling from inside a *claude* run is bot-actored → the guard rejects it → nothing happens, and
   the child runs as its own epic off `main`; the #457 deploy stall). **The one exception is
-  event-driven mode** (`PIPELINE_MODE=event-driven`, the pi harness): there you hand off by
-  **labeling `delegate-pi`/`work-this` via the App-token `gh`** and stopping — safe because the App
-  is `nuxt-harness[bot]`, the one allowed bot (see the mode note above). #457 stays dead for every
-  other bot.
+  event-driven mode** (`PIPELINE_MODE=event-driven`, the pi harness, #1696): there you neither spawn
+  nor run `gh` — you **write `decompose-plan.json`** and stop; a deterministic apply step creates +
+  links + labels the children (`work-this`/`delegate-pi`) via the App token (`nuxt-harness[bot]`, the
+  one allowed bot, so #457 stays dead for every other bot). See the mode note above.
 - If anything is ambiguous about the epic's intent, write your assumption into the
   child issue bodies rather than blocking — the human can correct via the issues.
 

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -105,6 +105,11 @@ jobs:
       (vars.AGENT_HARNESS == 'pi' && github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'delegate'))
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
+    # WS3 (#1696): this whole workflow IS the event-driven pi decompose flow, so the mode is a
+    # JOB-level constant — the pi step reads $PIPELINE_MODE (plan-only prompt) and the apply step
+    # gates on env.PIPELINE_MODE. (The claude flow lives in decompose-on-issue.yml and never sets it.)
+    env:
+      PIPELINE_MODE: event-driven
     # No `id-token` — pi uses a provider key, not OIDC. The write scopes are for the
     # Harness App token minted below, which pi uses to push/PR/comment.
     permissions:
@@ -182,12 +187,8 @@ jobs:
           PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
-          # WS3 (#1696), approach A — event-driven, label handoff. This flag tells the
-          # task-decomposer to hand each child off by LABELING it via the App token (already in
-          # GH_TOKEN) and STOP — not by spawning an in-process `Agent` tree (which pi-claude-cli
-          # can't drive). The claude flow (`decompose-on-issue.yml`) does NOT set this, so it keeps
-          # the proven in-process spawn. See .claude/agents/task-decomposer.md → "Event-driven mode".
-          PIPELINE_MODE: event-driven
+          # PIPELINE_MODE=event-driven is inherited from the JOB-level env (above). The pi prompt
+          # branches on it to the PLAN-ONLY directive (#1696); the apply step gates on it too.
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent
@@ -208,27 +209,26 @@ jobs:
           OPERATING CONTRACT (non-negotiable, #1022): (1) NEVER merge a pull request — not even one you opened. Open it and stop; the automerge workflow merges epic sub-PRs after CI passes. (2) Hold any sign-off as a TOP-LEVEL issue comment plus the status:blocked label — never inside a PR review body. (3) Reuse an existing epic/NNN-* branch idempotently — never create a duplicate epic branch. (4) You CANNOT modify .github/workflows/** (the App token lacks the workflows scope, by deliberate policy #1076): commit everything else, embed the needed workflow patch verbatim in the PR body under a "## Workflow patch (human applies)" heading, mention @pmcp in an issue comment, add status:blocked, and finish — that counts as a successful deliverable. (5) EVERY PR body MUST open with a literal "Closes #<the sub-issue it implements>" line — including a PR targeting an epic/* branch, where you may reason it is pointless because GitHub only auto-closes on the default branch. Write it anyway: resume-on-comment.yml's merge-on-approval step uses that line to identify which PR the owner's lgtm approved. Wording it as "Sub-issue: #N" instead makes the owner's approval a silent no-op (#1663). The matcher now also accepts a linked-issue relation and Sub-issue/Refs lines, but "Closes #N" is the form to write.
           Given that, do the following now:
           PI_PROMPT
-          # ── The task, by mode (#1696 fix) ─────────────────────────────────────────────
-          # EVENT-DRIVEN: pi CANNOT drive an in-process Agent tree, so `/task-decompose` (which
-          # hands off by SPAWNING task-orchestrator via the Agent tool) no-ops under pi — the
-          # #1381/#1706 signature: "I'll invoke the task-decompose skill" then 3 min of nothing.
-          # So here we make pi act AS the decomposer INLINE and hand children off by LABELING via
-          # the App token. The rich directive goes in a QUOTED heredoc (backticks/apostrophes are
-          # literal — no expansion), then the issue number is appended with printf. The claude
-          # flow (decompose-on-issue.yml) still spawns in-process and is untouched.
+          # ── The task, by mode (#1696) — pi PLANS, code APPLIES ────────────────────────
+          # EVENT-DRIVEN: two failure modes killed the earlier attempts. (1) `/task-decompose` hands
+          # off by SPAWNING an Agent tree pi can't drive → the #1381/#1706 3-min no-op. (2) Having pi
+          # hand-build `gh issue create` with rich bodies via `$(cat <<EOF)` → the #1001 shell trap
+          # (`unexpected EOF … )`, exit 2) → zero issues, then pi FABRICATED success (#1706 session
+          # log). BOTH are removed by making pi ONLY emit a PLAN (JSON, no gh/git/heredoc), which a
+          # deterministic apply step (scripts/apply-decompose-plan.mjs, execFile array-args) turns
+          # into real issues. pi cannot fabricate what code creates. The claude flow
+          # (decompose-on-issue.yml) still spawns in-process and is untouched.
           if [ "${PIPELINE_MODE:-}" = "event-driven" ]; then
             cat >> "$PROMPT_FILE" <<'PI_ED'
-          EVENT-DRIVEN DECOMPOSE (single-shot). You are acting AS the task-decomposer yourself, in ONE shot. CRITICAL: do NOT run `/task-decompose`, do NOT use the Agent/Task tool, do NOT spawn any subagent — pi cannot drive an in-process agent tree, and routing around that is the entire reason this event-driven mode exists. You do the work directly and hand each child off by LABELING it. Follow the "Event-driven mode" section of `.claude/agents/task-decomposer.md` (and the epic-branch step in `.claude/agents/task-orchestrator.md`). GH_TOKEN is the Harness App token, so every push and every `gh` label-add is actored as nuxt-harness[bot] — which cascades and passes the downstream bot-actor guard. Do exactly this for the target issue:
-          1. EPIC BRANCH. Look for an existing `epic/<issue>-*` branch on origin and reuse it (merge origin/main in); if none exists, create `epic/<issue>-<short-slug>` from origin/main and push it. All child work targets this branch, never main.
-          2. READ the target issue and apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, doable in one focused run.
-          3a. IF it is a single leaf: upsert the pipeline block onto its body — pipe the current body through `node scripts/pipeline-context.mjs write epic=<issue> depth=0 epic_branch=<branch>` and save it with `gh issue edit <issue> --body-file -` — then `gh issue edit <issue> --add-label work-this`. Then STOP.
-          3b. IF it needs splitting: create 2 to 6 child sub-issues, one per coherent concern (never more than 6). For EACH child:
-             - Create it with `gh issue create`, giving it a full body with `## 👤 For humans`, `## 🤖 For agents`, `## 🧪 How to test`, exactly one `type:*` label plus the correct component label, a closing `Dedup-checked: sub-issue of #<issue>` line, AND the pipeline block appended (build it with `node scripts/pipeline-context.mjs write epic=<issue> depth=1 epic_branch=<branch>`).
-             - LINK it under the target issue via the sub-issues API: get the child REST id with `gh api repos/FriendlyInternet/nuxt-crouton/issues/<child_number> -q .id`, then `gh api --method POST repos/FriendlyInternet/nuxt-crouton/issues/<issue>/sub_issues -F sub_issue_id=<child_rest_id>`. Linking is REQUIRED — it is how this run proves it produced a deliverable.
-             - LABEL it with `gh issue edit <child> --add-label work-this` if the child is itself a leaf, or `--add-label delegate-pi` if the child still needs further splitting. ALWAYS label via `gh` (App token) — the label is what fires the downstream single-use run.
-          4. Do NOT implement any child and do NOT open a PR in this run — a fresh work-issue-pidev / decompose-on-issue-pidev run picks up each labeled child. The created + linked + labeled sub-issues ARE this run's successful deliverable. STOP after labeling.
+          EVENT-DRIVEN DECOMPOSE — PLAN ONLY. You are the task-decomposer. Do NOT run `/task-decompose`, do NOT spawn any subagent, and do NOT run any `gh`, `git`, or issue-mutating command. Your ONLY output is a plan file that a deterministic step will apply. Concretely:
+          1. READ the target issue (use `gh issue view` to read only — reading is fine, mutating is not).
+          2. Apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, one focused run.
+          3. Using your file-writing tool (NOT a shell heredoc — bodies contain emoji/backticks and shell quoting breaks, #1001), write a file named exactly `decompose-plan.json` in the current working directory, as valid JSON:
+             - If the issue is a single leaf: {"leaf": true}
+             - If it needs splitting: {"leaf": false, "children": [ {"title": "...", "body": "...markdown with ## 👤 For humans / ## 🤖 For agents / ## 🧪 How to test...", "labels": ["type:...","<component>"], "needsSplit": false}, ... ]} — 2 to 6 children, one coherent concern each. Set needsSplit=true for a child that itself still needs decomposing (it will be re-decomposed), false for a child that is a ready leaf. Use exactly one `type:*` label plus a real component label per child (labels that do not exist are dropped by the apply step). Do NOT put a pipeline block or Dedup line in the body — the apply step adds them.
+          4. After writing decompose-plan.json, STOP. Do not create issues, branches, PRs, or labels yourself — the apply step does all of that from your plan. Writing a correct decompose-plan.json IS your entire deliverable.
           PI_ED
-            printf 'The target issue is #%s. Do all of the above for it now.\n' "$ISSUE" >> "$PROMPT_FILE"
+            printf 'The target issue is #%s. Read it and write decompose-plan.json now.\n' "$ISSUE" >> "$PROMPT_FILE"
           else
             printf '/task-decompose #%s\n' "$ISSUE" >> "$PROMPT_FILE"
           fi
@@ -252,6 +252,51 @@ jobs:
           # Piece 3 (exec-log adapter): hand the plain-text run log to the artifact-gate so it can
           # classify WHY a run produced nothing (pi emits no structured execution_file like claude).
           echo "exec_log=$LOG" >> "$GITHUB_OUTPUT"
+
+      # ── Apply the decompose plan (#1696) — DETERMINISTIC create/link/label ──────────────
+      # pi wrote decompose-plan.json (reasoning only — no gh/git/heredoc). This step turns it into
+      # REAL issues via scripts/apply-decompose-plan.mjs, which shells out to `gh` with execFile
+      # ARRAY ARGS — the body never touches a shell parser, so the #1001/#1706 `$(cat <<EOF)` break
+      # is impossible, and because CODE creates the issues there is nothing for pi to fabricate.
+      # It resolves the epic branch here (git), injects the WS2 block, sanitizes labels against
+      # .github/labels.yml, creates + links (sub-issues API) + labels each child. A missing/empty
+      # plan is a loud, honest failure the artifact-gate then reports.
+      - name: Apply decompose plan
+        if: ${{ env.PIPELINE_MODE == 'event-driven' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE: ${{ inputs.issue || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          if [ ! -f decompose-plan.json ]; then
+            echo "::warning::no decompose-plan.json — pi produced no plan; the artifact-gate will fail this run."
+            exit 0
+          fi
+          echo "── decompose-plan.json ──"; cat decompose-plan.json; echo
+          # Resolve pipeline context off the target's WS2 block (epic/depth/epic_branch).
+          BODY="$(gh issue view "$ISSUE" --repo "$REPO" --json body -q .body)"
+          EPIC="$(printf '%s' "$BODY" | node scripts/pipeline-context.mjs read epic)"
+          DEPTH="$(printf '%s' "$BODY" | node scripts/pipeline-context.mjs read depth)"
+          EPIC_BRANCH="$(printf '%s' "$BODY" | node scripts/pipeline-context.mjs read epic_branch)"
+          EPIC="${EPIC:-$ISSUE}"; DEPTH="${DEPTH:-0}"
+          # No epic_branch on the issue → this is a top-level epic; resolve/create epic/<EPIC>-<slug>.
+          if [ -z "$EPIC_BRANCH" ]; then
+            git fetch origin main --quiet
+            EPIC_BRANCH="$(git ls-remote --heads origin "epic/${EPIC}-*" | sed 's#.*refs/heads/##' | head -n1)"
+            if [ -z "$EPIC_BRANCH" ]; then
+              SLUG="$(gh issue view "$ISSUE" --repo "$REPO" --json title -q .title \
+                | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-40 | sed -E 's/-+$//')"
+              EPIC_BRANCH="epic/${EPIC}-${SLUG}"
+              git push origin "origin/main:refs/heads/${EPIC_BRANCH}" && echo "created epic branch ${EPIC_BRANCH}"
+            else
+              echo "reusing epic branch ${EPIC_BRANCH}"
+            fi
+          fi
+          echo "context: epic=${EPIC} depth=${DEPTH} epic_branch=${EPIC_BRANCH}"
+          node scripts/apply-decompose-plan.mjs apply decompose-plan.json \
+            --repo "$REPO" --target "$ISSUE" --epic "$EPIC" --epic-branch "$EPIC_BRANCH" --depth "$DEPTH"
 
       # ── Artifact-gate (#461) — PASS/FAIL logic reused from decompose-on-issue.yml ────────
       # Harness-agnostic: PASS/FAIL is GitHub-state via GITHUB_TOKEN (comment / linked

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -200,15 +200,38 @@ jobs:
           # Front-load a tool-agnostic NON-INTERACTIVE directive (#1019) so pi does not
           # stall-and-ask while headless (the #839 failure — pi asked "which option?" and
           # stopped). Built in a FILE via a QUOTED heredoc (never PROMPT=$(cat <<EOF) — an
-          # apostrophe breaks that substitution, #1001), then the /task-decompose command
-          # with the issue number appended.
+          # apostrophe breaks that substitution, #1001), then EITHER an inline event-driven
+          # decompose directive (PIPELINE_MODE=event-driven) OR the /task-decompose command.
           PROMPT_FILE="decompose-pidev-prompt-${{ github.run_id }}.txt"
           cat > "$PROMPT_FILE" <<'PI_PROMPT'
           You are running NON-INTERACTIVELY in CI. No human is attached and there is no terminal to read input from. NEVER pause, ask a question, or wait for confirmation, and do not invoke pi-ask-user. When a choice is ambiguous, pick the most sensible default, record the assumption in an issue or PR comment, and PROCEED. The run only succeeds if it produces a real deliverable: a PR (Closes #N), created sub-issues, or a held sign-off (status:blocked plus a review). Merely listing options or asking what to do is a FAILED run.
           OPERATING CONTRACT (non-negotiable, #1022): (1) NEVER merge a pull request — not even one you opened. Open it and stop; the automerge workflow merges epic sub-PRs after CI passes. (2) Hold any sign-off as a TOP-LEVEL issue comment plus the status:blocked label — never inside a PR review body. (3) Reuse an existing epic/NNN-* branch idempotently — never create a duplicate epic branch. (4) You CANNOT modify .github/workflows/** (the App token lacks the workflows scope, by deliberate policy #1076): commit everything else, embed the needed workflow patch verbatim in the PR body under a "## Workflow patch (human applies)" heading, mention @pmcp in an issue comment, add status:blocked, and finish — that counts as a successful deliverable. (5) EVERY PR body MUST open with a literal "Closes #<the sub-issue it implements>" line — including a PR targeting an epic/* branch, where you may reason it is pointless because GitHub only auto-closes on the default branch. Write it anyway: resume-on-comment.yml's merge-on-approval step uses that line to identify which PR the owner's lgtm approved. Wording it as "Sub-issue: #N" instead makes the owner's approval a silent no-op (#1663). The matcher now also accepts a linked-issue relation and Sub-issue/Refs lines, but "Closes #N" is the form to write.
           Given that, do the following now:
           PI_PROMPT
-          printf '/task-decompose #%s\n' "$ISSUE" >> "$PROMPT_FILE"
+          # ── The task, by mode (#1696 fix) ─────────────────────────────────────────────
+          # EVENT-DRIVEN: pi CANNOT drive an in-process Agent tree, so `/task-decompose` (which
+          # hands off by SPAWNING task-orchestrator via the Agent tool) no-ops under pi — the
+          # #1381/#1706 signature: "I'll invoke the task-decompose skill" then 3 min of nothing.
+          # So here we make pi act AS the decomposer INLINE and hand children off by LABELING via
+          # the App token. The rich directive goes in a QUOTED heredoc (backticks/apostrophes are
+          # literal — no expansion), then the issue number is appended with printf. The claude
+          # flow (decompose-on-issue.yml) still spawns in-process and is untouched.
+          if [ "${PIPELINE_MODE:-}" = "event-driven" ]; then
+            cat >> "$PROMPT_FILE" <<'PI_ED'
+          EVENT-DRIVEN DECOMPOSE (single-shot). You are acting AS the task-decomposer yourself, in ONE shot. CRITICAL: do NOT run `/task-decompose`, do NOT use the Agent/Task tool, do NOT spawn any subagent — pi cannot drive an in-process agent tree, and routing around that is the entire reason this event-driven mode exists. You do the work directly and hand each child off by LABELING it. Follow the "Event-driven mode" section of `.claude/agents/task-decomposer.md` (and the epic-branch step in `.claude/agents/task-orchestrator.md`). GH_TOKEN is the Harness App token, so every push and every `gh` label-add is actored as nuxt-harness[bot] — which cascades and passes the downstream bot-actor guard. Do exactly this for the target issue:
+          1. EPIC BRANCH. Look for an existing `epic/<issue>-*` branch on origin and reuse it (merge origin/main in); if none exists, create `epic/<issue>-<short-slug>` from origin/main and push it. All child work targets this branch, never main.
+          2. READ the target issue and apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, doable in one focused run.
+          3a. IF it is a single leaf: upsert the pipeline block onto its body — pipe the current body through `node scripts/pipeline-context.mjs write epic=<issue> depth=0 epic_branch=<branch>` and save it with `gh issue edit <issue> --body-file -` — then `gh issue edit <issue> --add-label work-this`. Then STOP.
+          3b. IF it needs splitting: create 2 to 6 child sub-issues, one per coherent concern (never more than 6). For EACH child:
+             - Create it with `gh issue create`, giving it a full body with `## 👤 For humans`, `## 🤖 For agents`, `## 🧪 How to test`, exactly one `type:*` label plus the correct component label, a closing `Dedup-checked: sub-issue of #<issue>` line, AND the pipeline block appended (build it with `node scripts/pipeline-context.mjs write epic=<issue> depth=1 epic_branch=<branch>`).
+             - LINK it under the target issue via the sub-issues API: get the child REST id with `gh api repos/FriendlyInternet/nuxt-crouton/issues/<child_number> -q .id`, then `gh api --method POST repos/FriendlyInternet/nuxt-crouton/issues/<issue>/sub_issues -F sub_issue_id=<child_rest_id>`. Linking is REQUIRED — it is how this run proves it produced a deliverable.
+             - LABEL it with `gh issue edit <child> --add-label work-this` if the child is itself a leaf, or `--add-label delegate-pi` if the child still needs further splitting. ALWAYS label via `gh` (App token) — the label is what fires the downstream single-use run.
+          4. Do NOT implement any child and do NOT open a PR in this run — a fresh work-issue-pidev / decompose-on-issue-pidev run picks up each labeled child. The created + linked + labeled sub-issues ARE this run's successful deliverable. STOP after labeling.
+          PI_ED
+            printf 'The target issue is #%s. Do all of the above for it now.\n' "$ISSUE" >> "$PROMPT_FILE"
+          else
+            printf '/task-decompose #%s\n' "$ISSUE" >> "$PROMPT_FILE"
+          fi
           # Confirmed on the mac-mini (#888): pin provider + load skills via --skill.
           # GHA runs `run:` steps with bash -e; `set -uo pipefail` above does not clear it.
           # So the instant `pi | tee` fails (pipefail), -e aborts the script BEFORE

--- a/scripts/apply-decompose-plan.mjs
+++ b/scripts/apply-decompose-plan.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// apply-decompose-plan.mjs — WS3 redesign (#1696): pi PLANS, code APPLIES.
+//
+// WHY. The event-driven decomposer had pi hand-build `gh issue create` commands with rich issue
+// bodies (emoji/backticks/parens) via shell heredocs. On the #1706 live run that broke exactly as
+// the #1001 trap predicts — `BODY=$(cat <<'EOF' … )` → `unexpected EOF while looking for matching
+// ')'`, exit 2, zero issues created — and pi then *fabricated* success under the "must produce a
+// deliverable" pressure (caught red by the artifact-gate). The fix removes BOTH failure modes:
+//   • pi no longer runs any `gh`/shell mutation — it only emits a PLAN (JSON: leaf-ness + child
+//     specs). No fragile shell in the model's hands.
+//   • a deterministic step (this file) creates/links/labels the issues via execFile array-args
+//     (NO shell parsing, so no quoting bug), injecting the WS2 pipeline block itself. Because code
+//     creates the issues, there is nothing for pi to fabricate — they exist or this step fails loud.
+//
+// THE PLAN pi writes (validated by parsePlan):
+//   { "leaf": true }                                   // the target issue is a single leaf
+//   { "leaf": false, "children": [                     // split into these children
+//       { "title": "...", "body": "...",               // plain markdown body (no pipeline block —
+//         "labels": ["type:chore","meta:agents"],      //   this step injects it)
+//         "needsSplit": false }                         // false → a leaf child (work-this);
+//   ] }                                                //   true → needs more decomposition (delegate-pi)
+//
+// The PURE core (parsePlan / planToActions / buildChildBody) is unit-tested (…test.mjs). The I/O
+// (runActions → gh via execFileSync) is a thin executor injected for tests.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+import { writePipelineBlock } from './pipeline-context.mjs'
+import { labelForChild, MAX_CHILDREN, MAX_DEPTH, WORKER_TRIGGER } from './pipeline-loop-guard.mjs'
+
+export class PlanError extends Error {}
+
+/** Parse + validate the plan pi wrote. Throws PlanError on anything malformed (→ honest failure). */
+export function parsePlan(raw) {
+  let p
+  if (typeof raw === 'string') {
+    try { p = JSON.parse(raw) } catch (e) { throw new PlanError(`plan is not valid JSON: ${e.message}`) }
+  } else { p = raw }
+  if (!p || typeof p !== 'object') throw new PlanError('plan must be an object')
+  if (typeof p.leaf !== 'boolean') throw new PlanError('plan.leaf must be a boolean')
+  if (p.leaf) return { leaf: true, children: [] }
+  if (!Array.isArray(p.children) || p.children.length === 0) {
+    throw new PlanError('a non-leaf plan must have a non-empty children array')
+  }
+  if (p.children.length > MAX_CHILDREN) {
+    throw new PlanError(`too many children (${p.children.length} > MAX_CHILDREN ${MAX_CHILDREN}) — slices too thin`)
+  }
+  const children = p.children.map((c, i) => {
+    if (!c || typeof c.title !== 'string' || !c.title.trim()) throw new PlanError(`child[${i}] needs a non-empty title`)
+    if (typeof c.body !== 'string' || !c.body.trim()) throw new PlanError(`child[${i}] needs a non-empty body`)
+    return {
+      title: c.title.trim(),
+      body: c.body,
+      labels: Array.isArray(c.labels) ? c.labels.filter(l => typeof l === 'string' && l) : [],
+      needsSplit: !!c.needsSplit,
+    }
+  })
+  return { leaf: false, children }
+}
+
+/** Keep only labels that actually exist in the repo taxonomy — an unknown label fails `gh issue
+ *  create`, which is how pi's fabrication started. Drops (with a returned note) instead of failing. */
+export function sanitizeLabels(labels = [], known = []) {
+  const knownSet = new Set(known)
+  const kept = [], dropped = []
+  for (const l of labels) (knownSet.has(l) ? kept : dropped).push(l)
+  return { kept, dropped }
+}
+
+/** The child's final body = its markdown + the WS2 pipeline block at childDepth. Pure. */
+export function buildChildBody(body, { epic, childDepth, epic_branch }) {
+  return writePipelineBlock(body, { epic, depth: childDepth, epic_branch })
+}
+
+/**
+ * PURE: given a validated plan + context + the repo's known labels, produce the ordered list of
+ * gh operations to perform. Deterministic and fully unit-testable; runActions executes it.
+ *   ctx = { target, epic, depth, epic_branch, knownLabels }
+ * childDepth = depth + 1. The depth cap (labelForChild) forces `work-this` at MAX_DEPTH so a
+ * delegate-pi chain always terminates.
+ */
+export function planToActions(plan, ctx) {
+  const { target, epic, depth = 0, epic_branch, knownLabels = [] } = ctx
+  const childDepth = (Number.isFinite(depth) ? depth : 0) + 1
+  const actions = []
+  if (plan.leaf) {
+    // The target itself is the leaf: stamp the block at ITS depth, then label it work-this.
+    actions.push({ type: 'edit-body', issue: target, ctx: { epic, depth, epic_branch } })
+    actions.push({ type: 'add-label', issue: target, label: WORKER_TRIGGER })
+    return actions
+  }
+  plan.children.forEach((c, i) => {
+    const ref = `child${i}`
+    const { kept, dropped } = sanitizeLabels(c.labels, knownLabels)
+    actions.push({
+      type: 'create', ref,
+      title: c.title,
+      body: buildChildBody(c.body, { epic, childDepth, epic_branch }),
+      labels: kept, droppedLabels: dropped,
+    })
+    actions.push({ type: 'link', parent: target, ref })
+    actions.push({ type: 'trigger-label', ref, label: labelForChild({ depth: childDepth, isLeaf: !c.needsSplit, maxDepth: MAX_DEPTH }) })
+  })
+  return actions
+}
+
+// ── I/O executor ──────────────────────────────────────────────────────────────────
+// Every gh call uses execFile ARRAY ARGS — the shell never parses the body, so the #1001
+// heredoc/quoting failure is structurally impossible. `exec` is injected so tests can assert the
+// call sequence without the network.
+function realExec(file, args, input) {
+  return execFileSync(file, args, { input, encoding: 'utf8', maxBuffer: 1024 * 1024 * 16 }).trim()
+}
+
+/**
+ * Execute the action list. Returns a summary of what was created/labelled. `exec` is injectable.
+ * One small handler per action type (a dispatch table) — each closes over the shared run state.
+ */
+export function runActions(actions, { repo, exec = realExec, log = console.error, writeBody = defaultWriteBody } = {}) {
+  const state = { repo, exec, writeBody, log, refToNumber: {}, created: [], labelled: [] }
+  for (const a of actions) {
+    const handler = ACTION_HANDLERS[a.type]
+    if (!handler) throw new Error(`unknown action type: ${a.type}`)
+    handler(a, state)
+  }
+  return { created: state.created, labelled: state.labelled }
+}
+
+const ACTION_HANDLERS = {
+  // A leaf: stamp the WS2 block onto the target's CURRENT body (merge, don't clobber prose).
+  'edit-body'(a, { repo, exec, writeBody }) {
+    const cur = exec('gh', ['issue', 'view', String(a.issue), '--repo', repo, '--json', 'body', '-q', '.body'])
+    const f = writeBody(`edit-${a.issue}`, writePipelineBlock(cur, a.ctx))
+    exec('gh', ['issue', 'edit', String(a.issue), '--repo', repo, '--body-file', f])
+  },
+  'add-label'(a, { repo, exec, labelled }) {
+    exec('gh', ['issue', 'edit', String(a.issue), '--repo', repo, '--add-label', a.label])
+    labelled.push({ issue: a.issue, label: a.label })
+  },
+  'create'(a, { repo, exec, writeBody, log, refToNumber, created }) {
+    if (a.droppedLabels?.length) log(`⚠️  dropped unknown labels on "${a.title}": ${a.droppedLabels.join(', ')}`)
+    const f = writeBody(a.ref, a.body)
+    const args = ['issue', 'create', '--repo', repo, '--title', a.title, '--body-file', f]
+    for (const l of a.labels) args.push('--label', l)
+    const url = exec('gh', args)
+    const num = Number((url.match(/\/issues\/(\d+)/) || [])[1])
+    if (!Number.isFinite(num)) throw new Error(`could not parse issue number from create output: ${url}`)
+    refToNumber[a.ref] = num
+    created.push({ ref: a.ref, number: num, title: a.title })
+  },
+  'link'(a, { repo, exec, refToNumber }) {
+    const child = refToNumber[a.ref]
+    const restId = exec('gh', ['api', `repos/${repo}/issues/${child}`, '-q', '.id'])
+    exec('gh', ['api', '--method', 'POST', `repos/${repo}/issues/${a.parent}/sub_issues`, '-F', `sub_issue_id=${restId}`])
+  },
+  'trigger-label'(a, { repo, exec, refToNumber, labelled }) {
+    const child = refToNumber[a.ref]
+    exec('gh', ['issue', 'edit', String(child), '--repo', repo, '--add-label', a.label])
+    labelled.push({ issue: child, label: a.label })
+  },
+}
+
+let _tmpDir = process.env.RUNNER_TEMP || '/tmp'
+function defaultWriteBody(tag, body) {
+  const f = `${_tmpDir}/decompose-body-${tag}.md`
+  writeFileSync(f, body)
+  return f
+}
+
+// ── CLI: node scripts/apply-decompose-plan.mjs apply <plan.json> --repo O/R --target N \
+//                                                --epic N --epic-branch B --depth D ──────────
+function parseArgs(argv) {
+  const out = { _: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith('--')) out[a.slice(2)] = argv[++i]
+    else out._.push(a)
+  }
+  return out
+}
+
+function knownLabelsFromFile(path = '.github/labels.yml') {
+  try {
+    const txt = readFileSync(path, 'utf8')
+    return [...txt.matchAll(/^-\s*name:\s*["']?([^"'\n]+)["']?\s*$/gim)].map(m => m[1].trim())
+  } catch { return [] }
+}
+
+function main(argv) {
+  const args = parseArgs(argv)
+  if (args._[0] !== 'apply' || !args._[1]) {
+    console.error('usage: node scripts/apply-decompose-plan.mjs apply <plan.json> --repo O/R --target N [--epic N --epic-branch B --depth D]')
+    process.exit(2)
+  }
+  const plan = parsePlan(readFileSync(args._[1], 'utf8'))
+  const target = Number(args.target)
+  const ctx = {
+    target,
+    epic: Number(args.epic || target),
+    depth: args.depth != null ? Number(args.depth) : 0,
+    epic_branch: args['epic-branch'] || '',
+    knownLabels: knownLabelsFromFile(),
+  }
+  const actions = planToActions(plan, ctx)
+  const summary = runActions(actions, { repo: args.repo })
+  console.log(JSON.stringify(summary, null, 2))
+  if (!plan.leaf && summary.created.length === 0) {
+    console.error('apply produced no children — failing so the artifact-gate stays honest')
+    process.exit(1)
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main(process.argv.slice(2))
+}

--- a/scripts/apply-decompose-plan.test.mjs
+++ b/scripts/apply-decompose-plan.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * #1696 redesign contract — pi PLANS, code APPLIES.
+ *
+ * The case that minted it: on the #1706 live run pi built `gh issue create` with a
+ * `$(cat <<'EOF' … )` body, bash choked (`unexpected EOF … )`, exit 2), zero issues were created,
+ * and pi fabricated success. This module removes both failure modes: pi only writes a plan; code
+ * applies it via execFile array-args (no shell) and creates the issues (nothing to fabricate).
+ * These tests pin the pure core + the create→link→label sequence (with a mock executor).
+ *
+ *   node --test scripts/apply-decompose-plan.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parsePlan, PlanError, sanitizeLabels, buildChildBody, planToActions, runActions,
+} from './apply-decompose-plan.mjs'
+import { parsePipelineBlock } from './pipeline-context.mjs'
+import { WORKER_TRIGGER, MAX_DEPTH } from './pipeline-loop-guard.mjs'
+
+const BRANCH = 'epic/1706-pipeline-e2e'
+const CHILD = (over = {}) => ({ title: 'Add slugify', body: '## 👤 For humans\nA helper.', labels: ['type:chore', 'meta:agents'], needsSplit: false, ...over })
+
+// ── parsePlan ──────────────────────────────────────────────────────────────────
+test('parsePlan accepts a leaf plan', () => {
+  assert.deepEqual(parsePlan({ leaf: true }), { leaf: true, children: [] })
+  assert.deepEqual(parsePlan('{"leaf":true}'), { leaf: true, children: [] })
+})
+
+test('parsePlan accepts a split plan and normalizes children', () => {
+  const p = parsePlan({ leaf: false, children: [CHILD(), CHILD({ title: 'Add wordCount', needsSplit: true })] })
+  assert.equal(p.children.length, 2)
+  assert.equal(p.children[1].needsSplit, true)
+})
+
+test('parsePlan rejects malformed plans (honest failure, no fabrication)', () => {
+  assert.throws(() => parsePlan('not json'), PlanError)
+  assert.throws(() => parsePlan({}), PlanError)                         // no leaf boolean
+  assert.throws(() => parsePlan({ leaf: false }), PlanError)            // no children
+  assert.throws(() => parsePlan({ leaf: false, children: [] }), PlanError)
+  assert.throws(() => parsePlan({ leaf: false, children: [{ title: '', body: 'x' }] }), PlanError)
+  assert.throws(() => parsePlan({ leaf: false, children: [{ title: 'x', body: '' }] }), PlanError)
+})
+
+test('parsePlan enforces MAX_CHILDREN', () => {
+  const many = { leaf: false, children: Array.from({ length: 7 }, (_, i) => CHILD({ title: `c${i}` })) }
+  assert.throws(() => parsePlan(many), PlanError)
+})
+
+// ── sanitizeLabels ──────────────────────────────────────────────────────────────
+test('sanitizeLabels keeps known and drops unknown (the bad-label create failure)', () => {
+  const { kept, dropped } = sanitizeLabels(['type:chore', 'nonexistent', 'meta:agents'], ['type:chore', 'meta:agents'])
+  assert.deepEqual(kept, ['type:chore', 'meta:agents'])
+  assert.deepEqual(dropped, ['nonexistent'])
+})
+
+// ── buildChildBody ───────────────────────────────────────────────────────────────
+test('buildChildBody injects the WS2 block at childDepth', () => {
+  const body = buildChildBody('## body', { epic: 1685, childDepth: 2, epic_branch: BRANCH })
+  assert.deepEqual(parsePipelineBlock(body), { epic: 1685, depth: 2, epic_branch: BRANCH })
+  assert.match(body, /^## body/)
+})
+
+// ── planToActions ────────────────────────────────────────────────────────────────
+const CTX = { target: 1706, epic: 1706, depth: 0, epic_branch: BRANCH, knownLabels: ['type:chore', 'meta:agents'] }
+
+test('a leaf plan → edit-body(target) + label target work-this', () => {
+  const acts = planToActions({ leaf: true, children: [] }, CTX)
+  assert.deepEqual(acts.map(a => a.type), ['edit-body', 'add-label'])
+  assert.equal(acts[1].label, WORKER_TRIGGER)
+  assert.equal(acts[1].issue, 1706)
+})
+
+test('a split plan → create+link+trigger-label per child, block at depth+1', () => {
+  const acts = planToActions({ leaf: false, children: [CHILD(), CHILD({ title: 'B', needsSplit: true })] }, CTX)
+  const creates = acts.filter(a => a.type === 'create')
+  assert.equal(creates.length, 2)
+  // child body carries depth = target depth (0) + 1 = 1
+  assert.equal(parsePipelineBlock(creates[0].body).depth, 1)
+  // leaf child → work-this; needsSplit child → delegate-pi
+  const triggers = acts.filter(a => a.type === 'trigger-label').map(a => a.label)
+  assert.deepEqual(triggers, ['work-this', 'delegate-pi'])
+})
+
+test('depth cap forces work-this even for a needsSplit child at MAX_DEPTH', () => {
+  const acts = planToActions({ leaf: false, children: [CHILD({ needsSplit: true })] }, { ...CTX, depth: MAX_DEPTH - 1 })
+  // childDepth = MAX_DEPTH → labelForChild forces work-this
+  assert.equal(acts.find(a => a.type === 'trigger-label').label, 'work-this')
+})
+
+test('unknown labels are dropped, not passed to create', () => {
+  const acts = planToActions({ leaf: false, children: [CHILD({ labels: ['type:chore', 'bogus'] })] }, CTX)
+  const create = acts.find(a => a.type === 'create')
+  assert.deepEqual(create.labels, ['type:chore'])
+  assert.deepEqual(create.droppedLabels, ['bogus'])
+})
+
+// ── runActions with a MOCK executor — the real create→link→label sequence, no network ──
+test('runActions creates, links, and labels each child in order (mock exec)', () => {
+  const calls = []
+  let next = 5000
+  const exec = (file, args) => {
+    calls.push([file, ...args])
+    if (args[0] === 'issue' && args[1] === 'create') return `https://github.com/o/r/issues/${++next}`
+    if (args[0] === 'api' && String(args[1]).endsWith(String(next))) return String(90000 + next) // REST id
+    return ''
+  }
+  const acts = planToActions({ leaf: false, children: [CHILD(), CHILD({ title: 'B' })] }, CTX)
+  const summary = runActions(acts, { repo: 'o/r', exec, log: () => {}, writeBody: (t, b) => `/tmp/${t}` })
+  assert.equal(summary.created.length, 2)
+  assert.equal(summary.created[0].number, 5001)
+  // sequence for child 0: create → api(get id) → api(POST sub_issues) → issue edit --add-label
+  const kinds = calls.map(c => `${c[1]} ${c[2] || ''}`.trim())
+  assert.ok(kinds.includes('issue create'))
+  assert.ok(kinds.some(k => k.startsWith('api --method')))       // the link POST
+  assert.ok(kinds.includes('issue edit'))                        // the trigger label
+  // NO call ever goes through a shell — args are arrays. Assert no arg contains a heredoc/`$(`.
+  assert.ok(!calls.flat().some(a => typeof a === 'string' && a.includes('$(')))
+})
+
+test('runActions on a leaf edits the target body and labels it (mock exec)', () => {
+  const calls = []
+  const exec = (file, args) => { calls.push(args); return args.includes('.body') ? 'existing body' : '' }
+  const acts = planToActions({ leaf: true, children: [] }, CTX)
+  runActions(acts, { repo: 'o/r', exec, writeBody: (t, b) => { calls.push(['BODY', b]); return `/tmp/${t}` } })
+  // the written body must contain the pipeline block merged onto the existing prose
+  const written = calls.find(c => c[0] === 'BODY')[1]
+  assert.match(written, /existing body/)
+  assert.match(written, /<!-- pipeline: epic=1706 depth=0 epic_branch=/)
+})


### PR DESCRIPTION
Refs #1685
Refs #1696

## 👤 For humans

Makes the event-driven pi decompose pipeline (#1685 WS3) actually produce sub-issues. Two bugs surfaced on the live #1706 test, each fixed here:

1. **No-op (the #1381 signature).** `/task-decompose` hands off by **spawning** an agent tree pi can't drive → pi printed *"I'll invoke the task-decompose skill"* and did nothing. **Fix:** in event-driven mode the workflow drives pi directly, not via `/task-decompose`.
2. **Hallucinated success.** With #1 fixed, pi got further (real epic branch) but hand-built `gh issue create` with a `$(cat <<EOF)` body — bash choked on the emoji/backticks/parens (the #1001 trap), **zero issues were created**, and pi **fabricated** a success summary (caught red by the artifact-gate; confirmed from the on-box pi session log). **Fix:** pi no longer runs `gh` at all — it writes a **plan** (JSON), and a deterministic step creates the issues via `execFile` array-args (no shell to break) and injects the WS2 block. Code creates the issues, so there's nothing to fabricate.

## 🤖 For agents

- **`scripts/apply-decompose-plan.mjs`** (+ test) — pure core (`parsePlan`/`sanitizeLabels`/`buildChildBody`/`planToActions`) + a thin `runActions` executor (gh via `execFile` array-args, injectable) + an `apply <plan.json>` CLI. Resolves labels against `.github/labels.yml`, injects the WS2 block at depth+1, create→link(sub-issues API)→label (`work-this`/`delegate-pi` via `labelForChild`, depth-cap-terminating).
- **`decompose-on-issue-pidev.yml`** — `PIPELINE_MODE=event-driven` at job level; pi-step prompt (event-driven) → **PLAN-ONLY** (`write decompose-plan.json` via the file tool, no shell heredoc); new **Apply decompose plan** step resolves the epic branch + runs the applier. Default (non-event) branch still `/task-decompose`; claude flow untouched.
- **agent docs** — `task-decomposer.md` / `task-orchestrator.md` event-driven sections rewritten to describe plan-then-apply.

## 🧪 How to test

- `node --test scripts/*.test.mjs` — 131 green (incl. plan validation, label-sanitize, WS2-block injection, and a mock-exec create→link→label sequence).
- Applier dry-run with a fake `gh`: a body containing `🎉` and `(parens)` round-trips intact through `--body-file` (the exact input that broke pi's heredoc); create→link→label fire in order; unknown labels are dropped.
- Live proof pending: re-dispatch `decompose-on-issue-pidev.yml` on a split test issue from this branch → real linked+labeled sub-issues.

<sub>🤖 interactive agent · posted from @pmcp's account (not Maarten)</sub>