### PR TITLE
fix(root): run CI + E2E on every PR regardless of base branch (#1698)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,12 @@ on:
       - 'scripts/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci.yml'
+  # NB: deliberately NO `branches:` filter (#1698). A PR opened against a stacked
+  # epic branch and later auto-retargeted to main never re-fires `pull_request`
+  # (`base_ref_changed` is not a default activity type), so a `branches: [main]`
+  # filter silently skipped typecheck/tests on #1668 and auto-merge treated the
+  # absent checks as passing. Running on every PR regardless of base is the fix.
   pull_request:
-    branches: [main]
     paths:
       - 'packages/**'
       - 'apps/**'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,8 +17,12 @@ on:
       - 'e2e/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/e2e.yml'
+  # NB: deliberately NO `branches:` filter (#1698). A PR opened against a stacked
+  # epic branch and later auto-retargeted to main never re-fires `pull_request`
+  # (`base_ref_changed` is not a default activity type), so a `branches: [main]`
+  # filter silently skipped typecheck/tests on #1668 and auto-merge treated the
+  # absent checks as passing. Running on every PR regardless of base is the fix.
   pull_request:
-    branches: [main]
     paths:
       - 'packages/**'
       - 'fixtures/**'


### PR DESCRIPTION
Refs #1698 (part 1 of 2). Root-caused from the #1668 incident.

## 👤 For humans

A PR merged to `main` today with typecheck, tests and e2e **never having run** — not failed, never started. It shipped a broken import that surfaced hours later as a red fanfare staging deploy, during unrelated work.

## 🔍 Root cause

`automatic_base_change_succeeded` at **10:26:55** on #1668's timeline.

| time | what happened |
|---|---|
| 10:25:20 | PR **opened against a stacked epic branch**, not `main` |
| 10:25:24 | 9 workflows fire — **`CI` and `E2E` do not** |
| 10:26:55 | parent merged → GitHub **auto-retargets** the base to `main` |
| — | that fires `base_ref_changed`, **not** a default `pull_request` type → nothing re-triggers |
| 10:30:07 | auto-merge merges. Nothing red, because nothing ran |

Nothing malfunctioned. `branches: [main]` did exactly what it says at `opened` time; the trigger set just has no coverage for "base changed afterwards".

## Why it's `branches:`, not `paths:`

The issue originally guessed a paths mismatch or a concurrency interaction. Both are ruled out by the evidence:

- `deploy-apps.yml` filters on the **identical** `packages/**` and **did** run on that PR — so the paths matched fine.
- `simplify-review.yml` also has a `paths` filter and ran.
- The **only** two workflows that didn't run are the **only** two whose `pull_request` trigger also carries **`branches: [main]`**.

Also ruled out: `GITHUB_TOKEN` anti-recursion (9 workflows *did* fire) and the #1523 concurrency block (group is per-head-ref and unique; no cancelled run exists).

## 🤖 The change

Dropped `branches: [main]` from the **`pull_request`** trigger of `ci.yml` and `e2e.yml`. `push` keeps its `branches: [main]` — only the PR trigger changes.

```
ci.yml  → pull_request keys: paths | push keys: branches, paths
e2e.yml → pull_request keys: paths | push keys: branches, paths
```

**Cost:** stacked sub-PRs now also run CI/E2E. That's the intended behaviour, not a side effect — they were the exact case going unchecked.

**Frequency, measured:** 1 of the last 40 merged PRs was auto-retargeted (#1668 itself). Rare — but silent and total when it hits.

## ⏳ Not fixed here — part 2

Auto-merge still treats a check that **never reported** as passing. That's the deeper half of #1698: part 1 closes the hole we found, part 2 closes the ones we haven't. I'd keep #1698 open for it after this merges.

## 🧪 How to test

Open a PR against a non-`main` branch that touches `packages/**`, and confirm `Type Check Apps` and the E2E matrix now appear in its checks. Before this change they were absent.