### PR TITLE
docs(crouton-auth): document isPending as a resolved-latch (#1703)

### DIFF
--- a/packages/crouton-auth/README.md
+++ b/packages/crouton-auth/README.md
@@ -291,7 +291,7 @@ const {
   user,                    // Ref<User | null>
   loading,                 // Ref<boolean>
   error,                   // Ref<string | null>
-  isPending,               // From session
+  isPending,               // From session — a resolved-latch, see useSession()
   sessionError,            // Session error
 
   // Computed
@@ -388,7 +388,7 @@ const {
   activeOrganization,      // Ref<Team | null>
 
   // Status
-  isPending,               // Ref<boolean>
+  isPending,               // Ref<boolean> — see below
   error,                   // Ref<Error | null>
   isAuthenticated,         // ComputedRef<boolean>
 
@@ -397,6 +397,24 @@ const {
   clear,                   // () => Promise<void>
 } = useSession()
 ```
+
+#### `isPending` is a resolved-latch, not an in-flight flag
+
+It starts `true` and flips to `false` the first time the session resolves — then **never
+returns to `true`**. Read it as *"do we know who the user is yet?"*, not *"is a request in
+flight right now?"*.
+
+Use it to hold a decision until auth is known (route guards, redirects). Do **not** use it
+to drive a loading spinner on a refresh — it will not go back to `true` for background
+revalidation, and a UI that waits for that will wait forever.
+
+This changed in #1703. Previously it flipped on every fetch, including background
+revalidation triggered by better-auth's `$sessionSignal`. Because every consumer in the
+monorepo already treated it as a latch, that churn re-armed all of them at once — enough to
+restart an in-flight navigation and strand a user on a spinner.
+
+`clear()` (logout) tears down the session state, the in-flight request caches and the
+default-org repair latch, so the next user on a shared device starts clean.
 
 ---
 
@@ -408,7 +426,8 @@ Team (organization) management with mode-aware behavior.
 const {
   // State
   currentTeam,             // ComputedRef<Team | null>
-  teams,                   // ComputedRef<Team[]>
+  teams,                   // ComputedRef<Team[]> — populated by refreshTeams() / SSR, NOT
+                           // by better-auth's useListOrganizations atom (#1703)
   members,                 // ComputedRef<Member[]>
   currentRole,             // ComputedRef<MemberRole | null>
   loading,                 // Ref<boolean>


### PR DESCRIPTION
Doc-sync follow-up to #1703 / PR #1708. Docs only — no code.

Packages-approved: README-only change in `packages/crouton-auth`, documenting the public-API semantics that PR #1708 altered.

## 👤 For humans

#1703 changed what `isPending` means, but the README still described it as a bare
`Ref<boolean>`. Anyone reading that would reasonably wire it to a loading spinner — and it
now never returns to `true`, so that spinner would hang forever. Given the bug we just
fixed was a hanging spinner, leaving this undocumented seemed like a good way to cause the
next one.

## 🤖 For agents

I skipped `/sync-docs` on the production commits in #1708 (I ran it against a tests-only
first commit and did not re-run it once real code landed). This closes that gap.

- **`useSession()`** — new *"isPending is a resolved-latch"* section: `true` until the
  session first resolves, then never `true` again. States plainly that it is for holding a
  decision until auth is known (route guards, redirects) and **not** for driving loading UI
  on revalidation. Records why it changed and that `clear()` now also tears down the
  in-flight caches and the default-org repair latch.
- **`useAuth()`** — cross-reference from its re-exported `isPending`.
- **`useTeam()`** — note that `teams` is populated by `refreshTeams()` / SSR, not by
  better-auth's `useListOrganizations` atom, which is never mounted under the vanilla client
  (root cause tracked in #1713).

## 🧪 How to test

Read `packages/crouton-auth/README.md` under `useSession()` and confirm the described
behaviour matches `app/composables/useSession.ts` — `isPendingState` initialises `true`
(line ~67) and is only ever set `false` (in `fetchSession`'s `finally`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)