### PR TITLE
fix(crouton-sales): import toast drops its numbers — interpolate through t(), not after it

### DIFF
--- a/packages/crouton-sales/app/components/EventWorkspace/ProductImportModal.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/ProductImportModal.vue
@@ -148,11 +148,17 @@ interface ImportResult {
   createdLocations: string[]
 }
 
+/**
+ * Interpolate through `t()`, never by hand afterwards: vue-i18n compiles `{created}` as a
+ * named placeholder and renders it as an EMPTY STRING when `t()` is called without params —
+ * so a post-hoc `.replace('{created}', …)` finds nothing left to replace and the toast reads
+ * "aangemaakt, overgeslagen, mislukt" with every number missing (#1722).
+ */
 const summaryOf = (r: ImportResult) =>
-  t('sales.import.doneBody', '{created} created, {skipped} skipped, {errors} failed')
-    .replace('{created}', String(r.created))
-    .replace('{skipped}', String(r.skipped))
-    .replace('{errors}', String(r.errors.length))
+  t('sales.import.doneBody', {
+    params: { created: r.created, skipped: r.skipped, errors: r.errors.length },
+    fallback: '{created} created, {skipped} skipped, {errors} failed',
+  })
 
 /**
  * Surface the server's own reason when it gave one — "nothing was saved" alone leaves


### PR DESCRIPTION
Closes #1722

Packages-approved: continuation of the owner's in-session approval for the `packages/crouton-sales` import fix (#1707) — this is the same feature's summary toast, reported while verifying that fix on staging.

## 👤 For humans

The #1707 fix works — the owner's import went through on staging. But the success toast read **"aangemaakt, overgeslagen, mislukt"**: the three numbers were missing. They're back now.

## 🤖 For agents

**Root cause.** `summaryOf` interpolated *by hand, after* `t()`:

```js
t('sales.import.doneBody', '{created} created, …').replace('{created}', String(r.created))
```

The string-fallback form resolves to `{ fallback }` with **no params**, so `useT.translate()` takes the `i18n.t(key)` branch (`useT.ts:163`). vue-i18n compiles `{created}` as a named placeholder and renders it as an **empty string** when called without params — so `.replace()` had nothing left to match.

**Fix.** Pass the counts through `t()`'s own `params`, as every other placeholder string in this package already does.

**Isolated.** Swept every placeholder-carrying key in `crouton-sales`: `deleteAllOrdersDone`, `helpersLockedOut`, `helpersLoggedOut`, `resendQueued`, `orderCount`, `createNamed`, `syncedAgo` all pass params correctly. This was the only offender, and the only `.replace('{` applied to a `t()` result anywhere in the repo.

### Related finding — deliberately not fixed here

`useT.ts:181` and `:244` substitute with `params[k] || ''`. **`||` treats `0` as absent**, so a zero count renders as an empty string.

The normal path is unaffected — vue-i18n interpolates first and handles `0` correctly, and the later `.replace` finds no placeholders left. But a **team-overridden** key skips vue-i18n entirely and hits only that line, so an overridden `"{count} orders deleted"` would read `" orders deleted"` at zero.

It's a one-character fix (`||` → `??`), but it lives in `crouton-i18n` and affects every translated string in every app — that deserves its own approval and regression pass, not a ride-along on a sales bug fix. Documented in #1722.

## Verification

- `pnpm --filter kassa typecheck` — no errors in this file. One pre-existing error remains in `crouton-core/.../theme.patch.ts` (from #1387, untouched).
- `npx fallow audit` — no issues in the changed file.
- **Not verified end-to-end** — needs a staging import, below.

## 🧪 How to test

1. On staging, import 6+ products into an event.
2. **Before:** green toast reads "aangemaakt, overgeslagen, mislukt". **After:** "6 aangemaakt, 0 overgeslagen, 0 mislukt".
3. Re-run the identical paste so every row is a duplicate — this is the case that proves **zeros render**, not just non-zero counts: expect "0 aangemaakt, 6 overgeslagen, 0 mislukt".