### PR TITLE
fix(crouton-auth): drop the obsolete post-login sleep, fix a latent TDZ throw (#1712)

### DIFF
--- a/packages/crouton-auth/app/composables/useAuth.ts
+++ b/packages/crouton-auth/app/composables/useAuth.ts
@@ -96,36 +96,13 @@ export function useAuth() {
   // Get reactive session from useSession composable
   const { user: sessionUser, isAuthenticated, isPending, error: sessionError, refresh, clear, activeOrganization } = useSession()
 
-  /**
-   * Refresh session with retry for activeOrganization
-   *
-   * When auto-creating workspaces or using default teams, the database hook sets
-   * activeOrganizationId AFTER the session response is sent. This causes a timing
-   * issue where the initial refresh doesn't include the org. We retry after a delay
-   * to allow the hook to complete and the session to be updated in the database.
-   */
-  async function refreshWithOrgRetry(maxRetries = 3, delayMs = 200): Promise<void> {
-    await refresh()
-
-    // Only retry if auto-creating workspaces or using default team
-    const hasAutoSetup = config?.teams?.autoCreateOnSignup || config?.teams?.defaultTeamSlug
-    if (!hasAutoSetup) {
-      return
-    }
-
-    // If no activeOrg after initial refresh, retry with delays
-    for (let i = 0; i < maxRetries && !activeOrganization.value; i++) {
-      if (debug) {
-        console.log(`[@crouton/auth] refreshWithOrgRetry: attempt ${i + 1}/${maxRetries}, waiting ${delayMs}ms`)
-      }
-      await new Promise(resolve => setTimeout(resolve, delayMs))
-      await refresh()
-    }
-
-    if (debug && !activeOrganization.value) {
-      console.warn('[@crouton/auth] refreshWithOrgRetry: activeOrganization still null after retries')
-    }
-  }
+  // NOTE (#1712): a `refreshWithOrgRetry` wrapper used to sit here — it called
+  // refresh(), then slept and retried up to 3× waiting for activeOrganizationId
+  // to appear. It existed because the old `session.create.after` hook wrote the
+  // org AFTER the session response was already sent, so the first refresh
+  // genuinely couldn't see it. #1703 moved that to `session.create.before`, so
+  // the org is present before the session cookie is even written and there is
+  // nothing left to wait for. Call sites now use plain refresh().
 
   if (debug) {
     console.log('[@crouton/auth] useAuth: initialized', {
@@ -208,11 +185,11 @@ export function useAuth() {
       }
 
       if (debug) {
-        console.log('[@crouton/auth] login: calling refreshWithOrgRetry to update session state')
+        console.log('[@crouton/auth] login: refreshing session state')
       }
 
-      // Refresh session with retry to handle async org assignment
-      await refreshWithOrgRetry()
+      // Pull the new session into shared state (the server already set its org)
+      await refresh()
 
       if (debug) {
         console.log('[@crouton/auth] login: after refresh', {
@@ -320,11 +297,11 @@ export function useAuth() {
       }
 
       if (debug) {
-        console.log('[@crouton/auth] register: calling refreshWithOrgRetry to update session state')
+        console.log('[@crouton/auth] register: refreshing session state')
       }
 
-      // Refresh session with retry to handle async org assignment
-      await refreshWithOrgRetry()
+      // Pull the new session into shared state (the server already set its org)
+      await refresh()
 
       if (debug) {
         console.log('[@crouton/auth] register: after refresh', {

--- a/packages/crouton-auth/app/middleware/team-context.global.ts
+++ b/packages/crouton-auth/app/middleware/team-context.global.ts
@@ -34,25 +34,39 @@ export default defineNuxtRouteMiddleware(async (to) => {
   // Get session state
   const { isAuthenticated, activeOrganization, isPending } = useSession()
 
-  // Wait for session to load (important for initial navigation)
+  // Wait for the session to resolve (important for initial navigation).
+  //
+  // `isPending` is a resolved-latch (#1703): true until the session first
+  // resolves, then never true again — so this waits at most once per app.
+  //
+  // `unwatch` MUST be declared before watch() (#1712). With `immediate: true`
+  // the callback runs synchronously during the watch() call, i.e. before a
+  // `const unwatch = watch(...)` binding would be initialised — so if isPending
+  // were already false at that moment, calling unwatch() there threw a
+  // ReferenceError from the temporal dead zone. The `if` above happened to make
+  // that unreachable, which is exactly the kind of guard that quietly stops
+  // holding.
   if (isPending.value) {
-    // Wait for session to load (max 5 seconds)
     await new Promise<void>((resolve) => {
-      const unwatch = watch(
+      let unwatch: (() => void) | undefined
+      let timer: ReturnType<typeof setTimeout> | undefined
+
+      const finish = () => {
+        unwatch?.()
+        if (timer) clearTimeout(timer)
+        resolve()
+      }
+
+      unwatch = watch(
         () => isPending.value,
         (pending) => {
-          if (!pending) {
-            unwatch()
-            resolve()
-          }
+          if (!pending) finish()
         },
         { immediate: true }
       )
-      // Timeout after 5 seconds
-      setTimeout(() => {
-        unwatch()
-        resolve()
-      }, 5000)
+
+      // Don't block navigation forever if the session never resolves.
+      timer = setTimeout(finish, 5000)
     })
   }
 


### PR DESCRIPTION
Closes #1712

Packages-approved: both items are direct consequences of #1703 / PR #1708 and live in `packages/crouton-auth`. Owner approved the follow-up.

## 👤 For humans

Two small clean-ups the login fix left behind.

**Signing in no longer sleeps.** It used to refresh, then wait 200ms and retry, up to three times, hoping the server had got round to assigning your team. Since #1703 the server sets the team *before* the session cookie is written, so there is nothing to wait for. Login now does one refresh and no artificial delay.

**A bug that had never fired is closed.** A line in the team middleware would have thrown if the session happened to be ready slightly earlier than expected. It was safe only by accident — and #1703 changed the exact timing that accident relied on.

## 🤖 For agents

### 1. `refreshWithOrgRetry` removed (`app/composables/useAuth.ts`)

Worth correcting the issue's framing: it was **not** uncalled — `login()` and `register()` both invoked it. What was dead is the **retry loop**, which only ran when `autoCreateOnSignup` or `defaultTeamSlug` was set, and **no app in the repo sets either**. The `await refresh()` it wrapped is still needed, so call sites now use `refresh()` directly.

Its own docstring described the #1703 root cause verbatim — *"the database hook sets activeOrganizationId AFTER the session response is sent"* — which `session.create.before` eliminated.

Safe to delete: the wrapper was internal (never returned), and the public `refreshSession` already maps to `refresh`. Also removes a `setTimeout` sleep, which the house rules forbid.

### 2. Temporal-dead-zone throw fixed (`app/middleware/team-context.global.ts`)

```js
const unwatch = watch(() => isPending.value, (pending) => {
  if (!pending) { unwatch(); resolve() }   // ← TDZ if this runs synchronously
}, { immediate: true })
```

With `immediate: true` the callback runs **during** the `watch()` call, before a `const` binding is initialised. If `isPending` were already `false`, `unwatch()` threw `ReferenceError: Cannot access 'unwatch' before initialization`.

Unreachable today only because of the `if (isPending.value)` guard above it — and #1703 turned `isPending` from a per-request flag into a resolved-latch, changing exactly that ordering. Now `let unwatch` is declared first; the 5s timeout is also cleared on the normal path instead of being left pending.

## 🧪 How to test

1. Log in to kassa, velo and triage — each lands in its team, with no delay and no retry.
2. `grep -n setTimeout packages/crouton-auth/app/composables/useAuth.ts` → no matches.
3. For the TDZ: temporarily delete the `if (isPending.value)` guard at `team-context.global.ts` and load any page. On `main` this throws `ReferenceError: Cannot access 'unwatch' before initialization`; on this branch it does not.
4. `/e2e-smoke` — shared package code.

292 unit tests pass; `pnpm typecheck` clean across kassa/velo/triage; `npx fallow audit` reports no issues in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)