### PR TITLE
feat(root): column-level schema diff — catch a squash that reverts a corrective migration (#1717)

### DIFF
--- a/.claude/skills/db-migrations/SKILL.md
+++ b/.claude/skills/db-migrations/SKILL.md
@@ -70,6 +70,45 @@ Key paths (per app, e.g. `apps/kassa`):
   `--local`), `db:migrate:prod` / `db:migrate:staging` (`--remote`),
   `db:seed*` (crouton-seed). NB: never run `npx nuxt db generate` from repo root.
 
+## Squashing a migration history — run the schema diff FIRST (required)
+
+A squash regenerates the baseline **from the schema source**. A hand-written corrective
+migration that fixed the *database* but was never reflected back into that source is
+therefore **silently reverted**.
+
+This is not hypothetical. kassa's `0019_nullable_printer_location` made
+`sales_printers.locationId` nullable, healing a `0016` regression. The schema source
+still said `.notNull()`, so the #1455 squash brought the bug straight back — caught only
+when the production restore died on real rows:
+
+```
+NOT NULL constraint failed: sales_printers.locationId
+```
+
+**A table-NAME diff cannot see this** — the table exists on both sides. Compare columns:
+
+```bash
+# concatenate the OLD history in order, then diff against the regenerated baseline
+for f in $(git show HEAD:apps/<app>/server/db/migrations/sqlite | grep '\.sql$'); do
+  git show HEAD:apps/<app>/server/db/migrations/sqlite/$f
+done > /tmp/old_history.sql
+
+node scripts/schema-diff.mjs /tmp/old_history.sql \
+  apps/<app>/server/db/migrations/sqlite/0000_*.sql \
+  --live <the wrangler d1 export dump>
+```
+
+Exit 0 = a data-only restore should load cleanly. Exit 1 = it will fail; fix the schema
+source and regenerate **before** touching any database.
+
+**Always pass `--live`.** The migration files can have drifted from the database that
+actually exists; the live dump is what governs the restore. Without it the script can
+only flag the *shape* of the problem, not confirm it.
+
+**Restoring afterwards:** data only — never the old `d1_migrations` rows (that silently
+un-does the squash) — and insert in **foreign-key order**, because D1's export is
+alphabetical, so `account` precedes `user` and a naive reload dies on a constraint.
+
 ## Adding an APP collection (the common case)
 
 Use the **crouton** skill / CLI — don't hand-write the table. Edit the schema

--- a/scripts/schema-diff.mjs
+++ b/scripts/schema-diff.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Column-level schema diff for migration squashes (#1717).
+ *
+ * WHY THIS EXISTS: squashing a migration history regenerates the baseline from the
+ * SCHEMA SOURCE. A hand-written corrective migration that fixed the DATABASE but was
+ * never reflected back into that source is therefore SILENTLY REVERTED by the squash.
+ *
+ * That is not hypothetical. kassa's `0019_nullable_printer_location` made
+ * `sales_printers.locationId` nullable, healing a regression `0016` introduced. The
+ * schema source still said `.notNull()`, so the #1455 squash brought the bug straight
+ * back — and it was caught only when the production restore died on real data:
+ *
+ *     NOT NULL constraint failed: sales_printers.locationId
+ *
+ * A table-NAME diff cannot see this: the table exists on both sides. You have to
+ * compare COLUMNS and their constraints.
+ *
+ * Usage:
+ *   node scripts/schema-diff.mjs <old.sql> <new.sql> [--live <dump.sql>] [--json]
+ *
+ *   <old.sql>   concatenated OLD migration history (cat 0000..NNNN in order)
+ *   <new.sql>   the regenerated single baseline
+ *   --live      a `wrangler d1 export` dump of the LIVE database. This is the one
+ *               that governs a restore — the migration files can drift from reality.
+ *
+ * Exit codes: 0 = no restore-blocking drift, 1 = drift that will break a restore.
+ */
+import { readFileSync } from 'node:fs'
+
+/** Split a CREATE TABLE body on top-level commas (nested parens are not separators). */
+function splitColumns(body) {
+  const parts = []
+  let depth = 0
+  let cur = ''
+  for (const ch of body) {
+    if (ch === '(') depth++
+    if (ch === ')') depth--
+    if (ch === ',' && depth === 0) {
+      parts.push(cur.trim())
+      cur = ''
+    } else { cur += ch }
+  }
+  parts.push(cur.trim())
+  return parts
+}
+
+const CONSTRAINT_LINE = /^(?:FOREIGN|PRIMARY|UNIQUE|CONSTRAINT|CHECK)\b/i
+
+/** `\`col\` text NOT NULL` → ['col', 'text NOT NULL'] (whitespace-normalised). */
+function parseColumn(decl) {
+  if (CONSTRAINT_LINE.test(decl)) return null
+  // Group 2 must start non-whitespace: `\s*(.*)` is ambiguous (both can match spaces)
+  // and eslint flags it as super-linear backtracking.
+  // `\s+` (not `\s*`) before group 2: \w and \s are disjoint, so the name can't
+  // overlap the tail. `\s*` there is ambiguous and eslint flags the backtracking.
+  const m = decl.match(/^[`"[]?(\w+)[`"\]]?(?:\s+(\S[\s\S]*))?$/)
+  if (!m) return null
+  return [m[1], (m[2] || '').split(/\s+/).join(' ').replace(/,$/, '').trim()]
+}
+
+const STMT = new RegExp(
+  '(CREATE TABLE\\s+(?:IF NOT EXISTS\\s+)?[`"[]?\\w+[`"\\]]?\\s*\\([\\s\\S]*?\\);'
+  + '|DROP TABLE\\s+(?:IF EXISTS\\s+)?[`"[]?\\w+[`"\\]]?\\s*;'
+  + '|ALTER TABLE\\s+[`"[]?\\w+[`"\\]]?\\s+RENAME TO\\s+[`"[]?\\w+[`"\\]]?\\s*;)',
+  'gi'
+)
+
+/**
+ * Replay CREATE/DROP/RENAME so a drizzle table REBUILD resolves to its FINAL shape.
+ *
+ * Drizzle rebuilds a table as: CREATE __new_x → copy → DROP x → ALTER __new_x RENAME TO x.
+ * Without replaying, every rebuilt table reads as a spurious drop plus a stray __new_*.
+ * This is exactly how `0019` expressed its fix, so a differ that skips this step is
+ * blind to the very case the script exists for.
+ *
+ * @returns {Record<string, Record<string,string>>} table -> column -> normalised type
+ */
+export function finalTables(sql) {
+  const tables = {}
+  for (const [stmt] of sql.matchAll(STMT)) {
+    const s = stmt.trim()
+    if (/^CREATE/i.test(s)) {
+      const name = s.match(/CREATE TABLE\s+(?:IF NOT EXISTS\s+)?[`"[]?(\w+)/i)[1]
+      const body = s.slice(s.indexOf('(') + 1, s.lastIndexOf(')'))
+      const cols = {}
+      for (const decl of splitColumns(body)) {
+        const parsed = parseColumn(decl)
+        if (parsed) cols[parsed[0]] = parsed[1]
+      }
+      tables[name] = cols
+    } else if (/^DROP/i.test(s)) {
+      const name = s.match(/DROP TABLE\s+(?:IF EXISTS\s+)?[`"[]?(\w+)/i)[1]
+      delete tables[name]
+    } else {
+      const m = s.match(/ALTER TABLE\s+[`"[]?(\w+)[`"\]]?\s+RENAME TO\s+[`"[]?(\w+)/i)
+      if (m && tables[m[1]]) {
+        tables[m[2]] = tables[m[1]]
+        delete tables[m[1]]
+      }
+    }
+  }
+  for (const t of Object.keys(tables)) if (t.startsWith('__new')) delete tables[t]
+  return tables
+}
+
+const isNotNull = def => /\bNOT NULL\b/i.test(def)
+const hasDefault = def => /\bDEFAULT\b/i.test(def)
+
+/**
+ * Compare two schemas.
+ *
+ * `live` (when given) is authoritative for restore safety: the migration files can
+ * have drifted from the database that actually exists.
+ */
+export function diffSchemas(oldSql, newSql, liveSql = null) {
+  const oldT = finalTables(oldSql)
+  const newT = finalTables(newSql)
+  const liveT = liveSql ? finalTables(liveSql) : null
+
+  const droppedTables = Object.keys(oldT).filter(t => !(t in newT)).sort()
+  const addedTables = Object.keys(newT).filter(t => !(t in oldT)).sort()
+
+  const columns = []
+  for (const t of Object.keys(oldT).filter(x => x in newT).sort()) {
+    for (const c of [...new Set([...Object.keys(oldT[t]), ...Object.keys(newT[t])])].sort()) {
+      const before = oldT[t][c]
+      const after = newT[t][c]
+      if (before === undefined) columns.push({ table: t, column: c, kind: 'added', after })
+      else if (after === undefined) columns.push({ table: t, column: c, kind: 'removed', before })
+      else if (before.toLowerCase() !== after.toLowerCase()) {
+        columns.push({ table: t, column: c, kind: 'changed', before, after })
+      }
+    }
+  }
+
+  // Restore blockers — the failures that actually stop a data reload.
+  const blockers = []
+  if (liveT) {
+    for (const t of Object.keys(liveT)) {
+      if (!(t in newT)) continue // table not in the baseline: nothing to restore into
+      for (const c of Object.keys(liveT[t])) {
+        if (!(c in newT[t])) {
+          blockers.push({ table: t, column: c, reason: 'live column missing from the new baseline — INSERT will fail' })
+        }
+      }
+      for (const [c, def] of Object.entries(newT[t])) {
+        if (!isNotNull(def) || hasDefault(def)) continue
+        if (!(c in liveT[t])) {
+          blockers.push({ table: t, column: c, reason: 'NOT NULL with no DEFAULT and absent from live data — INSERT will fail' })
+        } else if (!isNotNull(liveT[t][c])) {
+          // THE kassa case (#1455): the column exists on both sides, so a presence
+          // check is blind to it. Live permits NULL, the new baseline forbids it —
+          // any existing NULL row fails the restore.
+          blockers.push({ table: t, column: c, reason: 'live column is NULLABLE but the new baseline makes it NOT NULL with no DEFAULT — existing NULL rows will fail the restore' })
+        }
+      }
+    }
+  } else {
+    // Without a live dump, flag the shape of the kassa regression: a column that
+    // became NOT NULL. Advisory — only a live dump can confirm it actually breaks.
+    for (const c of columns) {
+      if (c.kind === 'changed' && !isNotNull(c.before) && isNotNull(c.after) && !hasDefault(c.after)) {
+        blockers.push({ table: c.table, column: c.column, reason: 'became NOT NULL (no DEFAULT) — pass --live to confirm against real rows' })
+      }
+    }
+  }
+
+  return { droppedTables, addedTables, columns, blockers }
+}
+
+function main(argv) {
+  const args = argv.filter(a => a !== '--json')
+  const json = argv.includes('--json')
+  const liveIdx = args.indexOf('--live')
+  const live = liveIdx !== -1 ? args[liveIdx + 1] : null
+  const positional = args.filter((a, i) => a !== '--live' && (liveIdx === -1 || i !== liveIdx + 1))
+  const [oldPath, newPath] = positional.slice(2)
+
+  if (!oldPath || !newPath) {
+    console.error('usage: node scripts/schema-diff.mjs <old.sql> <new.sql> [--live <dump.sql>] [--json]')
+    process.exit(2)
+  }
+
+  const r = diffSchemas(
+    readFileSync(oldPath, 'utf8'),
+    readFileSync(newPath, 'utf8'),
+    live ? readFileSync(live, 'utf8') : null
+  )
+
+  if (json) {
+    console.log(JSON.stringify(r, null, 2))
+  } else {
+    console.log(`tables dropped: ${r.droppedTables.join(', ') || '(none)'}`)
+    console.log(`tables added:   ${r.addedTables.join(', ') || '(none)'}`)
+    console.log(`\ncolumn differences (${r.columns.length}):`)
+    for (const c of r.columns) {
+      if (c.kind === 'added') console.log(`  + ${c.table}.${c.column}  (${c.after})`)
+      else if (c.kind === 'removed') console.log(`  - ${c.table}.${c.column}  (was ${c.before})`)
+      else console.log(`  ~ ${c.table}.${c.column}  ${c.before}  →  ${c.after}`)
+    }
+    console.log(`\nrestore blockers (${r.blockers.length}):`)
+    for (const b of r.blockers) console.log(`  ✗ ${b.table}.${b.column} — ${b.reason}`)
+    if (!r.blockers.length) console.log('  ✓ none — a data-only restore should load cleanly')
+  }
+
+  process.exit(r.blockers.length ? 1 : 0)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main(process.argv)

--- a/scripts/schema-diff.mjs
+++ b/scripts/schema-diff.mjs
@@ -66,6 +66,28 @@ const STMT = new RegExp(
   'gi'
 )
 
+function applyCreate(tables, s) {
+  const name = s.match(/CREATE TABLE\s+(?:IF NOT EXISTS\s+)?[`"[]?(\w+)/i)[1]
+  const body = s.slice(s.indexOf('(') + 1, s.lastIndexOf(')'))
+  const cols = {}
+  for (const decl of splitColumns(body)) {
+    const parsed = parseColumn(decl)
+    if (parsed) cols[parsed[0]] = parsed[1]
+  }
+  tables[name] = cols
+}
+
+function applyDrop(tables, s) {
+  delete tables[s.match(/DROP TABLE\s+(?:IF EXISTS\s+)?[`"[]?(\w+)/i)[1]]
+}
+
+function applyRename(tables, s) {
+  const m = s.match(/ALTER TABLE\s+[`"[]?(\w+)[`"\]]?\s+RENAME TO\s+[`"[]?(\w+)/i)
+  if (!m || !tables[m[1]]) return
+  tables[m[2]] = tables[m[1]]
+  delete tables[m[1]]
+}
+
 /**
  * Replay CREATE/DROP/RENAME so a drizzle table REBUILD resolves to its FINAL shape.
  *
@@ -80,25 +102,9 @@ export function finalTables(sql) {
   const tables = {}
   for (const [stmt] of sql.matchAll(STMT)) {
     const s = stmt.trim()
-    if (/^CREATE/i.test(s)) {
-      const name = s.match(/CREATE TABLE\s+(?:IF NOT EXISTS\s+)?[`"[]?(\w+)/i)[1]
-      const body = s.slice(s.indexOf('(') + 1, s.lastIndexOf(')'))
-      const cols = {}
-      for (const decl of splitColumns(body)) {
-        const parsed = parseColumn(decl)
-        if (parsed) cols[parsed[0]] = parsed[1]
-      }
-      tables[name] = cols
-    } else if (/^DROP/i.test(s)) {
-      const name = s.match(/DROP TABLE\s+(?:IF EXISTS\s+)?[`"[]?(\w+)/i)[1]
-      delete tables[name]
-    } else {
-      const m = s.match(/ALTER TABLE\s+[`"[]?(\w+)[`"\]]?\s+RENAME TO\s+[`"[]?(\w+)/i)
-      if (m && tables[m[1]]) {
-        tables[m[2]] = tables[m[1]]
-        delete tables[m[1]]
-      }
-    }
+    if (/^CREATE/i.test(s)) applyCreate(tables, s)
+    else if (/^DROP/i.test(s)) applyDrop(tables, s)
+    else applyRename(tables, s)
   }
   for (const t of Object.keys(tables)) if (t.startsWith('__new')) delete tables[t]
   return tables
@@ -107,20 +113,8 @@ export function finalTables(sql) {
 const isNotNull = def => /\bNOT NULL\b/i.test(def)
 const hasDefault = def => /\bDEFAULT\b/i.test(def)
 
-/**
- * Compare two schemas.
- *
- * `live` (when given) is authoritative for restore safety: the migration files can
- * have drifted from the database that actually exists.
- */
-export function diffSchemas(oldSql, newSql, liveSql = null) {
-  const oldT = finalTables(oldSql)
-  const newT = finalTables(newSql)
-  const liveT = liveSql ? finalTables(liveSql) : null
-
-  const droppedTables = Object.keys(oldT).filter(t => !(t in newT)).sort()
-  const addedTables = Object.keys(newT).filter(t => !(t in oldT)).sort()
-
+/** Per-column added/removed/changed across the tables both schemas share. */
+function diffColumns(oldT, newT) {
   const columns = []
   for (const t of Object.keys(oldT).filter(x => x in newT).sort()) {
     for (const c of [...new Set([...Object.keys(oldT[t]), ...Object.keys(newT[t])])].sort()) {
@@ -133,77 +127,104 @@ export function diffSchemas(oldSql, newSql, liveSql = null) {
       }
     }
   }
+  return columns
+}
 
-  // Restore blockers — the failures that actually stop a data reload.
-  const blockers = []
-  if (liveT) {
-    for (const t of Object.keys(liveT)) {
-      if (!(t in newT)) continue // table not in the baseline: nothing to restore into
-      for (const c of Object.keys(liveT[t])) {
-        if (!(c in newT[t])) {
-          blockers.push({ table: t, column: c, reason: 'live column missing from the new baseline — INSERT will fail' })
-        }
-      }
-      for (const [c, def] of Object.entries(newT[t])) {
-        if (!isNotNull(def) || hasDefault(def)) continue
-        if (!(c in liveT[t])) {
-          blockers.push({ table: t, column: c, reason: 'NOT NULL with no DEFAULT and absent from live data — INSERT will fail' })
-        } else if (!isNotNull(liveT[t][c])) {
-          // THE kassa case (#1455): the column exists on both sides, so a presence
-          // check is blind to it. Live permits NULL, the new baseline forbids it —
-          // any existing NULL row fails the restore.
-          blockers.push({ table: t, column: c, reason: 'live column is NULLABLE but the new baseline makes it NOT NULL with no DEFAULT — existing NULL rows will fail the restore' })
-        }
-      }
-    }
-  } else {
-    // Without a live dump, flag the shape of the kassa regression: a column that
-    // became NOT NULL. Advisory — only a live dump can confirm it actually breaks.
-    for (const c of columns) {
-      if (c.kind === 'changed' && !isNotNull(c.before) && isNotNull(c.after) && !hasDefault(c.after)) {
-        blockers.push({ table: c.table, column: c.column, reason: 'became NOT NULL (no DEFAULT) — pass --live to confirm against real rows' })
-      }
+/** One table, compared against the live schema: what will actually break the reload. */
+function blockersForTable(t, newCols, liveCols) {
+  const out = []
+  for (const c of Object.keys(liveCols)) {
+    if (!(c in newCols)) {
+      out.push({ table: t, column: c, reason: 'live column missing from the new baseline — INSERT will fail' })
     }
   }
+  for (const [c, def] of Object.entries(newCols)) {
+    if (!isNotNull(def) || hasDefault(def)) continue
+    if (!(c in liveCols)) {
+      out.push({ table: t, column: c, reason: 'NOT NULL with no DEFAULT and absent from live data — INSERT will fail' })
+    } else if (!isNotNull(liveCols[c])) {
+      // THE kassa case (#1455): the column exists on both sides, so a presence check
+      // is blind to it. Live permits NULL, the new baseline forbids it — any existing
+      // NULL row fails the restore.
+      out.push({ table: t, column: c, reason: 'live column is NULLABLE but the new baseline makes it NOT NULL with no DEFAULT — existing NULL rows will fail the restore' })
+    }
+  }
+  return out
+}
 
-  return { droppedTables, addedTables, columns, blockers }
+/**
+ * No live dump: flag the SHAPE of the kassa regression (nullable → NOT NULL).
+ * Advisory — only real rows can confirm it actually breaks, hence the message.
+ */
+function blockersFromShape(columns) {
+  return columns
+    .filter(c => c.kind === 'changed' && !isNotNull(c.before) && isNotNull(c.after) && !hasDefault(c.after))
+    .map(c => ({ table: c.table, column: c.column, reason: 'became NOT NULL (no DEFAULT) — pass --live to confirm against real rows' }))
+}
+
+/**
+ * Compare two schemas.
+ *
+ * `liveSql` (when given) is authoritative for restore safety: the migration files can
+ * have drifted from the database that actually exists.
+ */
+export function diffSchemas(oldSql, newSql, liveSql = null) {
+  const oldT = finalTables(oldSql)
+  const newT = finalTables(newSql)
+  const liveT = liveSql ? finalTables(liveSql) : null
+
+  const columns = diffColumns(oldT, newT)
+  const blockers = liveT
+    ? Object.keys(liveT).filter(t => t in newT).flatMap(t => blockersForTable(t, newT[t], liveT[t]))
+    : blockersFromShape(columns)
+
+  return {
+    droppedTables: Object.keys(oldT).filter(t => !(t in newT)).sort(),
+    addedTables: Object.keys(newT).filter(t => !(t in oldT)).sort(),
+    columns,
+    blockers
+  }
+}
+
+/** @returns {{oldPath?:string, newPath?:string, live:string|null, json:boolean}} */
+export function parseArgs(argv) {
+  const json = argv.includes('--json')
+  const rest = argv.slice(2).filter(a => a !== '--json')
+  const i = rest.indexOf('--live')
+  const live = i === -1 ? null : rest[i + 1]
+  const positional = i === -1 ? rest : [...rest.slice(0, i), ...rest.slice(i + 2)]
+  return { oldPath: positional[0], newPath: positional[1], live, json }
+}
+
+const COLUMN_LINE = {
+  added: c => `  + ${c.table}.${c.column}  (${c.after})`,
+  removed: c => `  - ${c.table}.${c.column}  (was ${c.before})`,
+  changed: c => `  ~ ${c.table}.${c.column}  ${c.before}  →  ${c.after}`
+}
+
+function report(r) {
+  console.log(`tables dropped: ${r.droppedTables.join(', ') || '(none)'}`)
+  console.log(`tables added:   ${r.addedTables.join(', ') || '(none)'}`)
+  console.log(`\ncolumn differences (${r.columns.length}):`)
+  for (const c of r.columns) console.log(COLUMN_LINE[c.kind](c))
+  console.log(`\nrestore blockers (${r.blockers.length}):`)
+  for (const b of r.blockers) console.log(`  ✗ ${b.table}.${b.column} — ${b.reason}`)
+  if (!r.blockers.length) console.log('  ✓ none — a data-only restore should load cleanly')
 }
 
 function main(argv) {
-  const args = argv.filter(a => a !== '--json')
-  const json = argv.includes('--json')
-  const liveIdx = args.indexOf('--live')
-  const live = liveIdx !== -1 ? args[liveIdx + 1] : null
-  const positional = args.filter((a, i) => a !== '--live' && (liveIdx === -1 || i !== liveIdx + 1))
-  const [oldPath, newPath] = positional.slice(2)
-
+  const { oldPath, newPath, live, json } = parseArgs(argv)
   if (!oldPath || !newPath) {
     console.error('usage: node scripts/schema-diff.mjs <old.sql> <new.sql> [--live <dump.sql>] [--json]')
     process.exit(2)
   }
-
   const r = diffSchemas(
     readFileSync(oldPath, 'utf8'),
     readFileSync(newPath, 'utf8'),
     live ? readFileSync(live, 'utf8') : null
   )
-
-  if (json) {
-    console.log(JSON.stringify(r, null, 2))
-  } else {
-    console.log(`tables dropped: ${r.droppedTables.join(', ') || '(none)'}`)
-    console.log(`tables added:   ${r.addedTables.join(', ') || '(none)'}`)
-    console.log(`\ncolumn differences (${r.columns.length}):`)
-    for (const c of r.columns) {
-      if (c.kind === 'added') console.log(`  + ${c.table}.${c.column}  (${c.after})`)
-      else if (c.kind === 'removed') console.log(`  - ${c.table}.${c.column}  (was ${c.before})`)
-      else console.log(`  ~ ${c.table}.${c.column}  ${c.before}  →  ${c.after}`)
-    }
-    console.log(`\nrestore blockers (${r.blockers.length}):`)
-    for (const b of r.blockers) console.log(`  ✗ ${b.table}.${b.column} — ${b.reason}`)
-    if (!r.blockers.length) console.log('  ✓ none — a data-only restore should load cleanly')
-  }
-
+  if (json) console.log(JSON.stringify(r, null, 2))
+  else report(r)
   process.exit(r.blockers.length ? 1 : 0)
 }
 

--- a/scripts/schema-diff.test.mjs
+++ b/scripts/schema-diff.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Contract for the squash schema differ (#1717).
+ *
+ * The headline case is the real one: kassa's `0019_nullable_printer_location` fixed
+ * `sales_printers.locationId` in the DATABASE but never in the schema source, so the
+ * #1455 squash silently reverted it and the production restore died on real rows.
+ * If this file's `reproduces the kassa regression` test ever goes green-by-accident,
+ * the differ has stopped doing the one job it exists for.
+ *
+ *   node --test scripts/schema-diff.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { finalTables, diffSchemas } from './schema-diff.mjs'
+
+// ── the kassa history, reduced to the shape that matters ─────────────────────
+// 0016 rebuilt the table with locationId NOT NULL (the regression);
+// 0019 rebuilt it again with locationId nullable (the corrective fix).
+const OLD_HISTORY = `
+CREATE TABLE \`sales_printers\` (
+  \`id\` text PRIMARY KEY NOT NULL,
+  \`locationId\` text NOT NULL,
+  \`title\` text NOT NULL
+);
+PRAGMA foreign_keys=OFF;
+CREATE TABLE \`__new_sales_printers\` (
+  \`id\` text PRIMARY KEY NOT NULL,
+  \`locationId\` text,
+  \`title\` text NOT NULL
+);
+INSERT INTO \`__new_sales_printers\` SELECT * FROM \`sales_printers\`;
+DROP TABLE \`sales_printers\`;
+ALTER TABLE \`__new_sales_printers\` RENAME TO \`sales_printers\`;
+PRAGMA foreign_keys=ON;
+`
+
+// The regenerated baseline: built from the schema source, which still said notNull().
+const NEW_BASELINE = `
+CREATE TABLE \`sales_printers\` (
+  \`id\` text PRIMARY KEY NOT NULL,
+  \`locationId\` text NOT NULL,
+  \`title\` text NOT NULL
+);
+`
+
+// What the live database actually looked like (post-0019): nullable, and rows use it.
+const LIVE_DUMP = `
+CREATE TABLE \`sales_printers\` (
+  \`id\` text PRIMARY KEY NOT NULL,
+  \`locationId\` text,
+  \`title\` text NOT NULL
+);
+INSERT INTO "sales_printers" VALUES('p1',NULL,'Receipt');
+`
+
+test('replays a drizzle table rebuild to its FINAL shape (not a spurious drop)', () => {
+  const t = finalTables(OLD_HISTORY)
+  assert.ok(t.sales_printers, 'sales_printers survived the DROP + RENAME')
+  assert.equal(t.sales_printers.locationId, 'text', '0019 left it nullable')
+  assert.ok(!Object.keys(t).some(n => n.startsWith('__new')), 'no __new_* leaks into the result')
+})
+
+test('reproduces the kassa regression: the squash reverts 0019 to NOT NULL', () => {
+  const { columns } = diffSchemas(OLD_HISTORY, NEW_BASELINE)
+  const hit = columns.find(c => c.table === 'sales_printers' && c.column === 'locationId')
+  assert.ok(hit, 'the differ must notice locationId at all')
+  assert.equal(hit.kind, 'changed')
+  assert.match(hit.after, /NOT NULL/i)
+  assert.doesNotMatch(hit.before, /NOT NULL/i)
+})
+
+test('a table-NAME diff would have missed it — the table exists on both sides', () => {
+  const { droppedTables, addedTables } = diffSchemas(OLD_HISTORY, NEW_BASELINE)
+  assert.deepEqual(droppedTables, [], 'no table dropped…')
+  assert.deepEqual(addedTables, [], '…and none added — which is why names alone are blind')
+})
+
+test('flags the restore blocker when the live dump is supplied', () => {
+  const { blockers } = diffSchemas(OLD_HISTORY, NEW_BASELINE, LIVE_DUMP)
+  const b = blockers.find(x => x.table === 'sales_printers' && x.column === 'locationId')
+  assert.ok(b, 'NOT NULL in the baseline vs a nullable live column must block')
+})
+
+test('without --live it still flags a nullable→NOT NULL change, marked as needing confirmation', () => {
+  const { blockers } = diffSchemas(OLD_HISTORY, NEW_BASELINE)
+  assert.equal(blockers.length, 1)
+  assert.match(blockers[0].reason, /--live/)
+})
+
+test('a NOT NULL column WITH a default is not a blocker', () => {
+  const oldS = 'CREATE TABLE `t` (`id` text PRIMARY KEY NOT NULL);'
+  const newS = 'CREATE TABLE `t` (`id` text PRIMARY KEY NOT NULL, `role` text DEFAULT \'user\' NOT NULL);'
+  const live = 'CREATE TABLE `t` (`id` text PRIMARY KEY NOT NULL);'
+  assert.deepEqual(diffSchemas(oldS, newS, live).blockers, [])
+})
+
+test('a live column absent from the new baseline blocks the restore', () => {
+  const oldS = 'CREATE TABLE `t` (`id` text NOT NULL, `gone` text);'
+  const newS = 'CREATE TABLE `t` (`id` text NOT NULL);'
+  const live = 'CREATE TABLE `t` (`id` text NOT NULL, `gone` text);'
+  const { blockers } = diffSchemas(oldS, newS, live)
+  assert.equal(blockers.length, 1)
+  assert.equal(blockers[0].column, 'gone')
+})
+
+test('the triage case: added nullable columns are NOT blockers', () => {
+  // What #1456 actually looked like — new columns the live DB lacks, all nullable.
+  const oldS = 'CREATE TABLE `team_settings` (`id` text NOT NULL);'
+  const newS = 'CREATE TABLE `team_settings` (`id` text NOT NULL, `notion_settings` text);'
+  const live = 'CREATE TABLE `team_settings` (`id` text NOT NULL);'
+  const { columns, blockers } = diffSchemas(oldS, newS, live)
+  assert.equal(columns.filter(c => c.kind === 'added').length, 1)
+  assert.deepEqual(blockers, [], 'nullable additions load fine — this is why triage was cleared')
+})


### PR DESCRIPTION
Closes #1717. From the #1452 postmortem.

## 👤 For humans

Squashing a migration history regenerates the baseline **from the schema source**. A hand-written corrective migration that fixed the *database* but was never reflected back into that source is therefore **silently reverted**.

That's what happened to kassa. `0019_nullable_printer_location` made `sales_printers.locationId` nullable, healing a regression `0016` introduced. The schema source still said `.notNull()`, so the #1455 squash brought the bug straight back — and it surfaced only when the production restore died on real rows:

```
NOT NULL constraint failed: sales_printers.locationId
```

This script would have caught it before anything was touched.

## 🤖 What it does

`scripts/schema-diff.mjs` — exports `finalTables()` + `diffSchemas()`, CLI with `--live` and `--json`, exit 1 on restore-blocking drift.

**It replays `CREATE`/`DROP`/`ALTER … RENAME`** so drizzle's `__new_*` table rebuilds resolve to their FINAL shape. Without that, every rebuilt table reads as a spurious drop — and a rebuild is *exactly* how `0019` expressed its fix, so a differ that skips this step is blind to the very case it exists for.

**Three blocker classes:**

| | why it breaks a restore |
|---|---|
| live column missing from the new baseline | the INSERT names a column that doesn't exist |
| NOT NULL, no DEFAULT, absent from live data | nothing to supply the value |
| **nullable live → NOT NULL in the baseline** | **the kassa case** — existing NULL rows are rejected |

That last one is invisible to a *presence* check (the column exists on both sides) **and** to a table-name diff (the table exists on both sides). It's the whole reason the script exists.

**`--live` is the authoritative input.** Migration files drift from the database that actually exists — triage proved this, where the files and the live schema disagreed by 9 columns. Without `--live` the script flags the *shape* of the problem and says so in the message rather than pretending to be sure.

## 🧪 Verification

- **8 tests**, including a fixture reproducing the kassa regression *and* the triage case (added nullable columns must **not** block), so it can't over-trigger into uselessness.
- **Checked against the real artifacts**, not just the fixture: the pre-#1684 baseline from `197a1a6` vs the actual `fanfare-db` production dump →

```
restore blockers (1):
  ✗ sales_printers.locationId — live column is NULLABLE but the new baseline makes it
    NOT NULL with no DEFAULT — existing NULL rows will fail the restore
```

- Full `scripts/*.test.mjs` suite: 139 pass. Lint clean (the two ambiguous-quantifier regexes were rewritten, not suppressed).

## 📖 Wired into the workflow

`db-migrations` gains a **required** "run the schema diff FIRST" section for squashes, carrying the two restore rules today's work established: never restore the old `d1_migrations` rows (it silently un-does the squash), and insert in **foreign-key order** (D1's export is alphabetical, so `account` precedes `user` and a naive reload dies on a constraint).

## Caveat, stated rather than hidden

The nullable→NOT NULL flag is **conservative**: it fires whenever live permits NULL, without parsing INSERT values to prove a NULL row actually exists. A false alarm before a restore is cheaper than a failed restore during one.
