### PR TITLE
fix(crouton-sales): inline category delete never fired — onClickOutside's capture-phase click beat the button

### DIFF
--- a/packages/crouton-sales/CLAUDE.md
+++ b/packages/crouton-sales/CLAUDE.md
@@ -401,7 +401,8 @@ before-redeem hook re-syncs the new one into the grant); a manual **"Log out all
 the requeue-failed-jobs button (`printqueues/retry-failed`), which also refreshes the LEDs.
 Printer rows keep the POS slide-out hover affordances (pencil right; drag grip left when
 `orderField` is set). The Categories and Locations cards were **removed** — categories are
-edited inline in the kassa (create/rename/reorder; delete via the team-level categories page),
+edited inline in the kassa (create/rename/reorder, plus a two-step delete inside rename mode —
+the team-level categories page remains the fuller form),
 locations via their team-level admin page; SettingsTab still queries `salesLocations` only for
 the printer subtitles. Each printer row carries an **online LED** derived from its **most recent
 print job** (slim `printqueues/status` endpoint, latest by `completedAt ?? createdAt`): green =

--- a/packages/crouton-sales/app/components/Client/CategoryTabs.vue
+++ b/packages/crouton-sales/app/components/Client/CategoryTabs.vue
@@ -61,12 +61,14 @@
       <span v-else class="truncate">{{ withCount(cat.title, counts?.[cat.id] || 0) }}</span>
 
       <!-- Delete (rename mode only): two-step — first tap arms, second deletes.
-           mousedown.prevent keeps the input focused so the click lands. -->
+           The `tab-delete-btn` class is load-bearing, not styling: onClickOutside
+           IGNORES it (see below). mousedown.prevent additionally keeps the input
+           focused so the caret doesn't jump between the two taps. -->
       <span
         v-if="editingId === cat.id"
         role="button"
-        :aria-label="confirmDeleteId === cat.id ? t('sales.common.remove') : t('common.delete')"
-        class="inline-flex items-center justify-center size-6 rounded-full shrink-0 active:scale-95 transition-all"
+        :aria-label="confirmDeleteId === cat.id ? t('sales.common.confirmDelete') : t('common.delete')"
+        class="tab-delete-btn inline-flex items-center justify-center size-6 rounded-full shrink-0 active:scale-95 transition-all"
         :class="confirmDeleteId === cat.id ? 'bg-error text-inverted' : 'bg-black/15 hover:bg-black/30'"
         @mousedown.stop.prevent
         @click.stop="onDeleteClick(cat.id)"
@@ -216,6 +218,9 @@ function startEdit(categoryId: string) {
   if (!cat) return
   editingId.value = categoryId
   editingTitle.value = cat.title
+  // Never inherit a previous session's armed confirm — rename mode always opens
+  // on the trash, so the destructive second tap is always a deliberate one (#1728).
+  confirmDeleteId.value = null
 }
 
 // Template refs double as autofocus + click-outside anchors. Blur alone can't
@@ -237,10 +242,20 @@ function setDraftInput(el: unknown) {
   draftInputEl.value = input
 }
 
-onClickOutside(editInputEl, commitEdit)
+// `ignore` is REQUIRED for the delete button, not a nicety (#1728). VueUse registers
+// this handler as a CAPTURE-phase `click` listener on window, so without the ignore it
+// runs BEFORE the button's own bubble-phase handler: commitEdit would clear `editingId`
+// + `confirmDeleteId`, Vue would unmount the button, and the delete that finally ran in
+// the bubble phase would see a cleared flag and merely re-arm — so the category could
+// never be deleted, and the stale armed flag made the next rename open on a check icon.
+// The button's `@mousedown.stop.prevent` cannot help: wrong event, wrong phase.
+onClickOutside(editInputEl, commitEdit, { ignore: ['.tab-delete-btn'] })
 onClickOutside(draftInputEl, commitCreate)
 
 function commitEdit() {
+  // Clear the armed confirm FIRST: the early return below used to leave it set, so a
+  // half-finished delete leaked into the next rename as a pre-armed check icon (#1728).
+  confirmDeleteId.value = null
   // Blur fires after enter — the first commit clears editingId, so bail.
   if (!editingId.value) return
   const id = editingId.value


### PR DESCRIPTION
Closes #1728

Packages-approved: owner approved this `packages/crouton-sales` fix in-session after reporting the bug ("can't delete a category, and the check icon does nothing").

## 👤 For humans

Deleting a category from the kassa was impossible. Tapping the trash silently dropped you out of rename mode; the next time you opened that same category it showed a red **check** that did nothing when clicked. Both are fixed — first tap arms, second tap deletes.

## 🤖 For agents

**Root cause.** `onClickOutside(editInputEl, commitEdit)` anchored to the **input alone**, so the sibling delete button counted as "outside". VueUse registers that handler as `useEventListener(window, 'click', …, { capture: true })` — **capture phase, on window**. Every click of the button therefore ran:

1. **capture** → `commitEdit()` clears `editingId` + `confirmDeleteId`
2. Vue unmounts the input and the button (`v-if="editingId === cat.id"`)
3. **bubble** → `onDeleteClick()` still runs (the propagation path is fixed at dispatch) but sees the flag cleared → **re-arms instead of deleting**

The `@mousedown.stop.prevent` guard could never help: wrong event *and* wrong phase — a bubble-phase `.stop` on the element cannot stop a capture listener on window that already ran.

One mechanism, both symptoms:

| Symptom | Cause |
|---|---|
| "Clicking the check does nothing" | Cleared in capture, re-armed in bubble — `emit('delete')` unreachable. `handleCategoryDelete` in `OrderInterface.vue` was correct all along and simply never called. |
| "Sometimes a trash, sometimes a check" | `commitEdit`'s early return (`if (!editingId.value) return`) fired **before** clearing `confirmDeleteId`, so the stale flag rendered the next rename pre-armed. |

"Empty category" was incidental — there is no emptiness guard; **no** category could be deleted from the kassa.

### Changes

- `onClickOutside(..., { ignore: ['.tab-delete-btn'] })` — the class is load-bearing, not styling; noted in the template.
- `commitEdit` clears the armed flag **before** its early return; `startEdit` resets it — rename mode always opens on the trash, so the destructive second tap is always deliberate.
- `aria-label` now uses the existing **`sales.common.confirmDelete`** (present in en/nl/fr). The old `sales.common.remove` exists in **no** locale and was announced to screen readers as the literal `[sales.common.remove]` — found while driving the fix. Reused the existing key rather than minting a near-duplicate.
- `CLAUDE.md` claimed delete lived only on the team-level page; corrected.

### Archaeology

`4365393e8` (2026-06-11) *close inline tab inputs on click-outside* added the capture-phase listener. `ca329ab3b` (2026-07-12) *delete a category inline from the POS edit mode* added the affordance **into that component**. **Not a regression** — it shipped broken and has never worked in any release.

## Verification — driven in a real browser, not reasoned

Booted kassa locally against seeded data and ran the sequence twice.

**With the fix stashed (original code), all three symptoms reproduced:**
- trash click → `stillInRenameMode: false`, button reverted to the pencil, category untouched
- re-entering rename → `i-lucide:check` + `bg-error` (exactly the icon in the bug report), `aria-label: "[sales.common.remove]"`
- clicking that check → categories unchanged

**With the fix applied:**
- first tap → `icon: check`, `armed: true`, **`stillInRenameMode: true`**
- second tap → category gone from the UI **and** from `sales_categories`
- next rename opens `trash-2`, `armed: false` — no stale leak
- regression: rename via **enter** persisted to the DB; rename via a genuine **click-outside** persisted **and** closed the input (the behaviour `4365393e8` exists for)
- armed `aria-label` now reads **"Bevestig verwijderen"**

### No unit test — deliberately

`crouton-sales` runs vitest with `environment: 'node'` and no `@vue/test-utils`/jsdom. The defect is **event-phase ordering in a real DOM**: a pure test of `onDeleteClick` passes identically before and after, so it would be theatre. Standing up component-test infra for this package is worth its own issue.

Gates: 156/156 package tests · `pnpm --filter kassa typecheck` clean for these files (the pre-existing `crouton-core` theme error from #1387 is untouched) · `npx fallow audit` exit 0 (its two findings are inherited, pre-existing in the file).

## 🧪 How to test

1. Kassa → edit mode (pencil) → click the **active** category tab's pencil.
2. Click the **trash** — it turns into a red check and the tab **stays** in rename mode. *(Before: edit mode exited, icon vanished.)*
3. Click the **check** — the category is deleted. *(Before: nothing.)*
4. Enter rename mode on another category — it shows a **trash**, never a check. *(Before: a previously-armed one opened pre-armed.)*
5. Regression: rename + enter, and rename + click far outside — both must still save.