### PR TITLE
fix(root): count a leaf plan as a deliverable in the pidev decompose gate (#1740)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -349,9 +349,23 @@ jobs:
               createdSubIssues = subs.some(s => new Date(s.created_at).getTime() >= sinceMs)
             } catch (e) { core.warning(`sub-issue check skipped: ${e.message}`) }
 
+            // ── LEAF DISPATCH (#1740) ──────────────────────────────────────────────────
+            // A leaf plan ({"leaf": true}) is NOT a no-op. The deterministic apply step
+            // (scripts/apply-decompose-plan.mjs → buildActionList) labels the target `work-this`
+            // (WORKER_TRIGGER), which triggers the single-use worker (work-issue-pidev.yml) whose
+            // PR lands in a SEPARATE run with its own artifact-gate. So "dispatched the worker" is a
+            // complete, honest deliverable for THIS decompose run. Without this branch a correctly-
+            // classified leaf false-fails as "produced nothing / underspecified" (the #1713 case —
+            // an exemplary issue mis-blamed as underspecified). Same class as the #1074 child-
+            // deliverable blind spot. Signal: a `work-this` labeled event on the target since t0.
+            const leafDispatched = timeline.some(e =>
+              e.event === 'labeled' && e.label && e.label.name === 'work-this' &&
+              new Date(e.created_at).getTime() >= sinceMs
+            )
+
             const signoffHeld = blocked && newComment
-            if (linkedPR || signoffHeld || alreadyClosed || createdSubIssues) {
-              core.info(`Artifact-gate OK for #${issue_number}: linkedPR=${linkedPR} signoffHeld=${signoffHeld} alreadyClosed=${alreadyClosed} createdSubIssues=${createdSubIssues}`)
+            if (linkedPR || signoffHeld || alreadyClosed || createdSubIssues || leafDispatched) {
+              core.info(`Artifact-gate OK for #${issue_number}: linkedPR=${linkedPR} signoffHeld=${signoffHeld} alreadyClosed=${alreadyClosed} createdSubIssues=${createdSubIssues} leafDispatched=${leafDispatched}`)
               // Result-comment-back (#1017) — only on a label-triggered run (a human is watching the
               // issue). This comment posts as the Harness App (nuxt-harness[bot]) — an unmistakable
               // bot account — so it uses the agent-pipeline provenance header, NOT the @pmcp disclaimer.
@@ -362,6 +376,7 @@ jobs:
                 const what = freshPR
                   ? `done → PR #${freshPR}`
                   : (createdSubIssues ? 'decomposed → sub-issues created (see the tree)'
+                    : leafDispatched ? 'classified as a leaf → handed to the `work-this` worker (its PR lands in a separate run)'
                     : signoffHeld ? 'held for sign-off (`status:blocked` + a review)'
                     : 'produced a deliverable — see the run')
                 await github.rest.issues.createComment({


### PR DESCRIPTION
Closes #1740

## 👤 For humans

Delegating a well-specified issue that pi correctly classifies as a single **leaf** (no split into sub-issues) was red-failing the pi.dev decompose run with a misleading comment:

> 🔴 this run produced nothing… the issue is **likely underspecified** — add a description + acceptance criteria.

That was backwards. On a leaf, pi's deliverable is the `work-this` label it stamps on the issue, which triggers the single-use worker (`work-issue-pidev.yml`) whose PR lands in a **separate** run. The decompose gate just didn't count that hand-off as a deliverable, so a correct outcome looked like a no-op. This was the [#1713](https://github.com/FriendlyInternet/nuxt-crouton/issues/1713) misdiagnosis (an exemplary issue mis-blamed as underspecified).

## 🤖 For agents

- File: `.github/workflows/decompose-on-issue-pidev.yml`, **"Artifact-gate — fail if the agent produced nothing"** step.
- Root cause: the OK set `linkedPR || signoffHeld || alreadyClosed || createdSubIssues` had no branch for a `{"leaf": true}` plan. `scripts/apply-decompose-plan.mjs` → `buildActionList` labels the target `work-this` (`WORKER_TRIGGER`, `scripts/pipeline-loop-guard.mjs:35`); the PR arrives from the downstream worker run and is invisible to this gate.
- Fix: derive `leafDispatched` from the already-fetched `timeline` — a `labeled` event with `label.name === 'work-this'` and `created_at >= sinceMs` — add it to the OK condition and the result-comment `what` message ("classified as a leaf → handed to the `work-this` worker"). No new API calls.
- **pidev-only.** `decompose-on-issue.yml` (claude variant) works the leaf inline in the same run — its gate sees a fresh PR — so it has no gap and is untouched. Same class as the #1074 child-deliverable and #839/#1019 stale-link blind spots.

## Note on provenance

An identical copy of this hunk already exists on branch `chore/pi-contract-canonical-1022` inside commit `3328d6ea3` (#1022) — a concurrent session committed+pushed its staged work and swept this hunk in before it could be committed standalone. That commit is on `origin`, so it wasn't rewritten. The hunk is **byte-identical**, so it de-duplicates cleanly whichever branch merges first. This PR is the clean, attributable home of the fix.

## 🧪 How to test

1. Re-dispatch a well-specified leaf issue (`delegate-pi`), or replay the #1713 path.
2. The **Decompose on issue (pi.dev variant)** run goes **green**; its comment reads *"classified as a leaf → handed to the `work-this` worker (its PR lands in a separate run)"*.
3. The `work-issue-pidev.yml` worker still fires from the `work-this` label and produces the PR.
4. Negative: a run where pi writes no `decompose-plan.json` still red-fails with "produced nothing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
