### PR TITLE
fix(crouton-core,crouton-printing,crouton-sales): chunk print-job enqueue under D1's 100-parameter cap

### DIFF
--- a/packages/crouton-core/package.json
+++ b/packages/crouton-core/package.json
@@ -10,6 +10,7 @@
     "./shared/seed": "./shared/seed/index.ts",
     "./shared/utils/date": "./shared/utils/date.ts",
     "./shared/utils/fs": "./shared/utils/fs.ts",
+    "./shared/utils/d1": "./shared/utils/d1.ts",
     "./shared/types/scaffold": "./shared/types/scaffold.ts",
     "./shared/utils/scaffold": "./shared/utils/scaffold.ts",
     "./app/types/app": "./app/types/app.ts",

--- a/packages/crouton-core/shared/utils/d1.ts
+++ b/packages/crouton-core/shared/utils/d1.ts
@@ -1,0 +1,90 @@
+/**
+ * @crouton-package crouton-core
+ * @description Cloudflare D1's bound-parameter ceiling, and how to stay under it.
+ *
+ * D1 refuses any query carrying more than 100 BOUND PARAMETERS
+ * (https://developers.cloudflare.com/d1/platform/limits/). A multi-row `INSERT` binds one per
+ * column per row, so the limit is on `rows × columns` — write a batch in one statement and it
+ * fails once the batch is big enough. Local SQLite allows 32 766, so this NEVER reproduces in
+ * development: it only ever fires on deployed D1.
+ *
+ * It has bitten twice — the bulk product import (#1707) and the print-job enqueue on the
+ * checkout path (#1710) — which is why the helper lives here rather than in either package.
+ *
+ * THE TRAP, and the reason `boundParamsPerRow` exists: drizzle also binds columns the row
+ * object does NOT contain, whenever the column declares a default (`$default`/`$defaultFn`).
+ * `Object.keys(row).length` therefore UNDERCOUNTS, and a chunk size derived from it can still
+ * exceed the cap while looking correct — print jobs count 16 keys but bind 18. Always derive
+ * the count from the table's columns, never from the row's own keys.
+ */
+
+/** D1's hard ceiling. Not tunable — this is the platform's number. */
+export const D1_MAX_BOUND_PARAMS = 100
+
+/** The shape we need off a drizzle column; kept structural so `shared/` stays dependency-free. */
+export interface ColumnLike { hasDefault?: boolean }
+
+/**
+ * How many parameters drizzle will actually bind for one row of this table.
+ *
+ * A column is bound when the row supplies it, OR when it declares a default that drizzle
+ * fills in. A column that is neither supplied nor defaulted is omitted from the statement
+ * entirely, so it costs nothing.
+ *
+ * Pass `getTableColumns(table)` from drizzle-orm as `columns`.
+ */
+export function boundParamsPerRow(
+  columns: Record<string, ColumnLike>,
+  row: Record<string, unknown>,
+): number {
+  let count = 0
+  for (const [name, column] of Object.entries(columns)) {
+    if (name in row || column?.hasDefault) count++
+  }
+  return count
+}
+
+/**
+ * Split rows into batches that each stay within the parameter cap.
+ *
+ * `columnsPerRow` is REQUIRED rather than inferred: inferring it from the row's own keys is
+ * exactly the undercount described above, and a silent undercount reproduces the very bug
+ * this helper exists to prevent. Use `boundParamsPerRow` (or `chunkRowsForTable`) to get it.
+ *
+ * A row too wide to ever fit still yields one row per batch — a batch size of 0 would spin
+ * forever. Such a statement will fail at D1, but that is a schema problem this cannot solve,
+ * and failing loudly beats hanging.
+ */
+export function chunkForBoundParams<T>(
+  rows: T[],
+  columnsPerRow: number,
+  maxParams: number = D1_MAX_BOUND_PARAMS,
+): T[][] {
+  if (!rows.length) return []
+  const size = Math.max(Math.floor(maxParams / Math.max(columnsPerRow, 1)), 1)
+  const chunks: T[][] = []
+  for (let i = 0; i < rows.length; i += size) chunks.push(rows.slice(i, i + size))
+  return chunks
+}
+
+/**
+ * Derive the per-row cost from the table, then chunk — the call every insert site wants:
+ *
+ * ```ts
+ * for (const batch of chunkRowsForTable(rows, getTableColumns(printJobs))) {
+ *   await db.insert(printJobs).values(batch)
+ * }
+ * ```
+ *
+ * Batches are NOT one transaction. A mid-run failure leaves earlier batches written, so the
+ * caller owns recovery (the product import re-detects written rows as duplicates; a failed
+ * ticket enqueue throws so checkout can surface it).
+ */
+export function chunkRowsForTable<T extends Record<string, unknown>>(
+  rows: T[],
+  columns: Record<string, ColumnLike>,
+  maxParams: number = D1_MAX_BOUND_PARAMS,
+): T[][] {
+  if (!rows.length) return []
+  return chunkForBoundParams(rows, boundParamsPerRow(columns, rows[0]!), maxParams)
+}

--- a/packages/crouton-core/tests/d1.test.ts
+++ b/packages/crouton-core/tests/d1.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  D1_MAX_BOUND_PARAMS,
+  boundParamsPerRow,
+  chunkForBoundParams,
+  chunkRowsForTable,
+} from '../shared/utils/d1'
+
+/**
+ * The contract that keeps a multi-row INSERT under D1's 100-bound-parameter cap (#1707, #1710).
+ * These pin the CEILING, not any particular batch size — what must hold is that no statement
+ * we hand to D1 can exceed it, whatever batching we choose.
+ */
+
+/** Stand-in for `getTableColumns(table)`: only `hasDefault` matters here. */
+const columns = (supplied: string[], defaulted: string[], plain: string[] = []) => {
+  const cols: Record<string, { hasDefault?: boolean }> = {}
+  for (const n of supplied) cols[n] = {}
+  for (const n of defaulted) cols[n] = { hasDefault: true }
+  for (const n of plain) cols[n] = {}
+  return cols
+}
+
+describe('boundParamsPerRow — what drizzle really binds', () => {
+  it('counts the columns the row supplies', () => {
+    const cols = columns(['a', 'b', 'c'], [])
+    expect(boundParamsPerRow(cols, { a: 1, b: 2, c: 3 })).toBe(3)
+  })
+
+  it('ALSO counts defaulted columns the row omits — the undercount that caused #1710', () => {
+    // printJobs in miniature: 2 supplied, 2 filled by $default, 2 neither.
+    const cols = columns(['id', 'payload'], ['createdAt', 'updatedAt'], ['errorMessage', 'completedAt'])
+    const row = { id: 'x', payload: 'p' }
+
+    expect(Object.keys(row)).toHaveLength(2) // what a naive helper would count
+    expect(boundParamsPerRow(cols, row)).toBe(4) // what D1 is actually charged
+  })
+
+  it('does not count a column that is neither supplied nor defaulted', () => {
+    const cols = columns(['a'], [], ['nullableNoDefault'])
+    expect(boundParamsPerRow(cols, { a: 1 })).toBe(1)
+  })
+
+  it('counts a defaulted column the row DOES supply exactly once', () => {
+    const cols = columns([], ['id'])
+    expect(boundParamsPerRow(cols, { id: 'explicit' })).toBe(1)
+  })
+})
+
+describe('chunkForBoundParams — the ceiling', () => {
+  const rows = (n: number) => Array.from({ length: n }, (_, i) => ({ i }))
+
+  it('never lets a batch exceed the cap', () => {
+    for (const [count, perRow] of [[8, 18], [43, 20], [100, 7], [3, 99]] as const) {
+      for (const batch of chunkForBoundParams(rows(count), perRow)) {
+        expect(batch.length * perRow).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS)
+      }
+    }
+  })
+
+  it('preserves every row, in order', () => {
+    const input = rows(43)
+    expect(chunkForBoundParams(input, 20).flat()).toEqual(input)
+  })
+
+  it('does not split a batch that already fits', () => {
+    expect(chunkForBoundParams(rows(5), 18)).toHaveLength(1) // 90 ≤ 100
+  })
+
+  it('issues nothing at all for an empty list', () => {
+    expect(chunkForBoundParams([], 18)).toEqual([])
+  })
+
+  it('still makes progress on a row too wide to ever fit — one per batch, never a zero-size chunk', () => {
+    const chunks = chunkForBoundParams(rows(3), 120)
+    expect(chunks).toHaveLength(3)
+    expect(chunks.every(c => c.length === 1)).toBe(true)
+  })
+
+  it('honours a caller-supplied cap', () => {
+    expect(chunkForBoundParams(rows(4), 10, 20)).toHaveLength(2) // 2 rows per batch
+  })
+})
+
+describe('chunkRowsForTable — derive then chunk', () => {
+  it('sizes batches by the TRUE cost, not the row keys', () => {
+    // 16 supplied + 2 defaulted = 18/row → 5 rows max, NOT the 6 that 16 keys would allow.
+    const supplied = Array.from({ length: 16 }, (_, i) => `c${i}`)
+    const cols = columns(supplied, ['createdAt', 'updatedAt'])
+    const row = Object.fromEntries(supplied.map(k => [k, 1]))
+    const rows = Array.from({ length: 8 }, () => ({ ...row }))
+
+    const chunks = chunkRowsForTable(rows, cols)
+
+    expect(chunks[0]).toHaveLength(5)
+    for (const batch of chunks) {
+      expect(batch.length * 18).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS)
+    }
+    expect(chunks.flat()).toHaveLength(8)
+  })
+
+  it('issues nothing for an empty list', () => {
+    expect(chunkRowsForTable([], { a: {} })).toEqual([])
+  })
+})

--- a/packages/crouton-printing/server/utils/print-job-queue.ts
+++ b/packages/crouton-printing/server/utils/print-job-queue.ts
@@ -14,6 +14,8 @@
  * everywhere (including the edge).
  */
 import { nanoid } from 'nanoid'
+import { getTableColumns } from 'drizzle-orm'
+import { chunkRowsForTable } from '@fyit/crouton-core/shared/utils/d1'
 
 /**
  * Print-job status codes. Text to match the on-site spooler contract
@@ -116,7 +118,18 @@ export async function enqueuePrintJobs(db: any, inputs: EnqueuePrintJobInput[]):
   if (inputs.length === 0) return []
   const { printJobs } = await import('../database/schema')
   const rows = inputs.map(buildRow)
-  await db.insert(printJobs).values(rows)
+
+  // D1 caps a query at 100 bound parameters and a multi-row INSERT binds one per column per
+  // row — a print job costs 18 (16 from buildRow, plus createdAt/updatedAt that drizzle fills
+  // from their defaults), so one statement stopped working at 6 tickets: an order spanning
+  // enough stations enqueued NOTHING and simply never printed (#1710).
+  //
+  // The #1539 single-insert property is preserved wherever it still fits (≤5 tickets, the
+  // overwhelming majority) — `chunkRowsForTable` only splits when D1 leaves no choice.
+  for (const batch of chunkRowsForTable(rows, getTableColumns(printJobs))) {
+    await db.insert(printJobs).values(batch)
+  }
+
   await emitCreated(db, rows)
   return rows.map(r => r.id)
 }

--- a/packages/crouton-printing/test/enqueue-bound-params.test.ts
+++ b/packages/crouton-printing/test/enqueue-bound-params.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+/**
+ * D1 refuses a query carrying more than 100 BOUND PARAMETERS
+ * (https://developers.cloudflare.com/d1/platform/limits/), and a multi-row INSERT binds one
+ * per column per row. `enqueuePrintJobs` wrote an order's whole ticket batch in one
+ * statement, so a big enough order failed to enqueue ANY ticket — on the checkout path,
+ * mid-service, where the only symptom is "nothing printed" (#1710).
+ *
+ * THE SUBTLE PART, and why these cases count parameters rather than rows: drizzle also binds
+ * the table's `$default` columns that the row object does NOT contain. `buildRow` returns 16
+ * keys, but `printJobs` adds `createdAt` + `updatedAt` — 18 real parameters per row. A chunk
+ * size derived from `Object.keys(row).length` would allow 6 rows (96 by its own count, 108 in
+ * reality) and still blow the cap. So the ceiling must be computed from the TRUE column count.
+ */
+
+const { hookCalls } = vi.hoisted(() => ({ hookCalls: [] as Array<{ name: string, payload: any }> }))
+vi.mock('nitropack/runtime', () => ({
+  useNitroApp: () => ({
+    hooks: { callHook: async (name: string, payload: any) => { hookCalls.push({ name, payload }) } }
+  })
+}))
+
+/** Records each insert().values() call separately, so we can size every statement. */
+function fakeDb() {
+  const batches: any[][] = []
+  return {
+    batches,
+    get inserted() { return this.batches.flat() },
+    insert: () => ({
+      values: async (v: any) => { batches.push(Array.isArray(v) ? v : [v]) }
+    })
+  }
+}
+
+/** The real per-row cost: 16 keys from buildRow + createdAt/updatedAt that drizzle binds. */
+const DRIZZLE_ADDED_COLUMNS = 2
+const boundParams = (batch: any[]) =>
+  batch.length * (Object.keys(batch[0] ?? {}).length + DRIZZLE_ADDED_COLUMNS)
+
+const ticket = (n: number) => ({
+  source: 'sales',
+  printerId: `printer-${n}`,
+  printerIp: `192.168.1.${70 + n}`,
+  printerPort: 9100,
+  printerTitle: `Station ${n}`,
+  driver: 'network-escpos',
+  payload: `TICKET-${n}`,
+  printMode: 'normal',
+  locationId: `loc-${n}`,
+  refType: 'order',
+  refId: 'order-1',
+  eventId: 'evt-1',
+  teamId: 'team-1'
+})
+const order = (n: number) => Array.from({ length: n }, (_, i) => ticket(i))
+
+describe('enqueuePrintJobs — D1 bound-parameter cap (#1710)', () => {
+  beforeEach(() => { hookCalls.length = 0 })
+
+  it('keeps every statement under the cap for an 8-station order', async () => {
+    const { enqueuePrintJobs } = await import('../server/utils/print-job-queue')
+    const db = fakeDb()
+
+    await enqueuePrintJobs(db, order(8))
+
+    // Guard: one statement really would have blown it (8 × 18 = 144).
+    expect(8 * (16 + DRIZZLE_ADDED_COLUMNS)).toBeGreaterThan(100)
+    expect(db.batches.length).toBeGreaterThan(0)
+    for (const batch of db.batches) expect(boundParams(batch)).toBeLessThanOrEqual(100)
+  })
+
+  it('still enqueues every ticket, and returns ids in input order', async () => {
+    const { enqueuePrintJobs } = await import('../server/utils/print-job-queue')
+    const db = fakeDb()
+
+    const ids = await enqueuePrintJobs(db, order(8))
+
+    expect(db.inserted).toHaveLength(8)
+    expect(ids).toHaveLength(8)
+    expect(db.inserted.map((r: any) => r.id)).toEqual(ids)
+    expect(db.inserted.map((r: any) => r.payload))
+      .toEqual(['TICKET-0', 'TICKET-1', 'TICKET-2', 'TICKET-3', 'TICKET-4', 'TICKET-5', 'TICKET-6', 'TICKET-7'])
+  })
+
+  it('does NOT split an order that already fits — the #1539 single-insert contract holds where physics allows', async () => {
+    const { enqueuePrintJobs } = await import('../server/utils/print-job-queue')
+    const db = fakeDb()
+
+    await enqueuePrintJobs(db, order(5)) // 5 × 18 = 90, under the cap
+
+    expect(db.batches).toHaveLength(1)
+  })
+
+  it('fires one printing:job:created per job across the split', async () => {
+    const { enqueuePrintJobs } = await import('../server/utils/print-job-queue')
+    const db = fakeDb()
+
+    await enqueuePrintJobs(db, order(8))
+
+    // The cloud-sync outbox mirror and order-status tracking depend on per-job
+    // hooks (#1539) — chunking may change the timing, never the count.
+    const created = hookCalls.filter(h => h.name === 'printing:job:created')
+    expect(created).toHaveLength(8)
+  })
+})

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/products/import.post.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/products/import.post.ts
@@ -18,7 +18,7 @@
  * (same split as `order-filters.ts` / `my-orders-shape.ts`); this handler is the
  * fetch → plan → insert delegate.
  */
-import { desc, eq } from 'drizzle-orm'
+import { desc, eq, getTableColumns } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import { requireTeamEvent } from '../../../../../../../utils/team-event'
 import { parseProductPaste } from '../../../../../../../../app/utils/parse-product-paste'
@@ -28,10 +28,10 @@ import {
   indexByTitle,
   readImportRequest,
   nextOrderAfter,
-  chunkForBoundParams,
   norm,
   type TitleRow,
 } from '../../../../../../../utils/plan-product-import'
+import { chunkRowsForTable } from '@fyit/crouton-core/shared/utils/d1'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
 import { salesCategories } from '~~/layers/sales/collections/categories/server/database/schema'
 import { salesLocations } from '~~/layers/sales/collections/locations/server/database/schema'
@@ -47,7 +47,7 @@ async function insertAndIndex(
   index: Map<string, string>,
 ): Promise<void> {
   if (!rows.length) return
-  for (const chunk of chunkForBoundParams(rows)) await db.insert(table).values(chunk as never)
+  for (const batch of chunkRowsForTable(rows, getTableColumns(table))) await db.insert(table).values(batch as never)
   for (const row of rows) index.set(norm(row.title), row.id)
 }
 
@@ -131,8 +131,8 @@ export default defineEventHandler(async (event) => {
   // not one transaction: a mid-import failure leaves the earlier rows written. That is the
   // recoverable direction — the parser flags every written row as a duplicate, so re-running
   // the same paste imports only what is missing.
-  for (const chunk of chunkForBoundParams(productRows)) {
-    await db.insert(salesProducts).values(chunk)
+  for (const batch of chunkRowsForTable(productRows, getTableColumns(salesProducts))) {
+    await db.insert(salesProducts).values(batch)
   }
 
   return {

--- a/packages/crouton-sales/server/utils/plan-product-import.ts
+++ b/packages/crouton-sales/server/utils/plan-product-import.ts
@@ -92,33 +92,6 @@ export function planProductImport(input: {
 }
 
 /**
- * Cloudflare D1 caps a query at 100 BOUND PARAMETERS, and a multi-row INSERT binds one per
- * column per row — so the ceiling is on `rows × columns`, not on rows. Writing a whole
- * import in one statement 500'd on staging at 43 products × 17 columns = 731 parameters,
- * while passing locally where SQLite allows 32 766 (#1707).
- *
- * https://developers.cloudflare.com/d1/platform/limits/
- *
- * Chunk size is DERIVED from the row's own shape rather than hardcoded, so it stays correct
- * when a collection gains a column (the failure mode is silent: a wider row just fits fewer
- * per statement). A row too wide to ever fit still yields one row per statement — a chunk
- * size of 0 would loop forever.
- */
-export const D1_MAX_BOUND_PARAMS = 100
-
-export function chunkForBoundParams<T extends Record<string, unknown>>(
-  rows: T[],
-  maxParams = D1_MAX_BOUND_PARAMS,
-): T[][] {
-  if (!rows.length) return []
-  const columns = Math.max(Object.keys(rows[0] as object).length, 1)
-  const size = Math.max(Math.floor(maxParams / columns), 1)
-  const chunks: T[][] = []
-  for (let i = 0; i < rows.length; i += size) chunks.push(rows.slice(i, i + size))
-  return chunks
-}
-
-/**
  * Turn planned rows into insertable product values. `order` continues after the event's
  * current highest so an import lands at the end of the list instead of colliding with
  * existing positions. Ids and timestamps are injected so this stays pure.

--- a/packages/crouton-sales/test/plan-product-import.test.ts
+++ b/packages/crouton-sales/test/plan-product-import.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseProductPaste } from '../app/utils/parse-product-paste'
-import { planProductImport, buildProductValues, indexByTitle, readImportRequest, nextOrderAfter, chunkForBoundParams } from '../server/utils/plan-product-import'
+import { planProductImport, buildProductValues, indexByTitle, readImportRequest, nextOrderAfter } from '../server/utils/plan-product-import'
 
 /**
  * Pure planning for the bulk product import (#1656, epic #1652).
@@ -176,63 +176,4 @@ describe('nextOrderAfter', () => {
   it('starts an empty event at 0', () => expect(nextOrderAfter([])).toBe(0))
   it('appends after the highest existing order', () => expect(nextOrderAfter([{ maxOrder: 12 }])).toBe(13))
   it('treats a null order as unset', () => expect(nextOrderAfter([{ maxOrder: null }])).toBe(0))
-})
-
-/**
- * The #1707 regression: D1 caps a query at 100 BOUND PARAMETERS, and a multi-row INSERT
- * binds one per column per row. The endpoint wrote every product in a single statement, so
- * a 43-row paste bound 731 parameters and the whole import 500'd on staging — while passing
- * locally, where SQLite allows 32 766. These cases pin the ceiling, not the chunk size:
- * what matters is that no statement we hand to D1 can ever exceed the cap.
- */
-describe('chunkForBoundParams — the D1 100-parameter cap (#1707)', () => {
-  const now = new Date('2026-08-03T10:00:00Z')
-  const ctx = {
-    eventId: 'e1',
-    stamp: { teamId: 't1', owner: 'u1', createdBy: 'u1', updatedBy: 'u1' },
-    now,
-    startOrder: 0,
-    newId: (() => { let n = 0; return () => `id${++n}` })(),
-  }
-
-  /** A product row as `buildProductValues` really emits it: 17 columns. */
-  const productRows = (n: number) => {
-    const p = plan(['Name\tPrice\tCategory\tLocation', ...Array.from({ length: n }, (_, i) => `P${i}\t3\tDrank\tBar`)].join('\n'))
-    return buildProductValues(p.toCreate, { categories: new Map(), locations: new Map() }, ctx)
-  }
-
-  const boundParams = (chunk: Record<string, unknown>[]) => chunk.length * Object.keys(chunk[0] ?? {}).length
-
-  it('never emits a chunk over the cap for the 43-row paste that broke staging', () => {
-    const rows = productRows(43)
-    expect(Object.keys(rows[0]!)).toHaveLength(17) // guard: the shape this ceiling is computed from
-    expect(rows.length * 17).toBeGreaterThan(100) // guard: one statement really would have blown it
-
-    for (const chunk of chunkForBoundParams(rows)) expect(boundParams(chunk)).toBeLessThanOrEqual(100)
-  })
-
-  it('writes every row exactly once, in order', () => {
-    const rows = productRows(43)
-    expect(chunkForBoundParams(rows).flat()).toEqual(rows)
-  })
-
-  it('issues no statement at all for an empty plan', () => {
-    expect(chunkForBoundParams([])).toEqual([])
-  })
-
-  it('holds the cap for the narrower relation rows too', () => {
-    const categories = Array.from({ length: 30 }, (_, i) => ({
-      id: `c${i}`, eventId: 'e1', title: `C${i}`, displayOrder: 0,
-      teamId: 't1', owner: 'u1', createdBy: 'u1', updatedBy: 'u1', createdAt: now, updatedAt: now,
-    }))
-    for (const chunk of chunkForBoundParams(categories)) expect(boundParams(chunk)).toBeLessThanOrEqual(100)
-  })
-
-  it('still makes progress on a row too wide to ever fit — one row per statement, never a zero-size chunk', () => {
-    const wide = Array.from({ length: 3 }, () => Object.fromEntries(
-      Array.from({ length: 120 }, (_, c) => [`col${c}`, c]),
-    ))
-    expect(chunkForBoundParams(wide)).toHaveLength(3)
-    expect(chunkForBoundParams(wide).every(c => c.length === 1)).toBe(true)
-  })
 })


### PR DESCRIPTION
Closes #1710

Packages-approved: owner asked for #1710 to be picked up; it spans `crouton-printing` (the bug), `crouton-core` (the shared helper's new home) and `crouton-sales` (the second caller).

## 👤 For humans

An order spanning enough kitchen stations enqueued **no tickets at all** — the whole batch was rejected, so nothing printed. It fails from the **6th ticket** onward, which is why a 2-location event never hit it. Orders now enqueue in batches that always fit.

The product import (#1707) had the same class of bug, so the "stay under the limit" rule now lives in **one place** both packages use.

## 🤖 For agents

Same root cause as #1707: D1 caps a query at **100 bound parameters** and a multi-row `INSERT` binds one per column per row. `enqueuePrintJobs` wrote an order's whole ticket batch in one statement — live on the checkout path via `generate-print-queues.ts:196` (the #1539 batch refactor).

### The part that matters beyond this fix

**Drizzle also binds columns the row object does not contain**, whenever the column declares a default. Verified against `getTableColumns`, not assumed:

```
printJobs: 20 columns · buildRow supplies 16 · createdAt+updatedAt come from defaults
→ 18 bound parameters per row → 5 rows max → breaks at 6 tickets
```

So `Object.keys(row).length` **undercounts** — and the helper shipped in #1707 did exactly that. It would have allowed 6 rows here (96 by its own count, **108** in reality) and still blown the cap.

**That undercount was already latent in the shipped import fix:** `salesProducts` counts 17 keys but binds 20 (`hasOptions`, `multipleOptionsAllowed`, `options` are defaulted), landing on *exactly* 100 — correct by luck, one added defaulted column away from silently breaking again. Both callers are now exact.

### Changes

| Package | Change |
|---|---|
| `crouton-core` | **New** `shared/utils/d1.ts` (exported at `@fyit/crouton-core/shared/utils/d1`): `D1_MAX_BOUND_PARAMS`, `boundParamsPerRow(columns, row)` (supplied ∪ defaulted), `chunkForBoundParams` (**`columnsPerRow` is required** — inferring it *is* the bug), `chunkRowsForTable`. Structurally typed, so `shared/` stays dependency-free. |
| `crouton-printing` | `enqueuePrintJobs` loops `chunkRowsForTable(rows, getTableColumns(printJobs))`. |
| `crouton-sales` | The import's three inserts use the shared helper; the local copy is deleted and its 5 tests move to core's 12. |

**Placement rationale:** both packages reach `crouton-core` (printing has it as a peer dep, sales as a direct dep), and this is a *database* constraint — not a printing or a sales concern.

### The #1539 trade-off, made explicit

#1539's single-insert property is preserved wherever it still fits (≤5 tickets — the overwhelming majority). At 6+, D1 leaves no choice. Its contract test passes unchanged, and a new case pins that we **only split when forced**. The per-job `printing:job:created` hook count is pinned too: chunking may change timing, never the count.

## Verification

Test-first, signed off before any implementation. `enqueue-bound-params.test.ts` was confirmed failing on exactly the cap case, with the other three passing as behaviour-preserving guards.

- `crouton-core` — **729 passed** (12 new)
- `crouton-printing` — **82 passed** (4 new)
- `crouton-sales` — **151 passed**
- `pnpm --filter kassa typecheck` — clean for every changed file
- `npx fallow audit` — no issues in 10 changed files

Two failures deliberately **not** touched, both confirmed identical on clean `main`: `poll-returns-all.integration.test.ts` (missing `better-sqlite3` locally) and `crouton-core/.../theme.patch.ts` TS2322 (from #1387).

## 🧪 How to test

Hard to trigger by hand — it needs an event with **6+ printers**, and it only fails on D1 (local SQLite allows 32 766 parameters). The tests are the practical check.

1. Configure an event with 6+ locations, each with an active printer.
2. Build an order touching every location; check out.
3. **Before:** the order saves, `print_jobs` has **no rows** for it, nothing prints. **After:** one ticket per location, all enqueued.
4. Regression: a 3-station order must still go in as a single insert (`enqueue-batch-contract.test.ts` covers this).