### PR TITLE
fix(crouton-i18n): useT drops a parameter value of 0 — || treats it as absent

### DIFF
--- a/packages/crouton-i18n/app/composables/__tests__/useT.test.ts
+++ b/packages/crouton-i18n/app/composables/__tests__/useT.test.ts
@@ -161,6 +161,39 @@ describe('useT', () => {
       expect(result).toBe('Welcome Bob to Dashboard')
     })
 
+    // #1756: `||` treats 0 / false / '' as absent, so a count of zero rendered as a
+    // BLANK. Reachable on the team-override path, which skips vue-i18n's own
+    // interpolation and relies solely on this substitution.
+    it('renders a count of 0 rather than blanking it', () => {
+      mockI18nT.mockImplementation((key: string) => {
+        if (key === 'items.count') return '{count} items'
+        return key
+      })
+
+      const { t } = useT()
+
+      expect(t('items.count', { params: { count: 0 } })).toBe('0 items')
+    })
+
+    it('renders a false parameter rather than blanking it', () => {
+      mockI18nT.mockImplementation((key: string) => {
+        if (key === 'flag.state') return 'enabled: {enabled}'
+        return key
+      })
+
+      const { t } = useT()
+
+      expect(t('flag.state', { params: { enabled: false } })).toBe('enabled: false')
+    })
+
+    it('renders zero on the TEAM-OVERRIDE path — the one that skips vue-i18n', () => {
+      const { t } = useT()
+      stateStore['teamTranslations'].value = { 'orders.deleted': '{count} bestelling(en) verwijderd' }
+      stateStore['teamTranslationsLoaded'].value = true
+
+      expect(t('orders.deleted', { params: { count: 0 } })).toBe('0 bestelling(en) verwijderd')
+    })
+
     it('handles missing parameters gracefully', () => {
       mockI18nT.mockImplementation((key: string) => {
         if (key === 'greeting') return 'Hello {name}'
@@ -258,6 +291,16 @@ describe('useT', () => {
       const result = tString('missing.key')
 
       expect(result).toBe('[missing.key]')
+    })
+  })
+
+  describe('tString() - zero-valued parameters (#1756)', () => {
+    it('renders a count of 0 rather than blanking it', () => {
+      const { tString } = useT()
+      stateStore['teamTranslations'].value = { 'items.count': '{count} items' }
+      stateStore['teamTranslationsLoaded'].value = true
+
+      expect(tString('items.count', { params: { count: 0 } })).toBe('0 items')
     })
   })
 

--- a/packages/crouton-i18n/app/composables/useT.ts
+++ b/packages/crouton-i18n/app/composables/useT.ts
@@ -176,9 +176,14 @@ export function useT() {
       translatedValue = fallback || placeholder || `[${key}]`
     }
 
-    // Apply parameter substitution
+    // Apply parameter substitution.
+    // `??`, never `||`: a count of 0 (or `false`) is a REAL value, and `||` blanked it —
+    // "{count} orders deleted" rendered as " orders deleted" (#1756). A genuinely absent
+    // param is still `undefined` and still renders empty, so nothing else changes.
+    // Mostly a no-op on the vue-i18n path (it has already substituted by here); this is
+    // the ONLY substitution for a team-overridden string, which skips vue-i18n entirely.
     if (params && translatedValue) {
-      translatedValue = translatedValue.replace(/\{(\w+)\}/g, (_, k) => params[k] || '')
+      translatedValue = translatedValue.replace(/\{(\w+)\}/g, (_, k) => String(params[k] ?? ''))
     }
 
     return translatedValue
@@ -239,9 +244,9 @@ export function useT() {
       value = fallback || placeholder || `[${key}]`
     }
 
-    // Apply parameter substitution
+    // Apply parameter substitution — same `??`-not-`||` rule as translate() (#1756).
     if (params && value) {
-      value = value.replace(/\{(\w+)\}/g, (_, k) => params[k] || '')
+      value = value.replace(/\{(\w+)\}/g, (_, k) => String(params[k] ?? ''))
     }
 
     return value


### PR DESCRIPTION
Closes #1756

Packages-approved: owner approved the `crouton-i18n` fix in-session after weighing it ("we need to fix this?" → yes, with the reachability evidence below).

## 👤 For humans

A translated message carrying a count rendered a **blank** where the number belongs whenever that number was zero — `" bestelling(en) verwijderd"` instead of `"0 bestelling(en) verwijderd"`. It only affects **team-customised** translations, which is why nobody has hit it.

## 🤖 For agents

Both substitution sites coalesced with `||`, which treats `0`, `false` and `''` as absent:

```ts
value.replace(/\{(\w+)\}/g, (_, k) => params[k] || '')
```

**Reachability is narrow but real.** Without a team override, `i18n.t(key, params)` runs first (`useT.ts:163`) and vue-i18n substitutes correctly, leaving no placeholders for that line. A **team-overridden** key skips vue-i18n entirely, so this is its *only* substitution — and its zeros vanished.

**Not currently firing:** `translations_ui` has **0 rows** in production, so every key resolves through the JSON locale files today. This is a landmine, not a live outage — it arms itself the first time someone uses the team-override feature on a key with a count. Already-shipped keys that can legitimately be zero: `sales.workspace.deleteAllOrdersDone`, `helpersLockedOut`, `helpersLoggedOut`, `sales.printQueue.resendQueued`, `clientsPanel.orderCount`, `sales.import.doneBody`.

### Why `??` is strictly safer than `||`

| param | `\|\|` today | `??` after |
|---|---|---|
| `0` | `''` ❌ | `'0'` ✅ |
| `false` | `''` ❌ | `'false'` ✅ |
| `''` | `''` | `''` — unchanged |
| `undefined` | `''` | `''` — unchanged |

A genuinely absent parameter still renders empty, so the existing **"handles missing parameters gracefully"** case passes untouched. Wrapped in `String()` so a non-string value can't slip through the replacer.

Fixed in **both** `translate()` and `translateString()` — they carry separate copies of the same line.

## Verification

Test-first. Four cases added to the existing `useT.test.ts`, confirmed failing with exactly the reported symptom before the fix:

```
expected ' items' to be '0 items'
expected 'enabled: ' to be 'enabled: false'
expected ' bestelling(en) verwijderd' to be '0 bestelling(en) verwijderd'
```

One of them drives the **team-override path specifically**, since that is the only reachable one in production.

- `@fyit/crouton-i18n` — **97 passed**, 1 pre-existing skip
- `pnpm --filter kassa typecheck` — clean for these files (the pre-existing `crouton-core` theme error from #1387 is untouched)
- `npx fallow audit` — no issues in 4 changed files

**Blast radius note:** this is a shared i18n primitive on every translated string in every app, so the PR's E2E fixture smoke is the meaningful integration gate here — worth a look before merging rather than trusting the unit tests alone.

## 🧪 How to test

Hard to reach by hand today (it needs a team-override row, and there are none). The unit tests are the practical check. To reproduce manually:

1. Insert a `translations_ui` row with a `teamId` for a key containing `{count}` — e.g. `sales.workspace.helpersLoggedOut`.
2. Trigger that message with a count of **0** — "Log out all helpers" when none are active.
3. **Before:** `" helper(s) uitgelogd"` — the number is missing. **After:** `"0 helper(s) uitgelogd"`.