### PR TITLE
fix(root): pi worker persists its work deterministically, not via pi (#1764)

### DIFF
--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -188,6 +188,19 @@ jobs:
       - id: t0
         run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      # Baseline the tree BEFORE pi runs, so the deterministic finish step commits ONLY pi's
+      # edits — never an incidental change from install/build (#1764 safety). In practice this
+      # list is empty: checkout is clean, the install is --frozen-lockfile, and every build
+      # output dir (node_modules/.nuxt/.output/dist) is gitignored so `git add -A` skips it.
+      # Recording it anyway means a future *tracked* build artifact can't silently leak into a
+      # worker's commit — the finish step unstages every path that was already dirty here.
+      - id: baseline
+        run: |
+          SCRATCH='decompose-pidev-(prompt|exec)-[0-9]+\.(txt|log)|pi-telemetry-out'
+          git status --porcelain 2>/dev/null | grep -vE "$SCRATCH" | cut -c4- > "$RUNNER_TEMP/pre-pi-dirty.txt" || true
+          echo "pre-pi non-scratch dirty paths: $(wc -l < "$RUNNER_TEMP/pre-pi-dirty.txt" | tr -d ' ')"
+          cat "$RUNNER_TEMP/pre-pi-dirty.txt" || true
+
       # ── The agent: pi.dev (replaces claude-code-action) ──────────────────────────
       # GH_TOKEN = the App token → pi's `gh`/git operations (sub-issues, epic branch,
       # the worker PR) act as the Harness App and cascade. ANTHROPIC_API_KEY = the
@@ -254,53 +267,80 @@ jobs:
           # classify WHY a run produced nothing (pi emits no structured execution_file like claude).
           echo "exec_log=$LOG" >> "$GITHUB_OUTPUT"
 
-      # ── FINISH-THE-COMMIT (#1764) — a no-tool-call `stop` is NOT the end of the job ──────
-      # pi (pi-claude-cli) runs one-shot with NO --max-turns (see "TWO LOAD-BEARING pi FACTS"
-      # above). On ~10/10 real worker runs it did the edits, then ended its turn NARRATING the
-      # commit ("Committing now via /commit", "Proceeding to open the PR", "No response
-      # requested.") WITHOUT emitting the commit/PR tool calls — leaving a dirty working tree
-      # that dies with the workspace, a red artifact-gate, and no PR (verified from the on-box
-      # ~/.pi/agent/sessions/*.jsonl, #1764). The one-shot loop has no continuation to nudge it,
-      # so we add one: if pi left real (tracked/new) files uncommitted, re-invoke it ONCE with a
-      # narrow "just commit + open the PR" prompt. Bounded to a single retry; if it STILL doesn't
-      # persist, `still_dirty=1` feeds the artifact-gate an accurate cause (not "underspecified").
+      # ── FINISH-THE-COMMIT (#1764) — persist pi's work DETERMINISTICALLY, never via pi ────
+      # pi (pi-claude-cli --print) runs one-shot with NO --max-turns. On ~10/10 real worker runs
+      # it did the edits, then ended its turn NARRATING the commit ("Committing now via /commit",
+      # "Proceeding to open the PR", "No response requested.") WITHOUT emitting the commit/PR tool
+      # calls — leaving a dirty tree, a red artifact-gate, and no PR (on-box ~/.pi/agent/sessions,
+      # #1764). Re-PROMPTING pi to just commit does NOT fix it — verified twice on-box: even a
+      # narrow "the tree is dirty, only commit + open the PR" prompt ends with pi saying "I'll
+      # commit…" and stopping, no tool call. So the workflow persists the work ITSELF: pi produces
+      # the edits, and THIS step commits + pushes + opens the PR deterministically in bash. pi is
+      # removed from the persistence path entirely.
       # NB the workflow's OWN scratch files (decompose-pidev-{prompt,exec}-*, pi-telemetry-out/)
-      # are untracked and always present — they must NOT count as "dirty" or this would false-fire
-      # on every successful run, so the dirty check greps them out.
+      # are untracked and always present — they must NOT be committed or count as "dirty", so both
+      # the dirty check and the staging exclude them.
       - id: finish
         if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
-          PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
           EPIC_BRANCH: ${{ steps.ctx.outputs.epic_branch }}
         run: |
           set -uo pipefail
           SCRATCH='decompose-pidev-(prompt|exec)-[0-9]+\.(txt|log)|pi-telemetry-out'
           dirty() { git status --porcelain 2>/dev/null | grep -vE "$SCRATCH" | grep -q . ; }
-          if ! dirty; then
-            echo "tree clean after pi (ignoring workflow scratch) — nothing to finish"
-            echo "still_dirty=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "::warning::pi left an uncommitted working tree — re-prompting once to finish the commit + PR (#1764)"
-          git status --porcelain | grep -vE "$SCRATCH" || true
+          BASE="main"; [ -n "${EPIC_BRANCH:-}" ] && BASE="$EPIC_BRANCH"
           git config user.name  "nuxt-harness[bot]"
           git config user.email "nuxt-harness[bot]@users.noreply.github.com"
-          TARGET="main"; [ -n "${EPIC_BRANCH:-}" ] && TARGET="the integration branch '${EPIC_BRANCH}'"
-          LOG="decompose-pidev-exec-${{ github.run_id }}.log"
-          FINISH_PROMPT="$(printf 'The previous turn edited files but ENDED WITHOUT COMMITTING — the working tree is still dirty. Do NOT make further code changes and do NOT re-do the work. Commit the EXISTING changes now via the /commit skill (it will create a branch if needed; target %s), then open ONE pull request whose FIRST body line is literally "Closes #%s". Verify the PR exists with `gh pr view` before you finish. If a PR for this branch already exists, just push and stop.' "$TARGET" "$ISSUE")"
-          set +e
-          command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent
-          pi --print --provider "$PI_PROVIDER" --model "$PI_MODEL" --skill .claude/skills "$FINISH_PROMPT" 2>&1 | tee -a "$LOG"
-          set -e
+
+          # 1) If pi left edits uncommitted, COMMIT THEM DETERMINISTICALLY (never re-prompt pi).
           if dirty; then
-            echo "::error::pi STILL left an uncommitted tree after the finish retry (#1764) — work not persisted"
+            echo "::warning::pi left an uncommitted tree — committing it deterministically (#1764)"
+            git status --porcelain | grep -vE "$SCRATCH" || true
+            BR="$(git branch --show-current)"
+            if [ -z "$BR" ] || [ "$BR" = "main" ]; then BR="work-${ISSUE}"; git checkout -b "$BR"; fi
+            git add -A
+            git reset -q -- 'decompose-pidev-*.txt' 'decompose-pidev-*.log' pi-telemetry-out 2>/dev/null || true
+            # scope to pi's edits: unstage anything that was already dirty before pi ran
+            # (build/install noise — normally none; see the `baseline` step).
+            if [ -s "$RUNNER_TEMP/pre-pi-dirty.txt" ]; then
+              while IFS= read -r p; do [ -n "$p" ] && git reset -q -- "$p" 2>/dev/null || true; done < "$RUNNER_TEMP/pre-pi-dirty.txt"
+            fi
+            if git diff --cached --quiet; then
+              echo "nothing to commit after excluding scratch"
+            else
+              TITLE="$(gh issue view "$ISSUE" --json title -q .title 2>/dev/null)"
+              [ -z "$TITLE" ] && TITLE="chore: finish work on #${ISSUE}"
+              git commit -q -m "$TITLE" -m "🤖 Auto-finished by the pi worker (#1764): pi edited these files but ended its turn without committing them; the workflow persisted the work. Refs #${ISSUE}"
+              echo "committed as: $TITLE"
+            fi
+          fi
+
+          # 2) Ensure the branch is pushed and a PR exists (pi also fails to open the PR itself).
+          git fetch origin "$BASE" --quiet 2>/dev/null || true
+          BR="$(git branch --show-current)"
+          if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$(git rev-list --count "origin/${BASE}..HEAD" 2>/dev/null || echo 0)" -gt 0 ]; then
+            git push -u origin "HEAD:${BR}" 2>&1 | tail -2
+            EXISTING="$(gh pr list --head "$BR" --base "$BASE" --json number -q '.[0].number' 2>/dev/null || true)"
+            if [ -z "$EXISTING" ]; then
+              gh pr create --base "$BASE" --head "$BR" \
+                --title "$(git log -1 --format=%s)" \
+                --body "$(printf 'Closes #%s\n\n🤖 Auto-opened by the pi worker finish step (#1764) — pi implemented this leaf but did not open the PR itself.' "$ISSUE")" 2>&1 | tail -3
+            else
+              echo "PR #${EXISTING} already open for ${BR}"
+            fi
+          else
+            echo "no commits ahead of ${BASE} on '${BR:-<none>}' — nothing to open a PR for"
+          fi
+
+          # 3) Verdict for the artifact-gate: a still-dirty tree here means the deterministic
+          #    commit itself failed (a git/tooling problem, not the narrate-then-stop fault).
+          if dirty; then
+            echo "::error::working tree STILL dirty after the deterministic finish (#1764)"
             echo "still_dirty=1" >> "$GITHUB_OUTPUT"
           else
-            echo "finish retry committed the tree"
             echo "still_dirty=0" >> "$GITHUB_OUTPUT"
           fi
 
@@ -316,8 +356,8 @@ jobs:
         env:
           PI_EXEC_LOG: ${{ steps.pi.outputs.exec_log }}
           CLAUDE_CONCLUSION: ${{ steps.pi.outputs.conclusion }}
-          # #1764: '1' when pi edited files but neither it nor the finish-commit retry persisted
-          # them — lets the gate name the narrate-then-stop cause instead of "underspecified".
+          # #1764: '1' only when the deterministic finish step could NOT persist pi's edits
+          # (a git/tooling failure) — lets the gate name that cause instead of "underspecified".
           PI_LEFT_DIRTY: ${{ steps.finish.outputs.still_dirty }}
           ISSUE_NUMBER: ${{ inputs.issue || github.event.issue.number }}
           TRIGGER: ${{ github.event_name }}
@@ -453,11 +493,11 @@ jobs:
                   why = 'the Anthropic key (`PI_PROVIDER_KEY`) is out of credit'
                   action = 'top up the account, then re-dispatch' // NB: not "enable auto-reload" — owner declined it (#1327); the pi-key-canary workflow tracks key health
                 } else if (process.env.PI_LEFT_DIRTY === '1') {
-                  // #1764: pi edited files but ended its turn without committing, and the
-                  // finish-commit retry above ALSO failed to persist. This is the harness's
-                  // narrate-then-stop fault — NOT an underspecified issue. Name it accurately.
-                  why = 'pi edited files but ended its turn WITHOUT committing them (the narrate-then-stop fault, #1764) — the finish-commit retry also failed to persist, so the work was discarded with the workspace'
-                  action = 'this is a harness bug, not an underspecified issue (see #1764) — the finish-retry itself is not emitting the commit; re-dispatch and, if it recurs, investigate why pi narrates the commit instead of running it'
+                  // #1764: pi edited files but the DETERMINISTIC finish step still could not
+                  // persist them — a git/tooling failure, not the narrate-then-stop fault (which
+                  // the finish step handles). Name it accurately, not "underspecified".
+                  why = 'the deterministic finish step could not persist pi\'s edits (a git/tooling failure, not the narrate-then-stop fault) — the working tree is still dirty (#1764)'
+                  action = 'open the run log — the finish step logged the git error; this is NOT an underspecified issue (see #1764)'
                 } else if (failed) {
                   why = 'the pi agent step errored before it built anything'
                   action = 'open the run log, fix the SDK/tooling error, then re-dispatch'
@@ -471,8 +511,8 @@ jobs:
 
             // #1764 fallback — an uncommitted tree is a definite cause even if the log is unreadable.
             if (!why && process.env.PI_LEFT_DIRTY === '1') {
-              why = 'pi edited files but ended its turn WITHOUT committing them (the narrate-then-stop fault, #1764) — the finish-commit retry also failed to persist'
-              action = 'harness bug, not an underspecified issue (see #1764); re-dispatch, and if it recurs investigate why the finish-retry is not emitting the commit'
+              why = 'the deterministic finish step could not persist pi\'s edits — the working tree is still dirty (#1764)'
+              action = 'open the run log for the finish step git error; not an underspecified issue (see #1764)'
             }
 
             // Fallback when the log is unreadable but the step itself failed.


### PR DESCRIPTION
Closes #1764

Supersedes the re-prompt approach in #1767 (merged), which a live run proved insufficient.

## 👤 For humans

PR #1767 tried to fix the pi worker's "narrates the commit then stops" fault by **re-prompting pi to commit** when it left a dirty tree. A live dispatch on #1733 ([run 30842463196](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/30842463196)) proved that doesn't work: pi ran `git status` twice, saw its own edits, and ended with *"I'll commit the existing quantity stepper color changes and open the PR."* → stopped, **no commit**. So `pi --print` narrates the commit no matter how narrowly you prompt it.

This removes pi from the persistence path entirely: **pi produces the edits, the workflow commits + pushes + opens the PR itself, in bash.**

## 🤖 For agents

- **`baseline` step (new, before pi):** records non-scratch dirty paths. Normally empty (checkout is clean, install is `--frozen-lockfile`, and `node_modules`/`.nuxt`/`.output`/`dist` are gitignored so `git add -A` skips them). Its purpose is a durable guarantee: the finish commit is scoped to *only pi's edits*, even if a build artifact ever becomes tracked.
- **`finish` step (rewritten):** if pi left a dirty tree → `git add -A`, unstage the workflow's own scratch (`decompose-pidev-{prompt,exec}-*`, `pi-telemetry-out`) **and** every baseline path, commit with the issue title as subject, push `HEAD`, and `gh pr create` (first body line `Closes #N`, base = `epic_branch` or `main`) — only if no PR exists for the branch (idempotent). Also opens the PR when pi committed locally but didn't push/PR.
- **`still_dirty=1`** now means the *deterministic commit* itself failed (a git/tooling error), not narrate-then-stop; the artifact-gate wording is updated accordingly.
- **Scope-creep answer:** since checkout is clean and only pi runs between baseline and finish, the committed set == pi's edits; the PR remains the review gate for anything pi did off-task.

Static validation: YAML parses (`baseline`→`pi`→`finish`→gate), gate JS `node --check` clean, `finish`/`baseline` `bash -n` clean, staging-scoping verified in a local git sim.

## 🧪 How to test

The real proof is a live dispatch on the mac-mini runner.

1. `workflow_dispatch` `work-issue-pidev.yml` with `issue=1733` (the leaf that lost its work twice).
2. **Expected:** green run — the `finish` step's `::warning::` fires (pi narrated), then it deterministically commits `ProductList.vue`/`Cart.vue`, pushes `work-1733-*`, and opens a PR `Closes #1733` against `epic/1729-…`. Branch has exactly pi's two edited files, nothing else.
3. Confirm the artifact-gate goes green via `linkedPR`, and the auto-opened PR's diff is scoped to pi's edits only.

> ⚠️ I'll dispatch this immediately after merge and report the result on #1764.
