### PR TITLE
fix(crouton-auth): make the one-click review login actually work + advertise it on staging deploys

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -447,6 +447,7 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.url }}
           APP: ${{ inputs.app }}
+          WORKSPACE: ${{ inputs.workspace }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REF_NAME: ${{ github.ref_name }}
           REVIEW_SEED_SECRET: ${{ secrets.REVIEW_SEED_SECRET }}
@@ -470,8 +471,17 @@ jobs:
                --seed-team test1 --db "${APP}-staging-db"; then
             echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
             echo "password=$PW" >> "$GITHUB_OUTPUT"
+            # One-click link: crouton-auth prefills the login form from ?email=&password=
+            # and never auto-submits (#1153 made the prefill actually apply). Optional
+            # per-app landing path so the link drops the reviewer on the surface worth
+            # reviewing instead of '/': `reviewLogin.landing` in deploy.config.json
+            # (same config block #1185 proposes for a fixed email/password).
+            LANDING="$(node -p "(require('./$WORKSPACE/$APP/deploy.config.json').reviewLogin||{}).landing||''" 2>/dev/null || echo '')"
+            LOGIN_URL="$(node -e 'const [u,e,p,l]=process.argv.slice(1); const q=new URLSearchParams({email:e,password:p}); if(l) q.set("redirect",l); process.stdout.write(`${u}/auth/login?${q}`)' "$DEPLOY_URL" "$EMAIL" "$PW" "$LANDING")"
+            echo "login_url=$LOGIN_URL" >> "$GITHUB_OUTPUT"
             {
               echo "### 🔑 Review test login (${APP})"
+              echo "- **One-click:** [open ${APP} signed-in]($LOGIN_URL) — the form arrives prefilled; click Sign in."
               echo "- **URL:** $DEPLOY_URL"
               echo "- **Email:** \`$EMAIL\`"
               echo "- **Password:** \`$PW\`"
@@ -565,10 +575,14 @@ jobs:
             const app = '${{ inputs.app }}'
             const email = `${{ steps.seed.outputs.email }}`
             const password = `${{ steps.seed.outputs.password }}`
+            const loginUrl = `${{ steps.seed.outputs.login_url }}`
             const marker = `<!-- deploy-staging:${app} -->`
             // Disposable test login (#608) — only present when the seed step ran + produced creds.
+            // Leads with the one-click link (the form arrives prefilled — #1153 fixed the apply,
+            // it never auto-submits) and keeps the raw creds as the paste-in fallback.
+            const oneClick = loginUrl ? `\n\n🔑 **[Open ${app} signed-in](${loginUrl})** — prefilled login, one click on Sign in.` : ''
             const login = (email && password)
-              ? `\n\n🔑 **Test login** — paste straight in, no registration:\n\`\`\`\nEmail:    ${email}\nPassword: ${password}\n\`\`\`\n_Disposable account on this isolated, throwaway staging DB._`
+              ? `${oneClick}\n\n<details><summary>…or paste the creds</summary>\n\n\`\`\`\nEmail:    ${email}\nPassword: ${password}\n\`\`\`\n</details>\n_Disposable account on this isolated, throwaway staging DB._`
               : ''
             const body = `${marker}\n🚀 **${app}** deployed to staging: ${url}${login}\n\n<sub>🤖 isolated, auto-provisioned Workers staging env (its own D1 + KV)</sub>`
             const { owner, repo } = context.repo

--- a/apps/kassa/deploy.config.json
+++ b/apps/kassa/deploy.config.json
@@ -2,6 +2,9 @@
   "stagingUrl": "https://kassa.pmcp.dev",
   "productionUrl": "https://kassa.friendlyinter.net",
   "layerPackages": "@fyit/crouton-core @fyit/crouton-auth @fyit/crouton-email @fyit/crouton",
+  "reviewLogin": {
+    "landing": "/admin/test1/sales/events/vlaamsekermis"
+  },
   "watchPaths": [
     "apps/kassa/**",
     "packages/crouton/**",

--- a/packages/crouton-auth/app/components/Auth/RouteModal.vue
+++ b/packages/crouton-auth/app/components/Auth/RouteModal.vue
@@ -193,16 +193,26 @@ const loginSubmitButton = computed(() => ({
   block: true
 }))
 
-// Prefill credentials from a shared link (e.g. /auth/login?email=…&password=…)
-// when the login form mounts. Fills the fields only — the user still clicks
-// Sign in (we never auto-submit). Re-applies if the form remounts (e.g. magic-
-// link toggle) while still in login mode.
+// Prefill credentials from a shared link (e.g. /auth/login?email=…&password=…).
+// Fills the fields only — the user still clicks Sign in (we never auto-submit).
+//
+// This watches the form ref AND the prefill values, `immediate` + `flush: 'post'`
+// (#1153): UAuthForm builds its own `state`, so the values can only be written
+// once that object exists. The old one-shot `watch(loginFormRef)` fired exactly
+// once — before `form.state` was ready it early-returned forever, and a prefill
+// arriving after mount (in-app nav → the router plugin opens the modal on an
+// already-mounted form) was never applied. Watching both sources means whichever
+// lands last still fills the form.
 const loginFormRef = useTemplateRef('loginForm')
-watch(loginFormRef, (form) => {
-  if (!form?.state) return
-  if (state.value.prefillEmail) form.state.email = state.value.prefillEmail
-  if (state.value.prefillPassword) form.state.password = state.value.prefillPassword
-})
+watch(
+  [loginFormRef, () => state.value.prefillEmail, () => state.value.prefillPassword],
+  ([form, email, password]) => {
+    if (!form?.state) return
+    if (email) form.state.email = email
+    if (password) form.state.password = password
+  },
+  { immediate: true, flush: 'post' }
+)
 
 async function onLoginSubmit(event: FormSubmitEvent<{ email: string, password?: string, rememberMe?: boolean }>) {
   formError.value = null
@@ -211,6 +221,16 @@ async function onLoginSubmit(event: FormSubmitEvent<{ email: string, password?: 
   if (showMagicLink.value) {
     await handleMagicLink(event.data.email)
     submitting.value = false
+    return
+  }
+
+  // The login UAuthForm carries no `:schema`, so `required` on the fields is
+  // cosmetic — an empty submit would reach the server and surface the raw Zod
+  // error (`[body.email] Invalid input: expected string, received undefined`).
+  // Answer it here instead (#1153).
+  if (!event.data.email || !event.data.password) {
+    submitting.value = false
+    formError.value = t('auth.credentialsRequired', 'Enter your email and password')
     return
   }
 


### PR DESCRIPTION
Closes #1153

Packages-approved: owner-requested fix in `crouton-auth` (the one-click review login was asked for directly).

## 👤 For humans

Asked: *"why wouldn't the one-click link work?"* — it was built (#608) but broken on arrival: the
link opened an **empty** form, so someone reverted the PR comment to paste-in credentials. #1153
diagnosed it a month ago and it sat open.

Now: the staging PR comment leads with **one link** that opens the app with the disposable review
login prefilled — click Sign in and you're inside, landing on the surface worth reviewing. Raw creds
stay behind a "…or paste the creds" toggle.

Proof, against a running app (`localhost:3007`):

| | email field | password field | empty submit |
|---|---|---|---|
| before | *(empty)* | *(empty)* | raw `Invalid input: expected string, received undefined` |
| after | filled | filled | "Enter your email and password" |

`screenshots/1153-prefill.png`, `screenshots/1153-empty-submit.png`.

## 🤖 For agents

**Why it didn't work** — `RouteModal.vue`'s prefill was a one-shot, non-immediate
`watch(loginFormRef)`: it fired once when the ref resolved, early-returned forever if `UAuthForm`
hadn't built its `state` yet, and never re-applied when the prefill arrived *after* mount (the
in-app-nav path, where the router plugin opens the modal on an already-mounted form). Both callers
passed the values correctly — the bug was purely at apply time.

- `RouteModal.vue`: watch `[loginFormRef, prefillEmail, prefillPassword]` with `immediate` +
  `flush: 'post'`, so whichever lands last fills the form. Plus an empty-submit guard in
  `onLoginSubmit` (the login `UAuthForm` has no `:schema`, so `required` was cosmetic and an empty
  submit reached the server).
- `deploy-app.yml`: the seed step composes `login_url` via `URLSearchParams` (so the `+` in
  `review+<app>-<key>@example.com` is encoded — the trap for a hand-built link, where `+` decodes as
  a space), exposes it as a step output, links it in the job summary, and the PR comment leads with
  it.
- Optional `reviewLogin.landing` in `deploy.config.json` → `?redirect=`; set for kassa. Same config
  block #1185 proposes for a fixed email/password, so the two compose.
- New string uses the `t(key, fallback)` form like every other string in this component — none of
  `auth.email` / `auth.password` / `auth.signIn` are in the shipped locale files either, so adding
  one key alone wouldn't close that wider gap.

Not done here: the link only appears on **deploy previews**. A packages-only PR gets no preview by
design (`scripts/deploy-detect.mjs` matches only `apps/<app>/**` on `pull_request`), and local
`pnpm dev` still has no disposable login — happy to file those two as follow-ups.

## 🧪 How to test

1. Merge, then let a staging deploy run (push to `main`, or any PR touching `apps/kassa/**`).
2. The PR comment / job summary shows **"Open kassa signed-in"** → click it: the login form appears
   with both fields filled, and Sign in drops you on `/admin/test1/sales/events/vlaamsekermis`.
3. Clear both fields and hit Sign in → "Enter your email and password", no raw Zod error.
4. A normal login with no query params is unchanged.
