### PR TITLE
fix(crouton-sales): reconcile printers/clients/events schema drift (adds missing driver field)

### DIFF
--- a/apps/kassa/schemas/clients.json
+++ b/apps/kassa/schemas/clients.json
@@ -2,5 +2,5 @@
   "id": { "type": "uuid", "meta": { "primaryKey": true } },
   "title": { "type": "string", "meta": { "required": true, "label": "Client Name", "maxLength": 200 } },
   "isReusable": { "type": "boolean", "meta": { "label": "Reusable", "default": true, "helpText": "Can be used across events" } },
-  "isActive": { "type": "boolean", "meta": { "label": "Active", "default": true } }
+  "isActive": { "type": "boolean", "meta": { "label": "Active", "default": true, "helpText": "Cleared when the end-of-tab receipt is printed" } }
 }

--- a/apps/kassa/schemas/events.json
+++ b/apps/kassa/schemas/events.json
@@ -10,7 +10,7 @@
   "isCurrent": { "type": "boolean", "meta": { "label": "Current Event", "default": false } },
   "requiresClient": { "type": "boolean", "meta": { "label": "Requires Client", "default": true, "helpText": "When enabled, orders must be linked to a client. Disable for loose orders." } },
   "helperPin": { "type": "string", "meta": { "label": "Helper PIN", "maxLength": 6, "helpText": "PIN for volunteer login" } },
-  "currency": { "type": "string", "meta": { "label": "Currency", "default": "EUR", "helpText": "ISO currency code used for order totals and receipts." } },
+  "currency": { "type": "string", "meta": { "label": "Currency", "default": "EUR", "helpText": "Currency used to display prices for this event (EUR or USD)." } },
   "metadata": { "type": "json", "meta": { "label": "Metadata" } },
   "archivedAt": { "type": "date", "meta": { "label": "Archived At" } }
 }

--- a/apps/kassa/schemas/printers.json
+++ b/apps/kassa/schemas/printers.json
@@ -4,10 +4,10 @@
   "locationId": { "type": "uuid", "refTarget": "locations", "meta": { "label": "Location", "helpText": "Routing key for kitchen printers only — receipt printers ignore it (PrinterForm requires it for type kitchen)" } },
   "title": { "type": "string", "meta": { "required": true, "label": "Printer Name", "maxLength": 100 } },
   "ipAddress": { "type": "string", "meta": { "required": true, "label": "IP Address" } },
-  "port": { "type": "string", "meta": { "label": "Port", "default": "9100", "helpText": "ESC/POS raw TCP port. 9100 is universal." } },
-  "status": { "type": "string", "meta": { "label": "Status", "default": "idle", "helpText": "Last-known printer state. Not updated by the spooler." } },
+  "port": { "type": "string", "meta": { "label": "Port", "default": "9100", "helpText": "ESC/POS raw TCP port. 9100 is universal. Stored as TEXT on purpose — every consumer coerces with Number(printer.port) (generate-print-queues.ts, end-receipt, test-print), so integer would mean migrating deployed tables for no gain (#1769)." } },
+  "status": { "type": "string", "meta": { "label": "Status", "default": "idle", "helpText": "VESTIGIAL — nothing reads this. The printer LED comes from the printer's most recent print job (app/utils/printer-led.ts reads job.status, not this column); the only consumer is duplicate.post.ts, which copies it verbatim. Do not wire logic to it (#1769)." } },
   "type": { "type": "string", "meta": { "label": "Printer Type", "default": "kitchen", "helpText": "kitchen = per-location tickets, receipt = combined customer receipt with footer text" } },
-  "driver": { "type": "string", "meta": { "label": "Driver", "default": "network-escpos", "helpText": "Print transport: network-escpos (drained on-site) or browser-print." } },
+  "driver": { "type": "string", "meta": { "label": "Driver", "default": "network-escpos", "helpText": "Print transport: network-escpos (drained on-site) or browser-print. Load-bearing — encodeTicket() picks the encoder from it, and generatePrintJobsForOrder emits no jobs for an unknown driver." } },
   "config": { "type": "json", "meta": { "label": "Config", "helpText": "Printer-specific configuration (driver options)." } },
   "showPrices": { "type": "boolean", "meta": { "label": "Show Prices on Receipt", "default": true } },
   "isActive": { "type": "boolean", "meta": { "label": "Active", "default": true } }

--- a/packages/crouton-sales/schemas/printers.json
+++ b/packages/crouton-sales/schemas/printers.json
@@ -4,9 +4,11 @@
   "locationId": { "type": "uuid", "refTarget": "locations", "meta": { "label": "Location", "helpText": "Routing key for kitchen printers only — receipt printers ignore it (PrinterForm requires it for type kitchen)" } },
   "title": { "type": "string", "meta": { "required": true, "label": "Printer Name", "maxLength": 100 } },
   "ipAddress": { "type": "string", "meta": { "required": true, "label": "IP Address" } },
-  "port": { "type": "integer", "meta": { "label": "Port", "default": 9100 } },
+  "port": { "type": "string", "meta": { "label": "Port", "default": "9100", "helpText": "ESC/POS raw TCP port. 9100 is universal. Stored as TEXT on purpose — every consumer coerces with Number(printer.port) (generate-print-queues.ts, end-receipt, test-print), so integer would mean migrating deployed tables for no gain (#1769)." } },
+  "status": { "type": "string", "meta": { "label": "Status", "default": "idle", "helpText": "VESTIGIAL — nothing reads this. The printer LED comes from the printer's most recent print job (app/utils/printer-led.ts reads job.status, not this column); the only consumer is duplicate.post.ts, which copies it verbatim. Do not wire logic to it (#1769)." } },
   "type": { "type": "string", "meta": { "label": "Printer Type", "default": "kitchen", "helpText": "kitchen = per-location tickets, receipt = combined customer receipt with footer text" } },
-  "status": { "type": "integer", "meta": { "label": "Status", "default": 0, "helpText": "0=ready, 1=printing, 9=error" } },
+  "driver": { "type": "string", "meta": { "label": "Driver", "default": "network-escpos", "helpText": "Print transport: network-escpos (drained on-site) or browser-print. Load-bearing — encodeTicket() picks the encoder from it, and generatePrintJobsForOrder emits no jobs for an unknown driver." } },
+  "config": { "type": "json", "meta": { "label": "Config", "helpText": "Printer-specific configuration (driver options)." } },
   "showPrices": { "type": "boolean", "meta": { "label": "Show Prices on Receipt", "default": true } },
   "isActive": { "type": "boolean", "meta": { "label": "Active", "default": true } }
 }


### PR DESCRIPTION
Packages-approved: owner approved crouton-sales edits in-session for the #1755 pass-screen work; this PR is schema-JSON only (no runtime code), reverses the port/status call on code evidence, and adds the `driver`/`config` fields the package schema was missing.

Refs #1769

## 👤 For humans

The package's copy of the sales schemas had drifted from kassa's. Most of it was harmless wording — but two differences were not, and one of them would have broken printing in any **new** app.

## 🤖 For agents

### 🔴 `driver` and `config` were missing from the package schema entirely

kassa had them; the package didn't. `driver` is load-bearing — `encodeTicket()` picks the encoder from it, and `generatePrintJobsForOrder` emits **no jobs** for an unknown driver. `crouton-sales/CLAUDE.md` documents it at length.

kassa was never affected (its own copy has both). This only ever bit an app generated fresh from the package schema, which would have had no `driver` column and therefore silently produced no print jobs. Both fields added.

### 🟠 `port` / `status`: integer → string (a reversed decision)

The initial call was "integer wins". Reversed on evidence:

```ts
// packages/crouton-sales/server/utils/generate-print-queues.ts:182
// salesPrinters.port is text-typed in the generated schema; coerce to a number.
printerPort: printer.port != null ? Number(printer.port) : null,
```

Three call sites (`generate-print-queues`, `end-receipt`, `test-print`) coerce with `Number()`, and one carries an explicit comment saying the column *is* text. The **package schema** was the side out of step — with the code *and* with every deployed table. Choosing string means no migration and no deployed data touched; choosing integer would have meant rebuilding `sales_printers` on live DBs to satisfy a file no code agreed with. (Printers schema drift already broke a prod deploy once — #1620.)

`status` is now documented as **vestigial**, because it is: nothing reads it. The printer LED is derived from the most recent print job (`printer-led.ts` reads `job.status`); the sole consumer is `duplicate.post.ts`, copying it verbatim. The comment says so, so nobody wires logic to it later.

### ⚪ clients / events

`helpText` wording synced. Cosmetic.

## Result

`apps/kassa/schemas/{printers,clients,events}.json` are now **byte-identical** to the package's.

## Deliberately not in this PR

`products.json` — the `categoryId` / `locationId` `required` divergence. That one isn't a sync, it's a **data decision**: making `locationId` required implies a NOT NULL migration plus backfilling any existing null rows on deployed DBs. It's also the root cause of #1766's unroutable items, so it wants a deliberate call rather than a drive-by. Stays open on #1769.

Also unaddressed: there is still **no mechanism** that would catch the next divergence. Every consuming app forks these files at install and drifts silently. A `--check` mode (like `gen-skills-doc.mjs --check`) is the obvious shape; noted in #1769's acceptance.

## 🧪 How to test

```bash
for f in apps/kassa/schemas/*.json; do
  diff "$f" "packages/crouton-sales/schemas/$(basename $f)"
done
```

Only `products.json` should differ. Then confirm printing still routes: the printers form saves, and a test print reaches its station (`port` is read through `Number()` either way, so behaviour is unchanged — this PR only aligns the declaration).

