### PR TITLE
fix(root): make pi finish its own work — completion enforcer + load the CI profile (#1764, #1782)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -239,7 +239,10 @@ jobs:
           # runs `true` as its own pipeline, clobbering PIPESTATUS[0] to 0 and masking the
           # failure as success. Verified empirically, #1299.)
           set +e
-          pi --print --provider "$PI_PROVIDER" --model "$PI_MODEL" --skill .claude/skills \
+          # --approve: trust the project so pi loads the lean .pi/settings.json CI profile AND the
+          # .pi/extensions/ completion-enforcer (#1782/#1764). Without it the untrusted runner path
+          # silently falls back to the global 28-extension profile (incl pi-ask-user) + ~2min startup.
+          pi --print --approve --provider "$PI_PROVIDER" --model "$PI_MODEL" --skill .claude/skills \
             "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
           RC=${PIPESTATUS[0]}
           set -e

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -256,7 +256,10 @@ jobs:
           # runs `true` as its own pipeline, clobbering PIPESTATUS[0] to 0 and masking the
           # failure as success. Verified empirically, #1299.)
           set +e
-          pi --print --provider "$PI_PROVIDER" --model "$PI_MODEL" --skill .claude/skills \
+          # --approve: trust the project so pi loads the lean .pi/settings.json CI profile AND the
+          # .pi/extensions/ completion-enforcer (#1782/#1764). Without it the untrusted runner path
+          # silently falls back to the global 28-extension profile (incl pi-ask-user) + ~2min startup.
+          pi --print --approve --provider "$PI_PROVIDER" --model "$PI_MODEL" --skill .claude/skills \
             "$(cat "$PROMPT_FILE")" 2>&1 | tee "$LOG"
           RC=${PIPESTATUS[0]}
           set -e

--- a/.pi/extensions/complete-work.ts
+++ b/.pi/extensions/complete-work.ts
@@ -1,0 +1,48 @@
+// Completion enforcer (#1764) — make pi FINISH its own work instead of narrating it.
+//
+// WHY: pi's agent loop (@earendil-works/pi-agent-core `agent-loop.js` L113-169) ends the instant
+// the model returns an assistant turn with ZERO tool calls. In `--print` there is no steering
+// queue to re-drive it, so when the model narrates its next action as prose — "Committing now via
+// /commit", "Proceeding to open the PR", "No response requested." — and ends the turn, the whole
+// run stops with the work uncommitted. Measured at ~96% of worker runs (#1764). No built-in
+// setting makes pi run-to-completion, and ralph-wiggum can't help (it re-drives only when the
+// model calls its own tool — the exact thing failing here).
+//
+// WHAT: hook `turn_end`; if a turn made no tool call and the task isn't declared complete,
+// re-inject a follow-up (`deliverAs: "followUp"` — proven to re-drive the loop in `--print`)
+// telling the model to PERFORM the action, not narrate it. Bounded by MAX; the model ends
+// cleanly by emitting the DONE sentinel. A turn that DID call a tool resets the counter, so a
+// normal multi-tool run is never touched — the hook only ever fires on a genuinely tool-less turn.
+//
+// LOADS ONLY WHEN THE PROJECT IS TRUSTED — the pidev workflows pass `--approve` (#1782), which is
+// also what makes the lean `.pi/settings.json` CI profile apply.
+const DONE = "PI_TASK_COMPLETE_NOTHING_LEFT";
+const MAX = Number(process.env.PI_COMPLETE_MAX_NUDGES || 4);
+
+export default function (pi: any) {
+  let nudges = 0;
+  const textOf = (m: any): string =>
+    m && Array.isArray(m.content)
+      ? m.content.filter((c: any) => c.type === "text").map((c: any) => c.text).join("\n")
+      : "";
+
+  pi.on("turn_end", async (event: any) => {
+    // A turn that called a tool is real progress — reset and let the loop continue naturally.
+    if (event.toolResults && event.toolResults.length > 0) { nudges = 0; return; }
+    const text = textOf(event.message);
+    if (text.includes(DONE)) return;                       // model declared genuine completion
+    if (nudges >= MAX) {
+      console.error(`[complete-work] cap ${MAX} reached — letting the run end (#1764)`);
+      return;                                              // hand off to the workflow's deterministic finish backstop
+    }
+    nudges++;
+    console.error(`[complete-work] tool-less turn — re-driving (nudge ${nudges}/${MAX}, #1764)`);
+    pi.sendUserMessage(
+      `You ended your turn WITHOUT calling any tool, but the task is not verifiably complete. ` +
+      `Do NOT describe or announce your next action — PERFORM it now by calling the appropriate tool ` +
+      `(run the git commit, open the PR, etc.). If — and only if — the task is genuinely and fully ` +
+      `complete with nothing left to do, reply with exactly: ${DONE}`,
+      { deliverAs: "followUp" }
+    );
+  });
+}


### PR DESCRIPTION
Closes #1782
Refs #1764

## 👤 For humans

Makes the pi worker **finish its own work** instead of narrating "Committing now…" and stopping (which was ~96% of runs, #1764). Two coupled fixes:

1. **Completion enforcer** (`.pi/extensions/complete-work.ts`): catches a turn where the model ends without calling a tool and re-drives it — "perform the action, don't describe it." pi then commits + opens the PR itself (via `/commit`), demoting the deterministic `git add -A` backstop (#1772) to a rare fallback.
2. **`--approve`** on the pi call: the runner checkout path isn't in pi's trust list, so pi was silently ignoring our lean `.pi/settings.json` CI profile *and* any project extension — loading the global 28-extension set instead (with `pi-ask-user`, the #839 stall risk) and paying ~2 min startup per run. `--approve` trusts the project so the intended profile + the enforcer load.

## 🤖 For agents

- **Root cause** (pi source): the agent loop ends on any tool-less turn (`agent-loop.js` L113-169); no run-to-completion setting; `ralph-wiggum` can't help (re-drives only when the model calls *its* tool). The enforcer hooks `turn_end`, and on `toolResults.length === 0` re-injects `sendUserMessage(..., {deliverAs:"followUp"})` (proven to re-drive `--print`), capped at `PI_COMPLETE_MAX_NUDGES=4`, model ends via a `DONE` sentinel. **Multi-tool-safe** — a tool-calling turn resets the counter, so it only fires on a genuinely tool-less turn.
- **`--approve`** added to `work-issue-pidev.yml` + `decompose-on-issue-pidev.yml`.

## Evidence (on-box, 2026-08-03)

- Enforcer re-drive: local logs show `turnIndex` advancing after a tool-less turn; multi-tool run stayed silent through 6 tool turns, fired once at the true end, commit landed.
- Trust: untrusted dir, **no `--approve`** → project extension NOT loaded, ~2 min startup; **`--approve`** → loaded, **18 s**.

## 🧪 How to test

1. Dispatch `work-issue-pidev.yml` on a leaf (e.g. #1733).
2. **Expected:** run log shows `[complete-work] … re-driving` when pi narrates, then **pi's own** `git commit` + PR (not the deterministic finish), startup down from ~2 min, and the loaded profile is the lean 8-package set (no `pi-ask-user`).
3. **Measure:** re-run the 24h self-commit-rate scan — it should climb well off 4%, and the backstop fire-rate should crater. #1764 closes on that measurement, not on merge.

> Verified live via a `--ref` dispatch before merge — result posted on #1764.
