### PR TITLE
chore(root): finish the #1222 migration — dead layer-packages input + un-migrated POC build

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -46,14 +46,6 @@ on:
         required: false
         default: '22'
         type: string
-      layer-packages:
-        description: >-
-          Space-separated pnpm filter names of dist-consumed framework packages
-          to build before the app (only those WITH a build script are built;
-          pure source layers like crouton-editor/pages/charts are skipped).
-        required: false
-        default: '@fyit/crouton-auth @fyit/crouton-core @fyit/crouton'
-        type: string
       review-pr:
         description: >-
           PR number to wire the preview-review bridge to (staging only, #607).
@@ -224,6 +216,8 @@ jobs:
       # 0.06s "Could not load @fyit/crouton" that killed the quotes-POC deploy). It
       # also subsumes the #745 cross-app cache-collision class: every entry contains
       # ALL dist, so no caller can restore a set missing a package it needs.
+      # The `layer-packages` input that fed that old subset build is gone (#1787) —
+      # it outlived its reader by 500-odd commits. Nothing selects packages anymore.
       - name: Warm @fyit package builds
         uses: ./.github/actions/warm-packages
 

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -126,7 +126,6 @@ jobs:
       environment: ${{ matrix.environment }}
       staging-url: ${{ matrix.stagingUrl }}
       production-url: ${{ matrix.productionUrl }}
-      layer-packages: ${{ matrix.layerPackages }}
       # PR-tied deploys wire the preview-review bridge to this PR (#607); on a manual
       # dispatch use the optional review_pr input; empty → the bridge stays off.
       review-pr: ${{ github.event.pull_request.number || github.event.inputs.review_pr }}

--- a/.github/workflows/deploy-pocs.yml
+++ b/.github/workflows/deploy-pocs.yml
@@ -130,7 +130,6 @@ jobs:
       workspace: pocs
       environment: staging
       staging-url: ${{ matrix.stagingUrl }}
-      layer-packages: ${{ matrix.layerPackages }}
       # PR-tied deploys wire the preview-review bridge to this PR (#607); on a manual
       # dispatch use the optional review_pr input; empty → the bridge stays off.
       review-pr: ${{ github.event.pull_request.number || github.event.inputs.review_pr }}
@@ -194,24 +193,14 @@ jobs:
       - name: Rebuild native build deps skipped by --ignore-scripts
         run: pnpm rebuild better-sqlite3 2>/dev/null || true
 
-      # Build the dist-consumed framework layers the app needs (same set + flow as
-      # deploy-app.yml; only packages WITH a build script are built).
-      - name: Build layer packages
-        env:
-          LAYER_PACKAGES: ${{ matrix.layerPackages }}
-        run: |
-          for pkg in $LAYER_PACKAGES @fyit/crouton-devtools; do
-            dir="packages/${pkg#@fyit/}"
-            if [ -d "$dir/dist" ] && [ -n "$(ls -A "$dir/dist" 2>/dev/null)" ]; then
-              echo "Skipping $pkg (already built this run)"
-              continue
-            fi
-            if node -e "process.exit(require('./$dir/package.json').scripts?.build ? 0 : 1)" 2>/dev/null; then
-              echo "Building $pkg"; pnpm --filter "$pkg" build
-            else
-              echo "Skipping $pkg (no build script / pure source layer)"
-            fi
-          done
+      # Ensure EVERY @fyit/* dist is present before the build — same action every
+      # other build path uses (#1222). This job used to hand-roll a subset build
+      # from `matrix.layerPackages`; that is exactly the per-caller subset which
+      # could miss a transitively-extended package and kill the build with
+      # "Could not load '@fyit/crouton'". It was the last caller left on the old
+      # mechanism after #1222 migrated deploy-app.yml (#1787).
+      - name: Warm @fyit package builds
+        uses: ./.github/actions/warm-packages
 
       - name: Prepare Nuxt (generate tsconfig)
         run: npx nuxt prepare


### PR DESCRIPTION
## 👤 For humans

This started as a wrong guess. I reported that kassa's `watchPaths` was missing `packages/crouton-sales/**` — it isn't; I'd read the file with `head -12` and the list is 12 lines long, so it cut off one line above the entry. Tracing the config properly to confirm that turned up something real instead.

`deploy-app.yml` takes an input called **`layer-packages`** — the list of framework packages to build before an app. **Nothing reads it.** #1222 replaced that mechanism with a step that builds *every* package from a cache, precisely because a hand-maintained subset kept missing one and killing deploys with `Could not load '@fyit/crouton'`. The input stayed behind.

And one job never made the move: the POC **version-preview** build still hand-rolls that same subset — the old code path, same failure mode, still live.

So: delete the dead input, and put that last job on the shared action.

## 🤖 For agents

**Finding 1 — dead input.** `deploy-app.yml` declared `layer-packages` (L49-56). Its only other occurrence in that file was the comment at L215 explaining that `warm-packages` superseded it. No step referenced it. Two callers still passed it (`deploy-apps.yml` L129, `deploy-pocs.yml` L133).

**Finding 2 — un-migrated build path.** `deploy-pocs.yml`'s version-preview job (`mode: version` dispatch) looped over `$LAYER_PACKAGES @fyit/crouton-devtools` building each package that had a build script. That is the per-caller subset build `warm-packages` exists to replace — see the action's own header citing the quotes-POC failure. The *main* POC deploy path goes through `deploy-app.yml` and was already migrated; only this dispatch-only job was missed, which is presumably why it went unnoticed.

### What changed

- `deploy-app.yml`: input removed; the L215 comment now says where it went, so the next reader doesn't go looking.
- `deploy-apps.yml`, `deploy-pocs.yml`: pass-throughs removed.
- `deploy-pocs.yml` version-preview: the loop → `uses: ./.github/actions/warm-packages`. Building everything also subsumes the hardcoded `@fyit/crouton-devtools` append.

### Deliberately not done

`layerPackages` in `deploy.config.json` and `deploy-detect.mjs` is **untouched**. It's now parsed into the matrix and consumed by nothing. Removing it is defensible, but #1443 plans to cross-reference `watchPaths` *against* `layerPackages` — and whether a field nothing reads is a fit source of truth is that issue's design call, not a side effect of this cleanup. Flagged there.

Worth recording for #1443: `layerPackages` and `watchPaths` disagree in **every** app — kassa watches 10 packages and "builds" 4; velo and triage split the same way. That's been harmless only because the build list is ignored.

## Checks

- `node --test scripts/*.test.mjs` → **146 pass** (`deploy-detect.test.mjs` fixtures still carry `layerPackages`; still valid, the field is still parsed)
- All three workflows parse; every caller's `with:` keys cross-checked against `deploy-app.yml`'s declared inputs — passing an undeclared input to a reusable workflow is a hard error, which was the actual risk in this diff
- `npx fallow audit` → pass

## 🧪 How to test

1. `grep -rn "layer-packages" .github/` → only explanatory comments; no input, no caller.
2. Merge to `main` touching an app's watched paths → its staging deploy runs green (packages still built, via `warm-packages`).
3. Dispatch `deploy-pocs.yml` with `mode: version` on any POC → still prints a preview URL; the log shows the `warm-packages` cache restore/build instead of the per-package loop. **This is the one path this PR actually changes behaviourally** — worth a dispatch before merging if you want it proven rather than reasoned.

Follow-up to #1222. Relevant to #1443.

Closes #1787
