### PR TITLE
fix(root): worker re-bases onto epic branch + decompose leaf-handoff fires fresh (#1764)

### DIFF
--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -321,32 +321,42 @@ jobs:
             echo "$NOTLEDGER" | sed 's/^/  ? /'
           fi
 
-          # 3) Stage EXACTLY the ledger paths (Aider/claude-code-action style — never add -A/-u).
+          # 3) Persist pi's edits DETERMINISTICALLY onto the CORRECT base. Capture the ledger
+          #    files' content, then recreate work-<issue> off origin/$BASE (the epic branch) and
+          #    restore ONLY those files onto it. This never depends on which branch pi left the tree
+          #    on — pi's own checkout of the epic branch is unreliable (#1741 committed against main
+          #    → the PR leaked 56 of main's commits vs the stale epic branch; #1733 happened to be
+          #    on the epic branch → clean). Re-basing here makes the PR diff EXACTLY pi's files
+          #    against the epic branch, every time.
+          CONTENT="$RUNNER_TEMP/ledger-content"; rm -rf "$CONTENT"; mkdir -p "$CONTENT"
           while IFS= read -r p; do
             [ -z "$p" ] && continue
-            git add -- "$p" 2>/dev/null || echo "::warning::could not stage $p"
+            [ -f "$p" ] && { mkdir -p "$CONTENT/$(dirname "$p")"; cp "$p" "$CONTENT/$p"; }
           done < "$LEDGER"
 
-          # 4) Commit (if anything staged) on a work-<issue> branch — NEVER on the epic branch
-          #    itself (pi checks out epic/<NN>, so a bare commit there means head==base and no PR
-          #    can open — the #1764 "no commits ahead of epic on epic" failure). checkout -B keeps
-          #    the staged changes since the work branch starts at the current (epic) HEAD.
-          if ! git diff --cached --quiet; then
-            BR="$(git branch --show-current)"
-            case "$BR" in work-*) : ;; *) BR="work-${ISSUE}"; git checkout -B "$BR" ;; esac
+          git fetch origin "$BASE" --quiet 2>/dev/null || true
+          git checkout -f -B "work-${ISSUE}" "origin/${BASE}" 2>&1 | tail -1
+          BR="work-${ISSUE}"
+
+          while IFS= read -r p; do
+            [ -z "$p" ] && continue
+            [ -f "$CONTENT/$p" ] && { mkdir -p "$(dirname "$p")"; cp "$CONTENT/$p" "$p"; git add -- "$p"; }
+          done < "$LEDGER"
+
+          # 4) Commit only what the ledger changed vs the base.
+          if [ "$N" -gt 0 ] && ! git diff --cached --quiet; then
             TITLE="$(gh issue view "$ISSUE" --json title -q .title 2>/dev/null)"
             [ -z "$TITLE" ] && TITLE="chore: implement #${ISSUE}"
             git commit -q -m "$TITLE" -m "🤖 Committed by the pi worker from pi's edited-file ledger (Pattern B, #1764/#1782). Refs #${ISSUE}"
-            echo "committed $N file(s) as: $TITLE"
+            echo "committed $N file(s) onto ${BR} (based on ${BASE}): $TITLE"
           else
-            echo "nothing staged from the ledger (pi committed already, or made no captured file changes)"
+            echo "nothing to commit (ledger empty, or no change vs ${BASE})"
           fi
 
-          # 5) Ensure the branch is pushed and a PR exists.
-          git fetch origin "$BASE" --quiet 2>/dev/null || true
-          BR="$(git branch --show-current)"
-          if [ -n "$BR" ] && [ "$BR" != "main" ] && [ "$(git rev-list --count "origin/${BASE}..HEAD" 2>/dev/null || echo 0)" -gt 0 ]; then
-            git push -u origin "HEAD:${BR}" 2>&1 | tail -2
+          # 5) Push + open the PR (base = the epic branch, head = work-<issue>). Force-push so a
+          #    re-dispatch idempotently re-bases the branch instead of failing non-fast-forward.
+          if [ "$(git rev-list --count "origin/${BASE}..HEAD" 2>/dev/null || echo 0)" -gt 0 ]; then
+            git push -u --force origin "HEAD:${BR}" 2>&1 | tail -2
             EXISTING="$(gh pr list --head "$BR" --base "$BASE" --json number -q '.[0].number' 2>/dev/null || true)"
             if [ -z "$EXISTING" ]; then
               gh pr create --base "$BASE" --head "$BR" \
@@ -356,7 +366,7 @@ jobs:
               echo "PR #${EXISTING} already open for ${BR}"
             fi
           else
-            echo "no commits ahead of ${BASE} on '${BR:-<none>}' — no PR to open"
+            echo "no commits ahead of ${BASE} — no PR to open"
           fi
 
           # 6) Verdict for the artifact-gate: pi wrote files but nothing landed on the branch = fail.

--- a/scripts/apply-decompose-plan.mjs
+++ b/scripts/apply-decompose-plan.mjs
@@ -135,6 +135,11 @@ const ACTION_HANDLERS = {
     exec('gh', ['issue', 'edit', String(a.issue), '--repo', repo, '--body-file', f])
   },
   'add-label'(a, { repo, exec, labelled }) {
+    // Force a FRESH labeled event (#1764): the leaf target may already carry work-this from a
+    // prior run, and a plain --add-label is then a silent no-op that fires NO `labeled` event —
+    // so the single-use worker never triggers and the decompose gate sees no `leafDispatched`
+    // (exactly the #1741 failure). Remove-then-add guarantees the event fires.
+    try { exec('gh', ['issue', 'edit', String(a.issue), '--repo', repo, '--remove-label', a.label]) } catch { /* wasn't present */ }
     exec('gh', ['issue', 'edit', String(a.issue), '--repo', repo, '--add-label', a.label])
     labelled.push({ issue: a.issue, label: a.label })
   },

--- a/scripts/apply-decompose-plan.test.mjs
+++ b/scripts/apply-decompose-plan.test.mjs
@@ -126,4 +126,8 @@ test('runActions on a leaf edits the target body and labels it (mock exec)', () 
   const written = calls.find(c => c[0] === 'BODY')[1]
   assert.match(written, /existing body/)
   assert.match(written, /<!-- pipeline: epic=1706 depth=0 epic_branch=/)
+  // #1764: work-this is applied as remove-then-add so a stale label still fires a fresh event
+  const labelCalls = calls.filter(c => Array.isArray(c) && c.includes('work-this'))
+  assert.ok(labelCalls.some(c => c.includes('--remove-label')), 'must remove work-this first')
+  assert.ok(labelCalls.some(c => c.includes('--add-label')), 'then re-add work-this')
 })


### PR DESCRIPTION
Refs #1764

Two pipeline fixes, the last gaps to a clean end-to-end run:

1. **Worker branch-base** (Fix 1, live-proven on #1809 → PR contained only the 1 edited file, no main-drift leak): finish step captures the ledger files, recreates work-<issue> off origin/<epic-branch>, restores only those files. Removes dependence on pi checking out the epic branch (the #1741 ~90-file bloat).

2. **Decompose leaf-handoff** (Fix 2, unit-tested): the leaf work-this label is applied remove-then-add so a stale label still fires a fresh event — fixes /delegate-pi producing nothing on #1741 (worker never triggered).

## 🧪 How to test
After merge: /delegate-pi on a small real leaf → decompose classifies leaf → fresh work-this → worker → clean PR with only the edited files.