### PR TITLE
Owner stays in the loop: pi PR status + @mention on red + auto-open epic→main PR (#1815)

### DIFF
--- a/.github/workflows/epic-ready-pr.yml
+++ b/.github/workflows/epic-ready-pr.yml
@@ -1,0 +1,135 @@
+name: Open epic→main PR when assembled
+
+# The "done" signal (#1815). Nothing else in the pipeline opens the epic→main PR — the worker only
+# opens sub-PRs against the epic branch, and automerge-epic-subpr.yml lands those INTO the epic
+# branch. So when an epic's LAST child closes and its branch is ahead of main, THIS opens the
+# epic/<n>-… → main PR (READY, never merged) and requests the owner's review, so "done" lands in the
+# owner's github.com/pulls/review-requested queue. The owner does the actual merge.
+#
+# TRIGGER = issues:closed, NOT pull_request:closed. A sub-PR merging into a non-default epic branch
+# does not auto-close its `Closes #NN` child — schedule-waves.yml closes it explicitly and THAT
+# emits issues:closed. Keying off issues:closed means the just-completed child already reads as
+# closed here (no race against schedule-waves), so "all children closed" is decidable in one pass.
+#
+# APP TOKEN, not GITHUB_TOKEN: a GITHUB_TOKEN-opened PR does not trigger pull_request CI — the same
+# cascade reason automerge-epic-subpr.yml uses the App token. The epic→main PR MUST run CI so the
+# owner reviews it green.
+#
+# The PR body deliberately does NOT carry `Closes #<epic>`: epics close via the /close-epic
+# postmortem flow (#856), so auto-closing on this merge would bypass the postmortem gate.
+
+on:
+  issues:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      epic_branch:
+        description: 'epic/<n>-<slug> branch to evaluate'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # One evaluation per epic at a time (two children closing at once must not double-open the PR).
+  group: epic-ready-${{ github.event.issue.number || github.event.inputs.epic_branch }}
+  cancel-in-progress: false
+
+jobs:
+  open-epic-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+      - uses: actions/github-script@v7
+        env:
+          OWNER_LOGIN: ${{ vars.PIPELINE_OWNER || 'pmcp' }}
+          DISPATCH_BRANCH: ${{ github.event.inputs.epic_branch }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo
+            const OWNER = process.env.OWNER_LOGIN || 'pmcp'
+            const ws = process.env.GITHUB_WORKSPACE
+            const { parsePipelineBlock } = await import(`${ws}/scripts/pipeline-context.mjs`)
+            const { parseEpicNumber, decideOpen } = await import(`${ws}/scripts/epic-ready.mjs`)
+
+            // Resolve (epicNumber, epicBranch) from either the closed child's pipeline block
+            // or a manual dispatch's branch input.
+            let epicNumber, epicBranch
+            if (context.eventName === 'workflow_dispatch') {
+              epicBranch = process.env.DISPATCH_BRANCH
+              epicNumber = parseEpicNumber(epicBranch)
+            } else {
+              const closed = context.payload.issue
+              const block = parsePipelineBlock(closed.body || '')
+              epicNumber = block.epic
+              epicBranch = block.epic_branch
+              if (!epicNumber) { core.info(`#${closed.number} has no pipeline block — not a pipeline child; skip.`); return }
+              if (epicNumber === closed.number) { core.info(`#${closed.number} is the epic itself — closed via /close-epic, not here; skip.`); return }
+            }
+            if (!epicNumber) { core.info(`could not resolve an epic number from ${epicBranch}; skip.`); return }
+
+            // Fall back to matching-refs if the block carried no branch (older children).
+            if (!epicBranch) {
+              try {
+                const refs = await github.paginate('GET /repos/{owner}/{repo}/git/matching-refs/heads/{prefix}',
+                  { owner, repo, prefix: `epic/${epicNumber}-` })
+                epicBranch = refs[0] ? refs[0].ref.replace('refs/heads/', '') : null
+              } catch (e) { core.warning(`matching-refs epic/${epicNumber}-: ${e.message}`) }
+            }
+            if (!epicBranch) { core.info(`no epic branch for #${epicNumber}; skip.`); return }
+
+            // 1) the epic's DIRECT sub-issues
+            let subIssues = []
+            try {
+              subIssues = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                { owner, repo, issue_number: epicNumber, per_page: 100 })
+            } catch (e) { core.warning(`sub-issues for #${epicNumber}: ${e.message}`); return }
+
+            // 2) any existing OPEN epic→main PR (idempotency guard)
+            const existing = await github.paginate(github.rest.pulls.list,
+              { owner, repo, state: 'open', head: `${owner}:${epicBranch}`, base: 'main', per_page: 100 })
+
+            // 3) commits the epic branch is ahead of main
+            let aheadCount = 0
+            try {
+              const cmp = (await github.rest.repos.compareCommitsWithBasehead(
+                { owner, repo, basehead: `main...${epicBranch}` })).data
+              aheadCount = cmp.ahead_by || 0
+            } catch (e) { core.warning(`compare main...${epicBranch}: ${e.message}`); return }
+
+            const { open, reason } = decideOpen({ subIssues, existingEpicMainPrs: existing, aheadCount })
+            core.info(`epic #${epicNumber} (${epicBranch}): ${open ? 'OPEN' : 'skip'} — ${reason}`)
+            if (!open) return
+
+            // Reference the epic WITHOUT closing it (postmortem gate, #856).
+            const epic = (await github.rest.issues.get({ owner, repo, issue_number: epicNumber })).data
+            const childList = subIssues.map(s => `- #${s.number} ${s.title}`).join('\n')
+            const cleanTitle = epic.title.replace(/^Epic:\s*/i, '')
+            const title = `Epic #${epicNumber}: ${cleanTitle}`.slice(0, 250)
+            const body =
+              `Assembles epic #${epicNumber} — all ${subIssues.length} children closed and merged into ` +
+              `\`${epicBranch}\`, ready for \`main\`.\n\n` +
+              `> Referenced, not \`Closes\` — the epic closes via the \`/close-epic\` postmortem flow (#856), ` +
+              `not on this merge.\n\n` +
+              `## 👤 For humans\n${cleanTitle}\n\n**Children (${subIssues.length}):**\n${childList}\n\n` +
+              `## 🧪 How to test\nReview the assembled \`${epicBranch}\` → \`main\` diff; CI runs on this PR. ` +
+              `Merge when green — you are the review gate.\n\n` +
+              `<sub>🤖 agent pipeline (CI) · epic→main assembler (#1815) · review requested from @${OWNER}</sub>`
+
+            let pr
+            try {
+              pr = (await github.rest.pulls.create({ owner, repo, head: epicBranch, base: 'main', title, body })).data
+            } catch (e) { core.setFailed(`create epic→main PR failed: ${e.message}`); return }
+            core.info(`Opened epic→main PR #${pr.number} (${epicBranch} → main).`)
+
+            try {
+              await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [OWNER] })
+              core.info(`Requested review from @${OWNER}.`)
+            } catch (e) { core.warning(`requestReviewers @${OWNER}: ${e.message}`) }

--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -37,9 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
+        env:
+          OWNER_LOGIN: ${{ vars.PIPELINE_OWNER || 'pmcp' }}
         with:
           script: |
             const { owner, repo } = context.repo
+            const OWNER = process.env.OWNER_LOGIN || 'pmcp'
             const PR_STICKY = '<!-- crouton-pipeline-status -->'
             const EPIC_ROLLUP = '<!-- crouton-epic-rollup -->'
             const now = new Date().toISOString().replace('T', ' ').slice(0, 16) + 'Z'
@@ -99,8 +102,30 @@ jobs:
                 `<sub>🤖 agent pipeline (#337) · \`${pr.head.ref}\` → \`${pr.base.ref}\` · ` +
                 `<a href="${pr.html_url}/checks">checks</a> · updated ${now}</sub>`
               await upsert(pr.number, PR_STICKY, body)
+              if (st.word === 'failing') await pingOnRed(pr, st)
               const epicMatch = /^epic\/(\d+)-/.exec(pr.base.ref)
               if (epicMatch) await updateEpic(Number(epicMatch[1]))
+            }
+
+            // One-shot @mention on a fresh failure — the ONLY loud signal (#1815). A red pipeline
+            // PR won't auto-merge into its epic (automerge-epic-subpr.yml leaves it open), so it
+            // needs the owner. Keyed by head SHA so a re-fired check_suite for the SAME commit
+            // never re-pings; a new failing commit (new SHA) does. Mentions don't fire on comment
+            // EDITS, so this is a distinct create guarded by the SHA marker (never the sticky).
+            async function pingOnRed(pr, st) {
+              const marker = `<!-- ci-fail-ping:${pr.head.sha} -->`
+              const comments = await github.paginate(github.rest.issues.listComments,
+                { owner, repo, issue_number: pr.number, per_page: 100 })
+              if (comments.some(c => (c.body || '').includes(marker))) return // already pinged this SHA
+              const body =
+                `${marker}\n` +
+                `🔴 **@${OWNER} — CI failed on this pipeline PR** (${st.failure} failing ` +
+                `check${st.failure === 1 ? '' : 's'}).\n\n` +
+                `A red sub-PR won't auto-merge into its epic — it needs you. ` +
+                `[Checks](${pr.html_url}/checks) · \`${pr.head.ref}\` → \`${pr.base.ref}\`.\n\n` +
+                `<sub>🤖 agent pipeline (CI) · failure notify (#1815)</sub>`
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body })
+              core.info(`Pinged @${OWNER} on red #${pr.number} (${pr.head.sha.slice(0, 7)}).`)
             }
 
             // One roll-up line on the parent epic, computed from sub-issue state + labels
@@ -146,7 +171,11 @@ jobs:
               let pr
               try { pr = (await github.rest.pulls.get({ owner, repo, pull_number })).data } catch { continue }
               if (pr.state !== 'open') continue
-              if (!pr.head.ref.startsWith('claude/issue-')) {
+              // Pipeline-authored branches: the old claude pipeline (`claude/issue-*`) AND the pi
+              // pipeline (`work-*`). The pi branches were silently skipped before #1815, so no pi
+              // worker PR ever got a status note — the main reason the owner saw no signal at all.
+              const isPipeline = pr.head.ref.startsWith('claude/issue-') || pr.head.ref.startsWith('work-')
+              if (!isPipeline) {
                 core.info(`#${pull_number} head ${pr.head.ref} is not a pipeline branch — skipping.`); continue
               }
               await updatePr(pr)

--- a/scripts/epic-ready.mjs
+++ b/scripts/epic-ready.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// epic-ready.mjs — the pure "is this epic assembled and ready to PR into main?" decision (#1815).
+//
+// WHY a pure module. The GitHub I/O (list sub-issues, list PRs, compare branches) lives in
+// .github/workflows/epic-ready-pr.yml; this file is the deterministic predicate it calls, so the
+// rule is unit-tested in isolation (mirrors apply-decompose-plan.mjs's pure-core / thin-executor
+// split). The workflow fires on `issues: closed` — by then schedule-waves.yml has already closed
+// the child whose sub-PR merged (a non-default-branch merge does NOT auto-close its `Closes #NN`,
+// so schedule-waves closes it explicitly), which is why "all sub-issues closed" is the correct
+// completeness signal and racing `pull_request: closed` is not.
+
+/** epic/<n>-<slug> → n (number), else null. */
+export function parseEpicNumber(ref) {
+  const m = /^epic\/(\d+)-/.exec(ref || '')
+  return m ? Number(m[1]) : null
+}
+
+/**
+ * Decide whether to open the epic→main PR. PURE.
+ *   subIssues:           [{ state: 'open'|'closed' }]  — the epic's DIRECT sub-issues
+ *   existingEpicMainPrs: [ ... ]                        — OPEN PRs already head=epic-branch base=main
+ *   aheadCount:          number                         — commits the epic branch is ahead of main
+ * Open iff the epic HAS children, ALL are closed, the branch actually landed work, and no PR exists.
+ * Any miss returns a human-readable `reason` (logged, never thrown — a false skip is safe, a false
+ * open is not, so the predicate is deliberately conservative).
+ */
+export function decideOpen({ subIssues = [], existingEpicMainPrs = [], aheadCount = 0 } = {}) {
+  if (existingEpicMainPrs.length > 0) return { open: false, reason: 'epic→main PR already open' }
+  if (subIssues.length === 0) return { open: false, reason: 'epic has no sub-issues' }
+  const openChildren = subIssues.filter(s => s.state !== 'closed').length
+  if (openChildren > 0) return { open: false, reason: `${openChildren} child issue(s) still open` }
+  if (aheadCount <= 0) return { open: false, reason: 'epic branch has no commits ahead of main' }
+  return { open: true, reason: `all ${subIssues.length} children closed + branch ${aheadCount} ahead of main` }
+}

--- a/scripts/epic-ready.test.mjs
+++ b/scripts/epic-ready.test.mjs
@@ -1,0 +1,51 @@
+// The pure epic→main-ready predicate (#1815). A false SKIP is safe; a false OPEN spams main — so
+// these pin the conservative rule: open only when children exist, ALL closed, branch ahead, no PR.
+//   node --test scripts/epic-ready.test.mjs
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseEpicNumber, decideOpen } from './epic-ready.mjs'
+
+test('parseEpicNumber pulls the number from an epic branch, else null', () => {
+  assert.equal(parseEpicNumber('epic/1701-cold-scaffold-first-run'), 1701)
+  assert.equal(parseEpicNumber('epic/42-x'), 42)
+  assert.equal(parseEpicNumber('work-1741'), null)
+  assert.equal(parseEpicNumber('main'), null)
+  assert.equal(parseEpicNumber(''), null)
+  assert.equal(parseEpicNumber(undefined), null)
+})
+
+const CLOSED = { state: 'closed' }
+const OPEN = { state: 'open' }
+
+test('opens when all children closed, branch ahead, no existing PR', () => {
+  const d = decideOpen({ subIssues: [CLOSED, CLOSED], existingEpicMainPrs: [], aheadCount: 3 })
+  assert.equal(d.open, true)
+})
+
+test('does NOT open while any child is still open', () => {
+  const d = decideOpen({ subIssues: [CLOSED, OPEN], existingEpicMainPrs: [], aheadCount: 3 })
+  assert.equal(d.open, false)
+  assert.match(d.reason, /1 child/)
+})
+
+test('does NOT open when an epic→main PR already exists (idempotent, no dup)', () => {
+  const d = decideOpen({ subIssues: [CLOSED], existingEpicMainPrs: [{ number: 9 }], aheadCount: 3 })
+  assert.equal(d.open, false)
+  assert.match(d.reason, /already open/)
+})
+
+test('does NOT open an epic with no sub-issues', () => {
+  const d = decideOpen({ subIssues: [], existingEpicMainPrs: [], aheadCount: 3 })
+  assert.equal(d.open, false)
+  assert.match(d.reason, /no sub-issues/)
+})
+
+test('does NOT open when the branch is not ahead of main (nothing to land)', () => {
+  const d = decideOpen({ subIssues: [CLOSED], existingEpicMainPrs: [], aheadCount: 0 })
+  assert.equal(d.open, false)
+  assert.match(d.reason, /ahead of main/)
+})
+
+test('defaults are safe — empty call never opens', () => {
+  assert.equal(decideOpen().open, false)
+})


### PR DESCRIPTION
Closes #1815

## 👤 For humans

Three changes so you're notified at exactly two moments — a deliverable is ready, or something broke — and never in between:

1. **Passive status now works for pi PRs.** `pipeline-pr-status.yml` already kept a sticky ✅/❌ note per PR + an epic roll-up, but was scoped to the old `claude/issue-*` prefix and **silently skipped every pi `work-*` PR** — a big reason you saw no signal. Now it covers `work-*`.
2. **Loud on red.** A red pipeline PR @mentions you **once per failing commit** (deduped). A red sub-PR won't auto-merge into its epic, so it needs you.
3. **Auto-open the epic→main PR (the "done" signal).** Nothing opened it before. When an epic's children are all merged and its branch is ahead of `main`, a new workflow opens `epic/<n>-… → main` (**ready, never merged**) and **requests your review** — so "done" lands in your [`/pulls/review-requested`](https://github.com/pulls/review-requested) queue. You do the merge.

This PR itself requests your review — that's mechanism #3, dogfooded.

## 🤖 For agents

- `scripts/epic-ready.mjs` — pure `decideOpen()` predicate (all children closed · branch ahead · no existing PR), 7 node:test cases. Conservative: a false skip is safe, a false open is not.
- `epic-ready-pr.yml` — fires on `issues:closed` (post-schedule-waves, race-free), reads epic+branch from the child's pipeline block, opens with the **App token** so CI fires; body references the epic **without** `Closes` (postmortem gate #856).
- `pipeline-pr-status.yml` — filter broadened to `work-*`; `pingOnRed()` keyed by `<!-- ci-fail-ping:<sha> -->`. Owner via `vars.PIPELINE_OWNER` (default `pmcp`).
- **Note:** touches `.github/workflows/**`, so it needs a human (you) to merge — the App token can't. All logic is `GITHUB_TOKEN`/App-token API calls; the only test-covered code is the pure predicate.

## 🧪 How to test

1. `delegate-pi` a leaf → its `work-*` PR gets a sticky ✅/❌ status.
2. Make a check go red → exactly one @mention; a re-run does not re-ping.
3. Let the epic's children merge → harness opens `epic/<n>-… → main` (ready) and requests your review; it never merges to main itself.