### PR TITLE
Option C: decompose holds for design sign-off (schema/diagram/mockup) instead of deadlocking worker children (#1821)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -220,10 +220,11 @@ jobs:
           EVENT-DRIVEN DECOMPOSE — PLAN ONLY. You are the task-decomposer. Do NOT run `/task-decompose`, do NOT spawn any subagent, and do NOT run any `gh`, `git`, or issue-mutating command. Your ONLY output is a plan file that a deterministic step will apply. Concretely:
           1. READ the target issue (use `gh issue view` to read only — reading is fine, mutating is not).
           2. Apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, one focused run.
-          3. Using your file-writing tool (NOT a shell heredoc — bodies contain emoji/backticks and shell quoting breaks, #1001), write a file named exactly `decompose-plan.json` in the current working directory, as valid JSON:
-             - If the issue is a single leaf: {"leaf": true}
-             - If it needs splitting: {"leaf": false, "children": [ {"title": "...", "body": "...markdown with ## 👤 For humans / ## 🤖 For agents / ## 🧪 How to test...", "labels": ["type:...","<component>"], "needsSplit": false}, ... ]} — 2 to 6 children, one coherent concern each. Set needsSplit=true for a child that itself still needs decomposing (it will be re-decomposed), false for a child that is a ready leaf. Use exactly one `type:*` label plus a real component label per child (labels that do not exist are dropped by the apply step). Do NOT put a pipeline block or Dedup line in the body — the apply step adds them.
-          4. After writing decompose-plan.json, STOP. Do not create issues, branches, PRs, or labels yourself — the apply step does all of that from your plan. Writing a correct decompose-plan.json IS your entire deliverable.
+          3. Using your file-writing tool (NOT a shell heredoc — bodies contain emoji/backticks and shell quoting breaks, #1001), write a file named exactly `decompose-plan.json` in the current working directory, as valid JSON — ONE of these three shapes:
+             - Single leaf: {"leaf": true}
+             - Split: {"leaf": false, "children": [ {"title": "...", "body": "...markdown with ## 👤 For humans / ## 🤖 For agents / ## 🧪 How to test...", "labels": ["type:...","<component>"], "needsSplit": false}, ... ]} — 2 to 6 children, one coherent concern each. Set needsSplit=true for a child that itself still needs decomposing, false for a ready leaf. Exactly one `type:*` label plus a real component label per child (unknown labels are dropped). Do NOT put a pipeline block or Dedup line in the body.
+             - DESIGN SIGN-OFF HOLD (#1821): if the epic needs a human DESIGN DECISION before any code — a genuinely ambiguous data model or UI layout, or a fork with no defensible default (e.g. which split strategy, which balance view) — do NOT create "decide & sign off" children (a code worker cannot build a decision and will deadlock). Instead HOLD: {"signoff": {"summary": "one short paragraph: why we're holding", "questions": ["the real fork to decide", "..."], "schema": {"collection": "name", "fields": { <crouton fieldsFile JSON: fieldName → {type, ...}> }}, "diagram": { <optional ticket-excalidraw graph.json: nodes+edges> }, "ui": "<optional self-contained HTML mockup>"}}. Propose your BEST-GUESS schema/UI so the human reacts to something concrete, and list the genuine forks as `questions`. The apply step renders these (a schema field-table, a diagram, a UI mockup screenshot), posts them on the epic, and holds `status:blocked`; the owner's `lgtm` reply resumes into build children. Include `schema` whenever the data model is the ambiguity; `diagram`/`ui` are optional. Only hold when the ambiguity is real — a well-specified epic just splits.
+          4. After writing decompose-plan.json, STOP. Do not create issues, branches, PRs, or labels yourself — the apply step does all of that from your plan. Writing a correct decompose-plan.json (split, leaf, OR signoff hold) IS your entire deliverable — a design sign-off hold is a complete, successful outcome, not a failure.
           PI_ED
             printf 'The target issue is #%s. Read it and write decompose-plan.json now.\n' "$ISSUE" >> "$PROMPT_FILE"
           else
@@ -295,8 +296,31 @@ jobs:
             fi
           fi
           echo "context: epic=${EPIC} depth=${DEPTH} epic_branch=${EPIC_BRANCH}"
+          APPLY_OUT="$RUNNER_TEMP/apply-out.txt"
           node scripts/apply-decompose-plan.mjs apply decompose-plan.json \
-            --repo "$REPO" --target "$ISSUE" --epic "$EPIC" --epic-branch "$EPIC_BRANCH" --depth "$DEPTH"
+            --repo "$REPO" --target "$ISSUE" --epic "$EPIC" --epic-branch "$EPIC_BRANCH" --depth "$DEPTH" \
+            | tee "$APPLY_OUT"
+
+          # A design sign-off hold (#1821) renders artifacts (schema table / diagram / mockup) into
+          # writeups/**; commit them to the epic branch so the raw URLs referenced in the posted
+          # comment resolve. Uses the App token remote so the push is authenticated.
+          ARTIFACTS="$(grep '^SIGNOFF_ARTIFACTS ' "$APPLY_OUT" | head -1 | cut -d' ' -f2-)"
+          if [ -n "$ARTIFACTS" ]; then
+            echo "committing signoff artifacts to ${EPIC_BRANCH}: $ARTIFACTS"
+            git config user.name  "nuxt-harness[bot]"
+            git config user.email "nuxt-harness[bot]@users.noreply.github.com"
+            git fetch origin "$EPIC_BRANCH" --quiet 2>/dev/null || true
+            git checkout -B "$EPIC_BRANCH" "origin/${EPIC_BRANCH}" 2>&1 | tail -1 || git checkout -B "$EPIC_BRANCH"
+            for f in $ARTIFACTS; do [ -f "$f" ] && git add -- "$f"; done
+            if ! git diff --cached --quiet; then
+              git commit -q -m "docs(root): design sign-off artifacts for #${ISSUE} (#1821)" \
+                -m "Rendered by the decompose signoff hold; referenced from the epic comment."
+              REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+              git push "$REMOTE" "HEAD:${EPIC_BRANCH}" 2>&1 | tail -1
+            else
+              echo "no artifact changes to commit"
+            fi
+          fi
 
       # ── Artifact-gate (#461) — PASS/FAIL logic reused from decompose-on-issue.yml ────────
       # Harness-agnostic: PASS/FAIL is GitHub-state via GITHUB_TOKEN (comment / linked

--- a/scripts/apply-decompose-plan.mjs
+++ b/scripts/apply-decompose-plan.mjs
@@ -23,7 +23,7 @@
 // The PURE core (parsePlan / planToActions / buildChildBody) is unit-tested (…test.mjs). The I/O
 // (runActions → gh via execFileSync) is a thin executor injected for tests.
 
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
 import { writePipelineBlock } from './pipeline-context.mjs'
@@ -38,7 +38,29 @@ export function parsePlan(raw) {
     try { p = JSON.parse(raw) } catch (e) { throw new PlanError(`plan is not valid JSON: ${e.message}`) }
   } else { p = raw }
   if (!p || typeof p !== 'object') throw new PlanError('plan must be an object')
-  if (typeof p.leaf !== 'boolean') throw new PlanError('plan.leaf must be a boolean')
+  // Design sign-off hold (#1821, Option C). When an epic has genuine design ambiguity, the
+  // decomposer must NOT spawn "decide & sign off" worker children (they deadlock the code worker,
+  // which has no render/hold tool). Instead it proposes the design and HOLDS on the epic: we render
+  // the artifacts (schema table / diagram / UI mockup) and post them + status:blocked, then the
+  // existing lgtm→resume-on-comment loop continues the decomposition into build children.
+  if (p.signoff && typeof p.signoff === 'object') {
+    const s = p.signoff
+    if (typeof s.summary !== 'string' || !s.summary.trim()) throw new PlanError('signoff.summary must be a non-empty string')
+    if (!Array.isArray(s.questions) || s.questions.length === 0) throw new PlanError('signoff.questions must be a non-empty array (the forks to decide)')
+    const questions = s.questions.filter(q => typeof q === 'string' && q.trim()).map(q => q.trim())
+    if (!questions.length) throw new PlanError('signoff.questions must contain at least one non-empty question')
+    return {
+      signoff: {
+        summary: s.summary.trim(),
+        questions,
+        // Optional rendered artifacts — best-effort; a bad one is skipped, the questions always post.
+        schema: (s.schema && typeof s.schema === 'object' && s.schema.fields) ? { collection: String(s.schema.collection || 'collection'), fields: s.schema.fields } : null,
+        diagram: (s.diagram && typeof s.diagram === 'object') ? s.diagram : null,
+        ui: (typeof s.ui === 'string' && s.ui.trim()) ? s.ui : null,
+      },
+    }
+  }
+  if (typeof p.leaf !== 'boolean') throw new PlanError('plan.leaf must be a boolean, or provide a `signoff` object')
   if (p.leaf) return { leaf: true, children: [] }
   if (!Array.isArray(p.children) || p.children.length === 0) {
     throw new PlanError('a non-leaf plan must have a non-empty children array')
@@ -84,6 +106,10 @@ export function planToActions(plan, ctx) {
   const { target, epic, depth = 0, epic_branch, knownLabels = [] } = ctx
   const childDepth = (Number.isFinite(depth) ? depth : 0) + 1
   const actions = []
+  if (plan.signoff) {
+    // Hold on the epic (target) for a design sign-off — no children are created (#1821).
+    return [{ type: 'signoff-hold', issue: target, epic_branch, signoff: plan.signoff }]
+  }
   if (plan.leaf) {
     // The target itself is the leaf: stamp the block at ITS depth, then label it work-this.
     actions.push({ type: 'edit-body', issue: target, ctx: { epic, depth, epic_branch } })
@@ -118,14 +144,68 @@ function realExec(file, args, input) {
  * One small handler per action type (a dispatch table) — each closes over the shared run state.
  */
 export function runActions(actions, { repo, exec = realExec, log = console.error, writeBody = defaultWriteBody } = {}) {
-  const state = { repo, exec, writeBody, log, refToNumber: {}, created: [], labelled: [] }
+  const state = { repo, exec, writeBody, log, refToNumber: {}, created: [], labelled: [], held: [], artifacts: [] }
   for (const a of actions) {
     const handler = ACTION_HANDLERS[a.type]
     if (!handler) throw new Error(`unknown action type: ${a.type}`)
     handler(a, state)
   }
-  return { created: state.created, labelled: state.labelled }
+  return { created: state.created, labelled: state.labelled, held: state.held, artifacts: state.artifacts }
 }
+
+// Render the artifacts pi proposed for a design sign-off. BEST-EFFORT: every render is guarded so a
+// bad proposal (wrong fieldsFile shape, unrenderable HTML) is skipped and the questions still post.
+// Returns { schemaMd, images:[{label,path}] } and pushes committed-artifact paths onto state.artifacts.
+// The render scripts are plain `node` (schema-review / ui-proposal / ticket-excalidraw) — pi-runnable.
+function renderSignoffArtifacts(signoff, state) {
+  const tmp = process.env.RUNNER_TEMP || '/tmp'
+  const out = { schemaMd: '', images: [] }
+  const tryRender = (label, fn) => {
+    try { fn() } catch (e) { state.log(`⚠️  signoff render skipped (${label}): ${e.message}`) }
+  }
+  if (signoff.schema) {
+    tryRender('schema', () => {
+      const col = signoff.schema.collection.replace(/[^a-z0-9_-]/gi, '') || 'collection'
+      const jf = `${tmp}/signoff-schema-${col}.json`
+      writeFileSync(jf, JSON.stringify(signoff.schema.fields, null, 2))
+      mkdirSync('writeups/schema-reviews', { recursive: true })
+      state.exec('node', ['.claude/skills/schema-review/render-schema.mjs', jf, '--collection', col, '--out-dir', 'writeups/schema-reviews'])
+      const md = `writeups/schema-reviews/${col}.md`
+      const html = `writeups/schema-reviews/${col}.html`
+      if (existsSync(md)) { out.schemaMd = readFileSync(md, 'utf8').trim(); state.artifacts.push(md) }
+      if (existsSync(html)) {
+        state.artifacts.push(html)
+        const png = `writeups/schema-reviews/${col}.png`
+        tryRender('schema-png', () => { state.exec('node', ['.claude/skills/ui-proposal/render.mjs', html, png]); if (existsSync(png)) { state.artifacts.push(png); out.images.push({ label: `Schema — ${col}`, path: png }) } })
+      }
+    })
+  }
+  if (signoff.diagram) {
+    tryRender('diagram', () => {
+      const gf = `${tmp}/signoff-diagram.json`
+      writeFileSync(gf, JSON.stringify(signoff.diagram, null, 2))
+      const before = new Set(state.artifacts)
+      state.exec('node', ['scripts/ticket-excalidraw.mjs', gf, '--out-dir', 'writeups/diagrams'])
+      // ticket-excalidraw names files by slug; pick up the freshly written .png.
+      const dir = 'writeups/diagrams'
+      const pngs = (existsSync(dir) ? readdirSync(dir) : []).filter(f => f.endsWith('.png')).map(f => `${dir}/${f}`)
+      const newest = pngs.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)[0]
+      if (newest && !before.has(newest)) { state.artifacts.push(newest); out.images.push({ label: 'Diagram', path: newest }) }
+    })
+  }
+  if (signoff.ui) {
+    tryRender('ui', () => {
+      const hf = `${tmp}/signoff-ui.html`
+      writeFileSync(hf, signoff.ui)
+      mkdirSync('writeups/ui-mockups', { recursive: true })
+      const png = 'writeups/ui-mockups/signoff-ui.png'
+      state.exec('node', ['.claude/skills/ui-proposal/render.mjs', hf, png])
+      if (existsSync(png)) { state.artifacts.push(png); out.images.push({ label: 'UI mockup', path: png }) }
+    })
+  }
+  return out
+}
+
 
 const ACTION_HANDLERS = {
   // A leaf: stamp the WS2 block onto the target's CURRENT body (merge, don't clobber prose).
@@ -133,6 +213,39 @@ const ACTION_HANDLERS = {
     const cur = exec('gh', ['issue', 'view', String(a.issue), '--repo', repo, '--json', 'body', '-q', '.body'])
     const f = writeBody(`edit-${a.issue}`, writePipelineBlock(cur, a.ctx))
     exec('gh', ['issue', 'edit', String(a.issue), '--repo', repo, '--body-file', f])
+  },
+  // Design sign-off hold (#1821): render the proposed artifacts, post them + the forks on the epic,
+  // and add status:blocked. Creates NO children — the lgtm→resume-on-comment loop continues later.
+  'signoff-hold'(a, state) {
+    const { repo, exec, writeBody } = state
+    const art = renderSignoffArtifacts(a.signoff, state)
+    const rawBase = a.epic_branch ? `https://raw.githubusercontent.com/${repo}/${a.epic_branch}` : null
+    const lines = []
+    lines.push('> 🤖 **pi.dev harness** · agent pipeline (CI · mac-mini) · _design sign-off gate (#1821)_')
+    lines.push('')
+    lines.push('## 🎨 Design sign-off needed before building')
+    lines.push('')
+    lines.push(a.signoff.summary)
+    lines.push('')
+    lines.push('### Decide these forks')
+    a.signoff.questions.forEach((q, i) => lines.push(`${i + 1}. ${q}`))
+    if (art.schemaMd) {
+      lines.push('')
+      lines.push('### Proposed schema')
+      lines.push(art.schemaMd)
+    }
+    if (art.images.length && rawBase) {
+      lines.push('')
+      lines.push('### Rendered')
+      for (const img of art.images) lines.push(`**${img.label}**\n\n![${img.label}](${rawBase}/${img.path})`)
+    }
+    lines.push('')
+    lines.push('---')
+    lines.push('Reply **`lgtm`** / **`approve`** to proceed to build, or answer the forks above and I\'ll revise. Holding on `status:blocked`.')
+    const f = writeBody(`signoff-${a.issue}`, lines.join('\n'))
+    exec('gh', ['issue', 'comment', String(a.issue), '--repo', repo, '--body-file', f])
+    try { exec('gh', ['issue', 'edit', String(a.issue), '--repo', repo, '--add-label', 'status:blocked']) } catch (e) { state.log(`addLabel status:blocked: ${e.message}`) }
+    state.held.push({ issue: a.issue, questions: a.signoff.questions.length, images: art.images.length })
   },
   'add-label'(a, { repo, exec, labelled }) {
     // Force a FRESH labeled event (#1764): the leaf target may already carry work-this from a
@@ -210,6 +323,14 @@ function main(argv) {
   const actions = planToActions(plan, ctx)
   const summary = runActions(actions, { repo: args.repo })
   console.log(JSON.stringify(summary, null, 2))
+  if (plan.signoff) {
+    // A design sign-off hold IS the deliverable (status:blocked + the posted forks/artifacts);
+    // the artifact-gate recognises signoffHeld. Emit the rendered files so the workflow commits
+    // them to the epic branch (their raw URLs are referenced in the posted comment).
+    if (summary.artifacts.length) console.log(`SIGNOFF_ARTIFACTS ${summary.artifacts.join(' ')}`)
+    if (!summary.held.length) { console.error('signoff plan produced no hold — failing'); process.exit(1) }
+    return
+  }
   if (!plan.leaf && summary.created.length === 0) {
     console.error('apply produced no children — failing so the artifact-gate stays honest')
     process.exit(1)

--- a/scripts/apply-decompose-plan.test.mjs
+++ b/scripts/apply-decompose-plan.test.mjs
@@ -41,6 +41,38 @@ test('parsePlan rejects malformed plans (honest failure, no fabrication)', () =>
   assert.throws(() => parsePlan({ leaf: false, children: [{ title: 'x', body: '' }] }), PlanError)
 })
 
+// ── signoff (Option C, #1821): a design sign-off hold instead of deadlocking design-worker children ──
+test('parsePlan accepts a signoff hold and normalizes it', () => {
+  const p = parsePlan({ signoff: { summary: 'schema + UI are ambiguous', questions: ['equal vs weighted?', '  ', 'matrix vs list?'] } })
+  assert.ok(p.signoff)
+  assert.equal(p.signoff.questions.length, 2)               // blank question dropped
+  assert.equal(p.signoff.schema, null)
+  assert.equal(p.signoff.diagram, null)
+  assert.equal(p.signoff.ui, null)
+})
+
+test('parsePlan keeps optional signoff artifacts when well-formed', () => {
+  const p = parsePlan({ signoff: { summary: 's', questions: ['q'], schema: { collection: 'expenses', fields: { amount: { type: 'number' } } }, ui: '<div>x</div>' } })
+  assert.equal(p.signoff.schema.collection, 'expenses')
+  assert.deepEqual(p.signoff.schema.fields, { amount: { type: 'number' } })
+  assert.equal(p.signoff.ui, '<div>x</div>')
+})
+
+test('parsePlan rejects a malformed signoff (honest failure)', () => {
+  assert.throws(() => parsePlan({ signoff: { questions: ['q'] } }), PlanError)          // no summary
+  assert.throws(() => parsePlan({ signoff: { summary: 's' } }), PlanError)              // no questions
+  assert.throws(() => parsePlan({ signoff: { summary: 's', questions: [] } }), PlanError)
+  assert.throws(() => parsePlan({ signoff: { summary: 's', questions: ['  '] } }), PlanError)
+})
+
+test('a signoff plan → one signoff-hold action on the target, no children', () => {
+  const acts = planToActions(parsePlan({ signoff: { summary: 's', questions: ['q1', 'q2'] } }), CTX)
+  assert.deepEqual(acts.map(a => a.type), ['signoff-hold'])
+  assert.equal(acts[0].issue, CTX.target)
+  assert.equal(acts[0].signoff.questions.length, 2)
+  assert.ok(!acts.some(a => a.type === 'create'))            // NEVER spawns worker children
+})
+
 test('parsePlan enforces MAX_CHILDREN', () => {
   const many = { leaf: false, children: Array.from({ length: 7 }, (_, i) => CHILD({ title: `c${i}` })) }
   assert.throws(() => parsePlan(many), PlanError)
@@ -115,6 +147,29 @@ test('runActions creates, links, and labels each child in order (mock exec)', ()
   assert.ok(kinds.includes('issue edit'))                        // the trigger label
   // NO call ever goes through a shell — args are arrays. Assert no arg contains a heredoc/`$(`.
   assert.ok(!calls.flat().some(a => typeof a === 'string' && a.includes('$(')))
+})
+
+test('runActions on a signoff hold comments the forks + blocks the epic, never creates children (mock exec)', () => {
+  const calls = []
+  let commentBody = ''
+  // Stub: node render scripts + gh all go through here; capture the comment body via writeBody.
+  const exec = (file, args) => { calls.push([file, ...args]); return '' }
+  const acts = planToActions(parsePlan({ signoff: { summary: 'schema + view ambiguous', questions: ['equal vs weighted?', 'matrix vs list?'] } }),
+    { ...CTX, epic_branch: BRANCH })
+  const summary = runActions(acts, { repo: 'o/r', exec, log: () => {}, writeBody: (t, b) => { commentBody = b; return `/tmp/${t}` } })
+  // held, not created
+  assert.equal(summary.held.length, 1)
+  assert.equal(summary.created.length, 0)
+  // posted a comment on the target epic + added status:blocked
+  const kinds = calls.map(c => c.slice(1, 4).join(' '))
+  assert.ok(kinds.some(k => k.startsWith('issue comment 1706')), 'comments on the epic')
+  assert.ok(calls.some(c => c.includes('--add-label') && c.includes('status:blocked')), 'adds status:blocked')
+  // NEVER creates a worker child for a design decision
+  assert.ok(!kinds.some(k => k.startsWith('issue create')), 'no children created')
+  // the comment carries the forks + the hold instruction
+  assert.match(commentBody, /equal vs weighted\?/)
+  assert.match(commentBody, /matrix vs list\?/)
+  assert.match(commentBody, /lgtm/i)
 })
 
 test('runActions on a leaf edits the target body and labels it (mock exec)', () => {


### PR DESCRIPTION
Closes #1821

## 👤 For humans
Fixes the gap the #1817 design-gate test exposed: the pi pipeline had no path for a *design decision*, so "decide & sign off the schema/UI" children were handed to a code worker that **deadlocked** — no question, schema table, or diagram ever reached you. Now the decomposer, when an epic is genuinely design-ambiguous, **proposes the design and holds on the epic**: renders a schema field-table (+ optional diagram / UI mockup), posts them with the real forks as questions, and blocks. Your `lgtm` resumes into build children via the existing resume loop.

## 🤖 For agents
- `apply-decompose-plan.mjs`: new plan shape `{"signoff":{summary,questions[],schema?,diagram?,ui?}}` → `signoff-hold` action (never `create`); renders best-effort via the existing bash-runnable scripts; posts forks + inline schema table + images; adds `status:blocked`.
- Workflow commits rendered `writeups/**` to the epic branch (raw-URL images resolve). Renders guarded — a bad proposal is skipped, questions always post.
- 8 new unit tests (24 total green). Decompose prompt teaches the third shape + that a hold is a *successful* deliverable.
- **Touches `.github/workflows/**`** — needs a human merge.

## 🧪 How to test
`delegate-pi` a design-ambiguous epic → the decompose run holds it with `status:blocked` + a comment carrying the forks and a schema table (not spawning deadlocking children). Reply `lgtm` → it resumes into build children.