### PR TITLE
Force-add sign-off PNGs past *.png gitignore so the hold image renders (#1821)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -321,7 +321,11 @@ jobs:
               git fetch origin "$EPIC_BRANCH" --quiet 2>/dev/null \
                 && git checkout -B "$EPIC_BRANCH" FETCH_HEAD 2>/dev/null \
                 || git checkout -B "$EPIC_BRANCH" 2>/dev/null
-              for f in $ARTIFACTS; do [ -f "$f" ] && git add -- "$f"; done
+              # -f: the rendered PNGs live under writeups/schema-reviews (and ui-mockups), which the
+              # global `*.png` .gitignore rule covers (only writeups/diagrams + ui-proposals are
+              # allowlisted). These are an explicit, known-safe sign-off artifact list, so force past
+              # the ignore — without -f `git add` silently skips the PNG and the comment's image 404s.
+              for f in $ARTIFACTS; do [ -f "$f" ] && git add -f -- "$f"; done
               if git diff --cached --quiet; then
                 echo "no artifact changes to commit"
               else


### PR DESCRIPTION
Follow-up to #1821. The design-hold comment's schema image 404'd because `writeups/schema-reviews/*.png` is caught by the global `*.png` ignore (only diagrams + ui-proposals are allowlisted). `git add -f` the explicit artifact list. Inline table already worked. Touches a workflow — needs a human merge.