### PR TITLE
fix(kassa): root dispatcher keeps its Nuxt instance across the await so '/' stops 500ing

### DIFF
--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -15,6 +15,14 @@ definePageMeta({
   layout: false,
   middleware: [
     async () => {
+      // Captured BEFORE the await below (#1839). Nuxt binds the middleware's
+      // instance with callWithNuxt, which only spans the synchronous portion —
+      // and this app doesn't enable experimental.asyncContext. So on the server
+      // the first `await` unbinds it, and a bare navigateTo() after it throws
+      // "[nuxt] instance unavailable" → a 500 on every signed-in load of '/'.
+      // runWithContext re-binds the instance for the post-await navigation.
+      const nuxtApp = useNuxtApp()
+
       const { loggedIn } = useAuth()
       if (!loggedIn.value) return navigateTo('/auth/login')
 
@@ -22,7 +30,9 @@ definePageMeta({
       // No slug: fall through and render the team-less message. Never spin.
       if (!slug) return
 
-      return navigateTo(`/admin/${slug}/sales/events`, { replace: true })
+      return nuxtApp.runWithContext(() =>
+        navigateTo(`/admin/${slug}/sales/events`, { replace: true })
+      )
     }
   ]
 })

--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -15,12 +15,19 @@ definePageMeta({
   layout: false,
   middleware: [
     async () => {
-      // Captured BEFORE the await below (#1839). Nuxt binds the middleware's
-      // instance with callWithNuxt, which only spans the synchronous portion —
-      // and this app doesn't enable experimental.asyncContext. So on the server
-      // the first `await` unbinds it, and a bare navigateTo() after it throws
-      // "[nuxt] instance unavailable" → a 500 on every signed-in load of '/'.
-      // runWithContext re-binds the instance for the post-await navigation.
+      // Captured BEFORE the await below (#1839).
+      //
+      // Nuxt's context is only bound for the SYNCHRONOUS part of a middleware;
+      // normally its build-time unctx transform patches every `await` to re-bind
+      // afterwards. That transform does not reach this callback: it descends into
+      // `definePageMeta.middleware` only when the value is directly a function,
+      // and skips it when the value is an ARRAY (unctx `transformFunctionBody`
+      // early-returns on anything that isn't a Function/Arrow expression).
+      //
+      // So here the context really is gone after `await`, and a bare navigateTo()
+      // threw "[nuxt] instance unavailable" — a 500 on every signed-in load of
+      // '/'. runWithContext re-binds it explicitly, which also means this keeps
+      // working regardless of the array form or the transform's coverage.
       const nuxtApp = useNuxtApp()
 
       const { loggedIn } = useAuth()

--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -82,7 +82,7 @@ async function signOut() {
   -->
   <div class="min-h-screen flex items-center justify-center bg-(--ui-bg)">
     <div class="text-center space-y-3 px-6">
-      <UIcon name="i-lucide-users" class="size-8 text-(--ui-text-dimmed)" />
+      <UIcon name="i-lucide-users" class="size-8 text-(--ui-text-dimmed)" aria-hidden="true" />
       <p class="text-(--ui-text-muted)">
         Geen team gevonden voor dit account. Vraag een uitnodiging aan je teambeheerder.
       </p>


### PR DESCRIPTION
Closes #1839

## 👤 For humans

Opening `https://kassa.pmcp.dev/` while signed in returned a 500 error page on **every** cold load. The root page — the one that decides which team's events page to send you to — was crashing on the server before it could redirect.

It looked like the events page was broken, but it wasn't. The 500 page still boots in the browser; the same redirect then succeeds client-side, so the address bar flips to `/admin/test1/sales/events` while the error page is still painted. Refreshing loads the events route directly (no root page involved) and works — exactly what was reported.

## 🤖 For agents

**Cause.** Nuxt binds its context only for the *synchronous* part of a route middleware, and compensates with a build-time `unctx` transform that rewrites each `await` into an `__executeAsync`/`__restore()` pair. Coverage is configured in `@nuxt/schema` `optimization.asyncTransforms` — `definePageMeta.middleware` **is** listed, but unctx's `transformFunctionBody` early-returns on anything that isn't a Function/Arrow expression:

```js
if (function_.type !== 'ArrowFunctionExpression' && function_.type !== 'FunctionExpression') return
```

The page used the **array** form — `middleware: [ async () => {...} ]` — so the property value is an `ArrayExpression`, the transform silently skips it, no `__restore()` is injected, and the context really is gone after the `await`. `navigateTo()` then throws `[nuxt] instance unavailable` during SSR.

Verified by running unctx 2.5.0's transformer with Nuxt 4.4.8's exact options:

```
❌ NOT TRANSFORMED   definePageMeta ARRAY form   (what this page had)
✅ TRANSFORMED       definePageMeta SINGLE-fn form
✅ TRANSFORMED       defineNuxtRouteMiddleware   (every packages/* middleware)
```

**Fix.** Capture `useNuxtApp()` before the await; issue the post-await navigation inside `nuxtApp.runWithContext()`. Chosen over switching to the single-function form because it doesn't depend on the transform firing — and the transform's coverage is exactly the subtlety that caused this.

**Archaeology.** First bad commit `e7f9d26f4` — _refactor(kassa): flatten the root dispatcher's defensive branching (#1703)_. The middleware as introduced in `248615c4a` kept its only `await` behind an `import.meta.client` guard, so the server path reached `navigateTo` synchronously. `e7f9d26f4` made the await unconditional.

The signed-out branch was never affected — it returns `navigateTo('/auth/login')` synchronously, which is why `/` 302'd fine without a session and only authenticated users saw the 500.

**No `packages/*` middleware is affected.** An earlier revision of this PR flagged `crouton-auth` `team-context.global.ts:106` and `crouton-admin` `team-admin.ts:58` as the same latent shape. That was wrong and is withdrawn: they're top-level `defineNuxtRouteMiddleware(async …)` calls, which unctx does transform. Confirmed against live staging — `GET /admin/bogus/sales/events` returns a server-side `302 → /admin/test1/sales/events`, issued by exactly that await-then-`navigateTo` path.

Recurrence guard tracked as #1845 (a repo-wide scan finds this was the only instance).

## 🧪 How to test

Before: signed-in `GET /` returns `500 {"message":"[nuxt] instance unavailable"}`. After: it redirects.

```bash
# sign in and keep the cookie jar
curl -s -c cookies.txt -X POST https://kassa.pmcp.dev/api/auth/sign-in/email \
  -H 'content-type: application/json' \
  -d '{"email":"review+kassa-main@example.com","password":"<staging review pw>"}'

# the assertion: was 500, must now be a redirect to /admin/<team>/sales/events
curl -s -b cookies.txt -o /dev/null -w '%{http_code} %{redirect_url}\n' https://kassa.pmcp.dev/

# unchanged signed-out behaviour (must stay 302 → /auth/login)
curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' https://kassa.pmcp.dev/
```

In a browser: open `https://kassa.pmcp.dev/` in a fresh tab with an active session. Before, you land on the orange "Serverfout / FOUT 500" page with the URL reading `/admin/test1/sales/events`. After, you land on the events grid directly.

Also confirm #1703 still holds: log in from `/auth/login` and check you're not stranded on a spinner.

## Checks

- `pnpm --filter kassa typecheck` — green
- `npx fallow audit` — no issues in the changed file
- No UI/schema/test sign-off gate: script-only change in `apps/`, no visual surface, no data model, no `packages/*` logic

> ⚠️ Not yet verified against a live deploy — staging only redeploys on merge to `main`. The curl above is the assertion to run once this lands.
