### PR TITLE
fix(crouton-pages): nav bar swallowed clicks across the whole viewport width

### DIFF
--- a/packages/crouton-pages/app/components/Nav.vue
+++ b/packages/crouton-pages/app/components/Nav.vue
@@ -189,7 +189,14 @@ const adminDropdownItems = computed<DropdownMenuItem[][]>(() => {
 })
 
 // Shared pill styles
-const pillClass = 'flex items-center gap-1 bg-muted/80 backdrop-blur-sm rounded-full border border-default shadow-lg shadow-neutral-950/5'
+// `pointer-events-auto` belongs HERE, on the visible pill — not on the wrapper's
+// direct children (#1842). The wrapper spans the full viewport width when docked
+// top (`inset-x-0`), and its child is only a flex row that right-aligns this
+// pill. Re-enabling pointer events at that level put an invisible, full-width,
+// z-50 click-catcher across the top of every page, swallowing clicks on whatever
+// sat beneath it — the workspace pane headers' ✕ and filter buttons, in the
+// report that found this.
+const pillClass = 'pointer-events-auto flex items-center gap-1 bg-muted/80 backdrop-blur-sm rounded-full border border-default shadow-lg shadow-neutral-950/5'
 
 // Full-screen pages (kassa and friends) own the whole viewport top — the
 // pills dock to the bottom-left corner there instead of reserving a top
@@ -204,7 +211,7 @@ const dockBottom = computed(() => pageLayout.value === 'full-screen')
        below the status bar — env(safe-area-inset-top) is 0 there; the max()
        keeps it clear of the notch in standalone/PWA mode). -->
   <div
-    class="fixed z-50 pointer-events-none [&>*]:pointer-events-auto"
+    class="fixed z-50 pointer-events-none"
     :class="dockBottom
       ? 'bottom-[max(1rem,env(safe-area-inset-bottom))] left-4 sm:left-6'
       : 'top-[max(0.25rem,env(safe-area-inset-top))] sm:top-6 inset-x-0 px-4 sm:px-6'"


### PR DESCRIPTION
Packages-approved: one-line pointer-events fix in the shared nav; owner reported and diagnosed the bug directly.

Closes #1842

## 👤 For humans

The floating nav pill sits at the top-right, but an **invisible strip belonging to it stretched the full width of the window** and ate every click underneath. Most visibly: you couldn't close a workspace pane, because its ✕ sat under that strip — and the button you'd use to escape was the broken one.

## 🤖 For agents

### Correction

My first theory was the splitter's resize-handle hit area, and it was **wrong**. The owner diagnosed the real cause from the DOM. That commit is reverted.

Worth recording *why* it was seductive: `SplitterResizeHandle` genuinely does expand its hit area beyond the visible divider (`coarse: 15, fine: 5`), and the pane headers' buttons genuinely do sit ~4px from a pane boundary. Every fact was true; the conclusion wasn't. It needed the DOM, not more source-reading.

### Real cause

```html
<div class="fixed z-50 pointer-events-none [&>*]:pointer-events-auto
            top-6 inset-x-0 px-4">      <!-- full viewport width -->
  <div class="relative flex items-center justify-end">   <!-- direct child -->
    <div class="…rounded-full…">        <!-- the only VISIBLE part -->
```

The wrapper correctly disables pointer events, then `[&>*]:pointer-events-auto` re-enables them on its direct child — which is merely a flex row that right-aligns the pill. Result: an invisible, full-width, `z-50` click-catcher across the top of every page.

### Fix

`pointer-events-auto` moves onto `pillClass` (the visible pill), and the blanket child selector is dropped. Purely a change of *which element captures pointer events* — no visual or layout change.

Verified all **23** interactive elements in the template sit inside a pill container, so nothing loses clickability.

### A second issue, deliberately not fixed here

The comment above `pillClass` says full-screen pages dock the pills bottom-left "instead of reserving a top strip" — but `pageLayout` is only ever set by the crouton-pages **public page route**. On an admin route it stays `'default'`, so `dockBottom` is false and the top strip renders over the workspace.

So the pills arguably shouldn't be in that position on admin routes at all. I left it alone: that moves UI around rather than fixing a defect, and it's your call. Happy to file it.

## 🧪 How to test

1. Open the event workspace with 2–3 panes open (Bestellingen / Data / Instellingen)
2. Click each pane's ✕ and the orders filter icon — **before:** nothing happens · **after:** they respond
3. Click anywhere along the top strip away from the pill — should reach what's underneath
4. Confirm the nav pill itself still works: theme toggle, edit pencil, dropdowns
