### PR TITLE
chore(root): CI guard for async middleware in the definePageMeta array form

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,13 @@ jobs:
       - name: Validate field types sync
         run: node scripts/validate-field-types-sync.mjs
 
+      # #1845: an async function inside the ARRAY form of definePageMeta({ middleware })
+      # never gets unctx's await-restore shim, so the Nuxt context is lost across the
+      # await and navigateTo() throws during SSR (#1839). Invisible to typecheck, to the
+      # build, and to eslint (which this workflow doesn't run) — hence a dedicated check.
+      - name: Check page middleware async context
+        run: node scripts/check-page-middleware.mjs
+
   mcp-server-tests:
     name: MCP Server Tests
     needs: changes

--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -15,6 +15,14 @@ definePageMeta({
   layout: false,
   middleware: [
     async () => {
+      // Captured BEFORE the await below (#1839). Nuxt binds the middleware's
+      // instance with callWithNuxt, which only spans the synchronous portion —
+      // and this app doesn't enable experimental.asyncContext. So on the server
+      // the first `await` unbinds it, and a bare navigateTo() after it throws
+      // "[nuxt] instance unavailable" → a 500 on every signed-in load of '/'.
+      // runWithContext re-binds the instance for the post-await navigation.
+      const nuxtApp = useNuxtApp()
+
       const { loggedIn } = useAuth()
       if (!loggedIn.value) return navigateTo('/auth/login')
 
@@ -22,7 +30,9 @@ definePageMeta({
       // No slug: fall through and render the team-less message. Never spin.
       if (!slug) return
 
-      return navigateTo(`/admin/${slug}/sales/events`, { replace: true })
+      return nuxtApp.runWithContext(() =>
+        navigateTo(`/admin/${slug}/sales/events`, { replace: true })
+      )
     }
   ]
 })

--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -15,12 +15,19 @@ definePageMeta({
   layout: false,
   middleware: [
     async () => {
-      // Captured BEFORE the await below (#1839). Nuxt binds the middleware's
-      // instance with callWithNuxt, which only spans the synchronous portion —
-      // and this app doesn't enable experimental.asyncContext. So on the server
-      // the first `await` unbinds it, and a bare navigateTo() after it throws
-      // "[nuxt] instance unavailable" → a 500 on every signed-in load of '/'.
-      // runWithContext re-binds the instance for the post-await navigation.
+      // Captured BEFORE the await below (#1839).
+      //
+      // Nuxt's context is only bound for the SYNCHRONOUS part of a middleware;
+      // normally its build-time unctx transform patches every `await` to re-bind
+      // afterwards. That transform does not reach this callback: it descends into
+      // `definePageMeta.middleware` only when the value is directly a function,
+      // and skips it when the value is an ARRAY (unctx `transformFunctionBody`
+      // early-returns on anything that isn't a Function/Arrow expression).
+      //
+      // So here the context really is gone after `await`, and a bare navigateTo()
+      // threw "[nuxt] instance unavailable" — a 500 on every signed-in load of
+      // '/'. runWithContext re-binds it explicitly, which also means this keeps
+      // working regardless of the array form or the transform's coverage.
       const nuxtApp = useNuxtApp()
 
       const { loggedIn } = useAuth()

--- a/apps/kassa/app/pages/index.vue
+++ b/apps/kassa/app/pages/index.vue
@@ -82,7 +82,7 @@ async function signOut() {
   -->
   <div class="min-h-screen flex items-center justify-center bg-(--ui-bg)">
     <div class="text-center space-y-3 px-6">
-      <UIcon name="i-lucide-users" class="size-8 text-(--ui-text-dimmed)" />
+      <UIcon name="i-lucide-users" class="size-8 text-(--ui-text-dimmed)" aria-hidden="true" />
       <p class="text-(--ui-text-muted)">
         Geen team gevonden voor dit account. Vraag een uitnodiging aan je teambeheerder.
       </p>

--- a/scripts/check-page-middleware.mjs
+++ b/scripts/check-page-middleware.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * check-page-middleware.mjs — guard the silent unctx gap behind #1839 (#1845).
+ *
+ * Nuxt binds its context only for the SYNCHRONOUS part of a route middleware. It
+ * compensates with a build-time unctx transform that rewrites each `await` into an
+ * `__executeAsync` / `__restore()` pair, re-binding the context afterwards. Which
+ * entry points get that treatment is config (`@nuxt/schema`
+ * `optimization.asyncTransforms`) — and unctx only descends into a property whose
+ * value is DIRECTLY a function (`transform.mjs` → `transformFunctionBody` returns
+ * early on anything that is not a Function/Arrow expression).
+ *
+ * So the array form is a blind spot:
+ *
+ *   defineNuxtRouteMiddleware(async () => …)              ✅ transformed
+ *   definePageMeta({ middleware: async () => … })          ✅ transformed
+ *   definePageMeta({ middleware: [async () => …] })        ❌ NOT transformed
+ *
+ * Only the last one loses the Nuxt instance across an `await`, and only during
+ * SSR — so `navigateTo()` after the await throws "[nuxt] instance unavailable"
+ * and the page 500s. It typechecks, it builds, and eslint does not run in CI, so
+ * nothing else in the toolchain can see it. That is #1839: the root page 500'd for
+ * every signed-in load, while presenting as if a DIFFERENT page were broken.
+ *
+ * A callback that re-binds the context itself (`nuxtApp.runWithContext(...)`) is
+ * fine — that is the sanctioned fix — so it is not reported.
+ *
+ * Deliberately dependency-free (Node core only), because the `scripts-tests` and
+ * `sync-validation` CI jobs run without `pnpm install`. That rules out a real
+ * parser, so this works on a comment/string-masked copy of the source and matches
+ * brackets by hand — accurate enough for a shape this specific, and it cannot be
+ * fooled by braces inside strings or comments.
+ *
+ *   node scripts/check-page-middleware.mjs [--json] [paths...]
+ *
+ * Exits 1 when anything is flagged.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+/** Roots scanned when no explicit paths are given. */
+export const DEFAULT_ROOTS = ['apps', 'packages', 'pocs', 'fixtures']
+
+const SKIP_DIRS = new Set(['node_modules', '.nuxt', '.output', 'dist', '.data', 'coverage', '.git'])
+
+/** definePageMeta keys the unctx transform is configured to descend into. */
+export const TRANSFORMED_KEYS = ['middleware', 'validate']
+
+const OPENERS = { '(': ')', '[': ']', '{': '}' }
+const CLOSERS = new Set([')', ']', '}'])
+
+/**
+ * Blank out comments and string/template literals, preserving length and newlines
+ * so every offset still lines up with the original. Bracket matching then can't be
+ * thrown off by a `}` inside a string or a commented-out block.
+ *
+ * @param {string} code
+ * @returns {string}
+ */
+export function maskLiteralsAndComments(code) {
+  const out = code.split('')
+  const blank = (from, to) => {
+    for (let k = Math.max(from, 0); k < to && k < out.length; k++) {
+      if (out[k] !== '\n') out[k] = ' '
+    }
+  }
+  let i = 0
+  while (i < code.length) {
+    const span = literalSpanAt(code, i)
+    if (!span) { i++; continue }
+    blank(span.blankFrom, span.blankTo)
+    i = span.next
+  }
+  return out.join('')
+}
+
+/**
+ * If a comment or string literal starts at `i`, describe the region to blank and
+ * where scanning resumes. Returns null when `i` is ordinary code.
+ */
+function literalSpanAt(code, i) {
+  const two = code.slice(i, i + 2)
+  if (two === '//') {
+    const end = code.indexOf('\n', i)
+    const stop = end === -1 ? code.length : end
+    return { blankFrom: i, blankTo: stop, next: stop }
+  }
+  if (two === '/*') {
+    const end = code.indexOf('*/', i + 2)
+    const stop = end === -1 ? code.length : end + 2
+    return { blankFrom: i, blankTo: stop, next: stop }
+  }
+  const quote = code[i]
+  if (quote !== '"' && quote !== "'" && quote !== '`') return null
+  const close = closingQuote(code, i, quote)
+  // Keep the quotes themselves so the code still reads as a literal; blank the body.
+  return { blankFrom: i + 1, blankTo: close - 1, next: close }
+}
+
+/** Index just past the quote closing the literal opened at `open`. */
+function closingQuote(code, open, quote) {
+  let j = open + 1
+  while (j < code.length) {
+    if (code[j] === '\\') { j += 2; continue }
+    if (code[j] === quote) return j + 1
+    j++
+  }
+  return code.length
+}
+
+/**
+ * Index of the bracket closing the one at `open`, or -1.
+ *
+ * @param {string} masked Output of maskLiteralsAndComments.
+ * @param {number} open Index of an opening bracket.
+ */
+export function matchBracket(masked, open) {
+  const want = OPENERS[masked[open]]
+  if (!want) return -1
+  const stack = [want]
+  for (let i = open + 1; i < masked.length; i++) {
+    const ch = masked[i]
+    if (OPENERS[ch]) stack.push(OPENERS[ch])
+    else if (CLOSERS.has(ch)) {
+      if (stack[stack.length - 1] !== ch) return -1
+      stack.pop()
+      if (!stack.length) return i
+    }
+  }
+  return -1
+}
+
+/** Split an array/argument body on its TOP-LEVEL commas. Returns [start, end) spans. */
+function topLevelElements(masked, from, to) {
+  const spans = []
+  let depth = 0
+  let start = from
+  for (let i = from; i < to; i++) {
+    const ch = masked[i]
+    if (OPENERS[ch]) depth++
+    else if (CLOSERS.has(ch)) depth--
+    else if (ch === ',' && depth === 0) {
+      spans.push([start, i])
+      start = i + 1
+    }
+  }
+  spans.push([start, to])
+  return spans.filter(([a, b]) => masked.slice(a, b).trim().length > 0)
+}
+
+/**
+ * Find async callbacks sitting inside the ARRAY form of a transformed
+ * definePageMeta key, which therefore never receive the await-restore shim.
+ *
+ * Works on raw source (TypeScript included) — no parse step.
+ *
+ * @param {string} code
+ * @returns {Array<{ key: string, index: number, protected: boolean }>}
+ */
+export function findUntransformedAsyncMiddleware(code) {
+  const masked = maskLiteralsAndComments(code)
+  const findings = []
+  for (const { braceAt, braceEnd } of pageMetaObjects(masked)) {
+    for (const key of TRANSFORMED_KEYS) {
+      for (const [valueAt, arrayEnd] of arrayValuesFor(masked, key, braceAt, braceEnd)) {
+        findings.push(...asyncElements(masked, key, valueAt, arrayEnd))
+      }
+    }
+  }
+  return findings
+}
+
+/** Spans of each `definePageMeta({ … })` object literal in the masked source. */
+function pageMetaObjects(masked) {
+  const objects = []
+  const callRe = /\bdefinePageMeta\s*\(/g
+  let call
+  while ((call = callRe.exec(masked)) !== null) {
+    const parenAt = call.index + call[0].length - 1
+    const parenEnd = matchBracket(masked, parenAt)
+    if (parenEnd === -1) continue
+    const braceAt = masked.indexOf('{', parenAt)
+    if (braceAt === -1 || braceAt > parenEnd) continue
+    const braceEnd = matchBracket(masked, braceAt)
+    if (braceEnd !== -1) objects.push({ braceAt, braceEnd })
+  }
+  return objects
+}
+
+/**
+ * Spans of `key: [ … ]` values on the object literal spanning [braceAt, braceEnd].
+ * The single-function form IS transformed by unctx, so only arrays are returned.
+ */
+function arrayValuesFor(masked, key, braceAt, braceEnd) {
+  const spans = []
+  const keyRe = new RegExp(`\\b${key}\\s*:`, 'g')
+  keyRe.lastIndex = braceAt
+  let keyMatch
+  while ((keyMatch = keyRe.exec(masked)) !== null && keyMatch.index < braceEnd) {
+    let valueAt = keyMatch.index + keyMatch[0].length
+    while (valueAt < braceEnd && /\s/.test(masked[valueAt])) valueAt++
+    if (masked[valueAt] !== '[') continue
+    const arrayEnd = matchBracket(masked, valueAt)
+    if (arrayEnd !== -1) spans.push([valueAt, arrayEnd])
+  }
+  return spans
+}
+
+/** Array elements that are async AND await — the shape that loses the context. */
+function asyncElements(masked, key, valueAt, arrayEnd) {
+  const findings = []
+  for (const [start, end] of topLevelElements(masked, valueAt + 1, arrayEnd)) {
+    const element = masked.slice(start, end)
+    // An await is what loses the context; no await, no exposure.
+    if (!/\basync\b/.test(element) || !/\bawait\b/.test(element)) continue
+    findings.push({
+      key,
+      // Point at the callback itself, not the `[` it follows.
+      index: start + (element.match(/^\s*/)?.[0].length ?? 0),
+      // Re-binding explicitly is the sanctioned fix (#1839).
+      protected: /runWithContext\s*\(/.test(element)
+    })
+  }
+  return findings
+}
+
+/** Extract the `<script>` / `<script setup>` blocks of an SFC with their offsets. */
+export function scriptBlocks(source) {
+  const blocks = []
+  const re = /<script\b[^>]*>/gi
+  let open
+  while ((open = re.exec(source)) !== null) {
+    const start = open.index + open[0].length
+    const close = source.indexOf('</script>', start)
+    if (close === -1) continue
+    blocks.push({ start, content: source.slice(start, close) })
+    re.lastIndex = close
+  }
+  return blocks
+}
+
+/**
+ * Scan one `.vue` source.
+ *
+ * @returns {Array<{ key: string, line: number, protected: boolean }>}
+ */
+export function scanSfc(source) {
+  if (!source.includes('definePageMeta')) return []
+
+  const findings = []
+  for (const block of scriptBlocks(source)) {
+    if (!block.content.includes('definePageMeta')) continue
+    for (const finding of findUntransformedAsyncMiddleware(block.content)) {
+      const absolute = block.start + finding.index
+      findings.push({
+        key: finding.key,
+        protected: finding.protected,
+        line: source.slice(0, absolute).split('\n').length
+      })
+    }
+  }
+  return findings
+}
+
+/** Recursively collect `.vue` files under a root, skipping build/vendor dirs. */
+export function collectVueFiles(root, out = []) {
+  let entries
+  try {
+    entries = readdirSync(root, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue
+    if (SKIP_DIRS.has(entry.name)) continue
+    const full = join(root, entry.name)
+    if (entry.isDirectory()) collectVueFiles(full, out)
+    else if (entry.name.endsWith('.vue')) out.push(full)
+  }
+  return out
+}
+
+/** Expand roots (dirs or explicit files) into the `.vue` files to scan. */
+function resolveFiles(roots) {
+  const files = []
+  for (const root of roots) {
+    try {
+      if (statSync(root).isDirectory()) collectVueFiles(root, files)
+      else files.push(root)
+    } catch { /* a root that isn't present is not a failure */ }
+  }
+  return files
+}
+
+function report(violations, scanned) {
+  if (!violations.length) {
+    console.log(`✓ No untransformed async page middleware (${scanned} .vue files scanned)`)
+    return
+  }
+  console.error(`\n✖ ${violations.length} untransformed async page middleware (#1839, #1845):\n`)
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}`)
+    console.error(`    async callback inside the ARRAY form of definePageMeta({ ${v.key}: [...] }).`)
+    console.error('    unctx does not inject the await-restore shim here, so the Nuxt context is')
+    console.error('    lost after the first `await` and navigateTo() throws "[nuxt] instance')
+    console.error('    unavailable" during SSR — that request 500s.')
+    console.error('')
+  }
+  console.error('  Fix: capture `const nuxtApp = useNuxtApp()` BEFORE the await and issue the')
+  console.error('  post-await navigation via `nuxtApp.runWithContext(() => navigateTo(...))`.')
+  console.error('  See apps/kassa/app/pages/index.vue for the worked example.\n')
+}
+
+function main(argv) {
+  const paths = argv.filter(a => !a.startsWith('--'))
+  const files = resolveFiles(paths.length ? paths : DEFAULT_ROOTS)
+
+  const violations = []
+  for (const file of files) {
+    for (const finding of scanSfc(readFileSync(file, 'utf8'))) {
+      if (finding.protected) continue
+      const rel = relative(process.cwd(), file)
+      violations.push({ file: rel.startsWith('..') ? file : rel, ...finding })
+    }
+  }
+
+  if (argv.includes('--json')) {
+    console.log(JSON.stringify({ scanned: files.length, violations }, null, 2))
+  } else {
+    report(violations, files.length)
+  }
+
+  return violations.length ? 1 : 0
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)))
+}

--- a/scripts/check-page-middleware.test.mjs
+++ b/scripts/check-page-middleware.test.mjs
@@ -1,0 +1,172 @@
+/**
+ * #1845 contract — the recurrence guard for #1839.
+ *
+ * The rule is narrow on purpose: only an `async` function literal that sits inside
+ * the ARRAY form of a transformed `definePageMeta` key is unreachable by unctx's
+ * await-restore transform. The single-function form and plain string references
+ * are both fine, and must stay unflagged — `middleware: ['auth', 'team-admin']` is
+ * the dominant idiom repo-wide.
+ *
+ *   node --test scripts/check-page-middleware.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  findUntransformedAsyncMiddleware,
+  scanSfc,
+  maskLiteralsAndComments,
+  matchBracket
+} from './check-page-middleware.mjs'
+
+const sfc = script => `<script setup lang="ts">\n${script}\n</script>\n\n<template><div /></template>\n`
+
+test('flags an async arrow inside the middleware ARRAY form', () => {
+  const found = findUntransformedAsyncMiddleware(`
+    definePageMeta({
+      middleware: [
+        async () => {
+          const slug = await resolveTeamSlug()
+          return navigateTo(\`/admin/\${slug}\`)
+        }
+      ]
+    })
+  `)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].key, 'middleware')
+  assert.equal(found[0].protected, false)
+})
+
+test('does NOT flag the single-function form — unctx transforms it', () => {
+  assert.deepEqual(findUntransformedAsyncMiddleware(`
+    definePageMeta({
+      middleware: async () => {
+        const slug = await resolveTeamSlug()
+        return navigateTo(\`/admin/\${slug}\`)
+      }
+    })
+  `), [])
+})
+
+test('does NOT flag string references — they resolve to wrapped named middleware', () => {
+  assert.deepEqual(
+    findUntransformedAsyncMiddleware(`definePageMeta({ middleware: ['auth', 'team-admin'] })`),
+    []
+  )
+})
+
+test('does NOT flag an async callback with no await — nothing to lose context across', () => {
+  assert.deepEqual(
+    findUntransformedAsyncMiddleware(`definePageMeta({ middleware: [async () => navigateTo('/x')] })`),
+    []
+  )
+})
+
+test('marks a runWithContext callback as protected — that is the sanctioned fix', () => {
+  const found = findUntransformedAsyncMiddleware(`
+    definePageMeta({
+      middleware: [
+        async () => {
+          const nuxtApp = useNuxtApp()
+          const slug = await resolveTeamSlug()
+          return nuxtApp.runWithContext(() => navigateTo(\`/admin/\${slug}\`))
+        }
+      ]
+    })
+  `)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].protected, true)
+})
+
+test('covers validate as well as middleware', () => {
+  const found = findUntransformedAsyncMiddleware(`
+    definePageMeta({ validate: [async (route) => { return await check(route) }] })
+  `)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].key, 'validate')
+})
+
+test('ignores non-transformed keys entirely', () => {
+  assert.deepEqual(
+    findUntransformedAsyncMiddleware(`definePageMeta({ other: [async () => { await x() }] })`),
+    []
+  )
+})
+
+test('scanSfc handles TypeScript syntax and points at the real SFC line', () => {
+  const source = sfc(`
+import type { Team } from '~/types'
+
+definePageMeta({
+  layout: false,
+  middleware: [
+    async (): Promise<unknown> => {
+      const team = await useTeam().refresh() as Team
+      return navigateTo(\`/admin/\${team.slug}\`)
+    }
+  ]
+})
+`)
+  const found = scanSfc(source)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].protected, false)
+
+  // Must point at the offending callback, resolved against the ORIGINAL file —
+  // a guard that cites the wrong line costs the reader the time it exists to save.
+  const expected = source.split('\n').findIndex(l => l.includes('async ():')) + 1
+  assert.equal(found[0].line, expected)
+})
+
+test('braces inside strings and comments do not break bracket matching', () => {
+  // The masking pass is the whole reason this can be parser-free: a `]` in a
+  // string or a commented-out block must not be mistaken for real structure.
+  const found = findUntransformedAsyncMiddleware(`
+    definePageMeta({
+      middleware: [
+        // ] } ) a commented-out closing run
+        async () => {
+          const label = 'a ] and a } inside a string'
+          const t = \`template with } and ]\`
+          await load(label, t)
+          return navigateTo('/x')
+        }
+      ]
+    })
+  `)
+  assert.equal(found.length, 1)
+  assert.equal(found[0].protected, false)
+})
+
+test('maskLiteralsAndComments preserves length and newlines', () => {
+  const code = `const a = 'xx' // yy\nconst b = 2`
+  const masked = maskLiteralsAndComments(code)
+  assert.equal(masked.length, code.length)
+  assert.equal(masked.split('\n').length, code.split('\n').length)
+  assert.ok(!masked.includes('xx'))
+  assert.ok(!masked.includes('yy'))
+  assert.ok(masked.includes('const b = 2'))
+})
+
+test('matchBracket finds the matching close across nesting', () => {
+  const code = 'f([1, [2, 3], {a: 4}])'
+  const masked = maskLiteralsAndComments(code)
+  assert.equal(matchBracket(masked, code.indexOf('[')), code.lastIndexOf(']'))
+})
+
+test('a second definePageMeta key on a nested object is not mistaken for the page key', () => {
+  assert.deepEqual(findUntransformedAsyncMiddleware(`
+    definePageMeta({
+      layout: false,
+      meta: { nested: { middleware: ['not-a-page-key'] } }
+    })
+  `), [])
+})
+
+test('scanSfc short-circuits on a file without definePageMeta', () => {
+  assert.deepEqual(scanSfc(sfc(`const x = await load()`)), [])
+})
+
+test('the fixed kassa root page is not flagged', async () => {
+  const { readFileSync } = await import('node:fs')
+  const source = readFileSync('apps/kassa/app/pages/index.vue', 'utf8')
+  assert.deepEqual(scanSfc(source).filter(f => !f.protected), [])
+})


### PR DESCRIPTION
Closes #1845

> **Stacked on #1841.** This branch contains that PR's commits too, because the new CI step scans the working tree and `apps/kassa/app/pages/index.vue` on `main` still has the #1839 defect — the check would (correctly) fail. Merge #1841 first; this diff then reduces to the three files below.

## 👤 For humans

#1839 was a page that returned a server error to every signed-in visitor, caused by a small authoring detail, and which pointed the blame at a *different* page than the broken one. It typechecked, it built, and eslint doesn't run in CI — so nothing could catch it before production.

This adds a check so the same mistake fails a PR instead.

## 🤖 For agents

**The rule.** Flag an `async` callback that both `await`s and sits inside the **array** form of `definePageMeta({ middleware | validate: [...] })`, unless it re-binds context itself via `runWithContext`.

**Why only that shape.** Nuxt binds context only for the synchronous part of a middleware and compensates with a build-time `unctx` transform. Coverage comes from `@nuxt/schema` `optimization.asyncTransforms`, but unctx's `transformFunctionBody` early-returns unless the property value is *directly* a Function/Arrow:

| form | transformed? |
|---|---|
| `defineNuxtRouteMiddleware(async () => …)` | ✅ |
| `definePageMeta({ middleware: async () => … })` | ✅ |
| `definePageMeta({ middleware: [async () => …] })` | ❌ |

Only the last loses context across an `await`, and only during SSR.

**Dependency-free on purpose.** The `scripts-tests` job states "No pnpm install: the tests use only Node core + the local .mjs modules", and `sync-validation` doesn't install either. So no parser is available: the check masks comments and string/template literals (preserving offsets), then matches brackets by hand. That's why a `}` or `]` inside a string or a commented-out block can't fool it — there's a test for exactly that.

**Deliberately narrow.** `middleware: ['auth', 'team-admin']` is the dominant idiom repo-wide and is untouched; only function literals inside the array qualify. A scan of all 805 `.vue` files finds zero violations today.

Wired into `ci.yml` → `sync-validation`, beside `check-docs.mjs` and `validate-field-types-sync.mjs`.

## 🧪 How to test

```bash
# 1. passes clean on the tree
node scripts/check-page-middleware.mjs
#    → ✓ No untransformed async page middleware (805 .vue files scanned)

# 2. it actually catches the real #1839 defect (exit 1, correct line)
mkdir -p /tmp/regress/apps/kassa/app/pages
git show 7c1ce844a:apps/kassa/app/pages/index.vue > /tmp/regress/apps/kassa/app/pages/index.vue
node scripts/check-page-middleware.mjs /tmp/regress; echo "exit=$?"
#    → ✖ 1 untransformed async page middleware … index.vue:17   exit=1

# 3. contracts
node --test scripts/check-page-middleware.test.mjs     # 14/14
node --test scripts/*.test.mjs                          # 175/175, nothing else regressed
```

Line 17 of the pre-fix file is the `async () => {` callback — the guard points at the offending function, not at the `[`.

To see it fail on purpose, add `middleware: [async () => { await x() }]` to any page's `definePageMeta` and re-run.

## Checks

- `node --test scripts/*.test.mjs` — 175/175
- `npx fallow audit` — clean on all 4 changed files (the first draft tripped the complexity gate at 17 cyclomatic / 42 cognitive; decomposed rather than suppressed)
- No sign-off gate: tooling under `scripts/`, no visual surface, no data model, no `packages/*` logic

## Considered & rejected

- **ESLint rule** → ❌ the root config ignores `apps/**` (where #1839 lived) and CI doesn't run eslint at all; it would not have caught this.
- **Enable `experimental.asyncContext`** → ❌ fixes it repo-wide via AsyncLocalStorage, but that's a global runtime change on Workers to paper over one authoring mistake, and it hides the mistake rather than surfacing it.
- **Ban the array form outright** → ❌ `middleware: ['auth']` is correct and everywhere.
- **Use a real parser (esbuild + acorn)** → ❌ drafted and working, then dropped: it broke the no-install invariant of the two CI jobs this runs in.
