### PR TITLE
crouton-pages: per-block visibility — audience, roles and viewport

### DIFF
--- a/docs/content/6.features/18.pages.md
+++ b/docs/content/6.features/18.pages.md
@@ -111,6 +111,33 @@ The block-based editor uses TipTap and Nuxt UI page components.
 | `collectionBlock` | Collection | Dynamic collection listing |
 | `addonBlock` | Addon | Addon/extension content |
 
+### Block Visibility
+
+Every block has an optional **Visibility** section in its settings panel, letting one
+page serve several audiences instead of maintaining near-duplicate pages:
+
+| Setting | Options | Default |
+|---------|---------|---------|
+| **Show to** | Anyone · Logged-out visitors only · Logged-in visitors only | Anyone |
+| **Roles** | Owner · Admin · Member (shown when "Logged in") | All roles |
+| **Screens** | Mobile · Tablet · Desktop | All screens |
+
+For example, a QR code that only makes sense to a visitor who hasn't signed in and is
+holding a phone: set **Show to** = *Logged-out visitors only* and **Screens** = *Mobile*.
+
+Leave the section alone and nothing changes — an unconfigured block renders exactly as
+it always did.
+
+::warning
+**This controls what is displayed, not what is accessible.** A hidden block is still
+present in the page source. For content that must stay private, set the **visibility of
+the page itself** (`members`, `admin` or `scoped`), which is enforced on the server.
+::
+
+Screen sizes are applied with CSS, so switching between them is instant and needs no
+reload. Audience and role conditions resolve just after the page loads, because public
+pages are cached and shared between visitors.
+
 ### Using the Editor
 
 ```vue

--- a/packages/crouton-pages/CLAUDE.md
+++ b/packages/crouton-pages/CLAUDE.md
@@ -339,6 +339,61 @@ Block properties with `type: 'image'` are rendered with `ImageEditor.vue`, which
 - Direct URL input mode
 - Emits image URL string via `v-model`
 
+### Per-block visibility (`blockVisibility`)
+
+Every block — core **and** addon — carries an optional `blockVisibility` attr
+holding per-block display conditions. It rides the same rails as `blockSize`:
+defined in `app/editor/extensions/block-utils.ts`, registered once as a TipTap
+**global attribute** (`page-blocks.ts` `addGlobalAttributes()` +
+`addon-block-factory.ts`), so no block type registers it individually.
+
+```ts
+interface BlockVisibility {
+  audience?: 'anonymous' | 'authenticated'        // omitted = anyone
+  roles?: ('owner' | 'admin' | 'member')[]        // naming any role implies authenticated
+  viewports?: ('mobile' | 'tablet' | 'desktop')[] // omitted/empty = all
+}
+```
+
+Sparse by design — the editor deletes keys that stop restricting anything and
+stores `null` rather than `{}`, so a block nobody configured carries nothing and
+needs no migration. Serializes into the page's existing `content` JSON (and to
+`data-block-visibility` on the HTML round-trip). Logic lives in
+`app/utils/block-visibility.ts`, unit-tested in `test/block-visibility.test.ts`.
+
+**⚠️ Presentation filter, NOT a security boundary.** A hidden block is still in
+the page payload; it just isn't displayed. Gate sensitive content with the
+page-level `visibility` field, which is enforced server-side. The property panel
+says so in as many words — the failure mode is an author assuming otherwise.
+
+**Why the two axes resolve differently.** The public page route declares
+`defineRouteRules({ swr: 3600 })` (`app/pages/[team]/[locale]/[...slug].vue`), so
+its HTML is cached for an hour and **shared between visitors**. Therefore:
+
+- **viewport → CSS classes** on the existing per-block wrapper in
+  `BlockContent.vue`. One hide-class per *excluded* band (`max-md:hidden`,
+  `md:max-lg:hidden`, `lg:hidden` — boundaries 768/1024, matching `Nav.vue` and
+  `layouts/public.vue`). Resolves per-device in the browser: cache-safe, no JS,
+  no flicker. These class strings must stay **whole literals** or Tailwind's
+  scanner purges them.
+- **audience/roles → after hydration only.** `audienceResolved` is false during
+  SSR *and* the first client render (so hydration matches), then true on mount.
+  Reading auth state during SSR would bake one visitor's session into the shared
+  cached HTML.
+
+A block with **no** audience gate takes neither path — no wrapper class, no
+deferral, byte-identical to before the feature existed. `hasAudienceGate()` is
+what decides that, and viewport-only blocks deliberately return false.
+
+Auth is read defensively: crouton-auth is not a dependency of this package, so
+`useSession()`/`useTeam()` are resolved in try/catch and an unknowable reader
+means **show** the block — a missing auth package can never blank a page. Same
+for corrupt stored values: every unusable input fails *open*.
+
+Editor previews (`BlockPropertyPanel`, `BlockEditorWithPreview`) pass
+`ignore-visibility` so an author always sees the block being configured, even
+one they just hid from themselves.
+
 ### Adding Custom Blocks
 
 1. Define type in `app/types/blocks.ts`

--- a/packages/crouton-pages/app/components/BlockContent.vue
+++ b/packages/crouton-pages/app/components/BlockContent.vue
@@ -5,8 +5,9 @@
  * Renders page content that is stored in block format (JSON).
  * Routes each block type to its appropriate render component.
  */
-import type { PageBlockContent, PageBlock, BlockSize } from '../types/blocks'
+import type { PageBlockContent, PageBlock, BlockSize, BlockAudienceContext, BlockAudienceRole } from '../types/blocks'
 import { parseBlockContent } from '../utils/content-detector'
+import { hasAudienceGate, matchesAudience, viewportClasses } from '../utils/block-visibility'
 
 // Addon blocks from croutonBlocks registry
 const { getBlock: getAddonBlock } = useCroutonBlocks()
@@ -31,6 +32,12 @@ function sanitizeHtml(html: string): string {
 interface Props {
   /** Raw JSON content string or parsed PageBlockContent */
   content: string | PageBlockContent | null | undefined
+  /**
+   * Render every block regardless of its `blockVisibility`.
+   * Used by the editor previews, where an author must always see the block
+   * they are configuring — even one they have just hidden from themselves.
+   */
+  ignoreVisibility?: boolean
 }
 
 const props = defineProps<Props>()
@@ -230,6 +237,90 @@ function getBlockSizeClass(block: PageBlock): string | undefined {
   return undefined
 }
 
+// ---------------------------------------------------------------------------
+// Block visibility
+//
+// The public page route is `swr: 3600` cached, so its HTML is shared between
+// visitors. Auth state must therefore never be read while rendering on the
+// server, or one visitor's session gets baked into the page everyone receives.
+//
+// So the two axes resolve differently:
+//   - viewport → CSS classes, which resolve per-device in the browser
+//   - audience/roles → after hydration only (see `audienceResolved`)
+// ---------------------------------------------------------------------------
+
+/**
+ * False during SSR *and* the first client render — so both agree and hydration
+ * matches — then true once mounted, when the session is safe to read.
+ */
+const audienceResolved = ref(false)
+onMounted(() => { audienceResolved.value = true })
+
+/**
+ * Auth sources, resolved once in setup — composables must not be called from a
+ * computed getter. Read defensively: crouton-auth is not a dependency of this
+ * package and may not be installed, in which case these stay null and the
+ * matcher treats the reader as unknowable (and shows the block).
+ */
+// Held as plain variables, not refs: they are bound once here and never
+// reassigned, and the computed below still tracks reads of their `.value`.
+// Typed structurally so any Ref/ComputedRef shape fits without importing
+// anything from crouton-auth.
+let sessionUser: { value: unknown } | null = null
+let teamRole: { value: unknown } | null = null
+
+try {
+  sessionUser = useSession().user
+} catch {
+  // crouton-auth not installed.
+}
+
+try {
+  teamRole = useTeam().currentRole
+} catch {
+  // No team context (or no auth package).
+}
+
+const audienceContext = computed<BlockAudienceContext>(() => {
+  // Before hydration the session must not be read at all: this component's
+  // markup is cached and shared between visitors.
+  if (!audienceResolved.value) return { authenticated: null, role: null }
+
+  const authenticated = sessionUser ? !!sessionUser.value : null
+
+  const current = teamRole?.value
+  const role: BlockAudienceRole | null
+    = current === 'owner' || current === 'admin' || current === 'member' ? current : null
+
+  return { authenticated, role }
+})
+
+/** The raw `blockVisibility` attr, if the block carries one. */
+function getBlockVisibility(block: PageBlock): unknown {
+  return (block.attrs as any)?.blockVisibility
+}
+
+/**
+ * Whether to render this block at all.
+ *
+ * A block with no audience gate returns true immediately and takes no new
+ * code path — identical to the behaviour before per-block visibility existed.
+ * A gated block stays out of the cached SSR markup and appears on hydration.
+ */
+function shouldRenderBlock(block: PageBlock): boolean {
+  if (props.ignoreVisibility) return true
+  const visibility = getBlockVisibility(block)
+  if (!hasAudienceGate(visibility)) return true
+  return audienceResolved.value && matchesAudience(visibility, audienceContext.value)
+}
+
+/** Wrapper classes for a block: its size, plus any viewport restrictions. */
+function getBlockWrapperClasses(block: PageBlock): (string | undefined)[] {
+  const size = getBlockSizeClass(block)
+  if (props.ignoreVisibility) return [size]
+  return [size, ...viewportClasses(getBlockVisibility(block))]
+}
+
 /** Tailwind classes per heading level */
 const headingClasses: Record<number, string> = {
   1: 'text-4xl font-bold tracking-tight text-[var(--ui-text-highlighted)] mt-8 mb-4',
@@ -246,7 +337,7 @@ const headingClasses: Record<number, string> = {
 
     <template v-if="renderableBlocks.length > 0">
       <template v-for="(block, index) in renderableBlocks" :key="(block as any).attrs?.blockId || `${block.type}-${index}`">
-        <div :class="getBlockSizeClass(block)">
+        <div v-if="shouldRenderBlock(block)" :class="getBlockWrapperClasses(block)">
           <!-- Dynamic blocks: fetch runtime data, must render client-side only -->
           <ClientOnly
             v-if="isClientOnlyBlock(block.type)"

--- a/packages/crouton-pages/app/components/Editor/BlockEditorWithPreview.vue
+++ b/packages/crouton-pages/app/components/Editor/BlockEditorWithPreview.vue
@@ -330,6 +330,7 @@ defineExpose({
               <div :style="previewZoomStyle">
                 <CroutonPagesBlockContent
                   :content="previewContent as any"
+                  ignore-visibility
                   class="p-4"
                 />
               </div>

--- a/packages/crouton-pages/app/components/Editor/BlockPropertyPanel.vue
+++ b/packages/crouton-pages/app/components/Editor/BlockPropertyPanel.vue
@@ -11,8 +11,9 @@
  * - Prevents feedback loops and focus stealing
  */
 import type { Node } from '@tiptap/pm/model'
-import type { BlockType, BlockPropertySchema, BlockSize } from '../../types/blocks'
+import type { BlockType, BlockPropertySchema, BlockSize, BlockVisibility, BlockAudienceRole, BlockViewport } from '../../types/blocks'
 import { getBlockDefinition } from '../../utils/block-registry'
+import { parseBlockVisibility } from '../../utils/block-visibility'
 
 const { t } = useT()
 const { blockName, fieldLabel, fieldDescription, fieldOptions } = useBlockI18n()
@@ -135,11 +136,79 @@ const blockSizeOptions = [
   { label: t('pages.blocks.sizeFull'), value: 'full' as BlockSize }
 ]
 
+// ---------------------------------------------------------------------------
+// Visibility (universal for all block types)
+//
+// Written to the `blockVisibility` attr as a SPARSE object: a key is only
+// present when it restricts something, so a block the author never configured
+// stores nothing at all.
+// ---------------------------------------------------------------------------
+
+const visibility = computed<BlockVisibility>(
+  () => parseBlockVisibility(localAttrs.value.blockVisibility) ?? {}
+)
+
+const audienceOptions = [
+  { label: t('pages.blocks.visibility.audienceAll'), value: 'all' },
+  { label: t('pages.blocks.visibility.audienceAnonymous'), value: 'anonymous' },
+  { label: t('pages.blocks.visibility.audienceAuthenticated'), value: 'authenticated' }
+]
+
+const roleOptions: { label: string, value: BlockAudienceRole }[] = [
+  { label: t('pages.blocks.visibility.roleOwner'), value: 'owner' },
+  { label: t('pages.blocks.visibility.roleAdmin'), value: 'admin' },
+  { label: t('pages.blocks.visibility.roleMember'), value: 'member' }
+]
+
+const viewportOptions: { label: string, value: BlockViewport }[] = [
+  { label: t('pages.blocks.visibility.viewportMobile'), value: 'mobile' },
+  { label: t('pages.blocks.visibility.viewportTablet'), value: 'tablet' },
+  { label: t('pages.blocks.visibility.viewportDesktop'), value: 'desktop' }
+]
+
+/** Roles only narrow a logged-in audience, so the picker is hidden otherwise. */
+const showRoles = computed(() => visibility.value.audience === 'authenticated')
+
+/** Apply a patch, dropping keys that no longer restrict anything. */
+function updateVisibility(patch: Partial<BlockVisibility>) {
+  const next: BlockVisibility = { ...visibility.value, ...patch }
+
+  if (!next.audience) delete next.audience
+  if (next.audience !== 'authenticated' || !next.roles?.length) delete next.roles
+  if (!next.viewports?.length || next.viewports.length === 3) delete next.viewports
+
+  // An empty object is no restriction — store nothing rather than `{}`.
+  onFieldChange('blockVisibility', Object.keys(next).length ? next : null)
+}
+
+function onAudienceChange(value: unknown) {
+  updateVisibility({ audience: value === 'all' ? undefined : value as BlockVisibility['audience'] })
+}
+
+function toggleRole(role: BlockAudienceRole, checked: boolean) {
+  const current = visibility.value.roles ?? []
+  updateVisibility({ roles: checked ? [...current, role] : current.filter(r => r !== role) })
+}
+
+function toggleViewport(viewport: BlockViewport, checked: boolean) {
+  // Absent means "all", so start from all three when narrowing for the first time.
+  const current = visibility.value.viewports ?? ['mobile', 'tablet', 'desktop']
+  const next = checked ? [...current, viewport] : current.filter(v => v !== viewport)
+  // Never let the author switch every screen off — that just hides the block.
+  updateVisibility({ viewports: next.length ? next : undefined })
+}
+
+function isViewportOn(viewport: BlockViewport): boolean {
+  return !visibility.value.viewports || visibility.value.viewports.includes(viewport)
+}
+
+/** True when the block carries any restriction — drives the summary badge. */
+const isRestricted = computed(() => Object.keys(visibility.value).length > 0)
+
 // Handle delete
 function onDelete() {
   emit('delete')
 }
-t
 </script>
 
 <template>
@@ -182,7 +251,7 @@ t
       </UButton>
       <div v-if="showPreview" class="relative overflow-hidden bg-muted/10" style="height: 200px;">
         <div style="transform: scale(0.33); transform-origin: top center; width: 303%; margin-left: -101.5%; pointer-events: none;">
-          <CroutonPagesBlockContent :content="previewDoc as any" class="p-4" />
+          <CroutonPagesBlockContent :content="previewDoc as any" ignore-visibility class="p-4" />
         </div>
       </div>
     </div>
@@ -200,6 +269,85 @@ t
             @update:model-value="onFieldChange('blockSize', $event)"
           />
         </UFormField>
+
+        <!-- Visibility (universal for all block types) -->
+        <UCollapsible>
+          <UButton
+            color="neutral"
+            variant="ghost"
+            block
+            class="group justify-between px-0"
+            trailing-icon="i-lucide-chevron-down"
+            :ui="{ trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200' }"
+          >
+            <span class="flex items-center gap-2 text-sm font-medium">
+              <UIcon :name="isRestricted ? 'i-lucide-eye-off' : 'i-lucide-eye'" class="size-4" />
+              {{ t('pages.blocks.visibility.title') }}
+              <UBadge v-if="isRestricted" color="warning" variant="subtle" size="sm">
+                {{ t('pages.blocks.visibility.restricted') }}
+              </UBadge>
+            </span>
+          </UButton>
+
+          <template #content>
+            <div class="space-y-4 pt-3">
+              <UFormField
+                :label="t('pages.blocks.visibility.audience')"
+                :description="t('pages.blocks.visibility.audienceHelp')"
+                name="blockVisibilityAudience"
+              >
+                <USelect
+                  :model-value="visibility.audience || 'all'"
+                  :items="audienceOptions as any"
+                  value-key="value"
+                  class="w-full"
+                  @update:model-value="onAudienceChange($event)"
+                />
+              </UFormField>
+
+              <UFormField
+                v-if="showRoles"
+                :label="t('pages.blocks.visibility.roles')"
+                :description="t('pages.blocks.visibility.rolesHelp')"
+                name="blockVisibilityRoles"
+              >
+                <div class="flex flex-col gap-2">
+                  <UCheckbox
+                    v-for="role in roleOptions"
+                    :key="role.value"
+                    :model-value="visibility.roles?.includes(role.value) ?? false"
+                    :label="role.label"
+                    @update:model-value="toggleRole(role.value, $event as boolean)"
+                  />
+                </div>
+              </UFormField>
+
+              <UFormField
+                :label="t('pages.blocks.visibility.viewports')"
+                :description="t('pages.blocks.visibility.viewportsHelp')"
+                name="blockVisibilityViewports"
+              >
+                <div class="flex flex-col gap-2">
+                  <UCheckbox
+                    v-for="viewport in viewportOptions"
+                    :key="viewport.value"
+                    :model-value="isViewportOn(viewport.value)"
+                    :label="viewport.label"
+                    @update:model-value="toggleViewport(viewport.value, $event as boolean)"
+                  />
+                </div>
+              </UFormField>
+
+              <UAlert
+                v-if="isRestricted"
+                color="neutral"
+                variant="subtle"
+                icon="i-lucide-info"
+                :description="t('pages.blocks.visibility.notSecurityNotice')"
+              />
+            </div>
+          </template>
+        </UCollapsible>
 
         <USeparator />
 

--- a/packages/crouton-pages/app/editor/extensions/addon-block-factory.ts
+++ b/packages/crouton-pages/app/editor/extensions/addon-block-factory.ts
@@ -9,7 +9,7 @@
 import { Node, mergeAttributes } from '@tiptap/core'
 import { VueNodeViewRenderer } from '@tiptap/vue-3'
 import type { CroutonBlockDefinition, CroutonBlockTipTapAttribute } from '@fyit/crouton-core/app/types/block-definition'
-import { generateBlockId, blockIdAttribute, blockSizeAttribute } from './block-utils'
+import { generateBlockId, blockIdAttribute, blockSizeAttribute, blockVisibilityAttribute } from './block-utils'
 import AddonBlockView from '../../components/Blocks/Views/AddonBlockView.vue'
 
 /**
@@ -24,7 +24,7 @@ function pascalCase(str: string): string {
  * Build TipTap attribute config from declarative definition.
  */
 function buildAttributes(attrs: Record<string, CroutonBlockTipTapAttribute>) {
-  const result: Record<string, any> = { ...blockIdAttribute, ...blockSizeAttribute }
+  const result: Record<string, any> = { ...blockIdAttribute, ...blockSizeAttribute, ...blockVisibilityAttribute }
 
   for (const [name, config] of Object.entries(attrs)) {
     const attrDef: any = {

--- a/packages/crouton-pages/app/editor/extensions/block-utils.ts
+++ b/packages/crouton-pages/app/editor/extensions/block-utils.ts
@@ -43,3 +43,33 @@ export const blockSizeAttribute = {
     }
   }
 }
+
+/**
+ * Block visibility attribute definition for TipTap extensions.
+ * Holds the per-block display conditions (audience, roles, viewports) applied
+ * when the block is rendered on the public page — see `app/utils/block-visibility.ts`.
+ *
+ * Defaults to null and serializes only when set, so a block that was never
+ * configured adds nothing to the stored document.
+ */
+export const blockVisibilityAttribute = {
+  blockVisibility: {
+    default: null,
+    parseHTML: (element: Element) => {
+      const raw = element.getAttribute('data-block-visibility')
+      if (!raw) return null
+      try {
+        return JSON.parse(raw)
+      } catch {
+        return null
+      }
+    },
+    renderHTML: (attributes: { blockVisibility?: unknown }) => {
+      const value = attributes.blockVisibility
+      if (!value || typeof value !== 'object') return {}
+      // An empty object carries no restriction — keep it out of the markup.
+      if (Object.keys(value as Record<string, unknown>).length === 0) return {}
+      return { 'data-block-visibility': JSON.stringify(value) }
+    }
+  }
+}

--- a/packages/crouton-pages/app/editor/extensions/page-blocks.ts
+++ b/packages/crouton-pages/app/editor/extensions/page-blocks.ts
@@ -8,7 +8,7 @@
 import { Extension } from '@tiptap/core'
 import Highlight from '@tiptap/extension-highlight'
 import type { CroutonBlockDefinition } from '@fyit/crouton-core/app/types/block-definition'
-import { blockSizeAttribute } from './block-utils'
+import { blockSizeAttribute, blockVisibilityAttribute } from './block-utils'
 import { HeroBlock } from './hero-block'
 import { SectionBlock } from './section-block'
 import { CTABlock } from './cta-block'
@@ -122,7 +122,7 @@ export const PageBlocks = Extension.create<PageBlocksOptions>({
     return [
       {
         types: [...coreBlockTypes, ...addonBlockTypes],
-        attributes: blockSizeAttribute
+        attributes: { ...blockSizeAttribute, ...blockVisibilityAttribute }
       }
     ]
   },

--- a/packages/crouton-pages/app/types/blocks.ts
+++ b/packages/crouton-pages/app/types/blocks.ts
@@ -520,6 +520,58 @@ export interface PageBlockContent {
 }
 
 // ============================================================================
+// Block Visibility (universal attr, like blockSize)
+// ============================================================================
+
+/**
+ * Screen sizes a block can be limited to. The boundaries are 768px and 1024px,
+ * matching the breakpoints the public surfaces already use (`Nav.vue`,
+ * `layouts/public.vue`).
+ */
+export type BlockViewport = 'mobile' | 'tablet' | 'desktop'
+
+/**
+ * Team roles a block can be limited to.
+ *
+ * Deliberately declared here rather than imported from `@fyit/crouton-auth`:
+ * crouton-pages does not depend on the auth package (it may not be installed),
+ * and the visibility matcher must degrade gracefully when it isn't. Kept in
+ * step with `MemberRole` in `@fyit/crouton-auth/types/auth.ts`.
+ */
+export type BlockAudienceRole = 'owner' | 'admin' | 'member'
+
+/**
+ * Per-block display conditions, stored on the universal `blockVisibility` attr.
+ *
+ * Sparse by design — an absent key means "no restriction", so a block that has
+ * never been configured carries nothing and renders exactly as it always did.
+ *
+ * NOT a security boundary: a hidden block is still present in the page payload,
+ * it simply isn't displayed. Gate genuinely sensitive content with the
+ * page-level `visibility` field, which is enforced server-side.
+ */
+export interface BlockVisibility {
+  /** Limit to logged-out or logged-in readers. Absent = anyone. */
+  audience?: 'anonymous' | 'authenticated'
+  /** Limit to these team roles. Naming any role implies `authenticated`. */
+  roles?: BlockAudienceRole[]
+  /** Limit to these screen sizes. Absent or empty = all. */
+  viewports?: BlockViewport[]
+}
+
+/**
+ * What the renderer knows about the current reader.
+ *
+ * `null` means "not knowable" — crouton-auth isn't installed, or the session
+ * hasn't resolved yet. The matcher shows the block in that case rather than
+ * hiding it, so a missing auth package can never blank a page.
+ */
+export interface BlockAudienceContext {
+  authenticated: boolean | null
+  role: BlockAudienceRole | null
+}
+
+// ============================================================================
 // Block Registry Types
 // ============================================================================
 

--- a/packages/crouton-pages/app/utils/block-visibility.ts
+++ b/packages/crouton-pages/app/utils/block-visibility.ts
@@ -1,0 +1,166 @@
+/**
+ * Block Visibility
+ *
+ * Pure helpers behind the universal `blockVisibility` attr — who sees a block,
+ * and on what screen. Kept free of Vue and of any auth import so the renderer
+ * can call them, tests can call them directly, and a future server-side
+ * enforcement pass could call them unchanged.
+ *
+ * Two axes, resolved by two different mechanisms, for one reason: the public
+ * page route is `swr: 3600` cached, so its HTML is shared across visitors.
+ *
+ * - **viewport** → CSS classes. Resolves per-device in the browser, so it is
+ *   cache-safe, needs no JS, and cannot flicker.
+ * - **audience/roles** → evaluated after hydration only. Reading auth state
+ *   during SSR would bake one visitor's session into the shared cached HTML.
+ *
+ * NOT a security boundary. Every unusable value fails *open* (block shown) —
+ * a corrupt attr should never blank a page. Gate sensitive content with the
+ * page-level `visibility` field instead, which is enforced server-side.
+ */
+import type {
+  BlockAudienceContext,
+  BlockAudienceRole,
+  BlockVisibility,
+  BlockViewport
+} from '../types/blocks'
+
+const AUDIENCES = ['anonymous', 'authenticated'] as const
+const ROLES: BlockAudienceRole[] = ['owner', 'admin', 'member']
+const VIEWPORTS: BlockViewport[] = ['mobile', 'tablet', 'desktop']
+
+/**
+ * Which roles satisfy a required role. Owner outranks admin, mirroring the
+ * page endpoint's own hierarchy (`[...slug].get.ts`, admin-visibility branch),
+ * so an owner is never locked out of something an admin can see.
+ */
+const ROLE_SATISFIES: Record<BlockAudienceRole, BlockAudienceRole[]> = {
+  owner: ['owner'],
+  admin: ['owner', 'admin'],
+  member: ['owner', 'admin', 'member']
+}
+
+/**
+ * Tailwind class that hides a block on exactly one viewport band.
+ *
+ * These must stay whole literal strings — Tailwind scans source text, so a
+ * class assembled at runtime would be purged from the build.
+ */
+const HIDE_ON: Record<BlockViewport, string> = {
+  mobile: 'max-md:hidden',
+  tablet: 'md:max-lg:hidden',
+  desktop: 'lg:hidden'
+}
+
+/** Narrow an untrusted value to a known audience. */
+function readAudience(value: unknown): BlockVisibility['audience'] | undefined {
+  return (AUDIENCES as readonly string[]).includes(value as string)
+    ? (value as BlockVisibility['audience'])
+    : undefined
+}
+
+/** Narrow an untrusted value to the known roles, dropping anything unrecognised. */
+function readRoles(value: unknown): BlockAudienceRole[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((r): r is BlockAudienceRole => ROLES.includes(r as BlockAudienceRole))
+}
+
+/** Narrow an untrusted value to the known viewports, dropping anything unrecognised. */
+function readViewports(value: unknown): BlockViewport[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((v): v is BlockViewport => VIEWPORTS.includes(v as BlockViewport))
+}
+
+/**
+ * Read the stored attr, which may be an object (JSON content storage) or a
+ * JSON string (the `data-block-visibility` HTML round-trip). Anything else
+ * reads as "no visibility set".
+ */
+export function parseBlockVisibility(value: unknown): BlockVisibility | undefined {
+  if (!value) return undefined
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as BlockVisibility)
+        : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  if (typeof value === 'object' && !Array.isArray(value)) return value as BlockVisibility
+
+  return undefined
+}
+
+/**
+ * Whether this block's display depends on who is looking.
+ *
+ * The renderer uses this to decide which blocks must wait for hydration.
+ * A block with no visibility — or with only viewport limits, which CSS handles
+ * — returns false and takes no new code path at all.
+ */
+export function hasAudienceGate(visibility: unknown): boolean {
+  const vis = parseBlockVisibility(visibility)
+  if (!vis) return false
+  return readAudience(vis.audience) !== undefined || readRoles(vis.roles).length > 0
+}
+
+/**
+ * Whether the current reader should see this block.
+ *
+ * Shows the block whenever the answer can't be determined: no visibility set,
+ * an unrecognised stored value, or auth state that isn't knowable.
+ */
+export function matchesAudience(
+  visibility: unknown,
+  ctx: BlockAudienceContext
+): boolean {
+  const vis = parseBlockVisibility(visibility)
+  if (!vis) return true
+
+  const audience = readAudience(vis.audience)
+  const roles = readRoles(vis.roles)
+
+  // Naming roles implies the reader must be logged in.
+  const requiresAuth = audience === 'authenticated' || roles.length > 0
+
+  if (audience === 'anonymous') {
+    // Unknowable auth state → show.
+    return ctx.authenticated === null ? true : !ctx.authenticated
+  }
+
+  if (requiresAuth) {
+    if (ctx.authenticated === null) return true
+    if (!ctx.authenticated) return false
+
+    if (roles.length > 0) {
+      // Logged in but the role is unknown → show rather than lock out.
+      if (!ctx.role) return true
+      return roles.some(required => ROLE_SATISFIES[required].includes(ctx.role!))
+    }
+  }
+
+  return true
+}
+
+/**
+ * Classes that hide this block on the viewports it excludes.
+ *
+ * Emits one hide-class per *excluded* band, so allowing everything (or nothing
+ * recognisable) emits nothing and the wrapper is untouched.
+ */
+export function viewportClasses(visibility: unknown): string[] {
+  const vis = parseBlockVisibility(visibility)
+  if (!vis) return []
+
+  const allowed = readViewports(vis.viewports)
+
+  // Empty means "no restriction" — either genuinely unset, or every entry was
+  // unrecognised. Hiding all three would blank the block over a typo.
+  if (allowed.length === 0) return []
+
+  return VIEWPORTS.filter(v => !allowed.includes(v)).map(v => HIDE_ON[v])
+}

--- a/packages/crouton-pages/i18n/locales/en.json
+++ b/packages/crouton-pages/i18n/locales/en.json
@@ -338,6 +338,26 @@
         "linkUrl": "Custom URL",
         "selectPage": "Select a page…",
         "searchPages": "Search pages…"
+      },
+      "visibility": {
+        "title": "Visibility",
+        "restricted": "Limited",
+        "audience": "Show to",
+        "audienceHelp": "Who sees this block on the public page.",
+        "audienceAll": "Anyone",
+        "audienceAnonymous": "Logged-out visitors only",
+        "audienceAuthenticated": "Logged-in visitors only",
+        "roles": "Roles",
+        "rolesHelp": "Limit to these team roles. Owners always see what admins see.",
+        "roleOwner": "Owner",
+        "roleAdmin": "Admin",
+        "roleMember": "Member",
+        "viewports": "Screens",
+        "viewportsHelp": "Screen sizes this block appears on.",
+        "viewportMobile": "Mobile",
+        "viewportTablet": "Tablet",
+        "viewportDesktop": "Desktop",
+        "notSecurityNotice": "A hidden block is still present in the page source — this controls what is shown, not what is accessible. For content that must stay private, set the visibility of the page itself."
       }
     },
     "fieldGroups": {

--- a/packages/crouton-pages/i18n/locales/fr.json
+++ b/packages/crouton-pages/i18n/locales/fr.json
@@ -338,6 +338,26 @@
         "linkUrl": "URL personnalisée",
         "selectPage": "Choisir une page…",
         "searchPages": "Rechercher des pages…"
+      },
+      "visibility": {
+        "title": "Visibilité",
+        "restricted": "Limité",
+        "audience": "Afficher pour",
+        "audienceHelp": "Qui voit ce bloc sur la page publique.",
+        "audienceAll": "Tout le monde",
+        "audienceAnonymous": "Visiteurs déconnectés uniquement",
+        "audienceAuthenticated": "Visiteurs connectés uniquement",
+        "roles": "Rôles",
+        "rolesHelp": "Limiter à ces rôles d'équipe. Les propriétaires voient toujours ce que voient les administrateurs.",
+        "roleOwner": "Propriétaire",
+        "roleAdmin": "Administrateur",
+        "roleMember": "Membre",
+        "viewports": "Écrans",
+        "viewportsHelp": "Tailles d'écran sur lesquelles ce bloc apparaît.",
+        "viewportMobile": "Mobile",
+        "viewportTablet": "Tablette",
+        "viewportDesktop": "Bureau",
+        "notSecurityNotice": "Un bloc masqué reste présent dans le source de la page — ceci contrôle ce qui est affiché, pas ce qui est accessible. Pour un contenu qui doit rester privé, définissez la visibilité de la page elle-même."
       }
     },
     "fieldGroups": {

--- a/packages/crouton-pages/i18n/locales/nl.json
+++ b/packages/crouton-pages/i18n/locales/nl.json
@@ -338,6 +338,26 @@
         "linkUrl": "Aangepaste URL",
         "selectPage": "Kies een pagina…",
         "searchPages": "Zoek pagina’s…"
+      },
+      "visibility": {
+        "title": "Zichtbaarheid",
+        "restricted": "Beperkt",
+        "audience": "Tonen aan",
+        "audienceHelp": "Wie dit blok op de publieke pagina ziet.",
+        "audienceAll": "Iedereen",
+        "audienceAnonymous": "Alleen uitgelogde bezoekers",
+        "audienceAuthenticated": "Alleen ingelogde bezoekers",
+        "roles": "Rollen",
+        "rolesHelp": "Beperk tot deze teamrollen. Eigenaars zien altijd wat beheerders zien.",
+        "roleOwner": "Eigenaar",
+        "roleAdmin": "Beheerder",
+        "roleMember": "Lid",
+        "viewports": "Schermen",
+        "viewportsHelp": "Schermformaten waarop dit blok verschijnt.",
+        "viewportMobile": "Mobiel",
+        "viewportTablet": "Tablet",
+        "viewportDesktop": "Desktop",
+        "notSecurityNotice": "Een verborgen blok staat nog steeds in de paginabron — dit bepaalt wat er getoond wordt, niet wat er toegankelijk is. Stel de zichtbaarheid van de pagina zelf in voor inhoud die privé moet blijven."
       }
     },
     "fieldGroups": {

--- a/packages/crouton-pages/test/block-visibility.test.ts
+++ b/packages/crouton-pages/test/block-visibility.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest'
+import {
+  matchesAudience,
+  viewportClasses,
+  parseBlockVisibility,
+  hasAudienceGate
+} from '../app/utils/block-visibility'
+import type { BlockVisibility, BlockAudienceContext } from '../app/types/blocks'
+
+/** Reader contexts the renderer can hand the matcher. */
+const ANON: BlockAudienceContext = { authenticated: false, role: null }
+const MEMBER: BlockAudienceContext = { authenticated: true, role: 'member' }
+const ADMIN: BlockAudienceContext = { authenticated: true, role: 'admin' }
+const OWNER: BlockAudienceContext = { authenticated: true, role: 'owner' }
+/** crouton-auth absent, or session not yet resolved. */
+const UNKNOWN: BlockAudienceContext = { authenticated: null, role: null }
+
+describe('matchesAudience — the untouched default', () => {
+  it('shows a block with no visibility at all', () => {
+    for (const ctx of [ANON, MEMBER, ADMIN, OWNER, UNKNOWN]) {
+      expect(matchesAudience(undefined, ctx)).toBe(true)
+    }
+  })
+
+  it('shows a block whose visibility sets only viewports', () => {
+    const vis: BlockVisibility = { viewports: ['mobile'] }
+    expect(matchesAudience(vis, ANON)).toBe(true)
+    expect(matchesAudience(vis, ADMIN)).toBe(true)
+  })
+})
+
+describe('matchesAudience — logged-out only (the QR case)', () => {
+  const vis: BlockVisibility = { audience: 'anonymous' }
+
+  it('shows to a logged-out reader', () => {
+    expect(matchesAudience(vis, ANON)).toBe(true)
+  })
+
+  it('hides from every logged-in reader, whatever the role', () => {
+    expect(matchesAudience(vis, MEMBER)).toBe(false)
+    expect(matchesAudience(vis, ADMIN)).toBe(false)
+    expect(matchesAudience(vis, OWNER)).toBe(false)
+  })
+
+  it('ignores roles — they are meaningless for an anonymous audience', () => {
+    expect(matchesAudience({ audience: 'anonymous', roles: ['admin'] }, ANON)).toBe(true)
+    expect(matchesAudience({ audience: 'anonymous', roles: ['admin'] }, ADMIN)).toBe(false)
+  })
+})
+
+describe('matchesAudience — logged-in only', () => {
+  const vis: BlockVisibility = { audience: 'authenticated' }
+
+  it('hides from a logged-out reader', () => {
+    expect(matchesAudience(vis, ANON)).toBe(false)
+  })
+
+  it('shows to any logged-in reader when no roles are named', () => {
+    expect(matchesAudience(vis, MEMBER)).toBe(true)
+    expect(matchesAudience(vis, ADMIN)).toBe(true)
+    expect(matchesAudience(vis, OWNER)).toBe(true)
+  })
+})
+
+describe('matchesAudience — roles', () => {
+  it('hides from a reader whose role is not named', () => {
+    expect(matchesAudience({ roles: ['admin'] }, MEMBER)).toBe(false)
+  })
+
+  it('shows to a reader whose role is named', () => {
+    expect(matchesAudience({ roles: ['admin'] }, ADMIN)).toBe(true)
+    expect(matchesAudience({ roles: ['member'] }, MEMBER)).toBe(true)
+  })
+
+  it('lets owner satisfy an admin check — owner outranks admin', () => {
+    // Mirrors the page endpoint's own hierarchy
+    // (server/api/teams/[id]/pages/[...slug].get.ts, admin-visibility branch).
+    expect(matchesAudience({ roles: ['admin'] }, OWNER)).toBe(true)
+  })
+
+  it('does NOT let admin satisfy an owner-only check', () => {
+    expect(matchesAudience({ roles: ['owner'] }, ADMIN)).toBe(false)
+    expect(matchesAudience({ roles: ['owner'] }, OWNER)).toBe(true)
+  })
+
+  it('treats naming roles as implying authenticated', () => {
+    expect(matchesAudience({ roles: ['member'] }, ANON)).toBe(false)
+  })
+
+  it('accepts a reader matching any one of several roles', () => {
+    expect(matchesAudience({ roles: ['admin', 'member'] }, MEMBER)).toBe(true)
+  })
+
+  it('ignores an empty roles array — it names no restriction', () => {
+    expect(matchesAudience({ audience: 'authenticated', roles: [] }, MEMBER)).toBe(true)
+    expect(matchesAudience({ roles: [] }, ANON)).toBe(true)
+  })
+})
+
+describe('matchesAudience — degrades to showing', () => {
+  it('shows an audience-gated block when auth state is unknown', () => {
+    // crouton-auth not installed, or the session has not resolved yet.
+    expect(matchesAudience({ audience: 'anonymous' }, UNKNOWN)).toBe(true)
+    expect(matchesAudience({ audience: 'authenticated' }, UNKNOWN)).toBe(true)
+    expect(matchesAudience({ roles: ['admin'] }, UNKNOWN)).toBe(true)
+  })
+
+  it('shows when the reader is logged in but the role is unknown', () => {
+    const noRole: BlockAudienceContext = { authenticated: true, role: null }
+    expect(matchesAudience({ roles: ['admin'] }, noRole)).toBe(true)
+    // The authenticated/anonymous split is still knowable, so it still applies.
+    expect(matchesAudience({ audience: 'anonymous' }, noRole)).toBe(false)
+  })
+
+  it('fails open on a corrupt stored value — this is not a security boundary', () => {
+    expect(matchesAudience({ audience: 'nonsense' } as any, MEMBER)).toBe(true)
+    expect(matchesAudience({ roles: 'admin' } as any, MEMBER)).toBe(true)
+    expect(matchesAudience({ roles: ['bogus'] } as any, MEMBER)).toBe(true)
+    expect(matchesAudience(null as any, MEMBER)).toBe(true)
+    expect(matchesAudience('junk' as any, MEMBER)).toBe(true)
+  })
+})
+
+describe('viewportClasses — one hidden-class per excluded viewport', () => {
+  it('emits nothing when every viewport is allowed', () => {
+    expect(viewportClasses(undefined)).toEqual([])
+    expect(viewportClasses({})).toEqual([])
+    expect(viewportClasses({ viewports: [] })).toEqual([])
+    expect(viewportClasses({ viewports: ['mobile', 'tablet', 'desktop'] })).toEqual([])
+  })
+
+  it('hides the two larger viewports for a mobile-only block', () => {
+    expect(viewportClasses({ viewports: ['mobile'] })).toEqual(['md:max-lg:hidden', 'lg:hidden'])
+  })
+
+  it('hides everything below desktop for a desktop-only block', () => {
+    expect(viewportClasses({ viewports: ['desktop'] })).toEqual(['max-md:hidden', 'md:max-lg:hidden'])
+  })
+
+  it('hides the gap for a mobile+desktop block', () => {
+    expect(viewportClasses({ viewports: ['mobile', 'desktop'] })).toEqual(['md:max-lg:hidden'])
+  })
+
+  it('hides mobile for a tablet+desktop block', () => {
+    expect(viewportClasses({ viewports: ['tablet', 'desktop'] })).toEqual(['max-md:hidden'])
+  })
+
+  it('is order-insensitive', () => {
+    expect(viewportClasses({ viewports: ['desktop', 'mobile'] })).toEqual(['md:max-lg:hidden'])
+  })
+
+  it('ignores unknown viewport names rather than hiding everything', () => {
+    expect(viewportClasses({ viewports: ['mobile', 'watch'] } as any)).toEqual(['md:max-lg:hidden', 'lg:hidden'])
+  })
+
+  it('emits nothing when the stored value is corrupt', () => {
+    expect(viewportClasses({ viewports: 'mobile' } as any)).toEqual([])
+    expect(viewportClasses({ viewports: ['bogus'] } as any)).toEqual([])
+    expect(viewportClasses(null as any)).toEqual([])
+  })
+})
+
+describe('hasAudienceGate — decides which blocks defer past hydration', () => {
+  it('is false for a block with no visibility, so it renders as it always did', () => {
+    expect(hasAudienceGate(undefined)).toBe(false)
+    expect(hasAudienceGate({})).toBe(false)
+  })
+
+  it('is false for a viewport-only block — CSS needs no deferral', () => {
+    expect(hasAudienceGate({ viewports: ['mobile'] })).toBe(false)
+  })
+
+  it('is true when an audience or roles are named', () => {
+    expect(hasAudienceGate({ audience: 'anonymous' })).toBe(true)
+    expect(hasAudienceGate({ audience: 'authenticated' })).toBe(true)
+    expect(hasAudienceGate({ roles: ['admin'] })).toBe(true)
+  })
+
+  it('is false for restrictions that name nothing', () => {
+    expect(hasAudienceGate({ roles: [] })).toBe(false)
+    expect(hasAudienceGate({ audience: 'nonsense' } as any)).toBe(false)
+  })
+})
+
+describe('parseBlockVisibility — the stored attr is untrusted', () => {
+  it('reads an object straight through', () => {
+    expect(parseBlockVisibility({ audience: 'anonymous' })).toEqual({ audience: 'anonymous' })
+  })
+
+  it('reads the JSON string form written into data-block-visibility', () => {
+    expect(parseBlockVisibility('{"audience":"anonymous","viewports":["mobile"]}'))
+      .toEqual({ audience: 'anonymous', viewports: ['mobile'] })
+  })
+
+  it('returns undefined for absent or unusable values', () => {
+    expect(parseBlockVisibility(undefined)).toBeUndefined()
+    expect(parseBlockVisibility(null)).toBeUndefined()
+    expect(parseBlockVisibility('')).toBeUndefined()
+    expect(parseBlockVisibility('not json')).toBeUndefined()
+    expect(parseBlockVisibility('[1,2]')).toBeUndefined()
+    expect(parseBlockVisibility(42)).toBeUndefined()
+  })
+})

--- a/packages/crouton-pages/vitest.config.ts
+++ b/packages/crouton-pages/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  define: {
+    'import.meta.server': false
+  },
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'happy-dom',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['app/utils/**/*.ts'],
+      exclude: ['test/**', 'app/types/**']
+    }
+  }
+})


### PR DESCRIPTION
Closes #1835

## 👤 What this is

Every page block gets an optional **Visibility** section in its settings — who sees it, and on which screens.

| Setting | Options |
|---|---|
| Show to | Anyone · Logged-out only · Logged-in only |
| Roles | Owner · Admin · Member *(only when "Logged in")* |
| Screens | Mobile · Tablet · Desktop |

Motivating case: a QR code that only makes sense to someone not signed in, holding a phone.

Leave it alone and nothing changes — an unconfigured block renders exactly as before.

**Presentation filter, not a security boundary.** A hidden block is still in the page source. The panel says so, in as many words. Sensitive content still belongs behind the page-level `visibility`.

## 🤖 The one design decision worth reviewing

The public route declares `defineRouteRules({ swr: 3600 })`, so its HTML is cached an hour and **shared between visitors**. So the two axes resolve differently on purpose:

- **viewport → CSS classes** on the existing per-block wrapper. Per-device in the browser: cache-safe, no JS, no flicker.
- **audience/roles → after hydration only.** `audienceResolved` is false during SSR *and* first client render (so hydration matches), true on mount. Reading the session during SSR would bake one visitor's auth state into the page everyone receives.

A block with no audience gate takes neither path — no class, no deferral, byte-identical to before.

Everything unusable **fails open**: corrupt stored value, missing crouton-auth, unresolved session → show the block. A bad setting can never blank a page.

## Approach

Rides the rails `blockSize` already uses — one attribute, registered once as a TipTap global attribute, so it covers core **and** addon blocks with no per-type opt-in. Serializes into the page's existing `content` JSON: no column, no migration.

## Evidence

Test-first: the 32-case contract went in red before implementation, then green.

Viewport bands verified against **real built CSS** (the risk was Tailwind not scanning a `.ts` inside a layer package — it does, via the `@source` glob in `apps/velo/app/assets/css/main.css:5`):

| class | media query | band |
|---|---|---|
| `max-md:hidden` | `not all and (min-width:48rem)` | < 768px |
| `md:max-lg:hidden` | `(min-width:48rem)` ∧ `not all and (min-width:64rem)` | 768–1023px |
| `lg:hidden` | `(min-width:64rem)` | ≥ 1024px |

`pnpm typecheck` clean (velo/triage/kassa) · `npx fallow audit` → *No issues in 14 changed files* · eslint errors unchanged at 702.

**Packages-approved:** owner approved editing `packages/crouton-pages` for this feature before implementation. Additive only — a new optional attribute plus a wrapper class; no change to `crouton-core` or `crouton-auth`.

## 🧪 How to test

1. `/admin/[team]/pages` → open a page in the editor, add a **QR code** block.
2. Click the block → settings panel. Under **Block size**, expand **Visibility**.
3. Set **Show to** = `Logged-out visitors only`, **Screens** = Mobile only. Save.
4. Public page, logged out, narrow viewport → QR is there.
5. Widen past 768px → it disappears. No reload, no flicker.
6. Log in, reload narrow → gone.
7. Open a page whose blocks set no visibility → unchanged.

**Still unverified:** step 4–6 on a deployed preview. The audience axis is designed around the shared `swr: 3600` cache, which local dev does not reproduce — worth doing on this PR's staging URL before merge.
