### PR TITLE
Design tweaks (rebased onto main) + "in bereiding" wording and click-to-filter

### DIFF
--- a/packages/crouton-core/app/components/SubBar.vue
+++ b/packages/crouton-core/app/components/SubBar.vue
@@ -116,17 +116,17 @@ onBeforeUnmount(() => cleanup())
 <template>
   <div
     ref="root"
-    class="flex items-center gap-2 py-1.5 bg-default overflow-x-auto transition-transform duration-200 ease-out"
+    class="min-h-8 flex items-center bg-default  transition-transform duration-200 ease-out"
     :class="[
       bordered ? 'border-b border-default' : '',
       // auto-hide: sticky ONLY while pinned (a scroll-up reveal); otherwise the
       // bar lives in flow. A plain `sticky` bar (no auto-hide) always pins.
       autoHide ? (pinned ? 'sticky top-0 z-10' : '') : (sticky ? 'sticky top-0 z-10' : ''),
       (autoHide && pinned && !shown) ? '-translate-y-full' : 'translate-y-0',
-      // Full-bleed inside a `p-4` pane: cancel the host's horizontal padding,
-      // re-inset the content by the same amount so it lines up with the padded
-      // siblings below. Plain `px-2` otherwise.
-      flush ? '-mx-4 px-4' : 'px-2',
+      // // Full-bleed inside a `p-4` pane: cancel the host's horizontal padding,
+      // // re-inset the content by the same amount so it lines up with the padded
+      // // siblings below. Plain `px-2` otherwise.
+      // flush ? '-mx-4 px-4' : 'px-2',
     ]"
     @transitionend="onSlideEnd"
   >

--- a/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/DataPanel.vue
@@ -52,19 +52,20 @@ onUnmounted(unhookMutation)
 </script>
 
 <template>
-  <div class="space-y-4">
+  <CroutonSubBar sticky auto-hide flush class="px-4">
+    <USwitch
+        v-model="includePersonnel"
+        :label="t('sales.workspace.dataPanel.includePersonnel')"
+    />
+  </CroutonSubBar>
+  <div class="space-y-4 p-4">
     <!-- Exclude staff orders from the totals by default; toggle folds them in.
          Sticky to the top of the scrolling pane (bleeds over the host's p-4
          padding via negative margins + a solid bg) so the personnel toggle
          stays reachable while the numbers below scroll. `-top-2` cancels the
          host's pt-2 so nothing scrolls into the 8px gap above the bar (#1608),
          and symmetric py-3 keeps the toggle centered at rest and when stuck. -->
-    <div class="sticky -top-2 z-10 -mx-4 -mt-2 flex items-center border-b border-default bg-default px-4 py-3">
-      <USwitch
-        v-model="includePersonnel"
-        :label="t('sales.workspace.dataPanel.includePersonnel')"
-      />
-    </div>
+
 
     <!-- Headline numbers + top products (polls, tracks fresh orders) -->
     <SalesDashboardSalesSummary
@@ -92,7 +93,7 @@ onUnmounted(unhookMutation)
 
     <!-- Personnel orders on their own — watch staff consumption regardless of
          the toggle above (always personnel-only) -->
-    <div v-if="hasCharts" class="rounded-2xl border border-default bg-elevated/40 p-4">
+    <div v-if="hasCharts && personnelMode === 'all'" class="rounded-2xl border border-default bg-elevated/40 p-4">
       <LazyCroutonChartsWidget
         :key="chartRefreshKey"
         :api-path="revenueKind.apiPath"

--- a/packages/crouton-sales/app/components/EventWorkspace/OrdersPaneBody.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/OrdersPaneBody.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+/**
+ * The orders pane's body — the `<Suspense>`-wrapped OrdersTab (#1846).
+ *
+ * Extracted because three places render exactly this: the Shell's desktop
+ * splitter pane, the Shell's narrow-mode slideover, and PaneHost's deep-entry
+ * modal. They must stay identical — OrdersTab is async-setup, so each host
+ * needs its own Suspense boundary, and a host that forgot the fallback would
+ * show a blank pane while the tab resolves.
+ *
+ * `filtersOpen` / `activeFilterCount` are passed straight through, because each
+ * host owns its own header and hosts the filter toggle there.
+ */
+defineProps<{ event: Record<string, any> }>()
+
+const filtersOpen = defineModel<boolean>('filtersOpen', { default: false })
+const emit = defineEmits<{ 'update:activeFilterCount': [count: number] }>()
+
+const { t } = useT()
+</script>
+
+<template>
+  <Suspense>
+    <SalesEventWorkspaceOrdersTab
+      v-model:filters-open="filtersOpen"
+      :event="event"
+      @update:active-filter-count="emit('update:activeFilterCount', $event)"
+    />
+    <template #fallback>
+      <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
+    </template>
+  </Suspense>
+</template>

--- a/packages/crouton-sales/app/components/EventWorkspace/OrdersPaneBody.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/OrdersPaneBody.vue
@@ -11,7 +11,9 @@
  * `filtersOpen` / `activeFilterCount` are passed straight through, because each
  * host owns its own header and hosts the filter toggle there.
  */
-defineProps<{ event: Record<string, any> }>()
+import type { SalesEvent } from '~~/layers/sales/collections/events/types'
+
+defineProps<{ event: SalesEvent }>()
 
 const filtersOpen = defineModel<boolean>('filtersOpen', { default: false })
 const emit = defineEmits<{ 'update:activeFilterCount': [count: number] }>()

--- a/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
@@ -57,12 +57,16 @@ const selectedPrintStatus = ref<string | null>(null)
 const ordersPageSize = 25
 const ordersPage = ref(1)
 
+// Narrow the list to the backlog. Declared here because `ordersUrl` reads it.
+const outstandingOnly = ref(false)
+
 const ordersUrl = computed(() => {
   const params = new URLSearchParams({ page: String(ordersPage.value), pageSize: String(ordersPageSize) })
   if (selectedHelperName.value) params.set('owner', selectedHelperName.value)
   if (selectedClientId.value) params.set('clientId', selectedClientId.value)
   if (selectedPrinterId.value) params.set('printerId', selectedPrinterId.value)
   if (selectedPrintStatus.value) params.set('printStatus', selectedPrintStatus.value)
+  if (outstandingOnly.value) params.set('outstanding', '1')
   return `/api/crouton-sales/teams/${teamParam.value}/events/${props.event.id}/orders?${params}`
 })
 
@@ -78,6 +82,16 @@ const orders = computed(() => ordersData.value?.items || [])
 // server computes it OUTSIDE the list filters, so it stays the event's real
 // backlog even while the table below is filtered down to one helper.
 const outstanding = computed(() => ordersData.value?.outstanding ?? 0)
+
+// Click the backlog to narrow the list to exactly those orders. This rides the
+// normal filter path (server-side, resets to page 1), so it composes with the
+// helper/client/printer filters rather than fighting them. The NUMBER itself
+// stays put — it is computed outside every filter by design (#1763), so it
+// keeps reading the true backlog while the list shows a slice of it.
+function toggleOutstandingOnly() {
+  outstandingOnly.value = !outstandingOnly.value
+  ordersPage.value = 1
+}
 
 const ordersPageCount = computed(() => Math.max(1, Math.ceil((ordersData.value?.total ?? 0) / ordersPageSize)))
 
@@ -388,15 +402,29 @@ function toggleExpand(id: string) {
          one number that does NOT follow them, and putting it below would imply
          it did. Zero is worth showing too — "nothing waiting" is the answer
          someone walked over to get. -->
-    <div class="flex items-center gap-2 text-sm">
-      <UIcon
-        :name="outstanding > 0 ? 'i-lucide-hourglass' : 'i-lucide-check-check'"
-        class="size-4"
-        :class="outstanding > 0 ? 'text-warning' : 'text-success'"
-      />
-      <span :class="outstanding > 0 ? 'text-highlighted font-medium' : 'text-muted'">
-        {{ outstanding > 0 ? t('sales.workspace.outstanding', { count: outstanding }) : t('sales.workspace.outstandingNone') }}
-      </span>
+    <UButton
+      v-if="outstanding > 0"
+      :color="outstandingOnly ? 'warning' : 'neutral'"
+      :variant="outstandingOnly ? 'subtle' : 'ghost'"
+      size="sm"
+      icon="i-lucide-hourglass"
+      :label="t('sales.workspace.outstanding', { count: outstanding })"
+      :aria-pressed="outstandingOnly"
+      :title="outstandingOnly ? t('sales.workspace.outstandingFilterClear') : t('sales.workspace.outstandingFilter')"
+      class="-ms-2"
+      :ui="{ leadingIcon: outstandingOnly ? '' : 'text-warning' }"
+      @click="toggleOutstandingOnly"
+    >
+      <template #trailing>
+        <UIcon v-if="outstandingOnly" name="i-lucide-x" class="size-3.5 opacity-70" />
+      </template>
+    </UButton>
+
+    <!-- Nothing outstanding: a statement, not a control — there is no slice to
+         filter to, so offering a button would be a dead end. -->
+    <div v-else class="flex items-center gap-2 text-sm text-muted">
+      <UIcon name="i-lucide-check-check" class="size-4 text-success" />
+      {{ t('sales.workspace.outstandingNone') }}
     </div>
 
     <!-- Filters live behind a toggle (in the pane header when the parent

--- a/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
@@ -419,7 +419,7 @@ function toggleExpand(id: string) {
              under the pane header, so they stay reachable while the orders list
              scrolls. Selects stack on a narrow pane and flow to columns when
              there's room (@container). -->
-        <CroutonSubBar sticky auto-hide flush :class="headerControlled ? '' : 'mt-2'">
+        <CroutonSubBar class="p-2 px-4" sticky auto-hide flush :class="headerControlled ? '' : 'mt-2'">
           <div class="w-full space-y-2">
             <div class="grid grid-cols-1 gap-2 @md:grid-cols-2 @2xl:grid-cols-4">
               <USelectMenu
@@ -480,135 +480,137 @@ function toggleExpand(id: string) {
     </UCollapsible>
     <!-- Loading state only before first data — the 5s poll flips `pending`
          on every refresh and would otherwise flicker the whole list. -->
-    <div v-if="ordersPending && orderRows.length === 0" class="p-6 text-center text-muted">
-      {{ t('sales.workspace.loadingOrders') }}
-    </div>
-    <ul
-      v-else-if="orderRows.length > 0"
-      role="list"
-      class="divide-y divide-default rounded-lg border border-default overflow-hidden"
-    >
-      <li
-        v-for="order in orderRows"
-        :key="order.id"
-        class="bg-default"
-        :class="order.isPersonnel ? 'border-s-2 border-s-warning' : ''"
+    <div class="px-4">
+      <div v-if="ordersPending && orderRows.length === 0" class="p-6 text-center text-muted">
+        {{ t('sales.workspace.loadingOrders') }}
+      </div>
+      <ul
+        v-else-if="orderRows.length > 0"
+        role="list"
+        class="divide-y divide-default rounded-lg border border-default overflow-hidden"
       >
-        <div
-          class="group relative overflow-hidden hover:bg-elevated/50 transition-colors cursor-pointer"
-          @click="toggleExpand(order.id)"
+        <li
+          v-for="order in orderRows"
+          :key="order.id"
+          class="bg-default"
+          :class="order.isPersonnel ? 'border-s-2 border-s-warning' : ''"
         >
-          <!-- Expand chevron slides in from the left edge (stays out while
-               the row is expanded), pushing the content inward — same
-               affordance pattern as the POS product cards. -->
           <div
-            class="absolute left-0 top-0 bottom-0 z-10 flex items-center ps-3
-                   transition-transform duration-200 ease-out"
-            :class="expandedIds.has(order.id) ? 'translate-x-0' : '-translate-x-full group-hover:translate-x-0 pointer-coarse:translate-x-0'"
+            class="group relative overflow-hidden hover:bg-elevated/50 transition-colors cursor-pointer"
+            @click="toggleExpand(order.id)"
           >
-            <UIcon
-              name="i-lucide-chevron-right"
-              class="shrink-0 text-dimmed transition-transform"
-              :class="expandedIds.has(order.id) ? 'rotate-90' : ''"
-            />
-          </div>
-
-          <div
-            class="flex items-center gap-3 px-3 py-2.5"
-            :class="expandedIds.has(order.id) ? 'ps-9' : 'group-hover:ps-9 pointer-coarse:ps-9'"
-          >
-          <!-- Staff orders: warning edge bar on the row (li), no badge -->
-          <span class="shrink-0 font-mono font-semibold tabular-nums text-muted">
-            #{{ order.eventOrderNumber ?? '—' }}
-          </span>
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-2">
-              <span class="font-medium truncate">{{ order.clientName || t('sales.orders.client') }}</span>
-            </div>
-            <p v-if="order.owner" class="text-xs text-muted truncate flex items-center gap-1">
-              <UIcon name="i-lucide-user" class="shrink-0" />
-              {{ order.owner }}
-            </p>
-          </div>
-          <!-- One LED per order: the combined worst status across all printers
-               (red wins, then orange, then green; grey = no tickets at all).
-               Hover popover breaks it down per printer. -->
-          <div v-if="printerList.length" class="shrink-0 flex items-center" @click.stop>
-            <UPopover mode="hover" :open-delay="150">
-              <span
-                class="block size-2.5 rounded-full transition-colors"
-                :class="orderLed(order.id).class"
+            <!-- Expand chevron slides in from the left edge (stays out while
+                 the row is expanded), pushing the content inward — same
+                 affordance pattern as the POS product cards. -->
+            <div
+              class="absolute left-0 top-0 bottom-0 z-10 flex items-center ps-3
+                     transition-transform duration-200 ease-out"
+              :class="expandedIds.has(order.id) ? 'translate-x-0' : '-translate-x-full group-hover:translate-x-0 pointer-coarse:translate-x-0'"
+            >
+              <UIcon
+                name="i-lucide-chevron-right"
+                class="shrink-0 text-dimmed transition-transform"
+                :class="expandedIds.has(order.id) ? 'rotate-90' : ''"
               />
-              <template #content>
-                <div class="p-3 space-y-3 min-w-52 max-w-72">
-                  <div v-for="printer in popoverPrinters(order.id)" :key="printer.id" class="space-y-1">
-                    <div class="flex items-center justify-between gap-3">
-                      <p class="text-sm font-semibold flex items-center gap-1.5 min-w-0">
-                        <UTooltip :text="printerLed(order.id, printer.id).label">
-                          <span
-                            class="size-2 rounded-full shrink-0 transition-colors"
-                            :class="printerLed(order.id, printer.id).class"
-                          />
-                        </UTooltip>
-                        <UIcon name="i-lucide-printer" class="shrink-0 text-muted" />
-                        <span class="truncate">{{ printer.title }}</span>
-                      </p>
-                      <span v-if="printerTime(order.id, printer.id)" class="text-xs text-dimmed tabular-nums">
-                        {{ printerTime(order.id, printer.id) }}
-                      </span>
+            </div>
+
+            <div
+              class="flex items-center gap-3 px-3 py-2.5"
+              :class="expandedIds.has(order.id) ? 'ps-9' : 'group-hover:ps-9 pointer-coarse:ps-9'"
+            >
+            <!-- Staff orders: warning edge bar on the row (li), no badge -->
+            <span class="shrink-0 font-mono font-semibold tabular-nums text-muted">
+              #{{ order.eventOrderNumber ?? '—' }}
+            </span>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                <span class="font-medium truncate">{{ order.clientName || t('sales.orders.client') }}</span>
+              </div>
+              <p v-if="order.owner" class="text-xs text-muted truncate flex items-center gap-1">
+                <UIcon name="i-lucide-user" class="shrink-0" />
+                {{ order.owner }}
+              </p>
+            </div>
+            <!-- One LED per order: the combined worst status across all printers
+                 (red wins, then orange, then green; grey = no tickets at all).
+                 Hover popover breaks it down per printer. -->
+            <div v-if="printerList.length" class="shrink-0 flex items-center" @click.stop>
+              <UPopover mode="hover" :open-delay="150">
+                <span
+                  class="block size-2.5 rounded-full transition-colors"
+                  :class="orderLed(order.id).class"
+                />
+                <template #content>
+                  <div class="p-3 space-y-3 min-w-52 max-w-72">
+                    <div v-for="printer in popoverPrinters(order.id)" :key="printer.id" class="space-y-1">
+                      <div class="flex items-center justify-between gap-3">
+                        <p class="text-sm font-semibold flex items-center gap-1.5 min-w-0">
+                          <UTooltip :text="printerLed(order.id, printer.id).label">
+                            <span
+                              class="size-2 rounded-full shrink-0 transition-colors"
+                              :class="printerLed(order.id, printer.id).class"
+                            />
+                          </UTooltip>
+                          <UIcon name="i-lucide-printer" class="shrink-0 text-muted" />
+                          <span class="truncate">{{ printer.title }}</span>
+                        </p>
+                        <span v-if="printerTime(order.id, printer.id)" class="text-xs text-dimmed tabular-nums">
+                          {{ printerTime(order.id, printer.id) }}
+                        </span>
+                      </div>
+                      <template v-for="job in printerJobs(order.id, printer.id)" :key="job.id">
+                        <p v-if="String(job.status ?? '') === '9' && job.errorMessage" class="text-xs text-error">
+                          {{ jobError(job) }}
+                        </p>
+                      </template>
                     </div>
-                    <template v-for="job in printerJobs(order.id, printer.id)" :key="job.id">
-                      <p v-if="String(job.status ?? '') === '9' && job.errorMessage" class="text-xs text-error">
-                        {{ jobError(job) }}
-                      </p>
-                    </template>
+                    <!-- Order generated no tickets at all (grey LED): explain once -->
+                    <p v-if="!popoverPrinters(order.id).length" class="text-xs text-muted">
+                      {{ t('sales.printQueue.noTicketForPrinter') }}
+                    </p>
                   </div>
-                  <!-- Order generated no tickets at all (grey LED): explain once -->
-                  <p v-if="!popoverPrinters(order.id).length" class="text-xs text-muted">
-                    {{ t('sales.printQueue.noTicketForPrinter') }}
-                  </p>
-                </div>
-              </template>
-            </UPopover>
+                </template>
+              </UPopover>
+            </div>
+            </div>
           </div>
-          </div>
-        </div>
-        <SalesEventWorkspaceOrderItems
-          v-if="expandedIds.has(order.id)"
-          :order-id="order.id"
-          :remarks="order.overallRemarks"
-          :location-remarks="order.locationRemarks"
-          :locations="locations || []"
-          :print-jobs="jobsByOrder.get(order.id) || []"
-          :has-printers="printerList.length > 0"
-          @retry-job="retryPrintJob"
-          @reprint-order="reprintOrder"
-          @delete-order="deleteOrder"
+          <SalesEventWorkspaceOrderItems
+            v-if="expandedIds.has(order.id)"
+            :order-id="order.id"
+            :remarks="order.overallRemarks"
+            :location-remarks="order.locationRemarks"
+            :locations="locations || []"
+            :print-jobs="jobsByOrder.get(order.id) || []"
+            :has-printers="printerList.length > 0"
+            @retry-job="retryPrintJob"
+            @reprint-order="reprintOrder"
+            @delete-order="deleteOrder"
+          />
+        </li>
+      </ul>
+      <!-- Same empty-state styling as the cart's "empty" block (Client/Cart.vue) -->
+      <div v-else class="p-12 flex flex-col items-center justify-center gap-3 text-muted">
+        <UIcon name="i-lucide-receipt" class="size-10 opacity-40" />
+        <p class="text-sm">{{ hasActiveFilters ? t('sales.workspace.noOrdersFiltered') : t('sales.workspace.noOrders') }}</p>
+      </div>
+      <!-- Older orders: newest page is the register's working set; history on demand -->
+      <div v-if="ordersPageCount > 1" class="flex items-center justify-center gap-3 pt-1">
+        <UButton
+          variant="ghost"
+          size="xs"
+          icon="i-lucide-chevron-left"
+          :disabled="ordersPage <= 1"
+          @click="ordersPage--"
         />
-      </li>
-    </ul>
-    <!-- Same empty-state styling as the cart's "empty" block (Client/Cart.vue) -->
-    <div v-else class="p-12 flex flex-col items-center justify-center gap-3 text-muted">
-      <UIcon name="i-lucide-receipt" class="size-10 opacity-40" />
-      <p class="text-sm">{{ hasActiveFilters ? t('sales.workspace.noOrdersFiltered') : t('sales.workspace.noOrders') }}</p>
-    </div>
-    <!-- Older orders: newest page is the register's working set; history on demand -->
-    <div v-if="ordersPageCount > 1" class="flex items-center justify-center gap-3 pt-1">
-      <UButton
-        variant="ghost"
-        size="xs"
-        icon="i-lucide-chevron-left"
-        :disabled="ordersPage <= 1"
-        @click="ordersPage--"
-      />
-      <span class="text-xs text-muted tabular-nums">{{ ordersPage }} / {{ ordersPageCount }}</span>
-      <UButton
-        variant="ghost"
-        size="xs"
-        icon="i-lucide-chevron-right"
-        :disabled="ordersPage >= ordersPageCount"
-        @click="ordersPage++"
-      />
+        <span class="text-xs text-muted tabular-nums">{{ ordersPage }} / {{ ordersPageCount }}</span>
+        <UButton
+          variant="ghost"
+          size="xs"
+          icon="i-lucide-chevron-right"
+          :disabled="ordersPage >= ordersPageCount"
+          @click="ordersPage++"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/packages/crouton-sales/app/components/EventWorkspace/PaneHost.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/PaneHost.vue
@@ -80,16 +80,12 @@ const settingsSaving = computed(() => settingsTab.value?.saving.value ?? false)
       </SalesEventWorkspacePaneHeader>
 
       <div class="flex-1 overflow-y-auto p-4 pt-2">
-        <Suspense v-if="pane === 'orders'">
-          <SalesEventWorkspaceOrdersTab
-            v-model:filters-open="ordersFiltersOpen"
-            :event="event"
-            @update:active-filter-count="ordersFilterCount = $event"
-          />
-          <template #fallback>
-            <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
-          </template>
-        </Suspense>
+        <SalesEventWorkspaceOrdersPaneBody
+          v-if="pane === 'orders'"
+          v-model:filters-open="ordersFiltersOpen"
+          :event="event"
+          @update:active-filter-count="ordersFilterCount = $event"
+        />
 
         <SalesEventWorkspaceClientsPanel v-else-if="pane === 'clients'" :event="event" />
 
@@ -105,15 +101,13 @@ const settingsSaving = computed(() => settingsTab.value?.saving.value ?? false)
 
       <!-- Settings Save: a fixed footer outside the scroll area (content
            scrolls above it, never behind). -->
-      <div
+      <SalesEventWorkspaceSettingsSaveBar
+          class="px-4"
         v-if="pane === 'settings'"
-        class="flex-none flex items-center justify-end gap-3 border-t border-default bg-default px-4 py-3"
-      >
-        <span v-if="settingsDirty" class="text-sm text-muted">{{ t('sales.workspace.unsavedChanges') }}</span>
-        <UButton :loading="settingsSaving" :disabled="!settingsDirty" :color="settingsDirty ? 'primary' : 'neutral'" :variant="settingsDirty ? 'solid' : 'soft'" @click="settingsTab?.save()">
-          {{ t('sales.common.save') }}
-        </UButton>
-      </div>
+        :dirty="settingsDirty"
+        :saving="settingsSaving"
+        @save="settingsTab?.save()"
+      />
     </template>
   </div>
 </template>

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsSaveBar.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsSaveBar.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+/**
+ * The settings pane's fixed save footer (#1846).
+ *
+ * SettingsTab hands its `{ save, dirty, saving }` API up to whichever host
+ * mounts it, and all three hosts (desktop pane, narrow slideover, PaneHost
+ * modal) render this identical bar below the scroll area. Extracted so the
+ * disabled/dirty styling can't drift between them. Horizontal padding stays
+ * with the host (Shell uses px-3, PaneHost px-4) via class passthrough.
+ */
+defineProps<{ dirty: boolean, saving: boolean }>()
+const emit = defineEmits<{ save: [] }>()
+
+const { t } = useT()
+</script>
+
+<template>
+  <div class="flex-none flex items-center justify-end gap-3 border-t border-default bg-default py-3">
+    <span v-if="dirty" class="text-sm text-muted">{{ t('sales.workspace.unsavedChanges') }}</span>
+    <UButton
+      :loading="saving"
+      :disabled="!dirty"
+      :color="dirty ? 'primary' : 'neutral'"
+      :variant="dirty ? 'solid' : 'soft'"
+      @click="emit('save')"
+    >
+      {{ t('sales.common.save') }}
+    </UButton>
+  </div>
+</template>

--- a/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/SettingsTab.vue
@@ -536,13 +536,13 @@ function helperExpiry(value: string): string {
     <!-- Scroll container (tabbed): hosts BOTH the sticky, auto-hiding section
          strip and the cards, so the strip hides on scroll-down and reveals on
          scroll-up. Standalone (non-tabbed) is a plain pass-through wrapper. -->
-    <div :class="tabbed ? 'flex-1 overflow-y-auto min-h-0 px-4' : ''">
+    <div :class="tabbed ? 'flex-1 overflow-y-auto min-h-0' : ''">
       <!-- Section picker on a shared CroutonSubBar (#307), styled like the
            pages editor's tabs — underline active, sticky + auto-hide. `flush`
            bleeds it out of the container's px-4 so the strip spans full width
            while the tabs line up with the padded cards below. -->
       <CroutonSubBar v-if="tabbed" sticky auto-hide flush>
-      <nav class="flex w-full items-center gap-0.5">
+      <nav class="flex w-full items-center">
         <UButton
           v-for="s in sections"
           :key="s.key"
@@ -563,7 +563,7 @@ function helperExpiry(value: string): string {
          printers (incl. receipt text), helpers (incl. PIN). Tabbed mode shows
          one at a time but keeps all mounted (v-show) so dirty state and the
          panel-wide save cover every tab. -->
-    <div class="grid grid-cols-1 gap-4 items-start" :class="tabbed ? 'pb-3 pt-3' : 'lg:grid-cols-3'">
+    <div class="grid grid-cols-1 gap-4 items-start" :class="tabbed ? '' : 'lg:grid-cols-3'">
       <!-- Event details (inline editable) -->
       <UCard v-show="!tabbed || activeSection === 'event'" :ui="eventCardUi">
         <template #header>

--- a/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
@@ -404,7 +404,7 @@ const kassaHeightStyle = computed(() =>
                 />
               </UChip>
             </SalesEventWorkspacePaneHeader>
-            <div class="flex-1 overflow-y-auto p-4 pt-2">
+            <div class="flex-1 overflow-y-auto">
               <Suspense>
                 <SalesEventWorkspaceOrdersTab
                   v-model:filters-open="ordersFiltersOpen"
@@ -443,7 +443,7 @@ const kassaHeightStyle = computed(() =>
               :title="t('sales.workspace.dataPanel.title')"
               @close="dataOpen = false"
             />
-            <div class="flex-1 overflow-y-auto p-4 pt-2">
+            <div class="flex-1 overflow-y-auto min-w-0 flex flex-col">
               <SalesEventWorkspaceDataPanel :event="event" :team-param="teamParam" />
             </div>
           </SplitterPanel>

--- a/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/Shell.vue
@@ -405,16 +405,11 @@ const kassaHeightStyle = computed(() =>
               </UChip>
             </SalesEventWorkspacePaneHeader>
             <div class="flex-1 overflow-y-auto">
-              <Suspense>
-                <SalesEventWorkspaceOrdersTab
-                  v-model:filters-open="ordersFiltersOpen"
-                  :event="event"
-                  @update:active-filter-count="ordersFilterCount = $event"
-                />
-                <template #fallback>
-                  <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
-                </template>
-              </Suspense>
+              <SalesEventWorkspaceOrdersPaneBody
+                v-model:filters-open="ordersFiltersOpen"
+                :event="event"
+                @update:active-filter-count="ordersFilterCount = $event"
+              />
             </div>
           </SplitterPanel>
         </template>
@@ -471,12 +466,12 @@ const kassaHeightStyle = computed(() =>
                 </template>
               </Suspense>
             </div>
-            <div class="flex-none flex items-center justify-end gap-3 border-t border-default bg-default px-3 py-3">
-              <span v-if="settingsDirty" class="text-sm text-muted">{{ t('sales.workspace.unsavedChanges') }}</span>
-              <UButton :loading="settingsSaving" :disabled="!settingsDirty" :color="settingsDirty ? 'primary' : 'neutral'" :variant="settingsDirty ? 'solid' : 'soft'" @click="settingsTab?.save()">
-                {{ t('sales.common.save') }}
-              </UButton>
-            </div>
+            <SalesEventWorkspaceSettingsSaveBar
+              class="px-3"
+              :dirty="settingsDirty"
+              :saving="settingsSaving"
+              @save="settingsTab?.save()"
+            />
           </SplitterPanel>
         </template>
       </SplitterGroup>
@@ -616,16 +611,11 @@ const kassaHeightStyle = computed(() =>
             </UChip>
           </SalesEventWorkspacePaneHeader>
           <div class="flex-1 overflow-y-auto p-4 pt-2">
-            <Suspense>
-              <SalesEventWorkspaceOrdersTab
-                v-model:filters-open="ordersFiltersOpen"
-                :event="event"
-                @update:active-filter-count="ordersFilterCount = $event"
-              />
-              <template #fallback>
-                <div class="p-6 text-center text-muted">{{ t('sales.common.loading') }}</div>
-              </template>
-            </Suspense>
+            <SalesEventWorkspaceOrdersPaneBody
+              v-model:filters-open="ordersFiltersOpen"
+              :event="event"
+              @update:active-filter-count="ordersFilterCount = $event"
+            />
           </div>
         </div>
       </template>
@@ -692,12 +682,12 @@ const kassaHeightStyle = computed(() =>
               </template>
             </Suspense>
           </div>
-          <div class="flex-none flex items-center justify-end gap-3 border-t border-default bg-default px-3 py-3">
-            <span v-if="settingsDirty" class="text-sm text-muted">{{ t('sales.workspace.unsavedChanges') }}</span>
-            <UButton :loading="settingsSaving" :disabled="!settingsDirty" :color="settingsDirty ? 'primary' : 'neutral'" :variant="settingsDirty ? 'solid' : 'soft'" @click="settingsTab?.save()">
-              {{ t('sales.common.save') }}
-            </UButton>
-          </div>
+          <SalesEventWorkspaceSettingsSaveBar
+            class="px-3"
+            :dirty="settingsDirty"
+            :saving="settingsSaving"
+            @save="settingsTab?.save()"
+          />
         </div>
       </template>
     </USlideover>

--- a/packages/crouton-sales/i18n/locales/en.json
+++ b/packages/crouton-sales/i18n/locales/en.json
@@ -619,8 +619,10 @@
         "settingsDesc": "Event details, printers, receipt text and helpers",
         "settingsStat": "printers"
       },
-      "outstanding": "{count} still waiting",
-      "outstandingNone": "Nothing waiting"
+      "outstanding": "{count} in progress",
+      "outstandingNone": "Nothing in progress",
+      "outstandingFilter": "Show only these",
+      "outstandingFilterClear": "Show all orders"
     },
     "helpers": {
       "title": "Active Helpers",

--- a/packages/crouton-sales/i18n/locales/fr.json
+++ b/packages/crouton-sales/i18n/locales/fr.json
@@ -618,8 +618,10 @@
         "settingsDesc": "Détails de l'événement, imprimantes, texte des tickets et aides",
         "settingsStat": "imprimantes"
       },
-      "outstanding": "{count} en attente",
-      "outstandingNone": "Rien en attente"
+      "outstanding": "{count} en préparation",
+      "outstandingNone": "Rien en préparation",
+      "outstandingFilter": "Afficher seulement celles-ci",
+      "outstandingFilterClear": "Afficher toutes les commandes"
     },
     "helpers": {
       "title": "Bénévoles actifs",

--- a/packages/crouton-sales/i18n/locales/nl.json
+++ b/packages/crouton-sales/i18n/locales/nl.json
@@ -619,8 +619,10 @@
         "settingsDesc": "Eventgegevens, printers, bontekst en helpers",
         "settingsStat": "printers"
       },
-      "outstanding": "{count} wachten nog",
-      "outstandingNone": "Niets in wachtrij"
+      "outstanding": "{count} in bereiding",
+      "outstandingNone": "Niets in bereiding",
+      "outstandingFilter": "Toon alleen deze",
+      "outstandingFilterClear": "Toon alle bestellingen"
     },
     "helpers": {
       "title": "Actieve helpers",

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/orders.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/orders.get.ts
@@ -54,10 +54,19 @@ function jobFilterConditions(db: any, salesOrders: any, f: OrderFilters) {
 // stay in sync. Column-equality filters here; print-job EXISTS filters above.
 // owner stores the helper displayName (stable across logins) — what the
 // OrdersTab helper filter sends. Undefined filters drop out via .filter().
-function buildWhere(db: any, salesOrders: any, teamId: string, eventId: string, f: OrderFilters) {
+function buildWhere(db: any, salesOrders: any, teamId: string, eventId: string, f: OrderFilters, salesHandovers?: any) {
   return and(
     eq(salesOrders.teamId, teamId),
     eq(salesOrders.eventId, eventId),
+    // Backlog-only (#1846): the same rule the count uses, applied to the LIST.
+    // A correlated NOT EXISTS rather than a join, so it composes with the other
+    // filters without changing the row shape or duplicating rows.
+    ...(f.outstanding && salesHandovers
+      ? [
+          ne(salesOrders.status, 'cancelled'),
+          sql`not exists (select 1 from ${salesHandovers} where ${salesHandovers.orderId} = ${salesOrders.id})`
+        ]
+      : []),
     ...[
       f.owner ? eq(salesOrders.owner, f.owner) : undefined,
       f.clientId ? eq(salesOrders.clientId, f.clientId) : undefined
@@ -100,7 +109,9 @@ export default defineEventHandler(async (event) => {
   const query = getQuery(event)
   const filters = parseOrderFilters(query)
   const { page, pageSize, offset } = parsePageParams(query)
-  const whereExpr = buildWhere(db, salesOrders, team.id, eventId, filters)
+  // Loaded up-front because the backlog-only filter needs it in the WHERE.
+  const { salesHandovers } = await import('~~/layers/sales/collections/handovers/server/database/schema')
+  const whereExpr = buildWhere(db, salesOrders, team.id, eventId, filters, salesHandovers)
 
   const rows = await (db as any)
     .select({

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/orders.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/events/[eventId]/orders.get.ts
@@ -50,6 +50,17 @@ function jobFilterConditions(db: any, salesOrders: any, f: OrderFilters) {
   ].filter(Boolean)
 }
 
+// Backlog-only (#1846): the same rule the count uses, applied to the LIST.
+// A correlated NOT EXISTS rather than a join, so it composes with the other
+// filters without changing the row shape or duplicating rows.
+function outstandingConditions(salesOrders: any, f: OrderFilters, salesHandovers?: any) {
+  if (!f.outstanding || !salesHandovers) return []
+  return [
+    ne(salesOrders.status, 'cancelled'),
+    sql`not exists (select 1 from ${salesHandovers} where ${salesHandovers.orderId} = ${salesOrders.id})`
+  ]
+}
+
 // Shared WHERE for both the list and the count so a filtered page and its total
 // stay in sync. Column-equality filters here; print-job EXISTS filters above.
 // owner stores the helper displayName (stable across logins) — what the
@@ -58,15 +69,7 @@ function buildWhere(db: any, salesOrders: any, teamId: string, eventId: string, 
   return and(
     eq(salesOrders.teamId, teamId),
     eq(salesOrders.eventId, eventId),
-    // Backlog-only (#1846): the same rule the count uses, applied to the LIST.
-    // A correlated NOT EXISTS rather than a join, so it composes with the other
-    // filters without changing the row shape or duplicating rows.
-    ...(f.outstanding && salesHandovers
-      ? [
-          ne(salesOrders.status, 'cancelled'),
-          sql`not exists (select 1 from ${salesHandovers} where ${salesHandovers.orderId} = ${salesOrders.id})`
-        ]
-      : []),
+    ...outstandingConditions(salesOrders, f, salesHandovers),
     ...[
       f.owner ? eq(salesOrders.owner, f.owner) : undefined,
       f.clientId ? eq(salesOrders.clientId, f.clientId) : undefined

--- a/packages/crouton-sales/server/utils/order-filters.ts
+++ b/packages/crouton-sales/server/utils/order-filters.ts
@@ -11,6 +11,16 @@ export interface OrderFilters {
   clientId?: string
   printerId?: string
   printStatus?: string
+  /**
+   * Narrow the LIST to the backlog (not cancelled, not handed over) — the
+   * click-through on the outstanding counter (#1846). Deliberately absent
+   * rather than `false` when off, so it drops out of the WHERE like the others.
+   *
+   * NB this filters the list only. The outstanding NUMBER is computed outside
+   * every filter (`planOutstandingCount`), so clicking it never makes it appear
+   * to shrink itself.
+   */
+  outstanding?: true
 }
 
 // Print-status buckets (crouton-printing job status is TEXT '0'|'1'|'2'|'9'):
@@ -38,7 +48,10 @@ export function parseOrderFilters(query: Record<string, unknown>): OrderFilters 
     owner: trimmed(query.owner),
     clientId: trimmed(query.clientId),
     printerId: trimmed(query.printerId),
-    printStatus: trimmed(query.printStatus)
+    printStatus: trimmed(query.printStatus),
+    // Only the literal '1' turns it on — a stray ?outstanding=0 or =false must
+    // not read as truthy, which a plain presence check would do.
+    outstanding: trimmed(query.outstanding) === '1' ? true : undefined
   }
 }
 

--- a/packages/crouton-sales/test/outstanding-count.test.ts
+++ b/packages/crouton-sales/test/outstanding-count.test.ts
@@ -78,3 +78,29 @@ describe('planOutstandingCount — matches the epic definition', () => {
     }).toEqual(OUTSTANDING_DEFINITION)
   })
 })
+
+describe('parseOrderFilters — the outstanding-only list filter (#1846)', () => {
+  it('reads ?outstanding=1 as a filter', async () => {
+    const { parseOrderFilters } = await import('../server/utils/order-filters')
+    expect(parseOrderFilters({ outstanding: '1' }).outstanding).toBe(true)
+  })
+
+  it('treats an absent flag as "show everything"', async () => {
+    const { parseOrderFilters } = await import('../server/utils/order-filters')
+    expect(parseOrderFilters({}).outstanding).toBeUndefined()
+  })
+
+  it('ignores any value other than 1, rather than guessing', async () => {
+    // A stray ?outstanding=0 or ?outstanding=false must not silently mean "on".
+    const { parseOrderFilters } = await import('../server/utils/order-filters')
+    expect(parseOrderFilters({ outstanding: '0' }).outstanding).toBeUndefined()
+    expect(parseOrderFilters({ outstanding: 'false' }).outstanding).toBeUndefined()
+  })
+
+  it('does NOT affect the count plan, which stays filter-blind', async () => {
+    // The list can be narrowed to the backlog; the NUMBER must still be the
+    // whole backlog, or clicking it would make it appear to shrink itself.
+    const before = planOutstandingCount({ teamId: 't', eventId: 'e' })
+    expect(before.params).toEqual(['t', 'e'])
+  })
+})


### PR DESCRIPTION
Packages-approved: owner authored the design commit and requested the counter changes in-session.

## 👤 For humans

Your design tweaks, rebased onto `main` so they actually land — plus the two counter changes you asked for.

**Why this PR exists at all:** the commit was made on `1762-pass-screen-block`, which had *already merged* via #1794. A commit on top of a merged branch isn't on `main` and never reaches anywhere. Worse, that branch predates WS4, so its `OrdersTab.vue` had no outstanding counter — applying those 242 changed lines to `main` as-is would most likely have **deleted the counter**, silently, looking like an ordinary design commit.

Cherry-picked onto `main` instead: git auto-merged cleanly, and the counter survived intact (verified — all 7 references present).

## 🤖 For agents

### 1. `some design tweaks` (unchanged, authored by the owner)

`SubBar.vue`, `DataPanel.vue`, `OrdersTab.vue`, `SettingsTab.vue`, `Shell.vue`. Cherry-picked verbatim; no edits.

### 2. Counter wording → "in bereiding"

Owner's phrasing, replacing my noun-less "17 wachten nog". `en`/`fr` follow the sense rather than translating the Dutch literally.

| | |
|---|---|
| nl | `{count} in bereiding` · `Niets in bereiding` |
| en | `{count} in progress` · `Nothing in progress` |
| fr | `{count} en préparation` · `Rien en préparation` |

### 3. Click the counter to filter the list

- Becomes a real `UButton` with `aria-pressed`, so a screen reader hears a toggle rather than decorative text
- **At zero it stays a plain statement** — there's no slice to filter to, so a button would be a dead end
- Rides the **existing** filter path (`?outstanding=1`, server-side, resets to page 1), so it composes with helper/client/printer rather than competing
- List filter is a correlated `NOT EXISTS`, not a join — composes with the other WHERE clauses without duplicating rows

**The number does not change when the filter is on.** It's computed outside every filter (`planOutstandingCount`, #1763); if clicking it made it shrink, the backlog would appear to drop. There's a test pinning that.

`?outstanding` only counts when literally `'1'` — a plain presence check would read `=0` and `=false` as ON. Both asserted off.

### Tests

4 cases added (11 in that file, **241** in the suite). Typecheck clean — run against a real `kassa` typecheck, not inferred.

## 🧪 How to test

1. Workspace → **Bestellingen** → the row reads **"17 in bereiding"**
2. Click it → list narrows to those orders; button goes amber with an ✕; **the number stays 17**
3. Click again → full list returns
4. Combine with a helper filter → both apply; the number still reads the whole backlog
5. Hand every order over → the row becomes plain text **"Niets in bereiding"**, not a button
