### PR TITLE
Worker commits generator output (two commits: inputs + generated), no longer drops it (#1849)

### DIFF
--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -198,6 +198,8 @@ jobs:
           git status --porcelain 2>/dev/null | grep -vE "$SCRATCH" | cut -c4- > "$RUNNER_TEMP/pre-pi-dirty.txt" || true
           echo "pre-pi non-scratch dirty paths: $(wc -l < "$RUNNER_TEMP/pre-pi-dirty.txt" | tr -d ' ')"
           cp scripts/pi-edited-files.mjs "$RUNNER_TEMP/pi-edited-files.mjs"
+          # pi-commit-plan.mjs imports ./pi-edited-files.mjs relatively, so stash it alongside (#1849).
+          cp scripts/pi-commit-plan.mjs "$RUNNER_TEMP/pi-commit-plan.mjs"
 
       # ── The agent: pi.dev (replaces claude-code-action) ──────────────────────────
       # GH_TOKEN = the App token → pi's `gh`/git operations (sub-issues, epic branch,
@@ -298,60 +300,59 @@ jobs:
           git config user.email "nuxt-harness[bot]@users.noreply.github.com"
           ROOT="$(git rev-parse --show-toplevel)"
 
-          # 1) Read THIS run's pi session — written to a PER-RUN dir by `--session-dir` on the pi
-          #    step. Deterministic: no scanning the shared ~/.pi/agent/sessions (contaminated by
-          #    other runners), no -newermt/$HOME fragility. Just the one .jsonl pi wrote here.
+          # 1) Read THIS run's pi session (per-run --session-dir). The ledger = files pi HAND-EDITED
+          #    (edit/write tools). Generator output (crouton config/generate_collection, produced via
+          #    a bash/MCP tool) is NOT a write-tool path, so it never appears in the ledger — which is
+          #    exactly why the old "commit only the ledger" DROPPED the generated collection (#1830).
           SESSION="$(ls -t "$RUNNER_TEMP/pi-session"/*.jsonl 2>/dev/null | head -1)"
-          LEDGER="$RUNNER_TEMP/pi-edited.txt"; : > "$LEDGER"
-          if [ -n "$SESSION" ] && [ -f "$SESSION" ]; then
-            echo "pi session: $SESSION"
-            node "$RUNNER_TEMP/pi-edited-files.mjs" "$SESSION" "$ROOT" > "$LEDGER" 2>/dev/null || true
-          else
-            echo "::warning::no pi session in $RUNNER_TEMP/pi-session — cannot build the edit ledger (#1764)"
-          fi
-          N="$(grep -c . "$LEDGER" 2>/dev/null || echo 0)"
-          echo "Pattern B — pi wrote $N file(s):"; sed 's/^/  + /' "$LEDGER" 2>/dev/null || true
+          if [ -n "$SESSION" ] && [ -f "$SESSION" ]; then echo "pi session: $SESSION"
+          else echo "::warning::no pi session in $RUNNER_TEMP/pi-session (#1764)"; fi
 
-          # 2) No silent gaps: report changed files NOT in the ledger (generator output via bash,
-          #    or artifacts). These are NOT committed by this step.
-          git status --porcelain 2>/dev/null | sed 's/^...//' | sort -u > "$RUNNER_TEMP/changed.txt" || true
-          NOTLEDGER="$(comm -23 "$RUNNER_TEMP/changed.txt" <(sort -u "$LEDGER") 2>/dev/null || true)"
-          if [ -n "$NOTLEDGER" ]; then
-            echo "::notice::changed but NOT in pi's edit ledger (not committed — generator output or artifacts):"
-            echo "$NOTLEDGER" | sed 's/^/  ? /'
-          fi
+          # 2) CLASSIFY the working tree into two buckets (#1849): inputs = the ledger (schema/config
+          #    pi authored), generated = every OTHER real change (the collection the CLI produced),
+          #    MINUS the shared junk denylist. Both are committed — as two commits, so history stays
+          #    granular (blame→schema, bisect→generator). `-uall` expands untracked DIRECTORIES to
+          #    files, or the generated collection would be an invisible collapsed `dir/` entry.
+          git status --porcelain -uall 2>/dev/null | sed 's/^...//; s/^.* -> //' | sort -u > "$RUNNER_TEMP/changed.txt" || true
+          PLAN="$(node "$RUNNER_TEMP/pi-commit-plan.mjs" "${SESSION:-/nonexistent}" "$ROOT" "$RUNNER_TEMP/changed.txt" 2>/dev/null || echo '{"inputs":[],"generated":[]}')"
+          printf '%s' "$PLAN" | node -e 'const p=JSON.parse(require("fs").readFileSync(0,"utf8"));const t=process.env.RUNNER_TEMP;require("fs").writeFileSync(t+"/inputs.txt",(p.inputs||[]).join("\n"));require("fs").writeFileSync(t+"/generated.txt",(p.generated||[]).join("\n"))'
+          NIN="$(grep -c . "$RUNNER_TEMP/inputs.txt" 2>/dev/null || echo 0)"
+          NGEN="$(grep -c . "$RUNNER_TEMP/generated.txt" 2>/dev/null || echo 0)"
+          echo "commit plan (#1849) — inputs=$NIN generated=$NGEN"
+          [ "$NIN"  -gt 0 ] && grep . "$RUNNER_TEMP/inputs.txt"    | sed 's/^/  input:     /'
+          [ "$NGEN" -gt 0 ] && grep . "$RUNNER_TEMP/generated.txt" | sed 's/^/  generated: /'
 
-          # 3) Persist pi's edits DETERMINISTICALLY onto the CORRECT base. Capture the ledger
-          #    files' content, then recreate work-<issue> off origin/$BASE (the epic branch) and
-          #    restore ONLY those files onto it. This never depends on which branch pi left the tree
-          #    on — pi's own checkout of the epic branch is unreliable (#1741 committed against main
-          #    → the PR leaked 56 of main's commits vs the stale epic branch; #1733 happened to be
-          #    on the epic branch → clean). Re-basing here makes the PR diff EXACTLY pi's files
-          #    against the epic branch, every time.
-          CONTENT="$RUNNER_TEMP/ledger-content"; rm -rf "$CONTENT"; mkdir -p "$CONTENT"
-          while IFS= read -r p; do
+          # 3) Capture BOTH buckets' content before the re-base checkout (which discards the working
+          #    tree), then recreate work-<issue> off origin/$BASE — never depends on which branch pi
+          #    left the tree on (#1741).
+          CONTENT="$RUNNER_TEMP/commit-content"; rm -rf "$CONTENT"; mkdir -p "$CONTENT"
+          cat "$RUNNER_TEMP/inputs.txt" "$RUNNER_TEMP/generated.txt" 2>/dev/null | while IFS= read -r p; do
             [ -z "$p" ] && continue
             [ -f "$p" ] && { mkdir -p "$CONTENT/$(dirname "$p")"; cp "$p" "$CONTENT/$p"; }
-          done < "$LEDGER"
+          done
 
           git fetch origin "$BASE" --quiet 2>/dev/null || true
           git checkout -f -B "work-${ISSUE}" "origin/${BASE}" 2>&1 | tail -1
           BR="work-${ISSUE}"
+          TITLE="$(gh issue view "$ISSUE" --json title -q .title 2>/dev/null)"; [ -z "$TITLE" ] && TITLE="chore: implement #${ISSUE}"
 
-          while IFS= read -r p; do
-            [ -z "$p" ] && continue
-            [ -f "$CONTENT/$p" ] && { mkdir -p "$(dirname "$p")"; cp "$CONTENT/$p" "$p"; git add -- "$p"; }
-          done < "$LEDGER"
+          stage_bucket() { while IFS= read -r p; do [ -z "$p" ] && continue; [ -f "$CONTENT/$p" ] && { mkdir -p "$(dirname "$p")"; cp "$CONTENT/$p" "$p"; git add -- "$p"; }; done < "$1"; }
 
-          # 4) Commit only what the ledger changed vs the base.
-          if [ "$N" -gt 0 ] && ! git diff --cached --quiet; then
-            TITLE="$(gh issue view "$ISSUE" --json title -q .title 2>/dev/null)"
-            [ -z "$TITLE" ] && TITLE="chore: implement #${ISSUE}"
-            git commit -q -m "$TITLE" -m "🤖 Committed by the pi worker from pi's edited-file ledger (Pattern B, #1764/#1782). Refs #${ISSUE}"
-            echo "committed $N file(s) onto ${BR} (based on ${BASE}): $TITLE"
-          else
-            echo "nothing to commit (ledger empty, or no change vs ${BASE})"
+          # 4a) Commit 1 — the inputs pi authored (the "why": schema/config). Blame-able, small.
+          stage_bucket "$RUNNER_TEMP/inputs.txt"
+          if [ "$NIN" -gt 0 ] && ! git diff --cached --quiet; then
+            git commit -q -m "$TITLE" -m "🤖 pi worker — hand-authored inputs (schema/config). Refs #${ISSUE} (#1764/#1849)"
+            echo "commit 1: $NIN input file(s) — $TITLE"
           fi
+          # 4b) Commit 2 — the generated/derived output (the "what the machine produced"). Separate
+          #     commit so a generator regression bisects cleanly and doesn't drown the decision.
+          stage_bucket "$RUNNER_TEMP/generated.txt"
+          if [ "$NGEN" -gt 0 ] && ! git diff --cached --quiet; then
+            git commit -q -m "generate: derived output for #${ISSUE}" -m "🤖 pi worker — generator/CLI output (e.g. crouton generate), committed separately from the inputs (#1849). Refs #${ISSUE}"
+            echo "commit 2: $NGEN generated file(s)"
+          fi
+          N=$((NIN + NGEN))
+          [ "$N" -eq 0 ] && echo "nothing to commit (no real changes vs ${BASE})"
 
           # 5) Push + open the PR (base = the epic branch, head = work-<issue>). Force-push so a
           #    re-dispatch idempotently re-bases the branch instead of failing non-fast-forward.
@@ -369,7 +370,32 @@ jobs:
             echo "no commits ahead of ${BASE} — no PR to open"
           fi
 
-          # 6) Verdict for the artifact-gate: pi wrote files but nothing landed on the branch = fail.
+          # 6) RUN RECORD (#1849) — a FACTUAL note on the PR: what landed, split by bucket, and what
+          #    changed but was excluded (junk). Derived from the commit plan + git, NOT pi's
+          #    narration — so it can't claim work it didn't do. This is the signal that would have
+          #    made #1830 (config committed, collection silently dropped) obvious at a glance.
+          PRNUM="$(gh pr list --head "$BR" --base "$BASE" --json number -q '.[0].number' 2>/dev/null || true)"
+          if [ -n "$PRNUM" ]; then
+            cat "$RUNNER_TEMP/inputs.txt" "$RUNNER_TEMP/generated.txt" 2>/dev/null | sort -u | grep . > "$RUNNER_TEMP/committed.txt" || true
+            EXCL="$(comm -23 <(sort -u "$RUNNER_TEMP/changed.txt" | grep .) "$RUNNER_TEMP/committed.txt" 2>/dev/null | grep -c . || echo 0)"
+            REC="$RUNNER_TEMP/run-record.md"
+            {
+              echo "> 🤖 **pi worker — run record** · _facts from the commit + git, not pi's narration (#1849)_"
+              echo
+              echo "**Committed ${N} file(s)** onto \`${BR}\` → \`${BASE}\`:"
+              echo "- 📝 inputs (hand-authored — schema/config): **${NIN}**"
+              [ "$NIN" -gt 0 ] && grep . "$RUNNER_TEMP/inputs.txt" | head -20 | sed 's#^#  - `#; s#$#`#'
+              echo "- ⚙️ generated (CLI/MCP output — e.g. \`crouton generate\`): **${NGEN}**"
+              [ "$NGEN" -gt 0 ] && grep . "$RUNNER_TEMP/generated.txt" | head -20 | sed 's#^#  - `#; s#$#`#'
+              [ "$NGEN" -gt 20 ] && echo "  - …and $((NGEN-20)) more"
+              echo "- 🗑️ changed but excluded as junk (node_modules/.nuxt/.pi/…): **${EXCL}**"
+              echo
+              echo "<sub>Acceptance (typecheck/boot) is a separate gate — this record only states what landed.</sub>"
+            } > "$REC"
+            gh pr comment "$PRNUM" --body-file "$REC" 2>&1 | tail -1 || true
+          fi
+
+          # 7) Verdict for the artifact-gate: pi wrote files but nothing landed on the branch = fail.
           AHEAD="$(git rev-list --count "origin/${BASE}..HEAD" 2>/dev/null || echo 0)"
           if [ "$N" -gt 0 ] && [ "$AHEAD" -eq 0 ]; then
             echo "::error::pi wrote $N file(s) but nothing landed on the branch (#1764)"

--- a/scripts/pi-commit-plan.mjs
+++ b/scripts/pi-commit-plan.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// pi-commit-plan.mjs — split a pi worker's changed files into TWO commits (#1849).
+//
+// WHY. The old Pattern B committed ONLY files pi hand-edited (the ledger) and dropped everything
+// else as "generator output". But a crouton scaffold/generate task's deliverable IS generator
+// output (`crouton config`/`generate_collection` write the collection via a CLI/MCP tool, not pi's
+// editor), so the collection never landed and the PR merged green missing its whole point (#1830).
+//
+// FIX: don't EXCLUDE by "who typed it" — CLASSIFY, and commit both, preserving granular history:
+//   • inputs    = the ledger (schema/config pi authored) → commit 1, the "why" (blame-able, small)
+//   • generated = everything else that changed, MINUS the junk denylist → commit 2, the "what the
+//                 machine produced" (labeled, derived)
+// Junk (pi scratch, node_modules, .nuxt/.output/dist, telemetry) is still excluded via the SAME
+// DENY regex the ledger uses — so we keep the anti-junk win and stop dropping real work.
+//
+// PURE given its inputs (session + the changed-file list); the workflow supplies the changed list
+// from `git status --porcelain -uall`. Unit-tested in pi-commit-plan.test.mjs.
+//
+// Usage: node scripts/pi-commit-plan.mjs <session.jsonl> <repoRoot> <changed-files.txt>
+//   changed-files.txt: one repo-relative path per line (untracked expanded to files, not dirs).
+//   → prints JSON: { "inputs": [...], "generated": [...] }
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DENY, ledgerFromSession } from './pi-edited-files.mjs';
+
+// Pure core: given the ledger set + the changed-file list, produce the two ordered buckets.
+export function planCommits({ ledger, changed }) {
+  const led = ledger instanceof Set ? ledger : new Set(ledger);
+  const seen = new Set();
+  const changedClean = [];
+  for (const raw of changed) {
+    const p = String(raw).trim();
+    if (!p || DENY.test(p) || seen.has(p)) continue;   // drop junk + dupes
+    seen.add(p);
+    changedClean.push(p);
+  }
+  // inputs = ledger files that actually changed (hand-authored, non-junk, existing).
+  const inputs = changedClean.filter(p => led.has(p)).sort();
+  // generated = everything else that changed and isn't junk (CLI/MCP output, new app dirs, etc.).
+  const generated = changedClean.filter(p => !led.has(p)).sort();
+  return { inputs, generated };
+}
+
+// I/O wrapper: read the ledger from the session and the changed list from a file.
+export function planFromFiles(sessionPath, repoRoot, changedPath) {
+  const ledger = fs.existsSync(sessionPath) ? ledgerFromSession(sessionPath, repoRoot) : new Set();
+  const changed = fs.existsSync(changedPath)
+    ? fs.readFileSync(changedPath, 'utf8').split('\n').map(s => s.trim()).filter(Boolean)
+    : [];
+  return planCommits({ ledger, changed });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [, , sessionPath, repoRoot, changedPath] = process.argv;
+  if (!sessionPath || !repoRoot || !changedPath) {
+    console.error('usage: pi-commit-plan.mjs <session.jsonl> <repoRoot> <changed-files.txt>');
+    process.exit(2);
+  }
+  process.stdout.write(JSON.stringify(planFromFiles(sessionPath, repoRoot, changedPath)) + '\n');
+}

--- a/scripts/pi-commit-plan.test.mjs
+++ b/scripts/pi-commit-plan.test.mjs
@@ -1,0 +1,69 @@
+// The commit-plan splitter (#1849) — the fix for #1830, where the generated collection was dropped.
+// Pins the classification: inputs = ledger (hand-authored), generated = the rest minus junk, both
+// committed. A false "generated" is at worst a noisy commit; DROPPING generated output is the bug
+// we're fixing, so these lock that it can't happen again.
+//   node --test scripts/pi-commit-plan.test.mjs
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { planCommits } from './pi-commit-plan.mjs'
+
+test('the #1830 case: generated collection lands in `generated`, config/schema in `inputs`', () => {
+  // pi hand-authored (ledger) the config + schema; `crouton config` GENERATED the collection.
+  const ledger = ['pocs/lend/crouton.config.js', 'pocs/lend/schemas/loans.json']
+  const changed = [
+    'pocs/lend/crouton.config.js',
+    'pocs/lend/schemas/loans.json',
+    // generated collection (NOT in the ledger — this is exactly what used to be dropped):
+    'pocs/lend/layers/main/collections/loans/app/components/List.vue',
+    'pocs/lend/layers/main/collections/loans/server/api/loans/index.get.ts',
+    'pocs/lend/server/database/schema/loans.ts',
+    // junk that must never be committed:
+    'pocs/lend/node_modules/x/index.js',
+    '.pi/npm/.gitignore',
+    'pi-telemetry-out/trace.jsonl',
+  ]
+  const { inputs, generated } = planCommits({ ledger, changed })
+  assert.deepEqual(inputs, ['pocs/lend/crouton.config.js', 'pocs/lend/schemas/loans.json'])
+  assert.deepEqual(generated, [
+    'pocs/lend/layers/main/collections/loans/app/components/List.vue',
+    'pocs/lend/layers/main/collections/loans/server/api/loans/index.get.ts',
+    'pocs/lend/server/database/schema/loans.ts',
+  ])
+  // the whole point: the generated collection is NOT empty this time.
+  assert.ok(generated.length >= 3, 'generated collection must be committed, not dropped')
+})
+
+test('junk is excluded from BOTH buckets (node_modules/.nuxt/.output/dist/.pi/telemetry)', () => {
+  const changed = ['app/real.ts', 'node_modules/a', 'app/.nuxt/x', 'dist/y', '.pi/z', 'pi-telemetry-out/t.jsonl', '.output/o']
+  const { inputs, generated } = planCommits({ ledger: [], changed })
+  assert.deepEqual(inputs, [])
+  assert.deepEqual(generated, ['app/real.ts'])
+})
+
+test('empty ledger (no session) → everything real falls to `generated`, never lost', () => {
+  const { inputs, generated } = planCommits({ ledger: [], changed: ['a.ts', 'b/c.vue', 'node_modules/x'] })
+  assert.deepEqual(inputs, [])
+  assert.deepEqual(generated, ['a.ts', 'b/c.vue'])
+})
+
+test('a pure hand-edit task (no generated output) puts everything in `inputs`', () => {
+  const ledger = ['packages/x/util.ts', 'packages/x/util.test.ts']
+  const { inputs, generated } = planCommits({ ledger, changed: [...ledger] })
+  assert.deepEqual(inputs, ['packages/x/util.test.ts', 'packages/x/util.ts'])
+  assert.deepEqual(generated, [])
+})
+
+test('dedupes and sorts; a ledger entry that did not actually change is not fabricated', () => {
+  // ledger claims 3 files but only 2 show up in the working tree → only those 2 are inputs.
+  const ledger = ['a.ts', 'b.ts', 'c.ts']
+  const changed = ['b.ts', 'b.ts', 'a.ts', 'gen/d.ts']
+  const { inputs, generated } = planCommits({ ledger, changed })
+  assert.deepEqual(inputs, ['a.ts', 'b.ts'])        // c.ts absent from changed → not committed
+  assert.deepEqual(generated, ['gen/d.ts'])
+})
+
+test('accepts Set or array for ledger', () => {
+  const p = planCommits({ ledger: new Set(['a.ts']), changed: ['a.ts', 'g.ts'] })
+  assert.deepEqual(p.inputs, ['a.ts'])
+  assert.deepEqual(p.generated, ['g.ts'])
+})

--- a/scripts/pi-edited-files.mjs
+++ b/scripts/pi-edited-files.mjs
@@ -8,45 +8,57 @@
 //
 // Usage: node scripts/pi-edited-files.mjs <session.jsonl> <repoRoot>
 //   → prints repo-relative paths (one per line) of files pi wrote to, deduped, existing only.
+// Also EXPORTS `DENY` and `ledgerFromSession()` so the commit-plan splitter (pi-commit-plan.mjs,
+// #1849) reuses the exact same junk-denylist and edit-tool parsing instead of duplicating them.
 import fs from 'node:fs';
 import path from 'node:path';
-
-const [, , sessionPath, repoRootArg] = process.argv;
-if (!sessionPath || !repoRootArg) {
-  console.error('usage: pi-edited-files.mjs <session.jsonl> <repoRoot>');
-  process.exit(2);
-}
-const repoRoot = path.resolve(repoRootArg);
+import { fileURLToPath } from 'node:url';
 
 // pi's file-writing tools. `edit` is confirmed (args: path/oldText/newText); the rest are
 // defensive so a new-file `write` or a rename can't silently slip the ledger.
-const WRITE_TOOLS = new Set(['edit', 'write', 'create', 'str_replace', 'multiedit', 'apply_patch']);
+export const WRITE_TOOLS = new Set(['edit', 'write', 'create', 'str_replace', 'multiedit', 'apply_patch']);
 // Never commit pi's own runtime/scratch, dependency installs, or build output — even if a tool
-// happened to touch them.
-const DENY = /(^|\/)(\.pi|node_modules|\.nuxt|\.output|dist)(\/|$)|decompose-pidev-(prompt|exec)-\d+\.(txt|log)|(^|\/)pi-telemetry-out(\/|$)/;
+// happened to touch them. Shared by the commit-plan splitter for the GENERATED bucket too (#1849).
+export const DENY = /(^|\/)(\.pi|node_modules|\.nuxt|\.output|dist)(\/|$)|decompose-pidev-(prompt|exec)-\d+\.(txt|log)|(^|\/)pi-telemetry-out(\/|$)/;
 
-const out = new Set();
-for (const line of fs.readFileSync(sessionPath, 'utf8').split('\n')) {
-  if (!line.trim()) continue;
-  let rec;
-  try { rec = JSON.parse(line); } catch { continue; }
-  const content = rec?.message?.content;
-  if (!Array.isArray(content)) continue;
-  for (const c of content) {
-    if (c?.type !== 'toolCall' || !WRITE_TOOLS.has(c.name)) continue;
-    const a = c.arguments || {};
-    for (const p of [a.path, a.file_path, a.filename, a.file, a.newPath, a.new_path]) {
-      if (typeof p !== 'string' || !p) continue;
-      const abs = path.resolve(repoRoot, p);
-      if (abs !== repoRoot && !abs.startsWith(repoRoot + path.sep)) continue; // outside the repo
-      const rel = path.relative(repoRoot, abs);
-      if (!rel || rel.startsWith('..')) continue;
-      if (DENY.test(rel)) continue;
-      out.add(rel);
+// The set of repo-relative paths pi WROTE via its edit/write tools (deduped, in-repo, non-deny,
+// existing). This is the "inputs / hand-authored" bucket — NOT generator output (which pi produced
+// via a bash/MCP tool, so it never appears as a write-tool path). Pure given (session, repoRoot).
+export function ledgerFromSession(sessionPath, repoRootArg) {
+  const repoRoot = path.resolve(repoRootArg);
+  const out = new Set();
+  for (const line of fs.readFileSync(sessionPath, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    let rec;
+    try { rec = JSON.parse(line); } catch { continue; }
+    const content = rec?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const c of content) {
+      if (c?.type !== 'toolCall' || !WRITE_TOOLS.has(c.name)) continue;
+      const a = c.arguments || {};
+      for (const p of [a.path, a.file_path, a.filename, a.file, a.newPath, a.new_path]) {
+        if (typeof p !== 'string' || !p) continue;
+        const abs = path.resolve(repoRoot, p);
+        if (abs !== repoRoot && !abs.startsWith(repoRoot + path.sep)) continue; // outside the repo
+        const rel = path.relative(repoRoot, abs);
+        if (!rel || rel.startsWith('..')) continue;
+        if (DENY.test(rel)) continue;
+        out.add(rel);
+      }
     }
   }
+  // Only keep paths that still exist (a file pi created then deleted shouldn't be staged as add).
+  return new Set([...out].filter(rel => fs.existsSync(path.join(repoRoot, rel))));
 }
-// Only emit paths that still exist (a file pi created then deleted shouldn't be staged as add).
-for (const rel of [...out].sort()) {
-  if (fs.existsSync(path.join(repoRoot, rel))) process.stdout.write(rel + '\n');
+
+// CLI (unchanged behaviour): print the ledger, one path per line.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [, , sessionPath, repoRootArg] = process.argv;
+  if (!sessionPath || !repoRootArg) {
+    console.error('usage: pi-edited-files.mjs <session.jsonl> <repoRoot>');
+    process.exit(2);
+  }
+  for (const rel of [...ledgerFromSession(sessionPath, repoRootArg)].sort()) {
+    process.stdout.write(rel + '\n');
+  }
 }


### PR DESCRIPTION
Closes #1849 (the commit half; acceptance/typecheck gate is the follow-up)

## 👤 For humans
The bug behind #1827's stalled build: the worker committed only files pi *typed by hand* and dropped everything the *generator* produced — so #1830 shipped config but no `loans` collection, and merged green. Now the worker **classifies** the tree into two commits — **inputs** (schema/config pi authored) and **generated** (the collection the CLI produced) — and commits both. History stays granular; the deliverable lands. Each PR gets a **factual run record** (files by bucket + junk excluded), derived from git, not pi's narration.

## 🤖 For agents
- `scripts/pi-commit-plan.mjs` — pure `planCommits`: `inputs` = ledger, `generated` = changed − junk − ledger. Reuses `DENY` + `ledgerFromSession` now exported from `pi-edited-files.mjs`. 6 unit tests (the #1830 case pinned) + 3 ledger regressions.
- Worker finish step: `git status -uall` → plan → capture both buckets before the re-base → **two commits** (inputs, then generated) → run-record comment on the PR.
- **Follow-up (the keystone):** acceptance gate — typecheck/boot the touched app, post a commit status so automerge holds a red result. Filed under #1849.
- Touches a workflow — needs a human merge.

## 🧪 How to test
Re-dispatch a scaffold+generate leaf → the PR now contains **two commits** (config/schema + the generated collection), and a run record listing both buckets. Before this, the generated collection was silently absent.