### PR TITLE
crouton scaffold emits a typecheck script — acceptance gate can verify scaffolded apps (#1866)

### DIFF
--- a/packages/crouton-cli/lib/scaffold-app.ts
+++ b/packages/crouton-cli/lib/scaffold-app.ts
@@ -141,6 +141,10 @@ function tmplPackageJson(vars: ScaffoldVars): string {
     dev: 'nuxt dev',
     generate: 'nuxt generate',
     preview: 'nuxt preview',
+    // A scaffolded app is verifiable out of the box — the worker acceptance gate (#1849/#1866)
+    // runs `pnpm --filter <app> typecheck`, and `nuxt typecheck` runs `nuxt prepare` first so
+    // auto-imports resolve (a raw `npx nuxt typecheck` without prepare false-fails on them).
+    typecheck: 'nuxt typecheck',
     // Runs the per-collection schema-smoke tests the generator emits (#785).
     test: 'vitest run',
     // Guarded: a whole-monorepo `pnpm install` (e.g. on Cloudflare) runs every


### PR DESCRIPTION
Closes #1866

## 👤 For humans
The worker acceptance gate (#1849) verifies apps via `pnpm --filter <app> typecheck`, but `crouton`-scaffolded apps shipped **no** `typecheck` script, so freshly-generated pocs landed on *neutral/unverified*. Now the scaffold emits `typecheck: 'nuxt typecheck'` (matching velo/pins) — every generated app is verifiable by the gate's proven script path out of the box.

## 🤖 For agents
- One line in `scaffold-app.ts`'s generated `scripts`. `nuxt typecheck` runs `nuxt prepare` first (auto-imports resolve) — a raw `npx nuxt typecheck` without prepare false-flagged 37 auto-import errors on clean generated code (#1863), so the gate uses the app's own script.
- No test snapshots the scripts object (verified); trivial string-property addition.

**Packages-approved:** owner explicitly approved this scaffold-template change in-session (packages hard-gate) to close #1866. Touches `packages/crouton-cli/` + a workflow-adjacent gate — needs a human merge.

## 🧪 How to test
`crouton init <name>` (or a pipeline scaffold) → the generated `package.json` has a `typecheck` script → the acceptance gate runs it (instead of neutral) and produces a real pass/fail.