### PR TITLE
fix(root): pi worker stops losing files and blaming the ticket (#1876)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -505,8 +505,12 @@ jobs:
                   action = 'open the run log, fix the SDK/tooling error, then re-dispatch'
                   if (tail.trim()) detail = tail.trim()
                 } else {
-                  why = 'pi finished without opening a PR, creating sub-issues, or holding for sign-off'
-                  action = 'the issue is likely underspecified — add a concrete description + acceptance criteria, then re-dispatch'
+                  // LAST RESORT — no known cause matched, so say that (#1876). The old text asserted
+                  // "the issue is likely underspecified" in the same confident voice as the real
+                  // detections above; on the worker twin that guess sent the owner to rewrite two
+                  // well-specified tickets while the actual bug was in the workflow's own shell.
+                  why = 'pi ran to completion but no PR, sub-issues, or sign-off hold appeared — and none of the known causes matched'
+                  action = 'open the run log before changing anything. Only if the log shows pi genuinely had nothing to act on is the issue underspecified'
                 }
               }
             } catch (e) { core.warning(`artifact-gate: could not read pi run log: ${e.message}`) }

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -304,7 +304,10 @@ jobs:
           #    (edit/write tools). Generator output (crouton config/generate_collection, produced via
           #    a bash/MCP tool) is NOT a write-tool path, so it never appears in the ledger — which is
           #    exactly why the old "commit only the ledger" DROPPED the generated collection (#1830).
-          SESSION="$(ls -t "$RUNNER_TEMP/pi-session"/*.jsonl 2>/dev/null | head -1)"
+          # `|| true` is LOAD-BEARING (#1876): with no session the glob never expands, `ls` exits 2,
+          # `pipefail` propagates it to the assignment and errexit kills the step HERE — making the
+          # ::warning:: below unreachable. The empty case must reach the `if`, not abort the job.
+          SESSION="$(ls -t "$RUNNER_TEMP/pi-session"/*.jsonl 2>/dev/null | head -1 || true)"
           if [ -n "$SESSION" ] && [ -f "$SESSION" ]; then echo "pi session: $SESSION"
           else echo "::warning::no pi session in $RUNNER_TEMP/pi-session (#1764)"; fi
 
@@ -314,8 +317,14 @@ jobs:
           #    granular (blame→schema, bisect→generator). `-uall` expands untracked DIRECTORIES to
           #    files, or the generated collection would be an invisible collapsed `dir/` entry.
           git status --porcelain -uall 2>/dev/null | sed 's/^...//; s/^.* -> //' | sort -u > "$RUNNER_TEMP/changed.txt" || true
-          PLAN="$(node "$RUNNER_TEMP/pi-commit-plan.mjs" "${SESSION:-/nonexistent}" "$ROOT" "$RUNNER_TEMP/changed.txt" 2>/dev/null || echo '{"inputs":[],"generated":[]}')"
-          printf '%s' "$PLAN" | node -e 'const p=JSON.parse(require("fs").readFileSync(0,"utf8"));const t=process.env.RUNNER_TEMP;require("fs").writeFileSync(t+"/inputs.txt",(p.inputs||[]).join("\n"));require("fs").writeFileSync(t+"/generated.txt",(p.generated||[]).join("\n"))'
+          # `--out` has the (unit-tested) splitter write both bucket files itself, CORRECTLY
+          # TERMINATED. The old inline `node -e` serialised with a bare `.join("\n")`, leaving the
+          # last path unterminated — and the `while IFS= read` loops below skip a final unterminated
+          # line, so the LAST file of each bucket was silently dropped from the commit while
+          # `grep -c` still counted it (#1876; it ate the one locale file #1874 was about).
+          # Pre-create both files so a splitter failure leaves empty buckets, not missing ones.
+          : > "$RUNNER_TEMP/inputs.txt"; : > "$RUNNER_TEMP/generated.txt"
+          node "$RUNNER_TEMP/pi-commit-plan.mjs" "${SESSION:-/nonexistent}" "$ROOT" "$RUNNER_TEMP/changed.txt" --out "$RUNNER_TEMP" >/dev/null 2>&1 || echo "::warning::commit-plan splitter failed — treating both buckets as empty (#1876)"
           NIN="$(grep -c . "$RUNNER_TEMP/inputs.txt" 2>/dev/null || true)"; NIN=${NIN:-0}
           NGEN="$(grep -c . "$RUNNER_TEMP/generated.txt" 2>/dev/null || true)"; NGEN=${NGEN:-0}
           echo "commit plan (#1849) — inputs=$NIN generated=$NGEN"
@@ -372,7 +381,12 @@ jobs:
           #    when the app has no typecheck to run.
           ACCEPT="neutral"; ACCEPT_MSG="could not typecheck the touched app — not verified"
           if [ "$HAVE_COMMITS" = "1" ]; then
-            APP_DIR="$(grep -hE '^(apps|pocs)/[^/]+/' "$RUNNER_TEMP/inputs.txt" "$RUNNER_TEMP/generated.txt" 2>/dev/null | sed -E 's#^((apps|pocs)/[^/]+)/.*#\1#' | sort -u | head -1)"
+            # `|| true` is LOAD-BEARING (#1876): a leaf whose diff is entirely `packages/**` (or
+            # `.github/`, `scripts/`, docs) matches NOTHING here, so grep exits 1, `pipefail`
+            # propagates it to the assignment and errexit kills the step — after the push, before
+            # `gh pr create`. That is exactly how #1874/#1875 pushed a branch and never opened a PR.
+            # No app dir is a legitimate NEUTRAL verdict below, not a crash.
+            APP_DIR="$(grep -hE '^(apps|pocs)/[^/]+/' "$RUNNER_TEMP/inputs.txt" "$RUNNER_TEMP/generated.txt" 2>/dev/null | sed -E 's#^((apps|pocs)/[^/]+)/.*#\1#' | sort -u | head -1 || true)"
             if [ -n "$APP_DIR" ] && [ -f "$APP_DIR/package.json" ]; then
               PKG="$(node -p "require('./$APP_DIR/package.json').name || ''" 2>/dev/null || true)"
               HAS_TC="$(node -e "process.exit(require('./$APP_DIR/package.json').scripts?.typecheck?0:1)" 2>/dev/null && echo 1 || echo 0)"
@@ -482,6 +496,9 @@ jobs:
           # #1764: '1' only when the deterministic finish step could NOT persist pi's edits
           # (a git/tooling failure) — lets the gate name that cause instead of "underspecified".
           PI_LEFT_DIRTY: ${{ steps.finish.outputs.still_dirty }}
+          # #1876: the finish step's own outcome. Without it the gate cannot tell "pi had nothing to
+          # do" from "the harness crashed mid-finish", and defaults to blaming the ISSUE.
+          FINISH_OUTCOME: ${{ steps.finish.outcome }}
           ISSUE_NUMBER: ${{ inputs.issue || github.event.issue.number }}
           TRIGGER: ${{ github.event_name }}
         with:
@@ -596,9 +613,33 @@ jobs:
             const fs = require('fs')
             let why = '', action = '', detail = ''
             const failed = process.env.CLAUDE_CONCLUSION === 'failure'
+
+            // ── HARNESS-FAILED-AFTER-COMMITTING (#1876) — checked FIRST ────────────────
+            // The gate's evidence used to be {pi's exit code, pi's stdout, the GitHub API}. The
+            // FINISH step was invisible to it, so when the finish step crashed after pushing a
+            // branch, every real cause missed and the run fell through to the `else` below and
+            // told the owner their ISSUE was underspecified — while a branch with their work sat
+            // on the remote (#1874/#1875). A pushed `work-<issue>` branch is proof the agent
+            // produced something; the only thing missing is the PR the harness died before opening.
+            let workBranch = null
+            try {
+              const ref = await github.rest.git.getRef({ ...context.repo, ref: `heads/work-${issue_number}` })
+              const commit = await github.rest.git.getCommit({ ...context.repo, commit_sha: ref.data.object.sha })
+              const committedAt = new Date(commit.data.committer?.date || 0).getTime()
+              if (committedAt >= sinceMs) workBranch = { sha: ref.data.object.sha.slice(0, 7) }
+            } catch (e) { /* no such branch — the ordinary "nothing was built" case */ }
+
+            if (workBranch && process.env.FINISH_OUTCOME === 'failure') {
+              why = `the HARNESS failed after committing — \`work-${issue_number}\` (\`${workBranch.sha}\`) was pushed this run, but the finish step died before opening the PR`
+              action = 'open the run log at the `finish` step — this is a workflow bug, NOT an underspecified issue. '
+                + 'Do not edit the issue; fix the workflow, delete the branch, and re-apply the label'
+            }
+
             try {
               const logFile = process.env.PI_EXEC_LOG
-              if (logFile && fs.existsSync(logFile)) {
+              // `!why` — never let the log-grep chain overwrite the harness-failure verdict above,
+              // whose evidence (a pushed branch + a failed finish step) is stronger than a regex (#1876).
+              if (!why && logFile && fs.existsSync(logFile)) {
                 const log = fs.readFileSync(logFile, 'utf8')
                 const tail = log.length > 600 ? log.slice(-600) : log
                 // GLM Coding Plan quota (z.ai) — checked FIRST: its 429 is distinct from an
@@ -625,9 +666,17 @@ jobs:
                   why = 'the pi agent step errored before it built anything'
                   action = 'open the run log, fix the SDK/tooling error, then re-dispatch'
                   if (tail.trim()) detail = tail.trim()
+                } else if (process.env.FINISH_OUTCOME === 'failure') {
+                  // The finish step failed but pushed nothing — still a harness fault, not the ticket.
+                  why = 'the finish step failed before it could commit anything'
+                  action = 'open the run log at the `finish` step — a workflow bug, not an underspecified issue'
                 } else {
-                  why = 'pi finished without opening a PR, creating sub-issues, or holding for sign-off'
-                  action = 'the issue is likely underspecified — add a concrete description + acceptance criteria, then re-dispatch'
+                  // LAST RESORT — no known cause matched. Say exactly that (#1876). The old text
+                  // asserted "the issue is likely underspecified", which is a GUESS printed in the
+                  // same confident voice as the real detections above; it sent the owner to rewrite
+                  // two well-specified tickets while the actual bug was in this workflow.
+                  why = 'pi ran to completion but no PR, sub-issues, or sign-off hold appeared — and none of the known causes matched'
+                  action = 'open the run log before changing anything. Only if the log shows pi genuinely had nothing to act on is the issue underspecified'
                 }
               }
             } catch (e) { core.warning(`artifact-gate: could not read pi run log: ${e.message}`) }

--- a/scripts/pi-commit-plan.mjs
+++ b/scripts/pi-commit-plan.mjs
@@ -42,6 +42,27 @@ export function planCommits({ ledger, changed }) {
   return { inputs, generated };
 }
 
+// Serialise ONE bucket to the exact bytes the finish step's readers need.
+//
+// A bucket file MUST end in a newline. `while IFS= read -r p` does NOT run the loop body for a
+// final UNTERMINATED line, so a plain `.join('\n')` silently drops the LAST path in the bucket —
+// which is how #1874's `nl.json` (the only file that ticket was actually about) never reached its
+// commit while the run record still counted it, because `grep -c` DOES see that last line (#1876).
+// Empty bucket → an empty file, never a blank line (a blank line would stage `$CONTENT/`).
+export function serializeBucket(list) {
+  const lines = (list || []).map(p => String(p).trim()).filter(Boolean);
+  return lines.length ? lines.join('\n') + '\n' : '';
+}
+
+// Write both bucket files into `dir` as `inputs.txt` / `generated.txt`. The finish step calls this
+// instead of serialising inline, so the round-trip is covered by pi-commit-plan.test.mjs rather
+// than only in production (#1876).
+export function writeBuckets(plan, dir) {
+  fs.writeFileSync(path.join(dir, 'inputs.txt'), serializeBucket(plan.inputs));
+  fs.writeFileSync(path.join(dir, 'generated.txt'), serializeBucket(plan.generated));
+  return plan;
+}
+
 // I/O wrapper: read the ledger from the session and the changed list from a file.
 export function planFromFiles(sessionPath, repoRoot, changedPath) {
   const ledger = fs.existsSync(sessionPath) ? ledgerFromSession(sessionPath, repoRoot) : new Set();
@@ -52,10 +73,18 @@ export function planFromFiles(sessionPath, repoRoot, changedPath) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const [, , sessionPath, repoRoot, changedPath] = process.argv;
-  if (!sessionPath || !repoRoot || !changedPath) {
-    console.error('usage: pi-commit-plan.mjs <session.jsonl> <repoRoot> <changed-files.txt>');
+  const argv = process.argv.slice(2);
+  const outIdx = argv.indexOf('--out');
+  const outDir = outIdx === -1 ? null : argv[outIdx + 1];
+  if (outIdx !== -1) argv.splice(outIdx, 2);
+  const [sessionPath, repoRoot, changedPath] = argv;
+  if (!sessionPath || !repoRoot || !changedPath || (outIdx !== -1 && !outDir)) {
+    console.error('usage: pi-commit-plan.mjs <session.jsonl> <repoRoot> <changed-files.txt> [--out <dir>]');
     process.exit(2);
   }
-  process.stdout.write(JSON.stringify(planFromFiles(sessionPath, repoRoot, changedPath)) + '\n');
+  const plan = planFromFiles(sessionPath, repoRoot, changedPath);
+  // --out writes the two bucket files directly (correctly terminated); stdout stays JSON either
+  // way so the previous contract still holds.
+  if (outDir) writeBuckets(plan, outDir);
+  process.stdout.write(JSON.stringify(plan) + '\n');
 }

--- a/scripts/pi-commit-plan.test.mjs
+++ b/scripts/pi-commit-plan.test.mjs
@@ -5,7 +5,10 @@
 //   node --test scripts/pi-commit-plan.test.mjs
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { planCommits } from './pi-commit-plan.mjs'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { planCommits, serializeBucket, writeBuckets } from './pi-commit-plan.mjs'
 
 test('the #1830 case: generated collection lands in `generated`, config/schema in `inputs`', () => {
   // pi hand-authored (ledger) the config + schema; `crouton config` GENERATED the collection.
@@ -66,4 +69,39 @@ test('accepts Set or array for ledger', () => {
   const p = planCommits({ ledger: new Set(['a.ts']), changed: ['a.ts', 'g.ts'] })
   assert.deepEqual(p.inputs, ['a.ts'])
   assert.deepEqual(p.generated, ['g.ts'])
+})
+
+// ── #1876: the SERIALISATION, not just the classification ────────────────────────────────
+// Every test above checks the pure function, which is why the bug that ate #1874's `nl.json`
+// shipped green: the buckets were classified correctly and then written without a trailing
+// newline, so the finish step's `while IFS= read -r` dropped the LAST path of each bucket.
+// These exercise the round-trip THROUGH THE FILE — the boundary that actually broke.
+
+test('#1876: a bucket file ends in a newline so `while read` sees the LAST entry', () => {
+  assert.equal(serializeBucket(['a.ts', 'b.ts', 'c.ts']), 'a.ts\nb.ts\nc.ts\n')
+  // The exact regression: `.join("\n")` alone leaves `c.ts` unterminated and invisible to `read`.
+  assert.notEqual(['a.ts', 'b.ts', 'c.ts'].join('\n'), serializeBucket(['a.ts', 'b.ts', 'c.ts']))
+})
+
+test('#1876: an empty bucket is an EMPTY file, never a blank line', () => {
+  // A blank line would make stage_bucket try to stage `$CONTENT/` — an empty file iterates zero times.
+  assert.equal(serializeBucket([]), '')
+  assert.equal(serializeBucket(undefined), '')
+  assert.equal(serializeBucket(['', '  ']), '')
+})
+
+test('#1876: writeBuckets round-trips every path back out, last one included', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-buckets-'))
+  writeBuckets({ inputs: ['en.json', 'fr.json', 'nl.json'], generated: [] }, dir)
+
+  // Read the file the way the workflow's shell does: split on newline, drop the trailing empty
+  // slot that a correctly-terminated file produces. `nl.json` sorts LAST — the #1874 victim.
+  const readBack = f => fs.readFileSync(path.join(dir, f), 'utf8').split('\n').filter(Boolean)
+  assert.deepEqual(readBack('inputs.txt'), ['en.json', 'fr.json', 'nl.json'])
+  assert.deepEqual(readBack('generated.txt'), [])
+
+  // The count the run record reports (`grep -c .`) must equal what the commit actually stages,
+  // or the harness reports files it did not commit — the second half of the #1876 defect.
+  assert.equal(readBack('inputs.txt').length, 3)
+  fs.rmSync(dir, { recursive: true, force: true })
 })


### PR DESCRIPTION
Closes #1876

## 👤 What this fixes

Two leaf issues were labelled `work-this` as a live test of the flow ([#1874](https://github.com/FriendlyInternet/nuxt-crouton/issues/1874), [#1875](https://github.com/FriendlyInternet/nuxt-crouton/issues/1875)). Both runs did the work correctly. Neither produced a PR — and the pipeline told the owner their **tickets** were the problem.

| | #1874 | #1875 |
|---|---|---|
| pi step | success, 1m40s | success, 17m41s |
| finish step | **failed, 2s** | **failed, 3s** |
| branch pushed | `work-1874` ✅ | `work-1875` ✅ |
| files in commit | 2 of 3 | 2 of ≥3 |
| PR | none | none |
| issue comment | *"the issue is likely underspecified"* | same |

Three defects, all introduced by the #1849 acceptance-gate work.

## 🤖 The three defects

### 1. The last file of every commit bucket was silently dropped

`pi-commit-plan.mjs`'s output was serialised with a bare `.join("\n")` — no trailing newline. The finish step reads those lists with `while IFS= read -r p`, which does **not** run the loop body for a final unterminated line. Both the CONTENT-capture loop and `stage_bucket()` read that way, so the last path was dropped twice.

`NIN`/`NGEN` are counted with `grep -c`, which *does* see the last line — so the count was right and the commit was wrong, and the run record reported files it never committed.

On #1874 the victim was `nl.json`, sorting last — the only file that ticket was about (kassa is NL-only). On #1875, that `server/…` survived proves a later-sorting entry existed and was lost; `test/…` sorts after `server/…`.

**Fix:** `serializeBucket()` + `writeBuckets()` in `pi-commit-plan.mjs`, a `--out <dir>` CLI flag, and the workflow calls it instead of an inline `node -e`.

### 2. A `packages/`-only diff killed the finish step before the PR

```bash
APP_DIR="$(grep -hE '^(apps|pocs)/[^/]+/' … | head -1)"
```

No match → grep exits 1 → `pipefail` propagates → `bash -e` aborts the step, immediately after the push and before `gh pr create`. The neighbouring counts all carry `|| true`; this one didn't.

A second instance of the same shape sat at line 307: `SESSION="$(ls -t …/*.jsonl … | head -1)"` — with no session the glob doesn't expand, `ls` exits 2, and the `::warning::no pi session` written for exactly that case on the next line was **unreachable**.

**Fix:** `|| true` on both. No app dir is a legitimate NEUTRAL verdict, not a crash.

### 3. The artifact-gate attributed a harness failure to the ticket

With no PR, the gate fell through to a hardcoded `else` and asserted *"the issue is likely underspecified"* — a guess printed in the same confident voice as its real detections (GLM quota, billing, dirty tree). Its evidence was only `{pi's exit code, pi's stdout, the GitHub API}`; **the finish step was invisible to it**, so the one thing that actually broke could never be named.

**Fix:** the gate now gets `FINISH_OUTCOME` and looks up the `work-<issue>` ref. A branch pushed this run + a failed finish step classifies as *"the HARNESS failed after committing"*, checked **before** the log-grep chain and guarded by `!why` so it can't be overwritten. The last-resort branch now says no known cause matched and to read the run log first, rather than naming a cause it didn't establish. Same reword applied to `decompose-on-issue-pidev.yml`.

## Why a green test suite missed defect 1

`pi-commit-plan.test.mjs` had six tests. All six called `planCommits` — the pure function. **None** called `planFromFiles`. Nothing wrote a bucket file or read one back. The classification was tested; the serialisation that broke wasn't.

Three new cases exercise the round-trip **through the file**, including an explicit `assert.notEqual` against the `.join('\n')` regression shape.

## Verification

Built the finish step's shell fragments against a synthetic session JSONL and ran **both** versions on identical input.

Old code — reproduces both symptoms:
```
reported by grep -c : 3
seen by while-read  : en.json, fr.json          ← nl.json gone
-- old APP_DIR probe --
step exit code = 1                              ← died before the next line
```

New code:
```
commit plan — inputs=3 generated=0
  staged: en.json / fr.json / nl.json
-- counts: reported=3  actually-staged=3 --  MATCH ✅
APP_DIR='' → verdict: neutral (no app touched)
REACHED THE END OF THE FINISH STEP ✅
```

Also: 37/37 pipeline script tests pass; both workflows parse as YAML; every embedded `github-script` block parses as JS.

## Scope notes

- `decompose-on-issue-pidev.yml` has **no finish step** — defects 1 and 2 are confined to `work-issue-pidev.yml`. Only defect 3 is shared.
- Checked and **cleared**, so nobody re-checks them: `[ "$NIN" -gt 0 ] && grep …` (errexit is exempt for the non-final command of an `&&` list), `EPIC_BRANCH="$(node pipeline-context.mjs …)"` (exits 2 only on a usage error), `TELE_DIR` (its step opens `set +e`), and the `while read` loops in `deploy-pocs.yml`/`e2e.yml` (they feed from `<<<` here-strings, which append a newline).
- No `pnpm typecheck` — nothing here is in an app's TS graph.
- No `crouton-failure-archaeology` entry yet: that skill's §E takes entries at close-out, not mid-fight. Due when #1876 closes.

## ⚠️ Residual risk

The gate's new branch lookup runs on the self-hosted runner path that has never been exercisable locally. The JS parses and the logic is verified in isolation, but the first real dispatch is its first true test. That untestability is the root cause behind the 19-fix-to-4-feat ratio on these files, and is tracked in #1878 (canary rig) — deliberately **not** in this PR.

## 🧪 How to test

1. Merge, then `git push origin --delete work-1874 work-1875` — both carry incomplete commits that would otherwise read as real work.
2. Re-apply `work-this` to #1874. Neither ticket needs editing.
3. **Before:** branch pushed, no PR, issue comment blaming the ticket.
4. **After:** a PR against `main` with `Closes #1874`, containing **all three** locale files — `nl.json` included — and a run record whose file count equals the number of files in the commit.
5. Repeat for #1875; confirm the test file is present.
6. Negative check: the acceptance verdict on a `packages/`-only leaf reads `neutral — could not typecheck the touched app`, and the job does not die.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGJ7DaXTFQ1jYfjWN62pkX


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGJ7DaXTFQ1jYfjWN62pkX)_