### PR TITLE
fix(root): build better-sqlite3's binding in CI so real-SQLite tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,14 @@ jobs:
       - name: Install dependencies (skip postinstall scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # --ignore-scripts above also skips better-sqlite3's native build, so any test
+      # that opens a real SQLite DB dies on "Could not locate the bindings file" and
+      # has to be skipped in CI — which is how the #1612 seed contract went dark.
+      # Same fix already live in deploy-app/docs/pocs (#154). No `|| true` here: in
+      # the test job a missing binding must fail loudly, not silently re-skip. (#1880)
+      - name: Build better-sqlite3's native binding
+        run: pnpm rebuild better-sqlite3
+
       - name: Cache layer builds
         id: layer-cache
         uses: actions/cache@v4


### PR DESCRIPTION
Closes #1880

## 👤 For humans

Tests that open a real SQLite database **cannot run in CI today** — the native module they need is never compiled there. The workaround has been to mark each one "local only", which means it guards nothing on the PR path: it runs only when someone remembers to run it by hand.

That isn't hypothetical. The #1612 local-seed fix — the one that stops seeded data silently disappearing — has exactly one test that writes to a real DB, and it's skipped in CI. A regression there lands green.

One line fixes it, and it's a line we already run in three other workflows.

## 🤖 For agents

**Root cause.** Every job in `ci.yml` installs with `pnpm install --frozen-lockfile --ignore-scripts` (8 occurrences). `--ignore-scripts` skips better-sqlite3's `install` script, so `better_sqlite3.node` is never built and any `new Database(...)` dies with:

```
Error: Could not locate the bindings file. Tried:
 → .../better-sqlite3@12.6.2/node_modules/better-sqlite3/build/Release/better_sqlite3.node
```

Root `package.json` already carries `pnpm.onlyBuiltDependencies: ["better-sqlite3"]`, so the build is **pre-approved** — `--ignore-scripts` is simply skipping it.

**Prior art — this is not a new remedy.** #154 hit the identical error in the docs Workers build and fixed it with `pnpm rebuild better-sqlite3`. That line is live in three workflows today and was never applied to `ci.yml`:

- `.github/workflows/deploy-app.yml:210`
- `.github/workflows/deploy-docs.yml:70`
- `.github/workflows/deploy-pocs.yml:223`

**This change.** One step in the `test` job, after install. Deliberately **no `|| true`** (unlike the deploy copies): in the test job a missing binding must fail loudly, not silently re-skip the very tests this exists to un-skip.

**Follow-up in the same issue, not done here** — once this lands, drop the guards so the tests actually run:
- `packages/crouton-cli/tests/unit/seed-local-write.test.ts:11` — `describe.skipIf(process.env.CI)`
- `packages/crouton-sales/test/per-product-totals.test.ts` — the `describeLocal` stopgap added in #1873

Kept separate so this PR is a pure CI change and the un-skipping is reviewable on its own.

## 🧪 How to test

1. On this PR, `Test Suite` should still be green — the rebuild adds the binding, and the currently-skipped tests stay skipped until the follow-up removes their guards.
2. The decisive check, after the guards come off: break the SQL predicate in `locationBlocksDeliverySql` on a scratch branch → `Test Suite` must go **red**. Today it stays green, which is the bug.
3. Confirm the rebuild costs seconds, not minutes.

## Note

Touches `.github/workflows/**`, so per #1816 this needs a human to merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DH1qkwceVwwZE3TZ8tXVC1)_