### PR TITLE
test(crouton-cli,crouton-sales): un-skip the real-SQLite tests now CI builds the binding

### DIFF
--- a/packages/crouton-cli/tests/unit/seed-local-write.test.ts
+++ b/packages/crouton-cli/tests/unit/seed-local-write.test.ts
@@ -7,8 +7,9 @@ import { runLocalSeed } from '../../lib/seed-app'
 
 // #1612 (behavioural proof) — the local runner must write into `<appDir>/.data/db/sqlite.db`
 // (the file nuxt dev reads) and never touch the miniflare `.wrangler` dir.
-// Local-only: CI lacks the better-sqlite3 native binding (same reason as crouton-printing #1539).
-describe.skipIf(process.env.CI)('local seed writes into .data/db/sqlite.db (#1612)', () => {
+// Runs everywhere since #1880: ci.yml rebuilds better-sqlite3's native binding after its
+// --ignore-scripts install, so this no longer has to be local-only.
+describe('local seed writes into .data/db/sqlite.db (#1612)', () => {
   it('a row from the local runner lands in the .data DB, and .wrangler is never touched', () => {
     const appDir = mkdtempSync(join(tmpdir(), 'seed-write-'))
     try {

--- a/packages/crouton-sales/test/per-product-totals.test.ts
+++ b/packages/crouton-sales/test/per-product-totals.test.ts
@@ -39,14 +39,10 @@ import {
 } from '../server/utils/location-handover'
 import { buildPerProductTotals } from '../server/utils/per-product-totals'
 
-// Local-only, and that is a known gap — not a preference. Every ci.yml job installs with
-// `pnpm install --ignore-scripts`, so better-sqlite3's native binding is never built and
-// `new Database()` below throws "Could not locate the bindings file". Same reason
-// crouton-cli's seed-local-write test is local-only. The rebuild that fixes it is already
-// live in the three deploy workflows (#154) and just needs applying to ci.yml — tracked in
-// #1880, which also removes this guard. Until then the drift these tests catch is unguarded
-// on the PR path: run them locally before touching the outstanding rule.
-const describeLocal = describe.skipIf(process.env.CI)
+// These open a real SQLite DB, which needs better-sqlite3's native binding. ci.yml rebuilds
+// it after the --ignore-scripts install (#1880), so they run on the PR path — which is the
+// point: the drift they catch (locationBlocksDeliverySql vs isOrderDelivered) is only
+// guarded if CI actually runs them.
 
 // ---------------------------------------------------------------------------
 // Minimal mirrors of the generated tables — only the columns the query reads.
@@ -107,7 +103,7 @@ beforeEach(() => {
 // 1. The two halves of the same sentence must agree.
 // ---------------------------------------------------------------------------
 
-describeLocal('locationBlocksDeliverySql — agrees with the pure rule, row for row', () => {
+describe('locationBlocksDeliverySql — agrees with the pure rule, row for row', () => {
   // Every combination the database can actually hold. `null` is not a curiosity
   // here: it is what pre-migration rows read, and reading it as "nothing to
   // confirm" would mark every historical order delivered on sight.
@@ -222,7 +218,7 @@ const totals = () => buildPerProductTotals(db, tables, {
 const byTitle = (rows: Array<{ product: string }>, title: string) =>
   rows.find(r => r.product === title)
 
-describeLocal('buildPerProductTotals — sold', () => {
+describe('buildPerProductTotals — sold', () => {
   beforeEach(seedVenue)
 
   it('sums quantities rather than counting order lines', async () => {
@@ -264,7 +260,7 @@ describeLocal('buildPerProductTotals — sold', () => {
   })
 })
 
-describeLocal('buildPerProductTotals — outstanding', () => {
+describe('buildPerProductTotals — outstanding', () => {
   beforeEach(seedVenue)
 
   it('counts units a requiring location has not bumped', async () => {
@@ -357,7 +353,7 @@ describeLocal('buildPerProductTotals — outstanding', () => {
   })
 })
 
-describeLocal('buildPerProductTotals — scoping', () => {
+describe('buildPerProductTotals — scoping', () => {
   beforeEach(seedVenue)
 
   it('never reads another team\'s or another event\'s orders', async () => {


### PR DESCRIPTION
Follow-up to #1883, completing #1880. Refs #1612, #1867.

## 👤 For humans

#1883 taught CI to build better-sqlite3's native binding. This is the half that makes it matter: two test files were marked "local only" because CI couldn't run them, and this takes those guards off.

Until now they guarded nothing on the PR path — they ran only when someone remembered to run them by hand.

## 🤖 For agents

**`packages/crouton-cli/tests/unit/seed-local-write.test.ts`** — dropped `describe.skipIf(process.env.CI)`.

This is the **only** test in the repo that writes to `.data/db/sqlite.db`, i.e. the sole behavioural proof of the #1612 local-seed fix. Its sibling `seed-local-target.test.ts` is pure — it checks `resolveSeedTarget`/`assertLocalSeedReady` path logic and never opens a DB. So while this one was skipped, a regression that sent local seeds back to the miniflare `.wrangler` DB would have merged green.

**`packages/crouton-sales/test/per-product-totals.test.ts`** — dropped the `describeLocal` stopgap added in #1873; the 4 blocks are plain `describe()` again.

These pin `locationBlocksDeliverySql` (SQL) against `isOrderDelivered` (TypeScript) row-for-row — two implementations of one sentence, which is exactly the shape that drifts. A drift guard that CI skips is not a guard.

**Unblocked by:** `ci.yml:288` — `pnpm rebuild better-sqlite3` after the `--ignore-scripts` install (#1883).

## 🧪 How to test

Verified locally with `CI=1` before pushing — the flag that previously caused the skip:

| File | Before | After |
|---|---|---|
| `per-product-totals.test.ts` | 20 skipped | **20 run, 20 passed** |
| `seed-local-write.test.ts` | 1 skipped | **1 run, 1 passed** |

On this PR, `Test Suite` is the real check: both files should now appear as executed, not skipped.

The decisive negative check, worth doing once: break the predicate in `locationBlocksDeliverySql` on a scratch branch → `Test Suite` must go **red**. Before #1883 + this PR it stayed green, which was the bug #1880 described.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DH1qkwceVwwZE3TZ8tXVC1)_