### PR TITLE
test(crouton-sales,crouton-cli): un-skip the real-SQLite tests now that CI builds the binding

### DIFF
--- a/packages/crouton-cli/tests/unit/seed-local-write.test.ts
+++ b/packages/crouton-cli/tests/unit/seed-local-write.test.ts
@@ -7,8 +7,9 @@ import { runLocalSeed } from '../../lib/seed-app'
 
 // #1612 (behavioural proof) — the local runner must write into `<appDir>/.data/db/sqlite.db`
 // (the file nuxt dev reads) and never touch the miniflare `.wrangler` dir.
-// Local-only: CI lacks the better-sqlite3 native binding (same reason as crouton-printing #1539).
-describe.skipIf(process.env.CI)('local seed writes into .data/db/sqlite.db (#1612)', () => {
+// Runs in CI now: ci.yml's test job rebuilds better-sqlite3's native binding (#1880). This is
+// the contract #1612 went dark behind — a skipped test reads exactly like a passing one.
+describe('local seed writes into .data/db/sqlite.db (#1612)', () => {
   it('a row from the local runner lands in the .data DB, and .wrangler is never touched', () => {
     const appDir = mkdtempSync(join(tmpdir(), 'seed-write-'))
     try {

--- a/packages/crouton-sales/test/per-product-totals.test.ts
+++ b/packages/crouton-sales/test/per-product-totals.test.ts
@@ -39,14 +39,10 @@ import {
 } from '../server/utils/location-handover'
 import { buildPerProductTotals } from '../server/utils/per-product-totals'
 
-// Local-only, and that is a known gap — not a preference. Every ci.yml job installs with
-// `pnpm install --ignore-scripts`, so better-sqlite3's native binding is never built and
-// `new Database()` below throws "Could not locate the bindings file". Same reason
-// crouton-cli's seed-local-write test is local-only. The rebuild that fixes it is already
-// live in the three deploy workflows (#154) and just needs applying to ci.yml — tracked in
-// #1880, which also removes this guard. Until then the drift these tests catch is unguarded
-// on the PR path: run them locally before touching the outstanding rule.
-const describeLocal = describe.skipIf(process.env.CI)
+// Runs in CI now: ci.yml's test job rebuilds better-sqlite3's native binding (#1880), so
+// `new Database()` no longer throws "Could not locate the bindings file". The alias stays
+// only so the describe blocks below read unchanged.
+const describeLocal = describe
 
 // ---------------------------------------------------------------------------
 // Minimal mirrors of the generated tables — only the columns the query reads.


### PR DESCRIPTION
Follow-up to #1880 / PR #1883.

## 👤 What this fixes

#1880 taught `ci.yml` to run `pnpm rebuild better-sqlite3`, but the tests that were skipped *because* CI couldn't build it are still skipped. They currently pass by not running.

## 🤖 Changes

Dropped `describe.skipIf(process.env.CI)` from:

- `packages/crouton-sales/test/per-product-totals.test.ts` — 20 cases: the `locationBlocksDeliverySql` SQL-vs-TS truth table (the guard that keeps the SQL and TypeScript halves of the handover rule from parting ways) and the sold/outstanding aggregation
- `packages/crouton-cli/tests/unit/seed-local-write.test.ts` — the #1612 `.data/db/sqlite.db` contract

Comments rewritten too — both still instructed the reader to run these locally.

## Verification

```
CI=1  crouton-sales     → 237/237 pass   (20 previously skipped)
CI=1  seed-local-write  →   1/1  pass
```

## Why it matters

A skipped test reads exactly like a passing one — which is precisely how the #1612 seed contract went dark, as the #1880 fix itself notes. Landing the CI fix and leaving the guards behind would have re-created that.

## 🧪 How to test

1. `cd packages/crouton-sales && CI=1 npx vitest run` → 237 passed, **0 skipped**.
2. `cd packages/crouton-cli && CI=1 npx vitest run tests/unit/seed-local-write.test.ts` → 1 passed.
3. On this PR, the `Test Suite` check should report more tests than on `main`.
4. Negative: `grep -rn "skipIf(process.env.CI)" packages/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGJ7DaXTFQ1jYfjWN62pkX


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGJ7DaXTFQ1jYfjWN62pkX)_