### PR TITLE
fix(root): read the claim signal before working an issue — the write-only status:in-progress gap

### DIFF
--- a/.claude/skills/issue-sanity-check/SKILL.md
+++ b/.claude/skills/issue-sanity-check/SKILL.md
@@ -30,6 +30,18 @@ Read the issue, then ask each — answer with one line of evidence (a link, a pa
    we're on Workers; it patches a file that's been deleted/rewritten.)
 3. **Duplicate / colliding?** — is there an open issue or epic for the same thing? (Reuse the
    `/issue-dedup` search. If yes, this is a merge, not two builds.)
+3b. **Already being worked — right now?** — the one an issue search misses, because the
+   collision isn't another *issue*, it's another *runner*. Check all three:
+   - the issue is **closed** (someone finished while you were reading it),
+   - an **open or merged PR** references it (`search_pull_requests "<N> in:body"`, then confirm a
+     `Closes #N`-style keyword — `Follow-up to #N` is not a claim),
+   - **`status:in-progress`** is on it and was stamped recently (check the label's event
+     timestamp, not just its presence — a crashed run leaves a stale one).
+   > Any of those → **🛑 Drop** (or 🔁 into "review/finish the existing PR"). This cost three
+   > duplicate builds on 2026-08-05 alone: #1478 started 8 min *after* #1473 closed its issue,
+   > and #1889 opened while #1888 was already open. The pipeline half of this gate is the
+   > `claim-guard` in `scripts/pipeline-loop-guard.mjs` (#1890) — it cannot see interactive
+   > sessions, which is exactly how #1622 and #1889 happened. **You are that half.**
 4. **Premise still true?** — does the "we think that…" hypothesis still hold, or did reality
    change? A wrong premise makes a perfectly-built feature worthless.
 5. **Cheaper alternative?** — is there a smaller change, an existing composable/skill, or a

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -150,6 +150,41 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: node scripts/pipeline-loop-guard.mjs bot-guard "$ACTOR"
 
+      # ── CLAIM GUARD (#1890) — is someone already on this issue? ──────────────────────
+      # Five workflows stamped `status:in-progress` and NOTHING read it, so two runners could
+      # build the same issue: #1478 started 8 min after #1473 closed its issue, and #1889 opened
+      # while #1888 was open. This is the read side. Facts are gathered here (API); the DECISION
+      # is the pure, unit-tested `decideClaim` — so the shipped guard IS the tested function.
+      # Contract: scripts/pipeline-loop-guard.test.mjs.
+      - name: Gather claim facts
+        id: claim-facts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
+            const { data: issue } = await github.rest.issues.get({ ...context.repo, issue_number })
+            // Linked PRs: anything whose body references this issue with a closing keyword.
+            const q = `repo:${context.repo.owner}/${context.repo.repo} is:pr ${issue_number} in:body`
+            const { data: found } = await github.rest.search.issuesAndPullRequests({ q, per_page: 20 })
+            const re = new RegExp(`(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))\\s+#${issue_number}\\b`, 'i')
+            const linkedPRs = []
+            for (const it of found.items || []) {
+              if (!re.test(it.body || '')) continue
+              linkedPRs.push({ number: it.number, state: it.state, merged: Boolean(it.pull_request?.merged_at) })
+            }
+            // When status:in-progress was applied (weakest signal → needs its timestamp).
+            let inProgressSince = null
+            if ((issue.labels || []).some((l) => (l.name || l) === 'status:in-progress')) {
+              const events = await github.paginate(github.rest.issues.listEvents, { ...context.repo, issue_number, per_page: 100 })
+              const last = events.filter((e) => e.event === 'labeled' && e.label?.name === 'status:in-progress').pop()
+              inProgressSince = last?.created_at || null
+            }
+            const facts = { issueState: issue.state, linkedPRs, inProgressSince, now: new Date().toISOString() }
+            require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/claim-facts.json`, JSON.stringify(facts))
+            core.info(`claim facts: ${JSON.stringify(facts)}`)
+      - name: Claim guard
+        run: node scripts/pipeline-loop-guard.mjs claim-guard < "$RUNNER_TEMP/claim-facts.json"
+
       - uses: pnpm/action-setup@v4
         with:
           # per-job dest — the default ~/setup-pnpm collides between the two

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -144,6 +144,41 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: node scripts/pipeline-loop-guard.mjs bot-guard "$ACTOR"
 
+      # ── CLAIM GUARD (#1890) — is someone already on this issue? ──────────────────────
+      # Five workflows stamped `status:in-progress` and NOTHING read it, so two runners could
+      # build the same issue: #1478 started 8 min after #1473 closed its issue, and #1889 opened
+      # while #1888 was open. This is the read side. Facts are gathered here (API); the DECISION
+      # is the pure, unit-tested `decideClaim` — so the shipped guard IS the tested function.
+      # Contract: scripts/pipeline-loop-guard.test.mjs.
+      - name: Gather claim facts
+        id: claim-facts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
+            const { data: issue } = await github.rest.issues.get({ ...context.repo, issue_number })
+            // Linked PRs: anything whose body references this issue with a closing keyword.
+            const q = `repo:${context.repo.owner}/${context.repo.repo} is:pr ${issue_number} in:body`
+            const { data: found } = await github.rest.search.issuesAndPullRequests({ q, per_page: 20 })
+            const re = new RegExp(`(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))\\s+#${issue_number}\\b`, 'i')
+            const linkedPRs = []
+            for (const it of found.items || []) {
+              if (!re.test(it.body || '')) continue
+              linkedPRs.push({ number: it.number, state: it.state, merged: Boolean(it.pull_request?.merged_at) })
+            }
+            // When status:in-progress was applied (weakest signal → needs its timestamp).
+            let inProgressSince = null
+            if ((issue.labels || []).some((l) => (l.name || l) === 'status:in-progress')) {
+              const events = await github.paginate(github.rest.issues.listEvents, { ...context.repo, issue_number, per_page: 100 })
+              const last = events.filter((e) => e.event === 'labeled' && e.label?.name === 'status:in-progress').pop()
+              inProgressSince = last?.created_at || null
+            }
+            const facts = { issueState: issue.state, linkedPRs, inProgressSince, now: new Date().toISOString() }
+            require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/claim-facts.json`, JSON.stringify(facts))
+            core.info(`claim facts: ${JSON.stringify(facts)}`)
+      - name: Claim guard
+        run: node scripts/pipeline-loop-guard.mjs claim-guard < "$RUNNER_TEMP/claim-facts.json"
+
       # ── WS2 pipeline context (#1695) — read epic_branch/depth/epic OFF the issue body ──
       # The single-use worker has no Agent-prompt channel; the parent wrote the context into a
       # `<!-- pipeline: epic=.. depth=.. epic_branch=.. -->` block on the issue. Fetch the body via

--- a/scripts/pipeline-loop-guard.mjs
+++ b/scripts/pipeline-loop-guard.mjs
@@ -4,7 +4,7 @@
 // so the invariants that broke at #457 can't silently regress when the decomposer starts
 // emitting labels.
 //
-// THE THREE INVARIANTS (each has a function here; the workflows / the decomposer wire to them):
+// THE FOUR INVARIANTS (each has a function here; the workflows / the decomposer wire to them):
 //
 //  1. BOT-ACTOR GUARD (#457/#1004) — a label applied from INSIDE a run must be actored by the
 //     Harness App (`nuxt-harness[bot]`, an allowed + cascading bot). Any OTHER `*[bot]` actor —
@@ -23,10 +23,16 @@
 //     `delegate-pi` child could beget a `delegate-pi` child forever. `MAX_CHILDREN` bounds one
 //     split. `withinCaps` is the decision the decomposer's label choice maps to.
 //
+//  4. CLAIM GUARD (#1890) — an issue that is already closed, already has an open/merged PR, or
+//     carries a fresh `status:in-progress` must NOT be worked again. Five workflows stamped that
+//     label and none read it, which cost three duplicate builds in one day (#1478/#1622/#1889).
+//     `decideClaim` is the read side; the workers call the `claim-guard` CLI below.
+//
 // These MUST stay in lockstep with the caps in `.claude/agents/task-decomposer.md` and the job
 // `if:` blocks in the two `*-pidev.yml` workflows. This file is the single tested source.
 
 import { pathToFileURL } from 'node:url'
+import { readFileSync } from 'node:fs'
 
 export const ALLOWED_BOT = 'nuxt-harness[bot]'
 export const MAX_DEPTH = 3
@@ -85,12 +91,91 @@ export function labelForChild({ depth = 0, isLeaf = false, maxDepth = MAX_DEPTH 
   return decideSplit({ depth, isLeaf, maxDepth }).action === 'leaf' ? WORKER_TRIGGER : 'delegate-pi'
 }
 
+/**
+ * INVARIANT 4 — is this issue already claimed? (#1890)
+ *
+ * Before #1890 the claim signal was WRITE-ONLY: five workflows stamped `status:in-progress`
+ * and nothing read it, so two runners could build the same issue. It cost three duplicate
+ * builds in one day — #1478 (started 8 min after #1473 closed the issue), #1622, #1889.
+ *
+ * Signals are ranked by how much they can be trusted, strongest first:
+ *   1. the issue is CLOSED            — timestamp-free, unambiguous: the work is over
+ *   2. a MERGED PR references it      — timestamp-free: the work already landed
+ *   3. an OPEN PR references it       — timestamp-free: another runner is on it
+ *   4. `status:in-progress` age < TTL — weakest; needs a clock, and a crashed run leaves it
+ *
+ * (4) is deliberately the last resort and TTL'd. A crashed run must not wedge an issue
+ * forever, so a stale stamp PROCEEDS (saying so), and an unparseable timestamp fails OPEN —
+ * the three strong signals still gate. A closed-but-unmerged PR does not claim anything: a
+ * rejected attempt should free the issue, not lock it.
+ */
+export const CLAIM_TTL_MINUTES = 90
+
+export function decideClaim({
+  issueState = 'open',
+  linkedPRs = [],
+  inProgressSince = null,
+  now = null,
+  ttlMinutes = CLAIM_TTL_MINUTES,
+  self = {},
+} = {}) {
+  if (issueState === 'closed') {
+    return { action: 'refuse', reason: 'the issue is already closed — its work is done or was dropped' }
+  }
+
+  // A PR of our own (a re-dispatch onto the same branch) is not a competing claim.
+  const others = (linkedPRs || []).filter((pr) => pr && pr.number !== self?.pr)
+  const merged = others.find((pr) => pr.merged)
+  if (merged) {
+    return { action: 'refuse', claimedBy: merged.number, reason: `PR #${merged.number} already merged for this issue` }
+  }
+  const open = others.find((pr) => pr.state === 'open')
+  if (open) {
+    return { action: 'refuse', claimedBy: open.number, reason: `PR #${open.number} is already open for this issue` }
+  }
+
+  const since = inProgressSince ? Date.parse(inProgressSince) : NaN
+  const at = now ? Date.parse(now) : NaN
+  if (Number.isFinite(since) && Number.isFinite(at)) {
+    const ageMin = (at - since) / 60_000
+    if (ageMin < ttlMinutes) {
+      return { action: 'refuse', reason: `status:in-progress was stamped ${Math.round(ageMin)}m ago (< ${ttlMinutes}m) — another run holds it` }
+    }
+    return { action: 'proceed', reason: `status:in-progress is stale (${Math.round(ageMin)}m > ${ttlMinutes}m) — treating the prior run as dead` }
+  }
+
+  return { action: 'proceed', reason: 'no claim found' }
+}
+
 // ── CLI ──────────────────────────────────────────────────────────────────────────
 //   node scripts/pipeline-loop-guard.mjs bot-guard <actor> [<allowed>]
 //     → exit 0 if allowed, exit 1 (with an ::error::) if a disallowed bot. Used as the
 //       workflow's Bot-actor guard step so the SHIPPED guard is the unit-tested function.
+//   node scripts/pipeline-loop-guard.mjs claim-guard < facts.json
+//     → facts.json is { issueState, linkedPRs, inProgressSince, now, self } gathered by the
+//       workflow's API step. Exit 0 to proceed; exit 1 (with an ::error::) when the issue is
+//       already claimed, so the run stops before spending a build on duplicate work (#1890).
 function main(argv) {
   const [cmd, ...rest] = argv
+  if (cmd === 'claim-guard') {
+    let facts = {}
+    try {
+      const raw = readFileSync(0, 'utf8').trim()
+      facts = raw ? JSON.parse(raw) : {}
+    } catch (err) {
+      // Fail OPEN on unreadable facts: a gather glitch must not wedge the pipeline. The
+      // duplicate-work risk is real but bounded; a permanently-blocked worker is worse.
+      console.log(`::warning::claim-guard could not read its facts (${err.message}) — proceeding.`)
+      return
+    }
+    const verdict = decideClaim(facts)
+    if (verdict.action === 'proceed') {
+      console.log(`Claim guard OK — ${verdict.reason}.`)
+      return
+    }
+    console.log(`::error::Claim guard: refusing to work this issue — ${verdict.reason}. This is a deliberate stop, not a build failure (#1890).`)
+    process.exit(1)
+  }
   if (cmd === 'bot-guard') {
     const actor = rest[0]
     const allowed = rest[1] || ALLOWED_BOT
@@ -101,7 +186,7 @@ function main(argv) {
     console.log(`::error::Bot-actor guard: '${actor}' may not drive the pi pipeline (only ${allowed}). Refusing to run.`)
     process.exit(1)
   }
-  console.error('usage: node scripts/pipeline-loop-guard.mjs bot-guard <actor> [<allowed>]')
+  console.error('usage: node scripts/pipeline-loop-guard.mjs bot-guard <actor> [<allowed>]\n       node scripts/pipeline-loop-guard.mjs claim-guard < facts.json')
   process.exit(2)
 }
 

--- a/scripts/pipeline-loop-guard.test.mjs
+++ b/scripts/pipeline-loop-guard.test.mjs
@@ -11,8 +11,8 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  botActorAllowed, jobShouldFire, decideSplit, labelForChild,
-  ALLOWED_BOT, MAX_DEPTH, MAX_CHILDREN, WORKER_TRIGGER,
+  botActorAllowed, jobShouldFire, decideSplit, labelForChild, decideClaim,
+  ALLOWED_BOT, MAX_DEPTH, MAX_CHILDREN, WORKER_TRIGGER, CLAIM_TTL_MINUTES,
 } from './pipeline-loop-guard.mjs'
 
 // ── Invariant 1: bot-actor guard (#457) ───────────────────────────────────────────
@@ -86,4 +86,94 @@ test('labelForChild routes leaves to work-this and splits to delegate-pi', () =>
   assert.equal(labelForChild({ depth: 1, isLeaf: false }), 'delegate-pi')
   // Depth cap forces work-this even for a would-be split.
   assert.equal(labelForChild({ depth: MAX_DEPTH, isLeaf: false }), 'work-this')
+})
+
+// ── Invariant 4: the claim guard (#1890) ──────────────────────────────────────────
+// Minted by three duplicate builds in one day (2026-08-05): #1478 (opened 8 min AFTER
+// #1473 closed the issue), #1622, and #1889 (opened while #1888 was open). Five workflows
+// already stamped `status:in-progress` and NOTHING read it — the claim signal was
+// write-only. These pin the read side.
+const T0 = '2026-08-05T10:00:00Z'
+const mins = (n) => new Date(Date.parse(T0) + n * 60_000).toISOString()
+
+test('a clean open issue with no PRs proceeds', () => {
+  assert.equal(decideClaim({ issueState: 'open', now: T0 }).action, 'proceed')
+})
+
+test('a CLOSED issue is refused — the #1478 case', () => {
+  // #1473 merged and closed #1458; the duplicate run started 8 minutes later.
+  const v = decideClaim({ issueState: 'closed', now: T0 })
+  assert.equal(v.action, 'refuse')
+  assert.match(v.reason, /closed/i)
+})
+
+test('an OPEN PR referencing the issue is refused — the #1889 case', () => {
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1888, state: 'open' }],
+    now: T0,
+  })
+  assert.equal(v.action, 'refuse')
+  assert.equal(v.claimedBy, 1888)
+})
+
+test('a MERGED PR referencing the issue is refused — the work already landed', () => {
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1888, state: 'closed', merged: true }],
+    now: T0,
+  })
+  assert.equal(v.action, 'refuse')
+  assert.equal(v.claimedBy, 1888)
+})
+
+test('a CLOSED-unmerged PR does not refuse — a rejected attempt frees the issue', () => {
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1889, state: 'closed', merged: false }],
+    now: T0,
+  })
+  assert.equal(v.action, 'proceed')
+})
+
+test('this run\'s OWN pr is ignored — a re-dispatch must not refuse itself', () => {
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1808, state: 'open' }],
+    self: { pr: 1808 },
+    now: T0,
+  })
+  assert.equal(v.action, 'proceed')
+})
+
+test('a FRESH status:in-progress is refused', () => {
+  const v = decideClaim({ issueState: 'open', inProgressSince: mins(-10), now: T0 })
+  assert.equal(v.action, 'refuse')
+  assert.match(v.reason, /in-progress/i)
+})
+
+test('a STALE status:in-progress proceeds — a crashed run must not wedge the issue forever', () => {
+  // TTL is 2x the workers' own `timeout-minutes: 45`, so a live run can never look stale.
+  const v = decideClaim({ issueState: 'open', inProgressSince: mins(-(CLAIM_TTL_MINUTES + 1)), now: T0 })
+  assert.equal(v.action, 'proceed')
+  assert.match(v.reason, /stale/i)
+})
+
+test('the TTL is at least twice the 45-minute worker timeout', () => {
+  assert.ok(CLAIM_TTL_MINUTES >= 90, `TTL ${CLAIM_TTL_MINUTES} must exceed a live run's ceiling`)
+})
+
+test('an unparseable in-progress timestamp fails OPEN on that weak signal', () => {
+  // The strong signals (closed issue / linked PR) still gate; a bad timestamp alone
+  // must not block work forever.
+  assert.equal(decideClaim({ issueState: 'open', inProgressSince: 'not-a-date', now: T0 }).action, 'proceed')
+})
+
+test('a strong signal outranks a stale label — closed issue still refuses', () => {
+  const v = decideClaim({
+    issueState: 'closed',
+    inProgressSince: mins(-(CLAIM_TTL_MINUTES + 1)),
+    now: T0,
+  })
+  assert.equal(v.action, 'refuse')
 })


### PR DESCRIPTION
Closes #1890

## 👤 For humans

Three times on 2026-08-05, two agents built the same thing. Each duplicate cost a full run and a PR someone had to close by hand:

| Issue | Winner | Duplicate |
|---|---|---|
| #1458 themes | #1473 | **#1478** — started 8 min *after* #1473 closed the issue |
| #1612 seed | landed elsewhere | **#1622** |
| #1880 un-skip | #1888 | **#1889** — opened while #1888 was open |

The signal that would have stopped all three already existed and was **inert**: five workflows stamp `status:in-progress`, and nothing ever read it. #1218 built the write half and closed; the read half was never built. This is the read half.

## 🤖 For agents

**`decideClaim` — invariant 4** in `scripts/pipeline-loop-guard.mjs`, alongside the three existing loop-guards. Refuses on, strongest signal first:

1. the issue is **closed** — timestamp-free; the work is over *(the #1478 case)*
2. a **merged** PR references it — the work already landed
3. an **open** PR references it — another runner is on it *(the #1889 case)*
4. `status:in-progress` newer than **`CLAIM_TTL_MINUTES`** — weakest, and last

**The TTL is derived, not guessed.** 90 minutes = 2× the workers' own `timeout-minutes: 45`, so a genuinely live run can never look stale, while a crashed one frees the issue within the hour instead of wedging it forever. That was the open design question on #1890; the number now has a reason attached to it in the code.

**Where it fails open, deliberately.** An unparseable timestamp or unreadable facts → *proceed*. A permanently-blocked worker is worse than a bounded duplicate risk, and the three timestamp-free signals still gate. A **closed-unmerged** PR is likewise not a claim — a rejected attempt should free the issue, not lock it.

**A re-dispatch doesn't refuse itself** — `self.pr` is excluded, preserving the existing `work-issue-pidev.yml:440` behaviour.

**Wiring.** Both pi entry points, immediately after the bot-actor guard. Facts are gathered by an API step; the *decision* is the pure function — so the shipped guard IS the tested one, matching the established bot-guard idiom. The linked-PR match requires a real closing keyword: `Follow-up to #1880` is not a claim (pinned in tests, since #1888's own body says exactly that).

**The interactive half.** `issue-sanity-check` gains check **3b**. No workflow gate can see a Claude Code session — and #1622 and #1889 both came from sessions, not pipelines — so the skill has to carry it. This is the half that would have caught #1889.

## Not in this PR

Item 3 of #1890 — the PR-time backstop flagging two open PRs with the same `Closes #NN` — is **not** here. Items 1 and 2 stop the run *before* it spends a build; the backstop only catches what slips past both, and is worth its own change. #1890 stays open for it. Flagging rather than quietly narrowing the scope.

## 🧪 How to test

```bash
node --test scripts/pipeline-loop-guard.test.mjs   # 23 passing (11 new)
```

Behaviourally, on a scratch issue:

1. Open a PR with `Closes #N`, then dispatch a worker at `#N` → the run stops at **Claim guard**, naming the PR, and opens nothing.
2. Close the issue, dispatch → same, citing the closed issue.
3. Stamp `status:in-progress`, dispatch → refused; back-date it past 90 min → proceeds, logging the stale claim.
4. Re-dispatch a worker onto an issue whose *own* PR is open → still proceeds.

Gates run in-session: 195/195 `scripts/*.test.mjs`, `npx fallow audit` clean on all 5 changed files, `gen-skills-doc --check` clean, both workflow YAMLs parse.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DH1qkwceVwwZE3TZ8tXVC1)_