### PR TITLE
fix(root): teardown targets a POC's real worker instead of a name that never existed

### DIFF
--- a/.github/workflows/teardown-app.yml
+++ b/.github/workflows/teardown-app.yml
@@ -98,7 +98,18 @@ jobs:
           ARGS=(--app "$APP" --scope "$SCOPE")
           if [ "$DRY" = "true" ]; then ARGS+=(--dry-run); fi
           if [ -n "$CONFIRM" ]; then ARGS+=(--confirm "$CONFIRM"); fi
-          node scripts/teardown-app.mjs "${ARGS[@]}"
+          # Tee the plan into the job summary (#1894). A dry run whose plan matches nothing still
+          # exits 0, so "result: success" in the summary was the only visible output and proved
+          # nothing — the actual names have to be readable from the run itself.
+          set -o pipefail
+          node scripts/teardown-app.mjs "${ARGS[@]}" 2>&1 | tee "$RUNNER_TEMP/teardown.log"
+          {
+            echo "### Cloudflare plan — \`$APP\`"
+            echo ""
+            echo '```'
+            cat "$RUNNER_TEMP/teardown.log"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # Mint a Nuxt Harness App installation token so branch deletes + issue closes
       # are attributed to nuxt-harness[bot] (same pattern as comment-dispatch.yml).

--- a/scripts/teardown-app.mjs
+++ b/scripts/teardown-app.mjs
@@ -30,11 +30,16 @@
  * A real run needs CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN in the env (the
  * same token the deploy workflows use — Workers Scripts/D1/KV Edit).
  */
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { dirname, join } from 'node:path'
 import { createInterface } from 'node:readline'
 import { findWranglerConfig, isAlreadyGone, parseJsonc, runWrangler } from './lib/wrangler-d1.mjs'
-import { readFileSync } from 'node:fs'
+import { readFileSync, existsSync } from 'node:fs'
+
+/** Read a file if it's there; '' when absent (labels.yml is optional context, not a dependency). */
+function readIfPresent(p) {
+  try { return readFileSync(p, 'utf8') } catch { return '' }
+}
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -100,19 +105,57 @@ function loadWrangler(app) {
 }
 
 /**
+ * Is `app` a POC or a launched app? (#1894)
+ *
+ * It matters because the two have DIFFERENT deploy shapes: `deploy-pocs.yml` gives a POC exactly
+ * ONE worker, at the BASE name, carrying the `<app>.pmcp.dev` route — there is no `-staging`
+ * sibling and no production counterpart. Resolving a POC the app way targets a worker that never
+ * existed, so the teardown silently no-ops and the site keeps serving (the bookmark-stash case).
+ *
+ * Pure — the caller supplies the facts. A directory outranks a label (a promoted POC keeps its
+ * stale `poc:` label); the label is what survives once the code PR is closed and the dir is gone,
+ * which is exactly when teardown runs. Unknown stays UNKNOWN and is treated conservatively.
+ */
+export function detectAppKind({ app, hasPocDir = false, hasAppDir = false, labelsText = '' } = {}) {
+  if (hasAppDir) return 'app'
+  if (hasPocDir) return 'poc'
+  if (labelsText.includes(`"app:${app}"`)) return 'app'
+  if (labelsText.includes(`"poc:${app}"`)) return 'poc'
+  return 'unknown'
+}
+
+/** Which envs a scope actually expands to. A POC has one deploy, whatever was asked for. */
+export function plannedEnvs(kind, scope) {
+  if (kind === 'poc') return ['staging']
+  return scope === 'both' ? ['staging', 'prod'] : [scope]
+}
+
+/**
+ * Does this teardown need the typed prod confirmation? A POC has no production to protect, so
+ * demanding one there teaches an operator to type prod confirmations as routine — which is the
+ * guard defeated. Anything not positively identified as a POC keeps the guard (fail closed).
+ */
+export function needsProdGuard(kind, scope) {
+  if (kind === 'poc') return false
+  return scope === 'prod' || scope === 'both'
+}
+
+/**
  * Resolve the { worker, d1, kvTitle, kvId } for one env scope. Prefers the real
  * names/ids from wrangler.jsonc; falls back to the crouton naming convention so a
  * teardown still works after the app's code has been deleted.
  */
-function resolveScope(app, env, config) {
-  const isProd = env === 'prod'
-  const worker = isProd ? app : `${app}-staging`
+export function resolveScope(app, env, config, kind = 'unknown') {
+  const isPoc = kind === 'poc'
+  const isProd = !isPoc && env === 'prod'
+  // A POC's single deploy lives at the BASE name — same slot a launched app calls prod.
+  const worker = (isProd || isPoc) ? app : `${app}-staging`
   // KV auto-provisions under the title "<worker>-<binding>" (binding is KV) → lowercased.
   const kvTitle = `${worker}-kv`
   let d1 = `${worker}-db`
   let kvId = null
 
-  const block = isProd ? config : config?.env?.staging
+  const block = (isProd || isPoc) ? config : config?.env?.staging
   if (block) {
     const dbName = block.d1_databases?.[0]?.database_name
     if (dbName) d1 = dbName
@@ -184,13 +227,34 @@ async function main() {
   }
 
   const config = loadWrangler(args.app)
-  const envs = args.scope === 'both' ? ['staging', 'prod'] : [args.scope]
-  const scopes = envs.map(env => resolveScope(args.app, env, config))
-  const hasProd = scopes.some(s => s.isProd)
+  const kind = detectAppKind({
+    app: args.app,
+    hasPocDir: existsSync(join(repoRoot, 'pocs', args.app)),
+    hasAppDir: existsSync(join(repoRoot, 'apps', args.app)),
+    labelsText: readIfPresent(join(repoRoot, '.github', 'labels.yml')),
+  })
+  const envs = plannedEnvs(kind, args.scope)
+  const scopes = envs.map(env => resolveScope(args.app, env, config, kind))
+  const hasProd = needsProdGuard(kind, args.scope)
 
   console.log(`\n  teardown-app: ${args.app}`)
   console.log(`    source : ${config ? findWranglerConfig(args.app, repoRoot) : 'wrangler.jsonc gone — using crouton naming convention'}`)
-  console.log(`    scope  : ${args.scope}\n`)
+  console.log(`    kind   : ${kind}${kind === 'poc' ? ' (one deploy, at the base name — no prod counterpart)' : ''}`)
+  console.log(`    scope  : ${args.scope}${kind === 'poc' && args.scope !== 'staging' ? ` → a POC has one env; treating as its single deploy` : ''}\n`)
+
+  // A plan built from a CONVENTION rather than the app's real config is a guess, and a guess
+  // that matches nothing exits 0 and reads as success (#1894). Say so loudly, not in passing.
+  if (!config) {
+    console.log('  ⚠ No wrangler.jsonc found — every name below is INFERRED from the crouton naming')
+    console.log('    convention, not read from the app. If the app deployed under different names,')
+    console.log('    this plan deletes NOTHING and still reports success. Verify against Cloudflare')
+    console.log('    (or the app\'s branch) before trusting a green run.\n')
+  }
+  if (kind === 'unknown') {
+    console.log('  ⚠ Could not tell whether this is a POC or a launched app (no directory, no')
+    console.log('    poc:/app: label). Falling back to the launched-app layout and KEEPING the prod')
+    console.log('    guard. If it was a POC, its worker is at the base name.\n')
+  }
 
   console.log('  Plan (delete these Cloudflare resources):')
   for (const s of scopes) {
@@ -244,7 +308,11 @@ async function main() {
   if (failed.length) process.exit(1)
 }
 
-main().catch((err) => {
-  console.error(`\n  teardown-app failed: ${err.message}\n`)
-  process.exit(1)
-})
+// Run only as a CLI — importing this module (e.g. from teardown-app.test.mjs, #1894) must not
+// execute a teardown. The decision helpers above are exported for that contract.
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => {
+    console.error(`\n  teardown-app failed: ${err.message}\n`)
+    process.exit(1)
+  })
+}

--- a/scripts/teardown-app.test.mjs
+++ b/scripts/teardown-app.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * #1894 contract — teardown must target the resources an app ACTUALLY has.
+ *
+ * The case that minted these: tearing down the retired `bookmark-stash` POC. The documented-safe
+ * `--scope staging` resolved `bookmark-stash-staging`, which never existed — so the run reported
+ * success and the live worker at `bookmark-stash.pmcp.dev` kept serving. The only path that
+ * reached it was `--scope both` with a typed PROD confirmation, on a POC that was never
+ * production. That trains an operator to type a prod confirm as routine, which is the whole
+ * point of the guard gone.
+ *
+ * A POC deployed by `deploy-pocs.yml` has exactly ONE deploy, at the BASE name, carrying the
+ * `<app>.pmcp.dev` route. There is no prod counterpart to protect.
+ *
+ *   node --test scripts/teardown-app.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { detectAppKind, resolveScope, plannedEnvs, needsProdGuard } from './teardown-app.mjs'
+
+// ── detectAppKind ─────────────────────────────────────────────────────────────────
+test('a live pocs/ directory identifies a POC', () => {
+  assert.equal(detectAppKind({ app: 'quotes', hasPocDir: true }), 'poc')
+})
+
+test('a live apps/ directory identifies a launched app', () => {
+  assert.equal(detectAppKind({ app: 'velo', hasAppDir: true }), 'app')
+})
+
+test('the poc: label identifies a POC after its directory is gone — the bookmark-stash case', () => {
+  // Teardown usually runs AFTER the code PR closed, so the directory is the one signal
+  // that has already disappeared. The label in .github/labels.yml outlives it.
+  const labels = '- name: "poc:bookmark-stash"\n  color: "c5def5"\n- name: "app:velo"\n'
+  assert.equal(detectAppKind({ app: 'bookmark-stash', labelsText: labels }), 'poc')
+})
+
+test('an app: label identifies a launched app after its directory is gone', () => {
+  const labels = '- name: "app:velo"\n- name: "poc:quotes"\n'
+  assert.equal(detectAppKind({ app: 'velo', labelsText: labels }), 'app')
+})
+
+test('a directory outranks a label (the label may be stale after promotion)', () => {
+  const labels = '- name: "poc:velo"\n'
+  assert.equal(detectAppKind({ app: 'velo', hasAppDir: true, labelsText: labels }), 'app')
+})
+
+test('no directory and no label is unknown — must not be guessed as either', () => {
+  assert.equal(detectAppKind({ app: 'ghost' }), 'unknown')
+})
+
+// ── resolveScope: a POC's only deploy is at the BASE name ─────────────────────────
+test('a POC resolves the BASE worker name, not <app>-staging — the #1894 bug', () => {
+  const r = resolveScope('bookmark-stash', 'staging', null, 'poc')
+  assert.equal(r.worker, 'bookmark-stash')
+  assert.equal(r.d1, 'bookmark-stash-db')
+  assert.equal(r.kvTitle, 'bookmark-stash-kv')
+})
+
+test('a POC reads its real names off the BASE wrangler block, not env.staging', () => {
+  const config = {
+    name: 'bookmark-stash',
+    d1_databases: [{ binding: 'DB', database_name: 'bookmark-stash-db' }],
+    env: { staging: { d1_databases: [{ database_name: 'bookmark-stash-staging-db' }] } },
+  }
+  assert.equal(resolveScope('bookmark-stash', 'staging', config, 'poc').d1, 'bookmark-stash-db')
+})
+
+test('a launched app keeps the existing staging/prod split', () => {
+  assert.equal(resolveScope('velo', 'staging', null, 'app').worker, 'velo-staging')
+  assert.equal(resolveScope('velo', 'prod', null, 'app').worker, 'velo')
+})
+
+test('an unknown kind keeps the conservative app split', () => {
+  // Fail safe: treat an unidentifiable app like a launched one, so the prod guard still applies.
+  assert.equal(resolveScope('ghost', 'staging', null, 'unknown').worker, 'ghost-staging')
+})
+
+// ── plannedEnvs / needsProdGuard ──────────────────────────────────────────────────
+test('a POC has exactly one env whatever scope was asked for', () => {
+  assert.deepEqual(plannedEnvs('poc', 'staging'), ['staging'])
+  assert.deepEqual(plannedEnvs('poc', 'both'), ['staging'])
+  assert.deepEqual(plannedEnvs('poc', 'prod'), ['staging'])
+})
+
+test('a launched app expands scopes as before', () => {
+  assert.deepEqual(plannedEnvs('app', 'staging'), ['staging'])
+  assert.deepEqual(plannedEnvs('app', 'prod'), ['prod'])
+  assert.deepEqual(plannedEnvs('app', 'both'), ['staging', 'prod'])
+})
+
+test('a POC never trips the prod guard — it has no production to protect', () => {
+  assert.equal(needsProdGuard('poc', 'both'), false)
+  assert.equal(needsProdGuard('poc', 'prod'), false)
+})
+
+test('a launched app still trips the prod guard', () => {
+  assert.equal(needsProdGuard('app', 'prod'), true)
+  assert.equal(needsProdGuard('app', 'both'), true)
+  assert.equal(needsProdGuard('app', 'staging'), false)
+})
+
+test('an UNKNOWN app still trips the prod guard — fail closed on the destructive path', () => {
+  assert.equal(needsProdGuard('unknown', 'prod'), true)
+  assert.equal(needsProdGuard('unknown', 'both'), true)
+})


### PR DESCRIPTION
Closes #1894

## 👤 For humans

Tearing down the retired `bookmark-stash` POC at the documented-safe `--scope staging` **deleted nothing and reported success** — the site kept serving. The only path that reached it was `--scope both` with a typed **PROD** confirmation, on something that was never production.

That second part is the real damage: it trains an operator to type prod confirmations as routine, which is exactly the reflex the guard exists to prevent. With POC teardown becoming a normal operation, that compounds.

## 🤖 For agents

**Root cause.** `deploy-pocs.yml` gives a POC exactly one worker, at the **base** name, carrying the `<app>.pmcp.dev` route. `resolveScope` assumed the launched-app shape (`<app>` = prod, `<app>-staging` = staging), so a POC's only deploy sat in the slot the script calls *prod*.

**Fix** — three exported, tested decisions:

| | |
|---|---|
| `detectAppKind` | `pocs/`/`apps/` dir → else the `poc:`/`app:` label in `labels.yml`. The dir is gone by teardown time; the label outlives it. Dir outranks label (a promoted POC keeps a stale one). |
| `plannedEnvs` | a POC has one env whatever scope was asked for |
| `needsProdGuard` | `false` for a POC; **`true` for `unknown`** — fail closed on the destructive path |

`resolveScope` now takes the kind and, for a POC, resolves the base name and reads the **base** wrangler block instead of `env.staging`.

**Two honesty fixes**, which is the half that nearly bit us:

- A plan built from the naming **convention** (no `wrangler.jsonc` — normal once the code PR is closed) now prints a loud ⚠ saying every name is inferred and *"this plan deletes NOTHING and still reports success"*. That line was previously a single easy-to-miss `source :` note above an authoritative-looking plan.
- `teardown-app.yml` tees the plan into the **job summary**. The CF step previously printed nothing visible — in run 30992611969 it completed in 0 s and the summary said `result | success`, which is what made a meaningless dry run look like proof.

Also added the CLI entry guard — importing the module used to execute `main()`, so a test run printed the help and exited 1.

## Verified

```
notes (POC, dir present)     → kind: poc  · delete --name notes            · no prod guard
velo (launched app)          → kind: app  · velo-staging + velo            · prod guard intact
bookmark-stash (both gone)   → kind: unknown · falls back + KEEPS the guard · both ⚠ shown
```

`bookmark-stash` reading `unknown` is correct, and worth knowing: its `poc:` label only ever existed on the unmerged #1651 branch, so it never reached `main`. The label signal works for POCs whose `labels.yml` change actually landed — for the rest, the conservative path plus the loud warning is the answer.

## 🧪 How to test

```bash
node --test scripts/teardown-app.test.mjs                                # 15 passing
node scripts/teardown-app.mjs --app notes --scope both --dry-run         # one env, base name
node scripts/teardown-app.mjs --app velo --scope both --dry-run          # unchanged split
node scripts/teardown-app.mjs --app ghost --scope staging --dry-run      # both ⚠ warnings
```

On a real run, the Cloudflare plan now appears in the workflow's job summary rather than only in the step log.

Gates: 199/199 `scripts/*.test.mjs`, `npx fallow audit` clean on all 3 files, workflow YAML parses.

**Touches `.github/workflows/**`** — needs a human to merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DH1qkwceVwwZE3TZ8tXVC1)_