### PR TITLE
fix: verify a fresh poc — scaffold a root tsconfig.json + gate prepares the env (#1872)

### DIFF
--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -395,8 +395,23 @@ jobs:
               # auto-imports (ref/defineEventHandler/useCrouton/…) resolve. A raw `npx nuxt typecheck`
               # WITHOUT prepare flags every auto-import as undefined — 37 false errors on a clean
               # generated poc (#1863). So no script ⇒ NEUTRAL (safe, non-blocking), never a false fail.
-              # (Reliably typechecking a scriptless fresh poc needs a prepare step — tracked follow-up.)
+              # (A scriptless fresh poc still can't be verified — no script to run prepare — but #1866
+              # makes every scaffold emit the script, so that case is legacy-only.)
               if [ "$HAS_TC" = "1" ] && [ -n "$PKG" ]; then
+                # PREPARE THE ENV (#1872) — the job's `pnpm install --frozen-lockfile` (top of the job)
+                # ran BEFORE pi scaffolded this poc, so the new workspace member was never linked: no
+                # `pocs/<name>/node_modules`, no `.nuxt`. `nuxt typecheck` then can't resolve Nuxt
+                # auto-imports and reports ~37 bogus `TS2304: Cannot find name` on fine code — which the
+                # AUTOIMP guard below (correctly) treats as NEUTRAL, so a good poc lands UNVERIFIED.
+                # Link it now: a NON-frozen install (a new importer changes the lockfile, so `--frozen`
+                # would error) scoped to this app + its workspace deps (`$PKG...`) against the warm store
+                # ⇒ seconds. That link is what lets `nuxt prepare` (run by the typecheck script below)
+                # generate the auto-import types, so the verdict becomes trustworthy — a real PASS on a
+                # fresh poc. Guarded (errexit is on for this step): a failed install just leaves the env
+                # unprepared, and the AUTOIMP→NEUTRAL guard still catches it — never a false FAIL.
+                echo "acceptance: linking $PKG into the workspace before typecheck (#1872)"
+                pnpm install --filter "$PKG..." --no-frozen-lockfile > "$RUNNER_TEMP/acc-install.log" 2>&1 \
+                  || { echo "::warning::acceptance: install for $PKG failed — env may be unprepared (#1872)"; tail -15 "$RUNNER_TEMP/acc-install.log" || true; }
                 echo "acceptance: pnpm --filter $PKG typecheck ($APP_DIR)"
                 if pnpm --filter "$PKG" typecheck > "$RUNNER_TEMP/acc.log" 2>&1; then TC_EXIT=0; else TC_EXIT=$?; fi
               else

--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -208,7 +208,8 @@ crouton init my-app --dry-run
 
 ### What `crouton init` Does
 
-1. **scaffold-app** — Creates the app skeleton (nuxt.config, package.json, schemas/, etc.) and
+1. **scaffold-app** — Creates the app skeleton (nuxt.config, package.json, **tsconfig.json**
+   — extends `./.nuxt/tsconfig.json` so `nuxt typecheck` resolves auto-imports, #1872 — schemas/, etc.) and
    writes a **`.crouton.json`** identifier (`{ name, kind: poc|app, cliVersion, scaffoldedAt }`) —
    provenance + the marker the guard reads. **It refuses only a dir that's already scaffolded**
    (has `.crouton.json` or `package.json`); it **scaffolds *into* a config-only dir** (one that has

--- a/packages/crouton-cli/lib/scaffold-app.ts
+++ b/packages/crouton-cli/lib/scaffold-app.ts
@@ -460,6 +460,22 @@ logs
 `
 }
 
+// The root tsconfig every Nuxt app needs: it EXTENDS the `.nuxt/tsconfig.json` that
+// `nuxt prepare` generates, which is what wires in the auto-import type declarations
+// (ref/defineEventHandler/useCrouton/…). Without this file `nuxt typecheck` runs
+// `vue-tsc` with default options, never sees `.nuxt`'s types, and reports every
+// auto-import as `TS2304: Cannot find name` — ~thousands of false errors on clean
+// generated code (#1872). #1866 gave the scaffold a `typecheck` SCRIPT but not the
+// tsconfig that makes it meaningful; this is that missing half. Byte-identical to the
+// root tsconfig in every working app (apps/velo, apps/triage, fixtures/*).
+export function tmplTsconfig(): string {
+  return `{
+  // https://nuxt.com/docs/guide/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
+}
+`
+}
+
 function tmplAppConfig(): string {
   return `import { translationsUiConfig } from '@fyit/crouton-i18n/app/composables/useTranslationsUi'
 
@@ -630,7 +646,7 @@ async function resolveScaffoldContext(
 }
 
 // The full file list: core + (optionally) Cloudflare + the .crouton.json identifier (#1233).
-async function buildScaffoldFiles(ctx: ScaffoldContext, outDir: string | undefined, cf: boolean): Promise<ScaffoldFile[]> {
+export async function buildScaffoldFiles(ctx: ScaffoldContext, outDir: string | undefined, cf: boolean): Promise<ScaffoldFile[]> {
   const { vars, authSecret } = ctx
   const identifier = JSON.stringify({
     crouton: true, name: vars.name,
@@ -639,6 +655,7 @@ async function buildScaffoldFiles(ctx: ScaffoldContext, outDir: string | undefin
   }, null, 2) + '\n'
   const files: ScaffoldFile[] = [
     { path: 'package.json', content: tmplPackageJson(vars) },
+    { path: 'tsconfig.json', content: tmplTsconfig() },
     { path: 'nuxt.config.ts', content: tmplNuxtConfig(vars) },
     { path: 'crouton.config.js', content: tmplCroutonConfig(vars) },
     { path: '.crouton.json', content: identifier },

--- a/packages/crouton-cli/tests/unit/scaffold-tsconfig.test.ts
+++ b/packages/crouton-cli/tests/unit/scaffold-tsconfig.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { buildScaffoldFiles, tmplTsconfig } from '../../lib/scaffold-app'
+
+// #1872 — a scaffolded app MUST ship a root tsconfig.json that extends `.nuxt/tsconfig.json`.
+// Without it, `nuxt typecheck` runs `vue-tsc` with default options, never sees the auto-import
+// type declarations `nuxt prepare` writes into `.nuxt`, and reports every auto-import
+// (ref/defineEventHandler/useCrouton/…) as `TS2304: Cannot find name` — thousands of false
+// errors on clean generated code. #1866 added the `typecheck` SCRIPT but not this file, so a
+// fresh poc could never be verified (the acceptance gate saw the auto-import misses and, rightly,
+// treated them as NEUTRAL — so a missing tsconfig would NOT fail the gate; this unit test is the
+// regression guard the gate can't be).
+const ctx = {
+  vars: {
+    name: 'probe',
+    features: [],
+    extends: ['@fyit/crouton-core', '@fyit/crouton-i18n'],
+    dialect: 'sqlite',
+    cf: false,
+    modules: {}
+  },
+  frameworkPackages: ['@fyit/crouton-core', '@fyit/crouton-i18n'],
+  features: [],
+  authSecret: 'test-secret'
+} as any
+
+describe('scaffold root tsconfig (#1872)', () => {
+  it('emits a root tsconfig.json that extends ./.nuxt/tsconfig.json', () => {
+    // It's JSONC (a `//` comment, which tsconfig allows) — assert the extends line directly
+    // rather than JSON.parse.
+    expect(tmplTsconfig()).toContain('"extends": "./.nuxt/tsconfig.json"')
+  })
+
+  it('the scaffold file set INCLUDES tsconfig.json (the #1866 omission)', async () => {
+    const files = await buildScaffoldFiles(ctx, 'pocs/probe', false)
+    const ts = files.find(f => f.path === 'tsconfig.json')
+    expect(ts, 'scaffold must emit tsconfig.json').toBeTruthy()
+    expect(ts!.content).toContain('"extends": "./.nuxt/tsconfig.json"')
+  })
+})


### PR DESCRIPTION
Closes #1872

Packages-approved: crouton-cli scaffold now emits the root tsconfig.json every working app already ships — owner-approved (the missing half of #1866's typecheck script).

## 👤 For humans
A freshly-scaffolded poc could never be **type-verified** by the acceptance gate: `nuxt typecheck` reported thousands of `Cannot find name 'ref'/'useCrouton'/'defineEventHandler'` errors on perfectly good generated code. The issue assumed the cause was an unprepared Nuxt env — it wasn't. The scaffold simply **never emitted a root `tsconfig.json`**, so `vue-tsc` never saw the auto-import types `nuxt prepare` writes into `.nuxt`. #1866 added a `typecheck` *script* but not the tsconfig that makes it mean anything. A fresh poc now typechecks cleanly (0 errors) and the gate reaches a real PASS.

## 🤖 For agents
Two commits, both #1872:
1. `fix(crouton-cli)` — `tmplTsconfig()` (`{ "extends": "./.nuxt/tsconfig.json" }`, byte-identical to apps/velo·triage·fixtures) added to `buildScaffoldFiles`' `files[]`. Exported `tmplTsconfig`+`buildScaffoldFiles`; new `scaffold-tsconfig.test.ts` asserts content **and** set-membership (the gate maps auto-import misses to NEUTRAL, so it can't self-catch a re-omission).
2. `fix(root)` — acceptance gate runs a non-frozen `pnpm install --filter <app>...` before typecheck, so it prepares the env itself instead of depending on pi's incidental install.

## 🧪 How to test
- `git show <sha>:packages/crouton-cli/lib/scaffold-app.ts` → `tmplTsconfig` present + in `files[]`.
- `pnpm --filter @fyit/crouton-cli test -- scaffold-tsconfig` → green.
- Evidence (real generated poc, `.nuxt` present both times): **no** root tsconfig → 8096 `TS2304` (37 app-local); **with** → typecheck exit 0. End-to-end fresh-scaffold PASS through the live gate verified on a throwaway leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)