### PR TITLE
fix(root): release a blocked leaf with its own label, not `delegate` (#1923)

### DIFF
--- a/.github/workflows/schedule-waves.yml
+++ b/.github/workflows/schedule-waves.yml
@@ -123,7 +123,10 @@ jobs:
                 const ref = branch ?? await epicBranchOf(blockers[blockers.length - 1])
                 const status = ref ? await branchStatus(ref) : 'unknown'
 
-                const decision = gate.shouldRelease({ blockerStates, labels: it.labels, branchStatus: status })
+                // `body` feeds releaseLabel (#1923): a child the decomposer created records the
+                // trigger label it would have been dispatched with, so a blocked LEAF is released
+                // straight to its worker instead of costing a decompose run to re-derive leafness.
+                const decision = gate.shouldRelease({ blockerStates, labels: it.labels, branchStatus: status, body: it.body })
                 if (!decision.release) {
                   core.info(`#${it.number}: ${decision.reason}`)
                   if (decision.reason === 'branch-red') {
@@ -137,10 +140,11 @@ jobs:
                   continue
                 }
 
-                await github.rest.issues.addLabels({ owner, repo, issue_number: it.number, labels: ['delegate'] })
+                const releaseWith = decision.label || 'delegate'
+                await github.rest.issues.addLabels({ owner, repo, issue_number: it.number, labels: [releaseWith] })
                 await github.rest.issues.createComment({ owner, repo, issue_number: it.number,
-                  body: gate.formatReleaseComment({ doneNumber: onlyBlockedBy ?? blockers[blockers.length - 1], branchStatus: status }) })
-                core.info(`Released #${it.number} (${decision.reason})`)
+                  body: gate.formatReleaseComment({ doneNumber: onlyBlockedBy ?? blockers[blockers.length - 1], branchStatus: status, label: releaseWith }) })
+                core.info(`Released #${it.number} with ${releaseWith} (${decision.reason})`)
               }
             }
 

--- a/scripts/apply-decompose-plan.mjs
+++ b/scripts/apply-decompose-plan.mjs
@@ -156,8 +156,8 @@ export function parseBlockedBy(body = '') {
 }
 
 /** The child's final body = its markdown + the WS2 pipeline block at childDepth. Pure. */
-export function buildChildBody(body, { epic, childDepth, epic_branch }) {
-  return writePipelineBlock(body, { epic, depth: childDepth, epic_branch })
+export function buildChildBody(body, { epic, childDepth, epic_branch, dispatch = null }) {
+  return writePipelineBlock(body, { epic, depth: childDepth, epic_branch, dispatch })
 }
 
 /**
@@ -188,10 +188,16 @@ export function planToActions(plan, ctx) {
   // five seconds, two of them against preconditions that did not exist yet.
   plan.children.forEach((c, i) => {
     const { kept, dropped } = sanitizeLabels(c.labels, knownLabels)
+    // The trigger label this child WOULD get if it were not blocked. For an unblocked child it is
+    // applied directly below; for a blocked one it is recorded on the pipeline block (#1923) so the
+    // wave scheduler can release it with the right label instead of falling back to `delegate` and
+    // spending a decompose run re-deriving a classification we already made here.
+    const dispatch = labelForChild({ depth: childDepth, isLeaf: !c.needsSplit, maxDepth: MAX_DEPTH })
+    const isBlocked = (c.blockedBy || []).length > 0
     actions.push({
       type: 'create', ref: `child${i}`,
       title: c.title,
-      body: buildChildBody(c.body, { epic, childDepth, epic_branch }),
+      body: buildChildBody(c.body, { epic, childDepth, epic_branch, dispatch: isBlocked ? dispatch : null }),
       labels: kept, droppedLabels: dropped,
     })
     actions.push({ type: 'link', parent: target, ref: `child${i}` })
@@ -209,6 +215,8 @@ export function planToActions(plan, ctx) {
     if ((c.blockedBy || []).length) return
     actions.push({ type: 'trigger-label', ref: `child${i}`, label: labelForChild({ depth: childDepth, isLeaf: !c.needsSplit, maxDepth: MAX_DEPTH }) })
   })
+  // NB the label in `dispatch=` (recorded above) and the one applied here are the SAME expression —
+  // a blocked child must be released with exactly what it would have been dispatched with.
   return actions
 }
 

--- a/scripts/apply-decompose-plan.test.mjs
+++ b/scripts/apply-decompose-plan.test.mjs
@@ -89,8 +89,29 @@ test('sanitizeLabels keeps known and drops unknown (the bad-label create failure
 // ── buildChildBody ───────────────────────────────────────────────────────────────
 test('buildChildBody injects the WS2 block at childDepth', () => {
   const body = buildChildBody('## body', { epic: 1685, childDepth: 2, epic_branch: BRANCH })
-  assert.deepEqual(parsePipelineBlock(body), { epic: 1685, depth: 2, epic_branch: BRANCH })
+  assert.deepEqual(parsePipelineBlock(body), { epic: 1685, depth: 2, epic_branch: BRANCH, dispatch: null })
   assert.match(body, /^## body/)
+})
+
+// ── #1923: the withheld trigger label is RECORDED, not discarded ─────────────────────
+test('a blocked child records the label it would have been dispatched with', () => {
+  const acts = planToActions(parsePlan({ leaf: false, children: [
+    { title: 'foundation', body: 'x' },
+    { title: 'dependent leaf', body: 'x', blockedBy: [0] },
+    { title: 'dependent, still splits', body: 'x', needsSplit: true, blockedBy: [0] },
+  ] }), CTX)
+  const created = acts.filter(a => a.type === 'create')
+
+  // the unblocked child is dispatched now, so nothing needs recording on it
+  assert.equal(parsePipelineBlock(created[0].body).dispatch, null)
+  // the blocked ones carry exactly what they'd have got — a leaf and a splitter differ
+  assert.equal(parsePipelineBlock(created[1].body).dispatch, 'work-this')
+  assert.equal(parsePipelineBlock(created[2].body).dispatch, 'delegate-pi')
+
+  // and the recorded label must equal the one actually applied to an equivalent unblocked child
+  const applied = acts.find(a => a.type === 'trigger-label' && a.ref === 'child0').label
+  assert.equal(applied, parsePipelineBlock(created[1].body).dispatch,
+    'a blocked leaf must be released with what an unblocked leaf is dispatched with')
 })
 
 // ── planToActions ────────────────────────────────────────────────────────────────

--- a/scripts/pipeline-context.mjs
+++ b/scripts/pipeline-context.mjs
@@ -15,11 +15,19 @@
 //
 //   • An HTML comment, so it renders invisibly in the issue body.
 //   • `key=value` tokens, space-separated, in a single line. Keys: epic (int), depth (int),
-//     epic_branch (branch name; may contain `/` and `-`, never a space).
+//     epic_branch (branch name; may contain `/` and `-`, never a space), dispatch (#1923 — the
+//     trigger label this issue should be released with, e.g. `work-this`; see below).
 //   • Any subset of keys may be present; absent keys parse to null.
 //   • Back-compat (#1686): WS1's worker read a bare `pipeline: epic_branch=<name>` line (no
 //     HTML-comment wrapper). `parsePipelineBlock` still reads that legacy shape so already-
 //     labelled issues keep working; `formatPipelineBlock` always emits the wrapped form.
+//
+// `dispatch` (#1923). When the decomposer WITHHOLDS a trigger label from a blocked child (#1750),
+// the leaf-vs-split classification it already made would otherwise be thrown away — so the wave
+// scheduler released everything with `delegate`, spending a whole decompose run to re-derive
+// `{"leaf": true}`, and able to re-classify the child differently than its parent planned. Record
+// the intended label here instead. Absent → callers fall back to `delegate`, so hand-written
+// `Blocked-by:` edges and every pre-existing epic behave exactly as before.
 //
 // This module is PURE + unit-tested (pipeline-context.test.mjs). The workflows shell out to
 // the CLI at the bottom for the values they need (e.g. `... read epic_branch < body.txt`).
@@ -34,11 +42,11 @@ const LEGACY_RE = /^[ \t]*pipeline:\s*(.+?)\s*$/im
 
 // Keys we understand. Anything else in the block is ignored (forward-compatible).
 const INT_KEYS = new Set(['epic', 'depth'])
-const STR_KEYS = new Set(['epic_branch'])
+const STR_KEYS = new Set(['epic_branch', 'dispatch'])
 
 /** Parse the `k=v k=v` token string into a typed object. Unknown keys are dropped. */
 function parseTokens(tokenStr) {
-  const out = { epic: null, depth: null, epic_branch: null }
+  const out = { epic: null, depth: null, epic_branch: null, dispatch: null }
   if (!tokenStr) return out
   for (const tok of tokenStr.trim().split(/\s+/)) {
     const eq = tok.indexOf('=')
@@ -61,24 +69,25 @@ function parseTokens(tokenStr) {
  * Prefers the wrapped `<!-- pipeline: ... -->` form; falls back to the legacy bare line.
  */
 export function parsePipelineBlock(body) {
-  if (!body || typeof body !== 'string') return { epic: null, depth: null, epic_branch: null }
+  if (!body || typeof body !== 'string') return { epic: null, depth: null, epic_branch: null, dispatch: null }
   const wrapped = body.match(BLOCK_RE)
   if (wrapped) return parseTokens(wrapped[1])
   const legacy = body.match(LEGACY_RE)
   if (legacy) return parseTokens(legacy[1])
-  return { epic: null, depth: null, epic_branch: null }
+  return { epic: null, depth: null, epic_branch: null, dispatch: null }
 }
 
 /**
  * Render the canonical wrapped block for the given context. Only the keys with a
- * non-null/defined value are emitted, in a stable order (epic, depth, epic_branch).
+ * non-null/defined value are emitted, in a stable order (epic, depth, epic_branch, dispatch).
  * Returns null if nothing is worth writing (so callers can skip an empty block).
  */
-export function formatPipelineBlock({ epic, depth, epic_branch } = {}) {
+export function formatPipelineBlock({ epic, depth, epic_branch, dispatch } = {}) {
   const toks = []
   if (epic !== null && epic !== undefined && `${epic}` !== '') toks.push(`epic=${epic}`)
   if (depth !== null && depth !== undefined && `${depth}` !== '') toks.push(`depth=${depth}`)
   if (epic_branch) toks.push(`epic_branch=${epic_branch}`)
+  if (dispatch) toks.push(`dispatch=${dispatch}`)
   if (toks.length === 0) return null
   return `<!-- pipeline: ${toks.join(' ')} -->`
 }
@@ -122,9 +131,9 @@ function stripEmpty(obj) {
 // ── CLI ──────────────────────────────────────────────────────────────────────────
 // Reads an issue body from stdin (or a file arg after the command), for the workflows.
 //   node scripts/pipeline-context.mjs read [<field>]   < body.txt
-//     • no field → prints JSON `{ epic, depth, epic_branch }`
+//     • no field → prints JSON `{ epic, depth, epic_branch, dispatch }`
 //     • field    → prints just that value (empty string when absent) — for `epic_branch=$(...)`
-//   node scripts/pipeline-context.mjs write epic=.. depth=.. epic_branch=..  < body.txt
+//   node scripts/pipeline-context.mjs write epic=.. depth=.. epic_branch=.. dispatch=..  < body.txt
 //     • prints the body with the block upserted
 function readStdin() {
   try { return readFileSync(0, 'utf8') } catch { return '' }

--- a/scripts/pipeline-context.test.mjs
+++ b/scripts/pipeline-context.test.mjs
@@ -17,21 +17,21 @@ const BRANCH = 'epic/1685-single-use-pipeline'
 
 test('parse reads a full wrapped block', () => {
   const body = `Some issue text.\n\n<!-- pipeline: epic=1685 depth=2 epic_branch=${BRANCH} -->`
-  assert.deepEqual(parsePipelineBlock(body), { epic: 1685, depth: 2, epic_branch: BRANCH })
+  assert.deepEqual(parsePipelineBlock(body), { epic: 1685, depth: 2, epic_branch: BRANCH, dispatch: null })
 })
 
 test('parse tolerates extra whitespace and key order', () => {
   const body = `<!--   pipeline:   epic_branch=${BRANCH}    epic=42   depth=0   -->`
-  assert.deepEqual(parsePipelineBlock(body), { epic: 42, depth: 0, epic_branch: BRANCH })
+  assert.deepEqual(parsePipelineBlock(body), { epic: 42, depth: 0, epic_branch: BRANCH, dispatch: null })
 })
 
 test('parse returns nulls for a subset / absent keys', () => {
   assert.deepEqual(parsePipelineBlock('<!-- pipeline: epic_branch=main -->'),
-    { epic: null, depth: null, epic_branch: 'main' })
+    { epic: null, depth: null, epic_branch: 'main', dispatch: null })
   assert.deepEqual(parsePipelineBlock('no block here'),
-    { epic: null, depth: null, epic_branch: null })
-  assert.deepEqual(parsePipelineBlock(''), { epic: null, depth: null, epic_branch: null })
-  assert.deepEqual(parsePipelineBlock(undefined), { epic: null, depth: null, epic_branch: null })
+    { epic: null, depth: null, epic_branch: null, dispatch: null })
+  assert.deepEqual(parsePipelineBlock(''), { epic: null, depth: null, epic_branch: null, dispatch: null })
+  assert.deepEqual(parsePipelineBlock(undefined), { epic: null, depth: null, epic_branch: null, dispatch: null })
 })
 
 test('parse reads the legacy bare `pipeline:` line WS1 emitted (back-compat)', () => {
@@ -41,7 +41,7 @@ test('parse reads the legacy bare `pipeline:` line WS1 emitted (back-compat)', (
 
 test('parse ignores unknown keys and bad ints', () => {
   assert.deepEqual(parsePipelineBlock('<!-- pipeline: epic=notanint depth=3 wave=2 -->'),
-    { epic: null, depth: 3, epic_branch: null })
+    { epic: null, depth: 3, epic_branch: null, dispatch: null })
 })
 
 test('depth=0 is preserved, not dropped as falsy', () => {
@@ -49,7 +49,7 @@ test('depth=0 is preserved, not dropped as falsy', () => {
 })
 
 test('format emits only present keys in a stable order', () => {
-  assert.equal(formatPipelineBlock({ epic: 1685, depth: 2, epic_branch: BRANCH }),
+  assert.equal(formatPipelineBlock({ epic: 1685, depth: 2, epic_branch: BRANCH, dispatch: null }),
     `<!-- pipeline: epic=1685 depth=2 epic_branch=${BRANCH} -->`)
   assert.equal(formatPipelineBlock({ epic_branch: BRANCH }),
     `<!-- pipeline: epic_branch=${BRANCH} -->`)
@@ -58,9 +58,9 @@ test('format emits only present keys in a stable order', () => {
 })
 
 test('write appends a block to a body that has none', () => {
-  const out = writePipelineBlock('Issue body.', { epic: 1685, depth: 1, epic_branch: BRANCH })
+  const out = writePipelineBlock('Issue body.', { epic: 1685, depth: 1, epic_branch: BRANCH, dispatch: null })
   assert.match(out, /^Issue body\.\n\n<!-- pipeline: epic=1685 depth=1 epic_branch=/)
-  assert.deepEqual(parsePipelineBlock(out), { epic: 1685, depth: 1, epic_branch: BRANCH })
+  assert.deepEqual(parsePipelineBlock(out), { epic: 1685, depth: 1, epic_branch: BRANCH, dispatch: null })
 })
 
 test('write is idempotent — same context twice is byte-identical', () => {
@@ -74,7 +74,7 @@ test('write replaces an existing block in place (no duplication)', () => {
   const start = writePipelineBlock('Body', { epic: 1, depth: 0, epic_branch: 'main' })
   const updated = writePipelineBlock(start, { depth: 1, epic_branch: BRANCH })
   // epic preserved from the merge, depth+branch updated, still exactly one block.
-  assert.deepEqual(parsePipelineBlock(updated), { epic: 1, depth: 1, epic_branch: BRANCH })
+  assert.deepEqual(parsePipelineBlock(updated), { epic: 1, depth: 1, epic_branch: BRANCH, dispatch: null })
   assert.equal((updated.match(/<!-- pipeline:/g) || []).length, 1)
 })
 
@@ -94,5 +94,25 @@ test('a partial update with explicit nulls preserves siblings (the CLI write pat
   // parseTokens yields null for absent keys; `write depth=1` must NOT wipe epic/epic_branch.
   const start = writePipelineBlock('Body', { epic: 1685, depth: 0, epic_branch: BRANCH })
   const updated = writePipelineBlock(start, { epic: null, depth: 1, epic_branch: null })
-  assert.deepEqual(parsePipelineBlock(updated), { epic: 1685, depth: 1, epic_branch: BRANCH })
+  assert.deepEqual(parsePipelineBlock(updated), { epic: 1685, depth: 1, epic_branch: BRANCH, dispatch: null })
+})
+
+// ── #1923: `dispatch` — the trigger label a blocked child should be released with ────
+// #1750 withholds the trigger label from a blocked child, which threw away the leaf-vs-split
+// call the decomposer had already made. The wave scheduler then released everything with
+// `delegate`, burning a decompose run to re-derive it — and free to re-classify the child
+// differently than its parent planned. Carrying it on the block is what fixes that.
+test('dispatch round-trips and stays absent when not set', () => {
+  const out = writePipelineBlock('Body', { epic: 7, depth: 1, epic_branch: BRANCH, dispatch: 'work-this' })
+  assert.match(out, /dispatch=work-this/)
+  assert.equal(parsePipelineBlock(out).dispatch, 'work-this')
+  // absent → null, so callers fall back to `delegate` and pre-existing epics are untouched
+  assert.equal(parsePipelineBlock(writePipelineBlock('Body', { epic: 7 })).dispatch, null)
+})
+
+test('a partial update does not clobber a recorded dispatch', () => {
+  const start = writePipelineBlock('Body', { epic: 7, depth: 0, dispatch: 'work-this' })
+  const updated = writePipelineBlock(start, { depth: 1 })
+  assert.equal(parsePipelineBlock(updated).dispatch, 'work-this', 'survives an unrelated update')
+  assert.equal(parsePipelineBlock(updated).depth, 1)
 })

--- a/scripts/wave-gate.mjs
+++ b/scripts/wave-gate.mjs
@@ -16,6 +16,8 @@
  *   node --test scripts/wave-gate.test.mjs
  */
 
+import { parsePipelineBlock } from './pipeline-context.mjs'
+
 /** Dedupe marker so a held wave is explained once, not on every re-check. */
 export const HOLD_MARKER = '<!-- wave-gate:held -->'
 
@@ -68,13 +70,39 @@ export function summarizeChecks(checkRuns = []) {
  * and this workflow has no timer to rescue it — the failure mode we are fixing is a SILENT
  * bad release, not a slow one.
  */
-export function shouldRelease({ blockerStates = [], labels = [], branchStatus = 'unknown' } = {}) {
+export function shouldRelease({ blockerStates = [], labels = [], branchStatus = 'unknown', body = '' } = {}) {
   if (isDispatched(labels)) return { release: false, reason: 'already-dispatched' }
   if (!blockerStates.length) return { release: false, reason: 'no-blockers' }
   if (blockerStates.some(s => s !== 'closed')) return { release: false, reason: 'blockers-open' }
   if (branchStatus === 'failure') return { release: false, reason: 'branch-red' }
-  return { release: true, reason: branchStatus === 'success' ? 'green' : `ungated-${branchStatus}` }
+  return {
+    release: true,
+    reason: branchStatus === 'success' ? 'green' : `ungated-${branchStatus}`,
+    label: releaseLabel(body),
+  }
 }
+
+/**
+ * WHICH label to release with (#1923).
+ *
+ * Default `delegate` — a full decompose run that works out what the issue is. Correct for a
+ * hand-sequenced epic, and for everything that predates the event-driven pipeline.
+ *
+ * But when the decomposer itself created the child it ALREADY applied the leaf test, and #1750
+ * withholds the trigger label from a blocked child — so that classification would be thrown away
+ * and re-derived by a whole extra decompose run (measured on the #1750 live-fire: #1919/#1920
+ * each cost one). Worse, the re-derivation is a judgement call that can come back DIFFERENT,
+ * quietly re-shaping a tree its parent already planned. So if the child recorded its intended
+ * label, honour it; otherwise fall back and behave exactly as before.
+ */
+export function releaseLabel(body = '') {
+  const { dispatch } = parsePipelineBlock(body)
+  return RELEASABLE.has(dispatch) ? dispatch : 'delegate'
+}
+
+// Allow-list, not passthrough: the body is model-authored, and this value becomes a label that
+// dispatches a run. Anything unrecognised falls back to `delegate` rather than being applied.
+const RELEASABLE = new Set(['work-this', 'delegate-pi', 'delegate'])
 
 /** The comment posted when a wave is held because its branch is red. */
 export function formatHoldComment({ issueNumber, branch, doneNumber }) {
@@ -88,10 +116,10 @@ export function formatHoldComment({ issueNumber, branch, doneNumber }) {
 }
 
 /** The comment posted on a normal release. */
-export function formatReleaseComment({ doneNumber, branchStatus }) {
+export function formatReleaseComment({ doneNumber, branchStatus, label = 'delegate' }) {
   const suffix = branchStatus === 'success'
     ? ' Its branch is green.'
     : ''
   return `🟢 **Unblocked — starting this workstream now.** Its last blocker (#${doneNumber}) just closed.${suffix}\n\n`
-    + `<sub>🤖 wave scheduler (#283) · applied \`delegate\`</sub>`
+    + `<sub>🤖 wave scheduler (#283) · applied \`${label}\`</sub>`
 }

--- a/scripts/wave-gate.test.mjs
+++ b/scripts/wave-gate.test.mjs
@@ -17,6 +17,7 @@ import {
   shouldRelease,
   formatHoldComment,
   formatReleaseComment,
+  releaseLabel,
   HOLD_MARKER,
 } from './wave-gate.mjs'
 
@@ -143,4 +144,39 @@ test('the hold comment is deduped, self-resolving and overridable', () => {
 test('the release comment names the blocker and only claims green when it is', () => {
   assert.match(formatReleaseComment({ doneNumber: 1655, branchStatus: 'success' }), /Its branch is green/)
   assert.doesNotMatch(formatReleaseComment({ doneNumber: 1655, branchStatus: 'unknown' }), /green/)
+})
+
+// ── #1923: release with the label the decomposer already chose ───────────────────────
+// Measured on the #1750 live-fire: #1919/#1920 were planned as leaves, blocked, then released
+// with `delegate` — each costing a decompose run purely to re-derive `{"leaf": true}`.
+test('releaseLabel honours a recorded dispatch, else falls back to delegate', () => {
+  assert.equal(releaseLabel('<!-- pipeline: epic=1 depth=1 dispatch=work-this -->'), 'work-this')
+  assert.equal(releaseLabel('<!-- pipeline: epic=1 depth=2 dispatch=delegate-pi -->'), 'delegate-pi')
+  // no record → exactly today's behaviour. Hand-sequenced epics and everything predating the
+  // event-driven pipeline must keep working untouched.
+  assert.equal(releaseLabel('<!-- pipeline: epic=1 depth=1 -->'), 'delegate')
+  assert.equal(releaseLabel('Blocked-by: #12\n\njust prose'), 'delegate')
+  assert.equal(releaseLabel(''), 'delegate')
+  assert.equal(releaseLabel(undefined), 'delegate')
+})
+
+test('an unrecognised dispatch value is NOT applied as a label', () => {
+  // the body is model-authored and this value becomes a label that starts a run — allow-list only
+  for (const bad of ['status:blocked', 'epic', 'rm -rf', 'WORK-THIS', 'delegate-hard']) {
+    assert.equal(releaseLabel(`<!-- pipeline: epic=1 dispatch=${bad} -->`), 'delegate', `must reject: ${bad}`)
+  }
+})
+
+test('shouldRelease carries the label through, and the comment names it', () => {
+  const d = shouldRelease({
+    blockerStates: ['closed'], labels: [], branchStatus: 'success',
+    body: '<!-- pipeline: epic=1 depth=1 dispatch=work-this -->',
+  })
+  assert.equal(d.release, true)
+  assert.equal(d.label, 'work-this')
+  assert.match(formatReleaseComment({ doneNumber: 5, branchStatus: 'success', label: d.label }), /applied `work-this`/)
+  // a held decision carries no label — nothing is applied
+  assert.equal(shouldRelease({ blockerStates: ['open'], body: '<!-- pipeline: dispatch=work-this -->' }).label, undefined)
+  // and the comment's default keeps the old wording for callers that pass nothing
+  assert.match(formatReleaseComment({ doneNumber: 5, branchStatus: 'success' }), /applied `delegate`/)
 })


### PR DESCRIPTION
Closes #1923

## 👤 For humans

#1750 stopped a blocked leaf from being dispatched before its blocker landed. But withholding the trigger label also **threw away the decomposer's leaf-vs-split decision** — so when the wave scheduler later released the child, it had nothing to go on and used `delegate`, kicking off a full decompose run whose only job was to work out again what had already been decided.

Measured on the #1750 live-fire, not assumed:

```
12:54:26  #1918 closes → scheduler releases #1919 delegate, #1920 delegate
12:54:38  decompose run on #1919   ← re-deriving {"leaf": true}
12:54:41  decompose run on #1920   ←
```

Both were planned as leaves. Now that decision is **recorded** when the label is withheld, and the scheduler applies it — so a blocked leaf goes straight to its worker.

The subtler win: re-deriving leafness asks a model a judgement question a second time, and it can answer *differently* — quietly re-shaping a tree its parent already planned.

## 🤖 For agents

**`pipeline-context.mjs`** — new optional `dispatch` key on the block. Emitted last, only when set; absent parses to `null`. The block was already documented as forward-compatible, so older readers tolerate the token.

**`apply-decompose-plan.mjs`** — a *blocked* child's block records `dispatch=<label>` from the **same `labelForChild(...)` expression** that would otherwise have been applied. Unblocked children record nothing (they're dispatched now).

**`wave-gate.mjs`** — new `releaseLabel(body)` → recorded label, else `delegate`. `shouldRelease` returns it; `formatReleaseComment` names it.

**`schedule-waves.yml`** — applies `decision.label`, defaulting to `delegate`.

### Two deliberate safety choices

**Allow-list, not passthrough.** The issue body is model-authored and this value becomes a label that *starts a run*. Anything outside `work-this` / `delegate-pi` / `delegate` falls back to `delegate` — tested with `status:blocked`, `delegate-hard`, wrong case, and junk.

**The fallback is the load-bearing case**, so it's tested directly rather than assumed: no pipeline block, no `dispatch` key, and prose-only `Blocked-by:` all still release with `delegate`. This scheduler serves every epic in the repo — hand-sequenced epics and everything predating the event-driven pipeline must behave exactly as today, and do.

## 🧪 How to test

`node --test scripts/pipeline-context.test.mjs scripts/wave-gate.test.mjs scripts/apply-decompose-plan.test.mjs` — 60 pass.

New cases: `dispatch` round-trip and survival of an unrelated partial update; a blocked leaf recording `work-this` while a blocked `needsSplit` child records `delegate-pi`; the recorded label being **identical** to what an equivalent unblocked child is dispatched with; the allow-list rejections; and every fallback shape.

Full `scripts/` suite green (19 files); `npx fallow audit` clean on all 7 changed files.

Not live-fired — proving it end-to-end means another dependent-chain probe plus a blocker close. The behaviour is unit-tested including the fallback; say the word if you'd rather see it run for real before merging.

Follow-up to #1750, split out because the release path is shared by every epic in the repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_0112Fx8AXJLvgEPHPpimBevY)_