### PR TITLE
feat(root): wire all five canaries + the packages/ canary target

### DIFF
--- a/.github/canaries.json
+++ b/.github/canaries.json
@@ -22,7 +22,7 @@
   "canaries": [
     {
       "id": "locale-3-files",
-      "issue": null,
+      "issue": 1927,
       "target": "pocs/canary/i18n/",
       "why": "#1876 defect 1 — the last file of a commit bucket was dropped, and in #1874 the dropped one was the only file that mattered. Three files in, three files out; nl.json asserted BY NAME because a count alone would pass on the wrong three.",
       "task": "change the `farewell` string in all three of pocs/canary/i18n/{nl,en,fr}.json",
@@ -36,7 +36,7 @@
     },
     {
       "id": "app-acceptance-pass",
-      "issue": null,
+      "issue": 1928,
       "target": "pocs/canary/src/greeting.ts",
       "why": "The acceptance gate's happy path — an apps/pocs change must resolve an APP_DIR and typecheck clean. Guards the #1876 APP_DIR probe that used to kill the whole finish step on a no-match.",
       "task": "add an exported `farewell(locale, name)` to pocs/canary/src/greeting.ts, mirroring `greet`",
@@ -48,7 +48,7 @@
     },
     {
       "id": "acceptance-red",
-      "issue": null,
+      "issue": 1929,
       "target": "pocs/canary/src/greeting.ts",
       "why": "A genuinely broken deliverable must open as a DRAFT so automerge (#339) skips it. If this canary ever goes non-draft, red work can land. The failure is REAL (a tight `Locale` union rejects the new key), not staged — a staged failure would prove nothing about the gate.",
       "task": "add a German greeting to the GREETINGS map in pocs/canary/src/greeting.ts WITHOUT widening the `Locale` union",
@@ -73,7 +73,7 @@
     },
     {
       "id": "genuine-no-op",
-      "issue": null,
+      "issue": 1930,
       "target": "pocs/canary/README.md",
       "why": "The one canary that SHOULD produce nothing. It guards the artifact-gate's honesty: no PR is correct here, but the failure comment must not assert a cause it never checked (#1751, #1876 defect 3).",
       "task": "an issue asking for something already true of pocs/canary/README.md, so there is nothing to build",


### PR DESCRIPTION
Follow-up to #1878 (rig) and #1910 (poc target). **All five canaries are now wired.**

| canary | issue | target |
|---|---|---|
| `locale-3-files` | #1927 | `pocs/canary/i18n/` |
| `app-acceptance-pass` | #1928 | `pocs/canary/src/greeting.ts` |
| `acceptance-red` | #1929 | `pocs/canary/src/greeting.ts` |
| `packages-logic-needs-test` | #1932 | `packages/canary-target/src/index.ts` ← **new** |
| `genuine-no-op` | #1930 | `pocs/canary/README.md` |

## `packages/canary-target` — a whole package for one canary

`packages-logic-needs-test` is the guard for #1885, and it's the only one a poc can't cover: the tests gate keys on `^packages/[^/]+/.*\.(ts|mjs|js)$` (`planTestsGate`), which no `pocs/` path matches no matter how it's shaped.

That left two options — a disposable package, or pointing repeated agent runs at real shared code. The second is the thing the `packages/` hard gate exists to prevent, so: a disposable package, approved before any edit was written.

**It's worth the folder.** #1885 is the one failure this rig exists for that has actually happened. On #1875 the worker shipped the logic with **none of its five agreed test cases** and nothing noticed — acceptance said "not verified", CI went green (a missing test breaks no build), and the PR was mergeable. Clause (7) now requires the test; this canary proves the requirement is *enforced* rather than merely written down.

**It ships `clamp` + its test as a reference pairing.** The canary asks the worker to add a function *and* its test, so the package demonstrates what that means rather than describing it.

Details that matter:
- `private: true`, no `exports` field — cannot be published by accident.
- Named `@fyit/canary-target`, **not** `@fyit/crouton-*`, so it sits outside the changesets `fixed: [["@fyit/crouton-*"]]` version group.
- **`packages-guard` needs no carve-out.** #1932 carries a `pkg:canary-target` label, and the guard already accepts a linked `pkg:*` issue as the declaration signal — the existing design covered this case.
- **No fallow exclusion needed**, unlike `pocs/canary`. Its test imports `src/`, so it's reachable from the graph. Verified rather than assumed: grepped a 266-line dead-code report for it, 0 hits.

## These tickets are permanent, and they say so loudly

Each leads with a **"this is a CANARY — do not close it, do not fix it, do not merge its PR"** banner. A standing ticket that reads like ordinary work gets closed by someone tidying the backlog, and the rig would then silently stop covering that case.

They're re-runnable because `mode=dispatch` closes the previous PR and deletes its branch before re-labelling — so every run starts from `main` and nothing a worker does ever lands.

## Two issues that fight their own agent

**#1929** asks for code that **deliberately does not compile** (adding `de` to `GREETINGS` without widening the `Locale` union), because it asserts `acceptance: FAILED` and a draft PR. The obvious failure mode is a competent agent helpfully fixing the type error — so the issue says up front that the type error *is* the deliverable, and rules out widening the union, casting, and `@ts-expect-error`.

**#1930** asks for something already true, and its correct outcome is that **nothing happens**. It says so explicitly: don't invent work, don't reword existing text to have something to commit, don't open an empty PR.

Whether either instruction actually holds is itself something the first run will tell us.

## A guard that was vacuously true is now real

The rig shipped with a test asserting every *wired* canary's `target` exists on disk. Until this PR there were no wired canaries, so it passed by checking nothing. It now verifies all five paths on every test run — the point at which it can actually catch a canary pointed at a deleted file.

## Verification

- 13/13 canary tests against the real shipped config; **251/251** across `scripts/*.test.mjs`
- 6/6 `@fyit/canary-target` tests; its `typecheck` clean
- `node scripts/check-docs.mjs` passes (the new package has its `CLAUDE.md`)
- `package-catalog.md` regenerated — 32 packages
- `npx fallow audit` → no issues in 10 changed files, exit 0
- The workflow's resolve step, executed verbatim, reports **5 wired canaries** and no warning

The `packages/` approval file was added before the edits and removed after, so the gate is re-engaged.

## 🧪 How to test

1. `node --test scripts/canary.test.mjs` → 13 pass; `pnpm --filter @fyit/canary-target test` → 6 pass.
2. Run `.github/workflows/canary.yml` with `mode=verify` (no dispatch) → self-tests its assertions, resolves 5 wired canaries, reports each as failing-because-no-observation. That's correct — nothing has been dispatched yet.
3. First real run: `mode=dispatch`, `only=locale-3-files`. Wait for the worker (2–45 min), then `mode=verify` → a pass/fail table in the job summary.
4. Then `only=genuine-no-op` — the one whose correct outcome is that nothing happens.
5. Then `only=packages-logic-needs-test` — the #1885 guard, and the most informative of the five.