### PR TITLE
docs: record the outline-editor sign-off (spec settled + HANDOFF)

### DIFF
--- a/pocs/crouton-builder-demo/HANDOFF.md
+++ b/pocs/crouton-builder-demo/HANDOFF.md
@@ -125,6 +125,33 @@ by porting the board into the old zoom shell):
 
 ## Signed-off design decisions (current truth)
 
+### Outline / DOM-tree editor — composition + responsiveness on one surface (#983, signed off 2026-08-05)
+
+**The direction for editing a page is an OUTLINE of its layout tree, not a free-floating card canvas.**
+A page is document flow, not a whiteboard — the saved page was always a `LayoutTree` (split/leaf/nested),
+so the free 2D card scatter implied absolute positioning it never had. The outline *shows* that tree and
+edits it directly (`pocs/crouton-builder`, route `/builder/outline/[pageId]`; the canvas board still
+coexists for now).
+
+- **Add from a list** (tap to insert) — drag is reserved for *rearranging*, never composing.
+- **Columns come from GROUPING**, per-group — select rows → "Group as Columns / Stack" wraps them into a
+  child layout, shown as **indentation**; each group carries a ⬌/⬍ toggle. There is **no page-global
+  Stack/Columns switch** — columns-vs-stack is layout-dependent (the correction that killed that toggle).
+- **Child layouts = nesting** — groups inside groups (nested `split`s), a `nested` node = a first-class
+  child layout. The outline is the recursive tree; the drop indicator is a **1D insertion line**, never
+  the ambiguous 2D edge/pane cue.
+- **Responsiveness is combined on the same surface** — the app's *real* slider breakpoint editor
+  (`CroutonLayoutBreakpointAuthor`) is embedded inline, bound to the same page, so its width slider /
+  device presets / scaled preview / variants / collapse motion are right there and a structure edit
+  updates the preview live. **Not** a separate mode, and **not** a reinvented device bar (that was tried
+  and rejected — it duplicated the real tool, worse).
+
+Supersedes the free-canvas *drag-to-compose* for composition (the `snap-dwell-arm` / `pane-drop-beside` /
+`ghost-ease-apart` board gestures below remain real, but are the reframed-away approach). **Deferred**
+(not blocking the sign-off): horizontal drag-to-nest (grouping-via-action already makes child layouts),
+cross-group reorder, and retiring the canvas so the outline is the sole editor. Spec: `outline-tree-editor`
+in `spec.json` (settled).
+
 ### Page model — one node is *the* page (#942)
 
 The board is a sandbox of layout candidates + loose draft blocks; **exactly one node is "the page"**

--- a/pocs/crouton-builder-demo/spec.json
+++ b/pocs/crouton-builder-demo/spec.json
@@ -358,17 +358,20 @@
   },
   {
     "id": "outline-tree-editor",
-    "behaviour": "Edit a page as an outline of its layout tree (DOM-like), not a free-floating card canvas. Adding is a list; drag is only for rearranging.",
-    "when": "editing a page: tap a block in a list to insert it; drag a row vertically to reorder; drag a row horizontally to nest/unnest; toggle a group's direction for columns (⬌) vs stack (⬍)",
-    "expect": "the outline IS the LayoutTree -- nesting depth = split children, a group's direction = flex row/column, a nested app = a nested node; the drop indicator is a simple 1D insertion line + indent guide (never the ambiguous 2D edge/pane cue); a live preview reflects every edit; there is no free-floating 2D card canvas",
-    "hook": "",
-    "howToTest": "1. open a page editor -> a vertical outline of the page's blocks + an add-from-list  2. tap a block in the list -> it inserts into the page (insertion line shows where)  3. drag a row up/down -> reorders  4. drag a row into a group (indent) -> it nests; toggle the group ⬌ -> its children become columns  5. the live preview updates to match",
-    "status": "proposed",
+    "behaviour": "Edit a page as an outline of its layout tree (DOM-like), with responsiveness combined into the SAME surface — not a free-floating card canvas and not a separate breakpoints mode. Add from a list; drag only rearranges; group to make columns / child layouts.",
+    "when": "editing a page (/builder/outline/[pageId]): tap a block from a list to add it; drag a row's handle to reorder within its group; tap rows to select then 'Group as Columns / Stack' to wrap them into a child layout (shown as indentation); a group row's ⬌/⬍ toggles columns vs stack; the app's real slider breakpoint editor (CroutonLayoutBreakpointAuthor) is embedded INLINE below, bound to the same page",
+    "expect": "the outline IS the LayoutTree (nesting depth = split children, a group's direction = flex row/column, a nested app = a nested node); the drop indicator is a simple 1D insertion line (never the ambiguous 2D edge/pane cue); COLUMNS come from grouping — a per-group ⬌/⬍, never a page-global switch (columns-vs-stack is layout-dependent); RESPONSIVENESS is authored on the same surface via the embedded real slider tool (its width slider / device presets / scaled preview / variants / collapse motion), and a structure edit updates that preview live; there is no free-floating 2D card canvas in this editor",
+    "hook": "outline-list",
+    "howToTest": "1. open a page -> tap 'Outline' -> the outline editor at /builder/outline/[pageId]  2. tap a block chip under 'Add a block' -> it appears as a row + in the preview  3. drag a row handle up/down -> reorders (1D insertion line)  4. tap two rows -> 'Group as Columns' -> they indent under a Columns group with a ⬌/⬍ toggle; Ungroup flattens  5. scroll to 'Responsive & preview' -> drag the width slider -> the same page reflows; a structure edit above updates it live",
+    "status": "settled",
+    "signedOff": "looks good — session walk 2026-08-05 (slice 4, combined structure + real breakpoint slider on one surface; landed in PR #1877)",
     "supersedes": "",
     "consideredRejected": [
-      "free-floating card canvas + drag-to-compose (reframes snap-dwell-arm / pane-drop-beside / ghost-ease-apart) -> the 2D drop is ambiguous (which edge / which pane / columns-or-rows), unreadable on a phone (IMG_2221); a page is document flow, not a whiteboard, so the tree was always the truth underneath the scattered cards",
-      "list-to-add but keep the canvas drag-to-compose -> leaves the ambiguous 2D gesture in place; only fixes half the problem",
-      "note: this is `proposed` -- it reframes the built canvas-compose entries above rather than superseding one; awaiting a human walk + sign-off before it becomes the settled contract"
+      "free-floating card canvas + drag-to-compose (reframes the built snap-dwell-arm / pane-drop-beside / ghost-ease-apart entries) -> the 2D drop is ambiguous (which edge / which pane / columns-or-rows), unreadable on a phone (IMG_2221); a page is document flow, not a whiteboard, so the tree was always the truth underneath the scattered cards",
+      "list-to-add but keep the canvas drag-to-compose -> ❌ leaves the ambiguous 2D gesture in place; only fixes half the problem",
+      "a page-global Stack/Columns toggle -> ❌ layout-dependent; columns-vs-stack belongs per-group (the built ⬌/⬍ on each group), not one page switch",
+      "a reinvented Phone/Tablet/Desktop device bar for responsiveness -> ❌ duplicated (worse) the app's existing slider breakpoint editor; embed the real CroutonLayoutBreakpointAuthor on the same surface instead",
+      "DEFERRED refinements (not yet built, not blocking the sign-off): horizontal drag-to-nest (grouping-via-action already creates child layouts); cross-group reorder; retiring the canvas board so the outline is the sole editor — the canvas still coexists"
     ]
   }
 ]


### PR DESCRIPTION
Refs epic #983 — a docs-only follow-up to the merged #1877, recording the 2026-08-05 sign-off of the outline / DOM-tree editor so the paper trail stays honest (done is *derived from a recorded sign-off*, not asserted).

## 👤 For humans

Captures what was walked and approved (slice 4): editing a page as an **outline of its layout tree**, columns from **grouping** (per-group ⬌/⬍, not a page-global switch), child layouts as **nesting**, and the app's **real breakpoint slider embedded on the same surface** (no separate mode, no reinvented device bar).

## 🤖 For agents

- `pocs/crouton-builder-demo/spec.json` — `outline-tree-editor` **proposed → settled** with a recorded `signedOff` (gate-spec-signoff passes). `when`/`expect`/`howToTest` rewritten to the BUILT behaviour (tap-to-group, not the deferred drag-to-nest; embedded `CroutonLayoutBreakpointAuthor`, not the rejected device bar). Rejections added (page-global toggle, reinvented bar); deferred refinements noted (drag-to-nest, cross-group reorder, retiring the canvas).
- `pocs/crouton-builder-demo/HANDOFF.md` — new "Outline / DOM-tree editor" current-truth decision; supersedes free-canvas drag-to-compose for composition.

Docs only — no code, no package edits. Graduation stays open (C1/C2 pending).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDKfxNXFhEVG8ctT4JttFF)_