### PR TITLE
ci(root): push the four main-writing data jobs with the Harness App token (#1133)

### DIFF
--- a/.claude/skills/crouton-ci-and-deploy-map/SKILL.md
+++ b/.claude/skills/crouton-ci-and-deploy-map/SKILL.md
@@ -156,10 +156,11 @@ Flow: build → deploy → sync ids → `wrangler d1 migrations apply <db-name> 
 
 `AGENT_RUNNER` (swap agent jobs to the self-hosted mac-mini; default ubuntu-latest) · `AGENT_HARNESS` (`pi` opt-in) · `CLEANUP_BRANCHES_APPLY` · `LABEL_READY_EPICS_APPLY` (write-gates for otherwise dry-run jobs) · `DIGEST_REPORT_EMAIL` / `DIGEST_EMAIL_FROM` / `RESEND_FROM` / `RED_TEAM_REPORT_EMAIL` (email rails) · `PROJECT_NAME` · `UNLIGHTHOUSE_SITE`.
 
-### Two auth rules every agent workflow obeys
+### Three auth rules every agent workflow obeys
 
 1. **The token-cascade rule** (the single most repeated fact across these files): GitHub suppresses workflow triggers for events initiated by the built-in `GITHUB_TOKEN`. Any mutation that must trigger a downstream workflow (apply `delegate` → decompose fires; merge → schedule-waves; close → strip-status; push → CI re-runs) is done with a **Harness App installation token**. Read-only or chain-terminal steps deliberately use `GITHUB_TOKEN`.
-2. **Job-level permissions only**: job-level `permissions` fully OVERRIDES (does not merge with) a workflow-level block, so `id-token: write` must sit on the job or the claude-code-action OIDC request fails. Stated verbatim in several workflows (e.g. `resume-on-comment.yml`).
+2. **The ruleset-bypass rule** (#1133): the `main` ruleset requires a PR, so **any workflow that pushes directly to `main` must push with the Harness App token** — the App is on the ruleset's bypass list, and `GITHUB_TOKEN` cannot be. GitHub Actions is not an installable App in the org, so adding it as a bypass actor is rejected outright (`422 — Actor GitHub Actions integration must be part of the ruleset source or owner organization`). The direct-to-`main` writers are `loop-station-inventory` · `loop-station-usage` · `loop-station-findings` · `bundle-budget`; all four commit with `[skip ci]`, which is what stops the App-token push (unlike a `GITHUB_TOKEN` push) from re-triggering the very workflow that made it.
+3. **Job-level permissions only**: job-level `permissions` fully OVERRIDES (does not merge with) a workflow-level block, so `id-token: write` must sit on the job or the claude-code-action OIDC request fails. Stated verbatim in several workflows (e.g. `resume-on-comment.yml`).
 
 Also: `anthropics/claude-code-action` is pinned to one SHA across several workflows with "keep in sync when bumping" — a manual multi-file sync liability; grep for the pin and check all of them when bumping (re-verify block).
 

--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -37,9 +37,18 @@ jobs:
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
+      # Push with the Harness App, not GITHUB_TOKEN — see loop-station-inventory.yml (#1133).
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history so the commit-back rebases cleanly
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/loop-station-findings.yml
+++ b/.github/workflows/loop-station-findings.yml
@@ -37,9 +37,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Push with the Harness App, not GITHUB_TOKEN — see loop-station-inventory.yml (#1133).
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/loop-station-inventory.yml
+++ b/.github/workflows/loop-station-inventory.yml
@@ -28,9 +28,21 @@ jobs:
   inventory:
     runs-on: ubuntu-latest
     steps:
+      # Push with the Harness App, not GITHUB_TOKEN (#1133). The `main` ruleset requires
+      # a PR, and GitHub Actions cannot be a ruleset bypass actor (422: "must be part of
+      # the ruleset source or owner organization") — only an installed App can, and
+      # `nuxt-harness` is on the bypass list. A GITHUB_TOKEN push would be rejected.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history so the commit-back rebases cleanly
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/loop-station-usage.yml
+++ b/.github/workflows/loop-station-usage.yml
@@ -30,9 +30,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Push with the Harness App, not GITHUB_TOKEN — see loop-station-inventory.yml (#1133).
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history so the commit-back rebases cleanly
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Refs #1133 — WS1 step 3.

## 👤 For humans

A ruleset now exists on `main` (currently **Disabled**) that will require every change to arrive by pull request with `CI Gate` green. Four workflows push trend data straight to `main` and would be rejected the moment it's switched on:

```
loop-station-inventory   loop-station-usage   loop-station-findings   bundle-budget
```

The obvious fix — put the GitHub Actions bot on the ruleset's bypass list — **is not possible**. GitHub rejects it outright:

```
422 Validation Failed
Actor GitHub Actions integration must be part of the ruleset source or owner organization
```

GitHub Actions isn't an installable App in the org, so `GITHUB_TOKEN` can never bypass a ruleset. Only an installed App can, and we have one: **Nuxt Harness**, already on the bypass list. So these four jobs now check out with the App token and push as the App.

This is the last thing standing between the ruleset and being switched to Active.

## 🤖 For agents

Per file: an `actions/create-github-app-token@v1` step (`id: app-token`) before checkout, and `token: ${{ steps.app-token.outputs.token }}` on `actions/checkout@v4`. Nothing else changes — the commit/rebase/push loop and the `github-actions[bot]` commit author are untouched, since only the *pushing token* matters for bypass.

**Behaviour delta worth knowing:** an App-token push **does** trigger workflows, where a `GITHUB_TOKEN` push does not. That's safe here only because all four commit messages carry `[skip ci]` — verified on each. If those commit steps are ever edited, keep the marker or `loop-station-inventory` will re-trigger itself on its own commit.

Ruleset `20463354` targets `~DEFAULT_BRANCH` with one bypass actor: app `4107840` (`nuxt-harness`), `bypass_mode: always`.

**Deliberately not in scope:**
- `fix-ci-on-failure.yml` — already uses the App token, and pushes only to `claude/issue-*`, which the ruleset doesn't target.
- `sync-changelogs.yml` — does push to `main`, but has failed **every run since #164** relocated `apps/docs` → `docs/`; its `working-directory: apps/docs` no longer exists. Dead, not blocking, tracked separately.

## 🧪 How to test

Can't be tested by merging alone — the ruleset is Disabled, so nothing is being rejected yet. The real test is the sequence:

1. Merge this.
2. Set ruleset `main` to **Active** (Settings → Rules → `main`).
3. Push any commit to `main` touching `.claude/**` or `packages/**` — `loop-station-inventory` fires.
4. Confirm the run is **green** and its `chore(loop-station): record context-budget inventory [skip ci]` commit is on `main`. A red run with `GH006: Protected branch update failed` means the App token didn't take.
5. Confirm no second `loop-station-inventory` run was triggered by that commit (the `[skip ci]` check).

Rollback if step 4 fails: flip the ruleset back to Disabled — the data jobs recover on their next run with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
