### PR TITLE
fix(docs): point the changelog sync at docs/, not the long-gone apps/docs (#1943)

### DIFF
--- a/.github/workflows/sync-changelogs.yml
+++ b/.github/workflows/sync-changelogs.yml
@@ -15,11 +15,24 @@ jobs:
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     defaults:
       run:
-        working-directory: apps/docs
+        # `docs`, NOT `apps/docs` — #164 relocated the docs site to the top level on
+        # 2026-06-15 and this was missed, so every run failed for seven weeks (#1943).
+        working-directory: docs
 
     steps:
+      # Push with the Harness App, not GITHUB_TOKEN — this job commits to `main`, which
+      # the ruleset rejects for a GITHUB_TOKEN push (#1133). See loop-station-inventory.yml.
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,20 +1,27 @@
-# apps/docs/scripts
+# docs/scripts
 
 ## sync-changelogs.ts
 
-> **Status: SUPERSEDED (2026-04-07).** Replaced by ThinkGraph Phase 2A
-> "Repo watchlist + daily digest". The workflow file
-> `.github/workflows/sync-changelogs.yml` is intentionally still active —
-> do not delete it yet, the apps/docs UI still reads
-> `data/changelog-releases.json` and migration to the new flow is pending.
+> **Status: LIVE — this is the only implementation (corrected 2026-08-05, #1943).**
+> It was marked SUPERSEDED on 2026-04-07 in favour of ThinkGraph Phase 2A
+> ("Repo watchlist + daily digest"), but **thinkgraph was itself retired on
+> 2026-07-01** (#1043), so the replacement no longer exists. The supersession
+> below is kept as history — do not act on it.
+>
+> Meanwhile #164 relocated `apps/docs` → top-level `docs/` on 2026-06-15 and the
+> workflow's `working-directory` was missed, so every run failed silently for seven
+> weeks and the `/changelogs` page served stale data. Fixed in #1943; if this page
+> looks frozen again, check that workflow's paths first.
 
 Fetches GitHub releases for tracked packages, generates AI summaries, and
 writes them to `data/changelog-releases.json`. Runs daily via the
 `sync-changelogs` GitHub Action.
 
-### What replaces it
+### What was going to replace it (historical — thinkgraph is retired, #1043)
 
-The same job is now done inside the `thinkgraph` app:
+The plan was to do the same job inside the `thinkgraph` app. That app was archived
+to `retired/pocs/` on 2026-07-01, so none of the below is running. Kept only as a
+design sketch in case the job ever moves off a committed JSON file:
 
 - **Storage**: D1 instead of a JSON file in this repo. Two collections:
   - `thinkgraph_watchedrepos` — the watchlist (repo, branch, lastCheckedSha,


### PR DESCRIPTION
Closes #1943.

## 👤 For humans

The docs site's `/changelogs` page tracks 14 upstream packages we actually depend on — `nuxt`, `vue`, `@nuxt/ui`, `drizzle-orm`, `better-auth`, `typescript`, `stripe`, `zod`, `nitro` and friends — pulls their GitHub releases daily and has Haiku write a summary plus an explicit **breaking-changes** list for each. It's the continuous version of the triage the `dependency-sweep` skill does by hand each quarter.

It has been serving data frozen at **2026-06-15** and failing on the mac-mini every morning since. One word was wrong.

## 🤖 For agents — how it broke

| Date | Event |
|---|---|
| 2026-04-07 | `docs/scripts/README.md` marks the script **SUPERSEDED** by ThinkGraph Phase 2A in `apps/thinkgraph` |
| 2026-06-15 | `82e4e2e09` (#164) relocates `apps/docs` → `docs/`; the workflow keeps `working-directory: apps/docs`. **First-bad-commit** — last good sync was 07:53 that morning, the relocation merged at 16:28 |
| 2026-07-01 | #1043 retires `thinkgraph` — the designated successor is archived to `retired/pocs/` |

The two mechanisms compound: the path broke it, and the stale SUPERSEDED banner is why seven weeks of daily red runs read as expected. The banner was false in both directions — the successor doesn't exist, and the "superseded" script is the only implementation.

**Changes:**
1. `working-directory: apps/docs` → `docs`. Script (`docs/scripts/sync-changelogs.ts`), data dir and the `git add data/changelog-releases.json` path all resolve from there.
2. Push with the Harness App token — it commits to `main`, which ruleset `20463354` rejects for a `GITHUB_TOKEN` push (#1133). Its commit message already carries `[skip ci]`, so the App-token push won't self-trigger.
3. `docs/scripts/README.md` — banner rewritten to record reality; the migration sketch is kept below it as history.

## 🧪 How to test

1. `gh workflow run sync-changelogs.yml` — green (it has failed every run since 2026-06-15).
2. `jq -r .lastSyncedAt docs/data/changelog-releases.json` on `main` → today, not `2026-06-15T07:53:40Z`.
3. `pnpm --filter @crouton/docs dev` → `/changelogs` lists releases from the last seven weeks with summaries and breaking-changes.
4. Exactly one workflow run results — the `[skip ci]` commit must not re-trigger anything.

Cost note: only *new* releases hit the API, capped at 500 output tokens on Haiku 3.5 — a few calls a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
