### PR TITLE
fix(docs): survive a concurrent main push in the changelog sync (#1943)

### DIFF
--- a/.github/workflows/sync-changelogs.yml
+++ b/.github/workflows/sync-changelogs.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0 # full history so the commit-back rebases cleanly
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -69,4 +70,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/changelog-releases.json
           git commit -m "chore(docs): sync changelog releases [skip ci]"
-          git push
+          # Rebase onto any concurrent main movement, then push — same loop the
+          # loop-station jobs use. A bare `git push` loses the race whenever a PR
+          # merges during the run ("! [rejected] main -> main (fetch first)", #1943);
+          # this job rewrites the whole data file, so a race is likely, not rare.
+          for i in 1 2 3 4; do
+            git pull --rebase origin main && git push origin HEAD:main && exit 0
+            echo "push attempt $i failed; retrying…"; sleep $((2 ** i))
+          done
+          exit 1


### PR DESCRIPTION
Closes #1943 (reopened — the first fix got further, then hit the next wall).

## 👤 For humans

#1944 fixed the path, and the sync ran end to end for the first time since 15 June: it found the script, fetched the releases, generated summaries, wrote 978 lines of data, committed. Then it lost the push:

```
! [rejected]  main -> main (fetch first)
```

PR #1945 merged into `main` during the run. This job has a bare `git push` with no retry, so **any** merge landing during its run kills it. Since it rewrites the whole data file every time, it holds that commit for a long window — the race is likely, not rare. That's been true all along; it just never got far enough to hit it.

## 🤖 For agents

- `fetch-depth: 0` on checkout — a shallow clone can't rebase.
- `git push` → the four-attempt `git pull --rebase origin main && git push origin HEAD:main` loop with exponential backoff, copied verbatim from `loop-station-inventory.yml`.

**Not a ruleset rejection.** Worth being precise since the ruleset went live the same hour: a rule denial reads `GH006: Protected branch update failed`. This was a plain non-fast-forward. Evidence the App token is working correctly: `0caaa0f23` (a loop-station inventory record) pushed to `main` under active enforcement at 15:53Z.

Failing run for reference: 31022529348.

## 🧪 How to test

1. `gh workflow run sync-changelogs.yml` → green.
2. `jq -r .lastSyncedAt docs/data/changelog-releases.json` on `main` → today, not `2026-06-15T07:53:40Z`.
3. `pnpm --filter @crouton/docs dev` → `/changelogs` lists releases from the last seven weeks with summaries and breaking-changes.
4. Confirm exactly one run resulted — the `[skip ci]` commit must not re-trigger anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
