### PR TITLE
fix(root): dispatch canaries with the Harness App token, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -38,6 +38,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # The label must be applied by the Harness App, NOT GITHUB_TOKEN. Actions' recursion guard
+      # means an event triggered by GITHUB_TOKEN never starts a new workflow run — so a
+      # `work-this` label added with it fires work-issue-pidev.yml exactly zero times. The whole
+      # dispatch would appear to succeed and silently do nothing, and the failure would only show
+      # up as a `verify` run 45 minutes later reporting no observations. Same reason the other
+      # cascade-dependent workflows mint this token (#572/#626/#1133).
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -71,10 +84,15 @@ jobs:
       - name: Dispatch
         if: inputs.mode == 'dispatch'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # App token, not GITHUB_TOKEN — see the note on the app-token step above. This is the
+          # one place in this workflow where the token choice is load-bearing: it is what makes
+          # the `work-this` label actually start a worker run.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           WIRED: ${{ steps.resolve.outputs.wired }}
         run: |
           set -uo pipefail
+          SINCE="$(date -u -d '2 minutes ago' +%Y-%m-%dT%H:%M:%SZ)"
+          COUNT=0
           for n in $(echo "$WIRED" | node -e 'JSON.parse(require("fs").readFileSync(0,"utf8")).forEach(c=>console.log(c.issue))'); do
             echo "── canary #$n ──"
             # Close any PR from the previous run and delete its branch, so the new run starts clean
@@ -88,8 +106,23 @@ jobs:
             gh issue edit "$n" --remove-label work-this 2>/dev/null || true
             sleep 2
             gh issue edit "$n" --add-label work-this 2>&1 | tail -1 || true
+            COUNT=$((COUNT + 1))
             echo "dispatched #$n"
           done
+
+          # TRIPWIRE for the exact failure the App token above fixes. A dispatch that starts no
+          # worker looks identical to a successful one — the step goes green, and the problem only
+          # surfaces as a `verify` run reporting "no observations" up to 45 minutes later, which
+          # reads as "the pipeline is broken" rather than "the dispatch never happened".
+          # A run is created within seconds of the label event, so a short wait is enough.
+          sleep 25
+          STARTED="$(gh run list --workflow work-issue-pidev.yml --limit 30 --json createdAt \
+            --jq "[.[] | select(.createdAt >= \"$SINCE\")] | length" 2>/dev/null || echo 0)"
+          if [ "${STARTED:-0}" -eq 0 ] && [ "$COUNT" -gt 0 ]; then
+            echo "::error::labelled $COUNT canary issue(s) but NO work-issue-pidev run started. The label event did not reach the worker — check the token (a GITHUB_TOKEN-triggered event never starts a workflow run) before blaming the pipeline."
+            exit 1
+          fi
+          echo "$STARTED worker run(s) started for $COUNT canary(ies)"
           echo "::notice::Canaries dispatched. Re-run this workflow with mode=verify once the runs finish (a worker takes 2–45 min)."
 
       # ── VERIFY ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #1878

**The canary dispatch would have done nothing.** Found while about to run the first one for real.

## The bug

`canary.yml` applies the `work-this` label using `GITHUB_TOKEN`. Actions' recursion guard means **an event triggered by `GITHUB_TOKEN` never starts a new workflow run** — so the label would have fired `work-issue-pidev.yml` exactly zero times.

The nasty part is the shape of the failure, not the failure itself:

- the dispatch step goes **green** — every `gh` call succeeds, the label really is applied
- nothing starts
- the only signal arrives up to **45 minutes later**, as a `verify` run reporting "no observations"
- which reads as *"the pipeline is broken"* — when the truth is *the dispatch never happened*

A rig built to stop the harness misdiagnosing itself would have opened with a misdiagnosis of its own.

## The fix

Mint the Harness App token and use it for the dispatch step — the same app, inputs, and reason as `decompose-on-issue-pidev.yml`, `bundle-budget.yml`, and the `loop-station-*` workflows, all of which carry a variant of *"push with the Harness App, not GITHUB_TOKEN"* (#572/#626/#1133). This is the one load-bearing token choice in the workflow; everything `verify` does is a read, where `GITHUB_TOKEN` is fine.

## Plus a tripwire, because green-but-dead is the real hazard

After labelling, count `work-issue-pidev` runs created since the step began. Zero runs with a non-zero label count is a hard error that names the likely cause:

```
::error::labelled 1 canary issue(s) but NO work-issue-pidev run started. The label
event did not reach the worker — check the token (a GITHUB_TOKEN-triggered event
never starts a workflow run) before blaming the pipeline.
```

A run is created within seconds of the label event, so a 25s wait settles it. This converts the failure from a silent 45-minute wait into an immediate, correctly-attributed error — which is the same property the rig is supposed to enforce on everything else.

## Verification

- `canary.yml` parses
- its 5 `run:` blocks extract clean and pass the same `shellcheck -S warning -e SC2086,SC2016,SC1091` the CI gate now enforces, plus `bash -n`

Not verifiable before merge: `workflow_dispatch` only runs a workflow from the default branch, so the first real dispatch *is* the test of this change. The tripwire exists precisely so that test fails loudly and accurately if I've got it wrong again.

## 🧪 How to test

1. Merge, then run `.github/workflows/canary.yml` with `mode=dispatch`, `only=locale-3-files`.
2. The step should end with `N worker run(s) started for 1 canary(ies)` — and a `work-issue-pidev` run should be visible in Actions within a minute.
3. If instead it errors with the message above, the token still isn't reaching the worker — check that `HARNESS_APP_ID` / `HARNESS_APP_PRIVATE_KEY` are readable from this workflow.
4. Once the worker finishes (2–45 min), re-run with `mode=verify`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGJ7DaXTFQ1jYfjWN62pkX)_