### PR TITLE
fix(root): flag a relation with no target instead of reporting "No relationships" (#1953)

### DIFF
--- a/.claude/skills/schema-review/SKILL.md
+++ b/.claude/skills/schema-review/SKILL.md
@@ -86,6 +86,32 @@ on any line and leave an **inline comment pinned to that exact field** ("make th
   committed `.md`, revises the schema field-by-field, re-renders, and replies to/resolves each
   thread. When running this skill by hand, point the reviewer at the committed `.md` in the diff.
 
+## Unresolved relations — the thing this gate exists to catch
+
+A field typed `relation` with **no `refTarget`** is the highest-value thing on the page: it is
+the one detail that makes the relation buildable, and it is the easiest to approve without
+noticing. The renderer marks it **⚠ not set** in the References column and replaces the
+relationships sketch with a warning naming each offender. It never reports "No relationships"
+for a collection that has relation fields.
+
+**Do not approve a schema carrying one.** Name the collection each points at, and check that
+collection is actually being generated — a target that doesn't exist produces an import to a
+missing file and fails the *build*, minutes later, with an error that names none of this.
+
+If **people** are the intended target, say so explicitly: in crouton they come from the
+auth/team side, not a generated collection, so it likely needs a different field type rather
+than a relation.
+
+Pass `--strict` to make it a hard gate (exit 1) — use that for a pre-generate check or CI. It
+is **off by default** because the decompose apply step calls this inside a best-effort guard,
+where a non-zero exit would drop the schema artifact from the sign-off comment entirely and
+hide the problem instead of showing it.
+
+> Minted by the #1825 chores POC: `assignee` and `lastDoneBy` were approved as untargeted
+> relations, the summary read "_No relationships._", the build instruction then invented
+> "references household members/users", the worker turned that into `refTarget: "users"`, and
+> the generated code imported a `users` collection nobody ever created.
+
 ## Conventions
 - One review per collection; re-render after every schema edit so the artifact never drifts.
 - The field table is the source of truth for review — keep it honest (mirror the actual JSON,

--- a/.claude/skills/schema-review/render-schema.mjs
+++ b/.claude/skills/schema-review/render-schema.mjs
@@ -78,10 +78,38 @@ for (const [name, def] of Object.entries(fieldsObj)) {
     default: meta.default ?? def.default ?? '',
     refTarget: def.refTarget || '',
     refScope: def.refScope || '',
+    // A field that DECLARES a relation but names no target (#1933-adjacent, the #1825 case).
+    // This is the whole point of the gate: it is the one detail that makes a relation
+    // buildable, and it was previously invisible here — see `unresolved` below.
+    unresolvedRef: isRelationType(def) && !def.refTarget,
   })
 }
 
+/** Does this field's TYPE declare a relation, regardless of whether a target was given? */
+function isRelationType(def) {
+  const t = String(def.type || '').toLowerCase()
+  return t === 'relation' || t === 'reference' || t === 'belongsto' || t === 'ref'
+}
+
 const relations = rows.filter((r) => r.refTarget)
+
+// ── UNRESOLVED REFERENCES (#1825) ─────────────────────────────────────────────────
+// The failure this exists to stop: `chores` was approved with `assignee (relation)` and
+// `lastDoneBy (relation)` and NO target on either. Because the relationship summary was
+// built as `rows.filter(r => r.refTarget)`, both dropped out and the sign-off rendered
+// "_No relationships._" — so there was nothing on screen to question. Downstream each step
+// made the hole more concrete without checking it: the build instruction invented the prose
+// "references household members/users", the worker turned that into `refTarget: "users"`,
+// and the generated import pointed at a collection nobody ever created. The build died
+// minutes later with 400 lines of module paths and no mention of the cause.
+//
+// So an untargeted relation is reported LOUDLY and never counted as "no relationships".
+// It is deliberately NOT a hard exit by default: this renderer is called by the decompose
+// apply step inside a best-effort guard, so exiting non-zero would SKIP the whole artifact
+// and post the sign-off questions with no schema at all — hiding the problem again, worse.
+// Visibility at approval time is the fix. Use --strict for a hard gate (see below).
+const unresolved = rows.filter((r) => r.unresolvedRef)
+const strict = argv.includes('--strict')
 
 // ── Markdown ──
 const yn = (b) => (b ? '✓' : '')
@@ -94,12 +122,30 @@ const md = [
   '|---|---|:--:|:--:|---|---|',
   ...rows.map(
     (r) =>
-      `| \`${r.name}\`${r.primaryKey ? ' 🔑' : ''}${r.unique ? ' ·uniq' : ''} | ${r.type} | ${yn(r.required)} | ${yn(r.translatable)} | ${r.default === '' ? '' : `\`${r.default}\``} | ${r.refTarget ? `\`${r.refTarget}\`${r.refScope ? ` (${r.refScope})` : ''}` : ''} |`,
+      `| \`${r.name}\`${r.primaryKey ? ' 🔑' : ''}${r.unique ? ' ·uniq' : ''} | ${r.type} | ${yn(r.required)} | ${yn(r.translatable)} | ${r.default === '' ? '' : `\`${r.default}\``} | ${r.refTarget ? `\`${r.refTarget}\`${r.refScope ? ` (${r.refScope})` : ''}` : r.unresolvedRef ? '⚠️ **not set**' : ''} |`,
   ),
   '',
+  ...(unresolved.length
+    ? [
+        `> ⚠️ **${unresolved.length} relation field${unresolved.length === 1 ? '' : 's'} with no target — do not approve as-is.**`,
+        '>',
+        ...unresolved.map(
+          (r) => `> - \`${collection}.${r.name}\` says it points at another collection, but doesn't say which.`,
+        ),
+        '>',
+        '> Whatever fills this blank later is a **guess**. Name the collection each one points at,',
+        '> and make sure that collection is actually being built — a target that does not exist',
+        '> generates an import to a missing file and fails the build, long after this decision.',
+        '> If people are meant to be the target, say so explicitly: they come from the auth/team',
+        '> side here, not from a generated collection, so this may need a different field type.',
+        '',
+      ]
+    : []),
   relations.length
     ? `**Relationships:** ${relations.map((r) => `\`${collection}.${r.name}\` → \`${r.refTarget}\``).join(' · ')}`
-    : '_No relationships._',
+    : unresolved.length
+      ? `_No **resolved** relationships — ${unresolved.length} unresolved above._`
+      : '_No relationships._',
   '',
 ].join('\n')
 
@@ -116,7 +162,7 @@ const rowHtml = rows
         <td class="c">${chip(r.required, 'req')}</td>
         <td class="c">${chip(r.translatable, 'i18n')}</td>
         <td>${r.default === '' ? '<span class="muted">—</span>' : `<code>${esc(r.default)}</code>`}</td>
-        <td>${r.refTarget ? `<span class="ref">→ ${esc(r.refTarget)}</span>${r.refScope ? ` <span class="muted">(${esc(r.refScope)})</span>` : ''}` : '<span class="muted">—</span>'}</td>
+        <td>${r.refTarget ? `<span class="ref">→ ${esc(r.refTarget)}</span>${r.refScope ? ` <span class="muted">(${esc(r.refScope)})</span>` : ''}` : r.unresolvedRef ? '<span class="warn">⚠ not set</span>' : '<span class="muted">—</span>'}</td>
       </tr>`,
   )
   .join('\n')
@@ -128,7 +174,9 @@ const relHtml = relations.length
           `<li><code>${esc(collection)}.${esc(r.name)}</code> <span class="arrow">→</span> <code>${esc(r.refTarget)}</code>${r.refScope ? ` <span class="muted">(${esc(r.refScope)})</span>` : ''}</li>`,
       )
       .join('\n')
-  : '<li class="muted">No relationships — this collection stands alone.</li>'
+  : unresolved.length
+    ? `<li class="warn">⚠ ${unresolved.length} relation field${unresolved.length === 1 ? '' : 's'} with NO target — ${unresolved.map((r) => `<code>${esc(r.name)}</code>`).join(', ')}. Name what each points at before approving; whatever fills the blank later is a guess.</li>`
+    : '<li class="muted">No relationships — this collection stands alone.</li>'
 
 const html = `<!DOCTYPE html>
 <!-- schema-review — generated by .claude/skills/schema-review/render-schema.mjs. No JS/CDN. -->
@@ -155,7 +203,8 @@ const html = `<!DOCTYPE html>
   code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:.92em;color:#cdd6e6;}
   .chip{display:inline-block;min-width:34px;font-size:11px;color:var(--muted);}
   .chip.on{color:#04231a;background:var(--green);font-weight:700;border-radius:999px;padding:1px 8px;}
-  .ref{color:var(--green);} .arrow{color:var(--muted);} .muted{color:var(--muted);}
+  .warn{color:#fbbf24;font-weight:600}
+    .ref{color:var(--green);} .arrow{color:var(--muted);} .muted{color:var(--muted);}
   h3{margin:28px 0 10px;font-size:15px;}
   .rel{background:#101725;border:1px solid var(--line);border-radius:14px;padding:14px 18px;}
   .rel ul{margin:0;padding:0;list-style:none;display:grid;gap:8px;font-size:13.5px;}
@@ -191,3 +240,17 @@ console.log(`✓ MD   → ${mdPath}`)
 console.log(
   `→ PNG:  node .claude/skills/ui-proposal/render.mjs ${htmlPath} screenshots/schema-review-${collection}.png`,
 )
+
+// --strict (#1825): exit non-zero when a relation names no target, for callers that want a
+// HARD gate (a pre-generate check, CI). Off by default on purpose — the decompose apply step
+// calls this inside a best-effort guard, where a non-zero exit would drop the whole schema
+// artifact from the sign-off comment and hide the very problem this reports.
+if (strict && unresolved.length) {
+  console.error(
+    `\n✖ ${unresolved.length} relation field${unresolved.length === 1 ? '' : 's'} with no target: ` +
+      `${unresolved.map((r) => `${collection}.${r.name}`).join(', ')}\n` +
+      `  Name the collection each points at, and make sure that collection is actually built — ` +
+      `an unresolved target generates an import to a missing file and fails the build later.`,
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
Closes #1953

## 👤 For humans

This is why the chores app's build crashed — and it wasn't the generator's fault.

The schema you approved showed two fields marked **`relation`** with **nothing to relate to**, and then printed **"_No relationships._"** underneath. There was nothing on screen to question. The one missing detail is the one that makes a relation buildable.

Three steps later, the build died importing a `users` collection nobody ever created.

Now those fields render **⚠ not set** and the summary names them instead of denying they exist.

**Before** (what you approved) → **after** (same schema, this branch):

| | References column | Summary |
|---|---|---|
| before | *(blank)* | `_No relationships._` |
| after | `⚠️ **not set**` ×2 | `⚠ 2 relation fields with NO target — assignee, lastDoneBy` |

## 🔍 Archaeology

```js
const relations = rows.filter((r) => r.refTarget)   // ← the bug
```

A relation-typed field with no `refTarget` has no `refTarget`, so it was filtered out of the summary *and* left an empty cell. Present since the renderer was written — it only became load-bearing when #1821 made this render the **sole basis** for an automated design sign-off.

The full chain is documented on #1953, with the reproduced build error.

## 🤖 For agents

- Detects `type: relation|reference|belongsTo|ref` with no `refTarget`.
- Markdown **and** HTML both mark it; the summary can no longer claim "No relationships" while unresolved ones exist.
- **`--strict`** exits 1, for a pre-generate check or CI. **Off by default, deliberately:** the decompose apply step calls this inside a best-effort `tryRender` guard, so a non-zero exit would drop the schema artifact from the sign-off comment entirely — hiding the problem instead of showing it. Visibility at approval time is the fix.
- Skill doc records the rule, the `--strict` tradeoff, and that **people are an auth/team concept here, not a generated collection** — so a relation may be the wrong field type entirely, which is exactly the question that should have reached a human.

## 🧪 How to test

Verified against the real schema, not a mock:

```
assignee   relation  → ⚠️ not set
lastDoneBy relation  → ⚠️ not set
⚠️ 2 relation fields with no target — do not approve as-is.
--strict → exit 1
```

And no false positive — a schema with real `refTarget`s renders `**Relationships:** posts.authorId → authors · posts.tagId → tags` and exits 0.

I also re-rendered the PNG and looked at it, since the picture is what a reviewer actually sees — the amber markers and the warning box both read clearly.

## Deliberately not in scope

- **The generator** (`packages/*`) still accepts a `refTarget` pointing at a collection that doesn't exist and emits a dangling import. That needs its own issue and your shared-code approval.
- The generated `queries.ts` also `leftJoin`s the same table twice under one alias, which looks invalid — but the build never reaches it, so I'm not claiming it.


---
_Generated by [Claude Code](https://claude.ai/code/session_0112Fx8AXJLvgEPHPpimBevY)_