### PR TITLE
chore(docs): deploy docs via its own docs-production env, not the shared one (#1133)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,13 @@ jobs:
   deploy:
     name: Deploy docs to Cloudflare Workers
     runs-on: ubuntu-latest
-    environment: production
+    # `docs-production`, NOT the shared `production` env (#1133). docs is a public
+    # content site that ships continuously on merge, and its own header (above) says
+    # it is explicitly NOT the #318 prod gate. Putting the required reviewer on
+    # `production` — so a cash-register app deploy needs a human click — would
+    # otherwise freeze every docs merge behind that same click. Separate env, no
+    # reviewer, branch policy restricted to `main`.
+    environment: docs-production
     permissions:
       contents: read
     env:


### PR DESCRIPTION
Refs #1133 (WS3 prerequisite).

## 👤 For humans

The `production` environment is about to get a required reviewer, so shipping a real app to production needs a deliberate human click (#318). The docs site declares that **same** environment but ships continuously on every merge to `main` — so without this, every docs merge would freeze behind that click too.

docs now has its own environment: no reviewer, `main`-only. Its own workflow header already said it is explicitly *not* the #318 prod gate — it's a public `@nuxt/content` site with no per-PR data and no cash-register surface.

## 🤖 For agents

One line: `environment: production` → `docs-production`.

`docs-production` is already created, with a custom deployment branch policy of `main` only and **no environment-scoped secrets**, so it inherits the org-level `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`.

**That inheritance was the real risk, and it was tested rather than assumed.** The shared `Production` environment carries its *own* copies of both secrets, which override the org values — and secret values can't be read back, so there was no way to compare them statically. A `pull_request` run wouldn't have caught it either: `deploy-docs.yml` only build-smokes on PRs, so credentials aren't exercised until the change is on `main`.

So the branch was temporarily allowed in `docs-production`'s policy and the workflow dispatched from it (run `31025426720`). The branch changes only a workflow file, so the built site was identical to `main`'s:

```
✨ Success! Uploaded 172 files (90 already uploaded) (14.81 sec)
Uploaded docs (21.60 sec)
Deployed docs triggers (1.53 sec)
Current Version ID: 745ac5a7-b29c-4d59-96d9-6a4e59781fd5
```

Authenticated fine on the inherited org credentials. The temporary branch allowance has been revoked — the policy is back to `main` only.

## 🧪 How to test

1. Merge, then push any change touching `docs/**`. `Deploy Docs` runs and deploys with **no** approval prompt; its deployment shows environment `docs-production`.
2. Environments page: `docs-production` has zero protection rules beyond the `main` branch policy, and zero secrets of its own.
3. After WS3 lands the reviewer on `production`, repeat step 1 — docs must *still* deploy without a click. That's the whole point of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
