### PR TITLE
fix(crouton-cli): refuse an unknown relation target instead of guessing (#1957)

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -377,6 +377,7 @@ rewritten every run regardless. Guarded by the write loop in `writeScaffold`
 | `lib/add-module.ts` | Module installation implementation |
 | `lib/rollback-collection.ts` | Remove a collection — files, schema barrel, `app.config`, `extends`. Barrel via `getSchemaPath` (modern→legacy). `orphanTableName`/`dropTableWarning` (the code-only-rollback warning) + `generateDropMigration` (`--drop-table` emit / `--dry-run` temp-out preview) — #1445 WS4 |
 | `lib/utils/generate-migrations.ts` | Direct migration generation (`generateMigrations`, `prepareSchemaForMigration`, `DuplicateTableError`) — resolve graph → duplicate gate → app's `db:generate` (drizzle-kit, no Nuxt). Deferral/throw failure contract. Used by config/`add`/`init` (#1445 WS2) |
+| `lib/utils/validate-ref-targets.ts` | `validateRefTargets` / `RefTargetError` — refuse an unknown `refTarget` before any file is written; person-shaped targets get a message pointing at #1958 (#1957) |
 | `lib/utils/helpers.ts` | Case conversion, type mapping |
 | `lib/utils/dialects.ts` | PostgreSQL/SQLite configs |
 | `lib/utils/detect-package-manager.ts` | Detect pnpm/yarn/npm |
@@ -415,6 +416,18 @@ lib/generators/
   "categoryId": { "type": "string", "refTarget": "categories" }
 }
 ```
+
+**`refTarget` must name a collection that exists (#1957).** It is validated in `writeScaffold`
+*before* anything is written: an unknown target throws `RefTargetError` naming the collection,
+the field, the bad target and the collections that do exist. Previously `database-queries.ts`
+fell through its `// or unknown — fall back to existing behavior` branch and emitted an import
+to a nonexistent path, so the failure surfaced minutes later as an unresolvable module in the
+*build* (the #1825 chores case). The check no-ops when no collection map is available (no
+config/targets), since nothing can be verified there.
+
+⚠️ **`refTarget` cannot reference a person.** Users live in `@fyit/crouton-auth`, not as a
+generated collection, so `refTarget: "users"` has no route to them — the error says so and
+points at **#1958**, which tracks giving fields a real way to reference a team member.
 
 ### Field Meta Properties
 

--- a/packages/crouton-cli/lib/generate-collection.ts
+++ b/packages/crouton-cli/lib/generate-collection.ts
@@ -15,6 +15,7 @@ import { detectRequiredDependencies, displayMissingDependencies, ensureLayersExt
 import { setupCroutonCssSource, displayManualCssSetupInstructions } from './utils/css-setup.ts'
 import { syncFrameworkPackages, addToNuxtConfigExtends, addRuntimeConfig } from './utils/update-nuxt-config.ts'
 import { addNamedSchemaExport, getSchemaPath } from './utils/update-schema-index.ts'
+import { validateRefTargets } from './utils/validate-ref-targets.ts'
 import { generateMigrations, DuplicateTableError } from './utils/generate-migrations.ts'
 import { addToAppConfig, resolveAppConfigPath } from './utils/update-app-config.ts'
 import { loadFields } from './utils/load-fields.ts'
@@ -1032,6 +1033,20 @@ function buildCollectionLayerMap(config: Record<string, any> | null): Map<string
   return map
 }
 
+// Every name a `refTarget` may legitimately use (#1957). BOTH forms are accepted because
+// `refTarget` names the generated DIRECTORY — which is the PLURAL — while the config (and so
+// `buildCollectionLayerMap`) is keyed by the collection name as written. apps/velo configures
+// `location` and its schema correctly says `refTarget: "locations"`; checking only the config
+// key would reject that valid, shipping schema. Verified by scanning every schema in the repo.
+function buildKnownRefTargets(config: Record<string, any> | null): Set<string> {
+  const names = new Set<string>()
+  for (const key of buildCollectionLayerMap(config).keys()) {
+    names.add(key)
+    names.add(toCase(key).plural.toLowerCase())
+  }
+  return names
+}
+
 // Build the core file set every collection gets: components, composable, CRUD
 // endpoints (+ hierarchy/sortable endpoints), queries, schema, types, the layer
 // nuxt.config and README.
@@ -1310,6 +1325,13 @@ async function registerCollectionInAppConfig(params: {
 }
 
 async function writeScaffold({ layer, collection, fields, dialect, autoRelations, dryRun, noDb, force = false, noTranslations = false, config = null, collectionConfig = null, hierarchy: hierarchyFlag = false, seed = false, seedCount = 25, noTests = false }: WriteScaffoldOptions): Promise<void> {
+  // REFUSE an unresolvable relation BEFORE anything is written or installed (#1957). The queries
+  // generator would otherwise fall through its `// or unknown — fall back to existing behavior`
+  // branch and emit an import to a collection that does not exist, turning a local, obvious
+  // mistake into an opaque build failure minutes later (the #1825 chores case). We hold the full
+  // collection map right here, so this is the cheapest possible place to catch it.
+  validateRefTargets(fields, buildKnownRefTargets(config), collection)
+
   const cases = toCase(collection)
   const base = path.resolve('layers', layer, 'collections', cases.plural)
 

--- a/packages/crouton-cli/lib/utils/validate-ref-targets.ts
+++ b/packages/crouton-cli/lib/utils/validate-ref-targets.ts
@@ -1,0 +1,110 @@
+/**
+ * #1957 — refuse an unknown relation target instead of guessing an import path.
+ *
+ * WHY. `database-queries.ts` resolves a field's `refTarget` against the app's collections and,
+ * when the lookup misses, falls through to
+ *   `// Same-layer sibling (or unknown — fall back to existing behavior)`
+ * emitting `import * as XSchema from '../../../x/server/database/schema'` regardless. No
+ * warning, exit 0. On the #1825 chores POC that produced an import to a `users` collection
+ * nobody created, and the failure surfaced minutes later as
+ *   `Cannot resolve "../../../users/server/database/schema" … and externals are not allowed!`
+ * after ~400 lines of module paths naming neither the schema, the field, nor `refTarget`.
+ *
+ * The generator holds the full collection map at that moment. This turns a silent guess into a
+ * local, readable refusal — one `if` earlier and minutes sooner.
+ *
+ * Deliberately runs BEFORE any file is written, so a rejected generate leaves nothing behind.
+ *
+ * ⚠️ NAMING: `refTarget` names the generated DIRECTORY, which is the PLURAL of the configured
+ * collection name — `apps/velo` configures `location` and its schema correctly says
+ * `refTarget: "locations"`. `collectionLayerMap` is keyed by the CONFIG name, so a naive
+ * `map.has(refTarget)` rejects that valid schema. The caller therefore passes an EXPANDED set
+ * holding both forms. (This is also why the generator's "unknown" fallback silently worked for
+ * years: every plural target missed the map and landed in the branch that happens to emit the
+ * right path.) Caught by scanning every schema in the repo before shipping this check.
+ */
+
+/** A field as `load-fields` yields it — only the parts this check needs. */
+export interface RefTargetField {
+  name: string
+  type?: string
+  refTarget?: string
+}
+
+export interface UnresolvedRef {
+  field: string
+  target: string
+}
+
+export class RefTargetError extends Error {
+  readonly unresolved: UnresolvedRef[]
+  constructor(message: string, unresolved: UnresolvedRef[]) {
+    super(message)
+    this.name = 'RefTargetError'
+    this.unresolved = unresolved
+  }
+}
+
+/**
+ * Targets that mean "a person". These are NOT typos — they are a real want with no mechanism
+ * (#1958: users live in the auth package, not as a generated collection, so `refTarget` has no
+ * route to them). The message must say that, or the author is left renaming a collection that
+ * was never going to work.
+ */
+const PERSON_TARGETS = new Set(['user', 'users', 'person', 'people', 'member', 'members', 'account', 'accounts'])
+
+/**
+ * Throw if any field references a collection the generator does not know about.
+ *
+ * @param fields          the collection's fields
+ * @param knownTargets    every acceptable target name, lowercased — BOTH the configured
+ *                        collection name and its plural directory form (see the NAMING note)
+ * @param collectionName  the collection being generated, for the message
+ *
+ * No-ops when the set is EMPTY: that means no config/targets were supplied, so nothing is known
+ * and nothing can be verified. Refusing every relation there would break generation paths that
+ * never had a map to begin with — absence of the map is not evidence of a bad target.
+ */
+export function validateRefTargets(
+  fields: RefTargetField[],
+  knownTargets: Set<string>,
+  collectionName: string,
+): void {
+  if (!knownTargets || knownTargets.size === 0) return
+
+  const unresolved: UnresolvedRef[] = []
+  for (const f of fields || []) {
+    const target = f?.refTarget
+    if (!target) continue
+    if (knownTargets.has(String(target).toLowerCase())) continue
+    unresolved.push({ field: f.name, target: String(target) })
+  }
+  if (unresolved.length === 0) return
+
+  const known = [...knownTargets].sort()
+  const lines = [
+    `Cannot generate "${collectionName}": ${unresolved.length} field${unresolved.length === 1 ? '' : 's'} reference${unresolved.length === 1 ? 's' : ''} a collection that does not exist.`,
+    '',
+    ...unresolved.map((u) => `  • ${collectionName}.${u.field} → "${u.target}"  (no such collection)`),
+    '',
+    `  Collections available here: ${known.join(', ')}`,
+  ]
+
+  // A person-shaped target is a capability gap, not a misspelling — say so, or the author
+  // burns time renaming something that could never have resolved.
+  if (unresolved.some((u) => PERSON_TARGETS.has(u.target.toLowerCase()))) {
+    lines.push(
+      '',
+      '  One of these looks like it means "a person". Users are not a generated collection here —',
+      '  they belong to the auth package — so a relation cannot reach them yet. Tracked as #1958.',
+      '  For now, model it another way (e.g. a plain string field you populate yourself).',
+    )
+  }
+
+  lines.push(
+    '',
+    '  Nothing was written. Fix the target (or remove the field) and generate again.',
+  )
+
+  throw new RefTargetError(lines.join('\n'), unresolved)
+}

--- a/packages/crouton-cli/tests/unit/utils/validate-ref-targets.test.ts
+++ b/packages/crouton-cli/tests/unit/utils/validate-ref-targets.test.ts
@@ -1,0 +1,115 @@
+/**
+ * #1957 — the generator must REFUSE an unknown relation target, not guess an import path.
+ *
+ * The case that minted it (#1825 chores POC): a field carried `refTarget: "users"`, no `users`
+ * collection existed, and `database-queries.ts` fell through to
+ *   `// Same-layer sibling (or unknown — fall back to existing behavior)`
+ * emitting `import * as usersSchema from '../../../users/server/database/schema'`. Nothing
+ * checked it. The build died minutes later on an unresolvable module, after ~400 lines of
+ * paths naming neither the schema, the field, nor `refTarget`.
+ *
+ * The generator holds the full collection map at that moment — it is one check away from
+ * saying so. This is that check.
+ */
+import { describe, it, expect } from 'vitest'
+import pluralize from 'pluralize'
+import { validateRefTargets, RefTargetError } from '../../../lib/utils/validate-ref-targets'
+
+// Mirrors buildKnownRefTargets: BOTH the config name and its plural directory form.
+const known = (...names: string[]) =>
+  new Set(names.flatMap((n) => [n.toLowerCase(), pluralize(n).toLowerCase()]))
+
+describe('validateRefTargets', () => {
+  it('accepts fields whose targets all exist (case-insensitively)', () => {
+    const fields = [
+      { name: 'title', type: 'string' },
+      { name: 'authorId', type: 'string', refTarget: 'authors' },
+      { name: 'tagId', type: 'string', refTarget: 'Tags' },
+    ]
+    expect(() => validateRefTargets(fields, known('authors', 'tags'), 'posts')).not.toThrow()
+  })
+
+  it('accepts a schema with no relations at all', () => {
+    expect(() => validateRefTargets([{ name: 'title', type: 'string' }], known(), 'posts')).not.toThrow()
+  })
+
+  // ── the #1825 case ────────────────────────────────────────────────────────────
+  it('THROWS on a target that does not exist, naming collection, field and target', () => {
+    const fields = [
+      { name: 'name', type: 'string' },
+      { name: 'assigneeId', type: 'string', refTarget: 'users' },
+    ]
+    let err: RefTargetError | undefined
+    try {
+      validateRefTargets(fields, known('chores'), 'chores')
+    } catch (e) {
+      err = e as RefTargetError
+    }
+    expect(err).toBeInstanceOf(RefTargetError)
+    // the message has to carry everything the build error did not
+    expect(err!.message).toContain('chores.assigneeId')
+    expect(err!.message).toContain('users')
+    expect(err!.message).toContain('chores')          // the collections that DO exist
+    expect(err!.unresolved).toEqual([{ field: 'assigneeId', target: 'users' }])
+  })
+
+  it('reports EVERY bad target at once, not just the first', () => {
+    const fields = [
+      { name: 'assigneeId', type: 'string', refTarget: 'users' },
+      { name: 'lastDoneById', type: 'string', refTarget: 'people' },
+      { name: 'roomId', type: 'string', refTarget: 'rooms' },
+    ]
+    let err: RefTargetError | undefined
+    try {
+      validateRefTargets(fields, known('rooms'), 'chores')
+    } catch (e) {
+      err = e as RefTargetError
+    }
+    // fixing them one build at a time is the slow path this exists to avoid
+    expect(err!.unresolved).toEqual([
+      { field: 'assigneeId', target: 'users' },
+      { field: 'lastDoneById', target: 'people' },
+    ])
+  })
+
+  it('points a person-shaped target at the feature issue instead of reading as a dead end', () => {
+    // `user`/`users`/`people`/`members` are a real want with no mechanism yet (#1958) — the
+    // message must not imply the author simply typo'd a collection name.
+    for (const target of ['user', 'users', 'People', 'members']) {
+      let err: RefTargetError | undefined
+      try {
+        validateRefTargets([{ name: 'ownerId', type: 'string', refTarget: target }], known('chores'), 'chores')
+      } catch (e) {
+        err = e as RefTargetError
+      }
+      expect(err!.message, `for target "${target}"`).toContain('#1958')
+    }
+  })
+
+  it('does not mistake a non-person unknown target for the person case', () => {
+    let err: RefTargetError | undefined
+    try {
+      validateRefTargets([{ name: 'roomId', type: 'string', refTarget: 'rooms' }], known('chores'), 'chores')
+    } catch (e) {
+      err = e as RefTargetError
+    }
+    expect(err!.message).not.toContain('#1958')
+  })
+
+  it('tolerates an empty collection map without inventing a failure', () => {
+    // no config/targets → nothing is known, so nothing can be verified. Refusing every relation
+    // here would break generation paths that never had a map to begin with.
+    expect(() => validateRefTargets([{ name: 'a', type: 'string', refTarget: 'x' }], new Set(), 'c')).not.toThrow()
+  })
+
+// ── the false positive this check nearly shipped with ────────────────────────────────
+it('accepts the PLURAL directory form of a singular config name (the apps/velo case)', () => {
+  // velo configures `location`; its schema correctly says `refTarget: "locations"`, because
+  // refTarget names the generated DIRECTORY. Matching only the config key would have refused
+  // a valid, shipping schema — and that is exactly why the generator's "unknown" fallback
+  // appeared to work: every plural target missed the map and landed in the branch that
+  // happens to emit the right path.
+  const fields = [{ name: 'locationId', type: 'string', refTarget: 'locations' }]
+  expect(() => validateRefTargets(fields, known('location', 'booking'), 'booking')).not.toThrow()
+})
+})


### PR DESCRIPTION
Closes #1957

Packages-approved: shared-code change to `crouton-cli` approved by @pmcp in-session; gate file used and removed, cross-app typecheck + full CLI suite run below.

## 👤 For humans

When a field said *"this points at X"* and X didn't exist, the generator wrote the import anyway and let the build die minutes later on an unreadable module path.

It now refuses up front:

```
Cannot generate "chores": 2 fields reference a collection that does not exist.

  • chores.assigneeId → "users"  (no such collection)
  • chores.lastDoneById → "users"  (no such collection)

  Collections available here: chores

  One of these looks like it means "a person". Users are not a generated collection here —
  they belong to the auth package — so a relation cannot reach them yet. Tracked as #1958.
  For now, model it another way (e.g. a plain string field you populate yourself).

  Nothing was written. Fix the target (or remove the field) and generate again.
```

That replaces ~400 lines of module paths that named neither the schema, the field, nor `refTarget`.

## ⚠️ The near-miss — read this bit

**My first version would have broken `apps/velo`**, and it passed its own tests.

`apps/velo` configures a collection as **`location`** and its schema correctly says **`refTarget: "locations"`** — because `refTarget` names the generated **directory**, which is the plural. My check compared against the config key, so it refused a valid, shipping schema.

I caught it by scanning **every schema in the repo** against the proposed rule before committing, rather than trusting the unit tests. Four schemas would have been refused.

It also explains why the buggy fallback survived so long: **every plural target missed the map and landed in the `// or unknown` branch, which happens to emit the correct path.** The fallback wasn't only masking errors — it was load-bearing for the normal case. Anyone fixing this by simply deleting the fallback would break every cross-collection reference in the repo.

The call site now passes both name forms, and a regression test pins the velo case.

## 🤖 For agents

- New pure `validateRefTargets` + `RefTargetError` (`lib/utils/validate-ref-targets.ts`).
- Called at the **top of `writeScaffold`** — before any file is written or dependency installed, so a rejected generate leaves nothing behind. One choke point covers both the `crouton config` and direct-generate paths, instead of patching all 7 generators that read `refTarget`.
- `buildKnownRefTargets(config)` expands each configured name to `{name, plural(name)}`.
- No-ops on an empty set (no config/targets) — nothing is known there, so nothing can be verified; refusing every relation would break generation paths that never had a map.
- Person-shaped targets (`user`/`people`/`member`/…) route to #1958 rather than reading as a typo.

## 🧪 How to test

- **387** crouton-cli tests pass (8 new, written **before** the implementation per the packages test-first gate — verified red first).
- **`pnpm typecheck` clean** on all 3 apps.
- **`npx fallow audit` clean.**
- **Repo-wide scan:** every `refTarget` in every app/POC schema still resolves — no shipping schema is refused.

```bash
node --test  # or: cd packages/crouton-cli && npx vitest run
```

## Deliberately out of scope

- **#1958** — actually letting a field reference a person. This PR makes that case fail *clearly* and points at it; it doesn't implement it.
- The suspected duplicate-alias `leftJoin` in generated `queries.ts` — the build never reaches it, so it stays a suspicion rather than a claim.

**Behaviour change, stated plainly:** some generates that "succeeded" before will now fail loudly. They were producing unbuildable code, so this is an improvement — but it is a change, not a pure bug fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_0112Fx8AXJLvgEPHPpimBevY)_