### PR TITLE
fix(crouton-auth): make useAuthClient nullable so SSR misuse fails typecheck

### DIFF
--- a/packages/crouton-auth/app/components/Account/ProfileForm.vue
+++ b/packages/crouton-auth/app/components/Account/ProfileForm.vue
@@ -10,7 +10,7 @@
  * ```
  */
 import type { FormSubmitEvent, FormError } from '@nuxt/ui'
-import { useAuthClient } from '../../../types/auth-client'
+import { requireAuthClient } from '../../../types/auth-client'
 
 const { t } = useT()
 
@@ -34,7 +34,6 @@ const emit = defineEmits<{
 const { user, refreshSession } = useAuth()
 const notify = useNotify()
 
-const authClient = useAuthClient()
 
 // Form state (populated from current user)
 const state = reactive({
@@ -125,7 +124,7 @@ async function onSubmit(event: FormSubmitEvent<typeof state>) {
   internalLoading.value = true
   try {
     // Update name and image
-    const result = await authClient.updateUser({
+    const result = await requireAuthClient().updateUser({
       name: event.data.name,
       image: event.data.image || undefined
     })
@@ -136,7 +135,7 @@ async function onSubmit(event: FormSubmitEvent<typeof state>) {
 
     // Handle email change separately (sends verification)
     if (emailChanged.value && event.data.email) {
-      const emailResult = await authClient.changeEmail({
+      const emailResult = await requireAuthClient().changeEmail({
         newEmail: event.data.email,
         callbackURL: window.location.href
       })

--- a/packages/crouton-auth/app/composables/useAuth.ts
+++ b/packages/crouton-auth/app/composables/useAuth.ts
@@ -21,7 +21,7 @@
  * ```
  */
 import type { User } from '../../types'
-import { useAuthClient } from '../../types/auth-client'
+import { useAuthClient, requireAuthClient } from '../../types/auth-client'
 
 export interface LoginCredentials {
   email: string
@@ -165,7 +165,7 @@ export function useAuth() {
     }
 
     try {
-      const result = await authClient.signIn.email({
+      const result = await requireAuthClient().signIn.email({
         email: credentials.email,
         password: credentials.password,
         rememberMe: credentials.rememberMe
@@ -216,7 +216,7 @@ export function useAuth() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.signIn.social({
+      const result = await requireAuthClient().signIn.social({
         provider: provider as 'github' | 'google' | 'discord',
         callbackURL: window.location.origin + '/auth/callback'
       })
@@ -245,7 +245,7 @@ export function useAuth() {
         throw new Error('Magic link is not enabled')
       }
 
-      const result = await authClient.signIn.magicLink({
+      const result = await requireAuthClient().signIn.magicLink({
         email,
         callbackURL: window.location.origin + '/auth/callback'
       })
@@ -277,7 +277,7 @@ export function useAuth() {
     try {
       // Ensure name is always a string (Better Auth requires it)
       const displayName = (data.name ?? data.email.split('@')[0]) as string
-      const result = await authClient.signUp.email({
+      const result = await requireAuthClient().signUp.email({
         email: data.email,
         password: data.password,
         name: displayName
@@ -328,7 +328,7 @@ export function useAuth() {
     loading.value = true
     error.value = null
     try {
-      await authClient.signOut()
+      await requireAuthClient().signOut()
       // Clear session state
       await clear()
     } catch (e: unknown) {

--- a/packages/crouton-auth/app/composables/usePasskeys.ts
+++ b/packages/crouton-auth/app/composables/usePasskeys.ts
@@ -12,11 +12,10 @@
  * ```
  */
 import type { PasskeyInfo, AddPasskeyOptions } from './useAuth'
-import { useAuthClient } from '../../types/auth-client'
+import { requireAuthClient } from '../../types/auth-client'
 
 export function usePasskeys() {
   const config = useAuthConfig()
-  const authClient = useAuthClient()
   const { refresh } = useSession()
 
   const loading = ref(false)
@@ -39,7 +38,7 @@ export function usePasskeys() {
         throw new Error('Passkeys are not enabled')
       }
 
-      const result = await authClient.signIn.passkey()
+      const result = await requireAuthClient().signIn.passkey()
 
       if (result.error) {
         throw new Error(result.error.message ?? 'Passkey login failed')
@@ -62,7 +61,7 @@ export function usePasskeys() {
         throw new Error('Passkeys are not enabled')
       }
 
-      const result = await authClient.signIn.passkey({
+      const result = await requireAuthClient().signIn.passkey({
         autoFill: true
       })
 
@@ -91,7 +90,7 @@ export function usePasskeys() {
         throw new Error('Passkeys are not enabled')
       }
 
-      const result = await authClient.passkey.addPasskey({
+      const result = await requireAuthClient().passkey.addPasskey({
         name: options?.name
       })
 
@@ -114,7 +113,7 @@ export function usePasskeys() {
         return []
       }
 
-      const result = await authClient.passkey.listUserPasskeys()
+      const result = await requireAuthClient().passkey.listUserPasskeys()
 
       if (result.error) {
         throw new Error(result.error.message ?? 'List passkeys failed')
@@ -142,7 +141,7 @@ export function usePasskeys() {
         throw new Error('Passkeys are not enabled')
       }
 
-      const result = await authClient.passkey.deletePasskey({ id })
+      const result = await requireAuthClient().passkey.deletePasskey({ id })
 
       if (result.error) {
         throw new Error(result.error.message ?? 'Delete passkey failed')

--- a/packages/crouton-auth/app/composables/usePasswordReset.ts
+++ b/packages/crouton-auth/app/composables/usePasswordReset.ts
@@ -11,10 +11,9 @@
  * </script>
  * ```
  */
-import { useAuthClient } from '../../types/auth-client'
+import { requireAuthClient } from '../../types/auth-client'
 
 export function usePasswordReset() {
-  const authClient = useAuthClient()
 
   const loading = ref(false)
   const error = ref<string | null>(null)
@@ -23,7 +22,7 @@ export function usePasswordReset() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.requestPasswordReset({
+      const result = await requireAuthClient().requestPasswordReset({
         email,
         redirectTo: window.location.origin + '/auth/reset-password'
       })
@@ -43,7 +42,7 @@ export function usePasswordReset() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.resetPassword({
+      const result = await requireAuthClient().resetPassword({
         token,
         newPassword: password
       })

--- a/packages/crouton-auth/app/composables/useTeam.ts
+++ b/packages/crouton-auth/app/composables/useTeam.ts
@@ -20,7 +20,7 @@
  * ```
  */
 import type { Team, MemberRole, Member, MemberWithUser } from '../../types'
-import { useAuthClient } from '../../types/auth-client'
+import { useAuthClient, requireAuthClient } from '../../types/auth-client'
 import { mapOrganizationToTeam } from '../../shared/utils/auth'
 
 export interface CreateTeamData {
@@ -255,7 +255,7 @@ export function useTeam() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.organization.setActive({
+      const result = await requireAuthClient().organization.setActive({
         organizationId: teamId
       })
 
@@ -278,7 +278,7 @@ export function useTeam() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.organization.setActive({
+      const result = await requireAuthClient().organization.setActive({
         organizationSlug: slug
       })
 
@@ -305,7 +305,7 @@ export function useTeam() {
         throw new Error('Cannot create more teams. Limit reached or not in multi-tenant mode.')
       }
 
-      const result = await authClient.organization.create({
+      const result = await requireAuthClient().organization.create({
         name: data.name,
         slug: data.slug!,
         logo: data.logo,
@@ -322,7 +322,7 @@ export function useTeam() {
 
       // Set the newly created org as active so the session cookie reflects it
       // before any navigation happens (prevents hydration mismatch)
-      await authClient.organization.setActive({
+      await requireAuthClient().organization.setActive({
         organizationId: result.data.id
       })
 
@@ -347,7 +347,7 @@ export function useTeam() {
         throw new Error('No active team to update')
       }
 
-      const result = await authClient.organization.update({
+      const result = await requireAuthClient().organization.update({
         organizationId: currentTeam.value.id,
         data: {
           name: data.name,
@@ -390,7 +390,7 @@ export function useTeam() {
         throw new Error('Only the team owner can delete the team')
       }
 
-      const result = await authClient.organization.delete({
+      const result = await requireAuthClient().organization.delete({
         organizationId: currentTeam.value.id
       })
 
@@ -420,7 +420,7 @@ export function useTeam() {
     }
 
     try {
-      const result = await authClient.organization.listMembers({
+      const result = await requireAuthClient().organization.listMembers({
         query: { organizationId: currentTeam.value.id }
       })
 
@@ -452,7 +452,7 @@ export function useTeam() {
         throw new Error('You do not have permission to invite members')
       }
 
-      const result = await authClient.organization.inviteMember({
+      const result = await requireAuthClient().organization.inviteMember({
         organizationId: currentTeam.value.id,
         email: data.email,
         role: data.role ?? 'member'
@@ -485,7 +485,7 @@ export function useTeam() {
         throw new Error('You do not have permission to remove members')
       }
 
-      const result = await authClient.organization.removeMember({
+      const result = await requireAuthClient().organization.removeMember({
         organizationId: currentTeam.value.id,
         memberIdOrEmail
       })
@@ -520,7 +520,7 @@ export function useTeam() {
         throw new Error('You do not have permission to manage members')
       }
 
-      const result = await authClient.organization.updateMemberRole({
+      const result = await requireAuthClient().organization.updateMemberRole({
         organizationId: currentTeam.value.id,
         memberId,
         role
@@ -562,7 +562,7 @@ export function useTeam() {
         throw new Error('Not authenticated')
       }
 
-      const result = await authClient.organization.removeMember({
+      const result = await requireAuthClient().organization.removeMember({
         organizationId: currentTeam.value.id,
         memberIdOrEmail: user.value.id
       })
@@ -590,7 +590,7 @@ export function useTeam() {
     if (!currentTeam.value) return []
 
     try {
-      const result = await authClient.organization.listInvitations({
+      const result = await requireAuthClient().organization.listInvitations({
         query: { organizationId: currentTeam.value.id }
       })
 
@@ -614,7 +614,7 @@ export function useTeam() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.organization.cancelInvitation({
+      const result = await requireAuthClient().organization.cancelInvitation({
         invitationId
       })
 
@@ -637,7 +637,7 @@ export function useTeam() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.organization.acceptInvitation({
+      const result = await requireAuthClient().organization.acceptInvitation({
         invitationId
       })
 
@@ -660,7 +660,7 @@ export function useTeam() {
     loading.value = true
     error.value = null
     try {
-      const result = await authClient.organization.rejectInvitation({
+      const result = await requireAuthClient().organization.rejectInvitation({
         invitationId
       })
 

--- a/packages/crouton-auth/app/composables/useTwoFactor.ts
+++ b/packages/crouton-auth/app/composables/useTwoFactor.ts
@@ -12,11 +12,10 @@
  * ```
  */
 import type { TotpSetupData, VerifyTotpOptions, TwoFactorStatus } from './useAuth'
-import { useAuthClient } from '../../types/auth-client'
+import { requireAuthClient } from '../../types/auth-client'
 
 export function useTwoFactor() {
   const config = useAuthConfig()
-  const authClient = useAuthClient()
   const { user: sessionUser, refresh } = useSession()
 
   const loading = ref(false)
@@ -35,7 +34,7 @@ export function useTwoFactor() {
         throw new Error('Two-factor authentication is not enabled')
       }
 
-      const result = await authClient.twoFactor.enable({ password })
+      const result = await requireAuthClient().twoFactor.enable({ password })
 
       if (result.error) {
         throw new Error(result.error.message ?? 'Enable 2FA failed')
@@ -65,7 +64,7 @@ export function useTwoFactor() {
         throw new Error('Two-factor authentication is not enabled')
       }
 
-      const result = await authClient.twoFactor.disable({ password })
+      const result = await requireAuthClient().twoFactor.disable({ password })
 
       if (result.error) {
         throw new Error(result.error.message ?? 'Disable 2FA failed')
@@ -87,7 +86,7 @@ export function useTwoFactor() {
       }
 
       // Better Auth 1.4.x: getTotpUri requires password
-      const result = await authClient.twoFactor.getTotpUri({ password })
+      const result = await requireAuthClient().twoFactor.getTotpUri({ password })
 
       if (result.error) {
         throw new Error(result.error.message ?? 'Get TOTP URI failed')
@@ -110,7 +109,7 @@ export function useTwoFactor() {
         throw new Error('Two-factor authentication is not enabled')
       }
 
-      const result = await authClient.twoFactor.verifyTotp({
+      const result = await requireAuthClient().twoFactor.verifyTotp({
         code: options.code,
         trustDevice: options.trustDevice
       })
@@ -137,7 +136,7 @@ export function useTwoFactor() {
         throw new Error('Two-factor authentication is not enabled')
       }
 
-      const result = await authClient.twoFactor.generateBackupCodes({ password })
+      const result = await requireAuthClient().twoFactor.generateBackupCodes({ password })
 
       if (result.error) {
         throw new Error(result.error.message ?? 'Generate backup codes failed')
@@ -160,7 +159,7 @@ export function useTwoFactor() {
         throw new Error('Two-factor authentication is not enabled')
       }
 
-      const result = await authClient.twoFactor.verifyBackupCode({ code })
+      const result = await requireAuthClient().twoFactor.verifyBackupCode({ code })
 
       if (result.error) {
         throw new Error(result.error.message ?? 'Verify backup code failed')
@@ -189,7 +188,7 @@ export function useTwoFactor() {
         return { enabled: false, hasTotp: false, hasBackupCodes: false }
       }
 
-      const result = await authClient.getSession()
+      const result = await requireAuthClient().getSession()
       const session = result.data
       const twoFactorEnabled = (session?.user as { twoFactorEnabled?: boolean })?.twoFactorEnabled ?? false
 

--- a/packages/crouton-auth/app/pages/auth/magic-link.vue
+++ b/packages/crouton-auth/app/pages/auth/magic-link.vue
@@ -7,7 +7,7 @@
  *
  * This page automatically verifies the magic link token and signs the user in.
  */
-import { useAuthClient } from '../../../types/auth-client'
+import { requireAuthClient } from '../../../types/auth-client'
 
 definePageMeta({
   layout: 'auth'
@@ -44,9 +44,8 @@ async function verifyMagicLink() {
   verifyError.value = null
 
   try {
-    const authClient = useAuthClient()
     // Better Auth 1.4.x requires query wrapper for token
-    const result = await authClient.magicLink.verify({
+    const result = await requireAuthClient().magicLink.verify({
       query: { token: token.value! }
     })
 

--- a/packages/crouton-auth/app/pages/auth/verify-email.vue
+++ b/packages/crouton-auth/app/pages/auth/verify-email.vue
@@ -7,7 +7,7 @@
  *
  * Also shows a resend verification email option.
  */
-import { useAuthClient } from '../../../types/auth-client'
+import { requireAuthClient } from '../../../types/auth-client'
 
 definePageMeta({
   layout: 'auth'
@@ -46,9 +46,8 @@ async function verifyEmail() {
   verifyError.value = null
 
   try {
-    const authClient = useAuthClient()
     // Better Auth 1.4.x requires query wrapper for token
-    const result = await authClient.verifyEmail({
+    const result = await requireAuthClient().verifyEmail({
       query: { token: token.value! }
     })
 
@@ -77,8 +76,7 @@ async function resendVerification() {
   resending.value = true
 
   try {
-    const authClient = useAuthClient()
-    const result = await authClient.sendVerificationEmail({
+    const result = await requireAuthClient().sendVerificationEmail({
       email: user.value.email,
       callbackURL: window.location.origin + '/auth/verify-email'
     })

--- a/packages/crouton-auth/types/auth-client.ts
+++ b/packages/crouton-auth/types/auth-client.ts
@@ -43,21 +43,46 @@ const _typedAuthClient = createAuthClient({
 export type CroutonAuthClient = typeof _typedAuthClient
 
 /**
- * Helper to get auth client with proper typing
- * Returns the typed auth client. Will throw on server-side if accessed.
+ * Get the auth client, or `null` when it isn't available.
+ *
+ * `auth-client.client.ts` is a CLIENT-ONLY plugin, so `$authClient` is
+ * `undefined` during SSR — hence the nullable return. This used to be typed
+ * non-nullable, which meant TypeScript could not flag an unguarded dereference
+ * and a 500-on-every-server-rendered-page shipped with a green typecheck (#1951,
+ * incident in #1738/#1884). Safe to call at setup; guard before you dereference.
+ *
+ * Inside a code path that only ever runs client-side (an event handler,
+ * `onMounted`), prefer `requireAuthClient()` — it is non-nullable and fails loudly.
  */
-export function useAuthClient(): CroutonAuthClient {
+export function useAuthClient(): CroutonAuthClient | null {
   const nuxtApp = useNuxtApp()
-  return nuxtApp.$authClient as CroutonAuthClient
+  return (nuxtApp.$authClient ?? null) as CroutonAuthClient | null
 }
 
 /**
- * Helper to get auth client with proper typing (nullable)
- * Returns null on server-side since authClient is client-only
+ * Get the auth client, throwing if it is unavailable.
+ *
+ * For CLIENT-ONLY code paths that genuinely cannot proceed without it. Call it
+ * INSIDE the handler, never at composable setup — setup runs during SSR, where
+ * this throws by design.
+ */
+export function requireAuthClient(): CroutonAuthClient {
+  const client = useAuthClient()
+  if (!client) {
+    throw new Error(
+      '[crouton-auth] auth client unavailable — it is client-only, so this ran during SSR. '
+      + 'Call requireAuthClient() inside a client-only path, or use useAuthClient() and guard the null.'
+    )
+  }
+  return client
+}
+
+/**
+ * @deprecated Redundant since `useAuthClient()` became honestly nullable (#1951).
+ * Use `useAuthClient()`; this is kept as an alias so existing call sites keep working.
  */
 export function useAuthClientSafe(): CroutonAuthClient | null {
-  const nuxtApp = useNuxtApp()
-  return (nuxtApp.$authClient ?? null) as CroutonAuthClient | null
+  return useAuthClient()
 }
 
 // Module augmentation for NuxtApp is defined in the generated .nuxt/types/*.d.ts files


### PR DESCRIPTION
Closes #1951

## 👤 For humans

`useAuthClient()` claimed to always return a client. It doesn't — the auth plugin is client-only, so it's `undefined` during SSR. That lie is why a bug that **500'd every server-rendered page** shipped with a completely green `pnpm typecheck` (the #1738/#1884 incident, fixed there by hand).

This makes the type honest, so the same mistake is now a compile error instead of a green build plus a broken app.

## 🤖 For agents

`packages/crouton-auth/types/auth-client.ts`:

- **`useAuthClient(): CroutonAuthClient | null`** — was non-nullable via `as CroutonAuthClient`, which laundered `undefined` into a non-null type. Docstring corrected too: it claimed *"Will throw on server-side if accessed"* and never threw.
- **`requireAuthClient(): CroutonAuthClient`** (new) — throws a named error. For client-only paths. Documented to be called *inside* the handler, never at composable setup.
- **`useAuthClientSafe()`** — now a deprecated alias; redundant once the main accessor is honest. Its 4 call sites keep working.

39 dereferences across 8 files switched to `requireAuthClient()`; 6 files no longer need a setup-time acquisition, so those lines are gone.

**Why not just make `useAuthClient()` throw, matching its docstring?** That's actively worse — composables acquire the client at *setup*, which runs during SSR. Throwing there breaks every server-rendered page. The throw has to be at the dereference, not the acquisition. Recorded in #1951's *Considered & rejected*.

## 🧪 How to test

The point of this change is the **negative control** — verified, not assumed:

```
# reintroduce the #1738 bug shape at setup in useTeam.ts:
  const _probe = typeof authClient.organization === 'object'   # no ?.

# BEFORE this PR: typecheck green (that's the bug)
# AFTER:  useTeam.ts(131,25): error TS18047: 'authClient' is possibly 'null'
```

Full verification on this base (rebased onto `main` after #1884 landed):

| Gate | Result |
|---|---|
| `pnpm --filter velo typecheck` | clean — 0 errors (39 when the type was first made honest) |
| `cd packages/crouton-auth && npx vitest run tests/unit` | **294 passed** / 15 files, 3 skipped, 33 todo |
| `E2E_FIXTURE=minimal … pnpm test:e2e` | **9 passed · 0 failed** |
| negative control above | ✅ now red |

## Known gap, deliberately not in scope

`Account/{DeleteAccount,LinkedAccounts,PasswordForm}.vue` each define their **own local** `function useAuthClient()` that shadows the shared import and still casts non-nullable. They're unaffected by this change and keep the old lie locally. That duplication was already flagged on #1884 as worth DRYing separately — folding it in here would mix a type-safety fix with a refactor of three components. Worth its own issue.

Related: #1738 / #1884 (the incident), #1739 (this is further evidence `fallbackTeams` is load-bearing for SSR).

---
_Generated by [Claude Code](https://claude.ai/code/session_012jYcm9SkjpdEQVWGHVXd9o)_