### PR TITLE
docs(root): how we author a gate — validate against the corpus, and never exit 0 having done nothing (#1965, #1966)

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -143,9 +143,18 @@ Check every changed file against this checklist. Skip categories that don't appl
 
 #### Gates, Checks & Flow Steps
 
-Applies when the diff adds or changes **a rule that judges other code** — a validator, a CI check, a
-sign-off gate. See `AGENTS.md` → *Authoring a gate* for the argument.
+Applies when the diff adds or changes **a rule that judges other code** (a validator, a CI check, a
+sign-off gate) or **a step that mutates state** (writes a file, commits, labels, dispatches). See
+`AGENTS.md` → *Authoring a gate* for the argument.
 
+- [ ] **Can this path exit 0 having done nothing?** The recurring defect is a silent no-op, not a crash:
+      `git add` on a gitignored path adds nothing (#1933) · `--add-label X` on an issue already carrying
+      `X` fires no event, so nothing downstream wakes (#1750) · `rows.filter(r => r.refTarget)` dropped
+      the relations *missing* a target, then reported "No relationships" (#1953)
+- [ ] **What in the output would prove it acted?** A count, a path, a diff — if the run's own output
+      can't distinguish "did the work" from "did nothing", say so and add the proof
+- [ ] **Where it can no-op, assert the effect** instead of assuming it — check the artifact is
+      committable rather than trusting the write; remove-then-add rather than hoping the event fires
 - [ ] **Was the rule run over the corpus, with the hit count reported?** Green unit tests only prove
       the rule matches its author's imagination — #1957's first version passed 8 and would have refused
       4 shipping schemas. Cheap to do:

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -141,6 +141,19 @@ Check every changed file against this checklist. Skip categories that don't appl
 - [ ] Team-scoped endpoints use `useTeamContext()`
 - [ ] Return types are consistent (not mixing shapes)
 
+#### Gates, Checks & Flow Steps
+
+Applies when the diff adds or changes **a rule that judges other code** — a validator, a CI check, a
+sign-off gate. See `AGENTS.md` → *Authoring a gate* for the argument.
+
+- [ ] **Was the rule run over the corpus, with the hit count reported?** Green unit tests only prove
+      the rule matches its author's imagination — #1957's first version passed 8 and would have refused
+      4 shipping schemas. Cheap to do:
+      `node scripts/corpus-check.mjs --glob 'apps/*/schemas/*.json' --rule ./my-rule.mjs`
+      (advisory — skip it when there's no meaningful corpus, e.g. a rule over one generated file)
+- [ ] **Does "no matches" mean clean, or mean the query was wrong?** A scan that matched nothing has
+      proved nothing
+
 #### Vue Components (*.vue files only)
 - [ ] Props have TypeScript types
 - [ ] Emits are declared with `defineEmits`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,24 @@ no `lgtm`, not done. Where the work has an enumerable contract (a behaviour spec
 comes from **comparison against the expected result**, not from re-reading the list: a list can't
 reveal its own gaps; running the real thing next to the contract can.
 
+## Authoring a gate
+
+The gates above judge other people's work, so a wrong gate is worse than no gate — it refuses correct
+code, or waves the broken case through. **Advisory**: apply this where it means something, not as
+ceremony.
+
+**Run the rule over the corpus, not just its tests.** Tests prove the rule matches its author's
+*imagination*; only the corpus proves it matches the repo. A validator for cross-collection references
+passed eight green unit tests and would have refused four shipping schemas, because it compared the
+reference against the *configured* name while the reference legitimately names the *generated* one
+(#1957). That same scan showed the fall-through branch it was "fixing" was load-bearing for the normal
+case — deleting it would have broken every cross-collection reference in the repo. Tests could not have
+shown that. The inverse shape is the same lesson: sign-off images were silently gitignored, so every
+hold posted a dead link, found by checking the artifact paths against the *real* ignore file (#1933).
+So: before merging, run the proposed rule over every file it would judge and report the hit count. Each
+refusal of existing code is then a claim to defend file by file. Skip it when there is no meaningful
+corpus (a rule over one generated file) — an empty corpus run proves nothing either way.
+
 ## Deciding vs asking
 
 The sign-off gates above are *pre-declared* decision points. Most forks aren't those — they surface

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,8 @@ reveal its own gaps; running the real thing next to the contract can.
 ## Authoring a gate
 
 The gates above judge other people's work, so a wrong gate is worse than no gate — it refuses correct
-code, or waves the broken case through. **Advisory**: apply this where it means something, not as
-ceremony.
+code, or waves the broken case through. Two checks, before a gate (or any rule, check or flow step)
+merges. Both are **advisory**: apply them where they mean something, not as ceremony.
 
 **Run the rule over the corpus, not just its tests.** Tests prove the rule matches its author's
 *imagination*; only the corpus proves it matches the repo. A validator for cross-collection references
@@ -94,6 +94,19 @@ hold posted a dead link, found by checking the artifact paths against the *real*
 So: before merging, run the proposed rule over every file it would judge and report the hit count. Each
 refusal of existing code is then a claim to defend file by file. Skip it when there is no meaningful
 corpus (a rule over one generated file) — an empty corpus run proves nothing either way.
+
+**Ask of every step: can this path exit 0 having done nothing?** The most common defect here is not a
+crash but a **silent no-op** — an operation that succeeds, does nothing, and reports nothing. Three in
+one session: adding a file on an ignored path (exits 0, adds nothing — every sign-off dropped its
+image, #1933); adding a label an issue already carries (fires no event, so the listener never woke,
+#1750); filtering a list by the very field being reported on (records missing it vanished, and the
+report cheerfully said "none", #1953). Each exits 0, each produces a plausible-looking result, and
+**none is visible in the run's own output** — you find it later by noticing an absence, which is the
+expensive way. So pair the question with a second one: *what in the output would prove it acted?* And
+where an operation can no-op, **assert the effect** rather than assume it — check the artifact is
+committable rather than trusting the write; remove-then-add rather than hoping the event fires.
+(No detector is proposed: a shell exit code, an API semantic and an array filter share no syntax. The
+value is in the question being asked.)
 
 ## Deciding vs asking
 

--- a/scripts/corpus-check.mjs
+++ b/scripts/corpus-check.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * corpus-check.mjs — run a proposed gate's rule over every file it would judge, before
+ * the gate merges (#1965).
+ *
+ *   node scripts/corpus-check.mjs --glob '<pattern>' --rule <rule.mjs> [--json] [--allow-empty]
+ *
+ * A gate's unit tests only prove it behaves as its author *imagined*. They cannot tell you
+ * whether the rule is right about the repo it will judge — for that you have to run it over
+ * the real corpus and look at what it refuses. Two cases from one session (#1751):
+ *
+ *   • #1957 — a `refTarget` validator compared the target against configured collection *names*.
+ *     Eight unit tests green. `refTarget` names the generated DIRECTORY, which is the plural:
+ *     apps/velo configures `location` and correctly says `refTarget: "locations"`. A corpus run
+ *     found 4 shipping schemas the rule would have refused — and, incidentally, that the
+ *     fall-through branch it was "fixing" was load-bearing for every plural target in the repo.
+ *   • #1933 — the inverse: sign-off PNGs were silently gitignored, so every design hold posted a
+ *     dead image link. Found by checking the artifact paths against the REAL `.gitignore`, not
+ *     against a fixture's.
+ *
+ * ADVISORY, not enforced: a gate over a single generated file has no meaningful corpus, and
+ * requiring a run there would be its own false positive. Reach for this when the rule judges a
+ * class of files that already exist.
+ *
+ * ── The rule module ──────────────────────────────────────────────────────────────────────────
+ * Any `.mjs` exporting `check` (or a default function):
+ *
+ *   export function check({ path, text, json }) {
+ *     // falsy        → the rule accepts this file
+ *     // string       → the rule REJECTS it, with this reason
+ *     return json.fields?.some(f => f.refTarget === 'users') ? 'refTarget "users"' : null
+ *   }
+ *
+ * A rejection is not automatically a bug — it is a claim you now have to defend file by file.
+ * The exit code says "your rule refuses code that already ships", which is the question worth
+ * answering before merge, so `--json` is there for when you want the data rather than a verdict.
+ *
+ * This script refuses to exit 0 on a zero-file glob (override: `--allow-empty`). A corpus run
+ * that matched nothing and reported "clean" would be exactly the silent no-op #1966 is about.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, dirname, relative, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Directories never worth scanning — build output and vendored code, not corpus. */
+export const SKIP_DIRS = ['node_modules', '.git', '.nuxt', '.output', '.wrangler', 'dist']
+
+/** Translate a glob (`**`, `*`, `?`) into an anchored RegExp over forward-slashed paths. */
+export function globToRegExp(pattern) {
+  let out = ''
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i]
+    if (c === '*') {
+      if (pattern[i + 1] === '*') {
+        // `**/` spans any number of directories (including none); a bare `**` spans anything.
+        if (pattern[i + 2] === '/') { out += '(?:[^/]*\\/)*'; i += 2 } else { out += '.*'; i += 1 }
+      } else {
+        out += '[^/]*'
+      }
+    } else if (c === '?') {
+      out += '[^/]'
+    } else {
+      out += c.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    }
+  }
+  return new RegExp(`^${out}$`)
+}
+
+/** Every file under `root` matching `pattern`, as repo-relative forward-slashed paths. */
+export function findFiles(pattern, root = ROOT) {
+  const re = globToRegExp(pattern)
+  const found = []
+  const walk = (dir) => {
+    let entries
+    try { entries = readdirSync(dir, { withFileTypes: true }) } catch { return }
+    for (const entry of entries) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.includes(entry.name)) walk(full)
+      } else {
+        const rel = relative(root, full).replace(/\\/g, '/')
+        if (re.test(rel)) found.push(rel)
+      }
+    }
+  }
+  walk(root)
+  return found.sort()
+}
+
+/** Read one corpus file into the shape a rule receives. `json` is null when it doesn't parse. */
+export function readCorpusFile(path, root = ROOT) {
+  const text = readFileSync(join(root, path), 'utf8')
+  let json = null
+  try { json = JSON.parse(text) } catch { /* not JSON — the rule gets `text` */ }
+  return { path, text, json }
+}
+
+/**
+ * Run `rule` over `files`. Pure — the caller does the reading, so a test can pass literals.
+ * @param {{files: Array<{path: string, text?: string, json?: any}>, rule: Function}} input
+ * @returns {{scanned: number, rejected: Array<{path: string, reason: string}>, errored: Array<{path: string, reason: string}>}}
+ */
+export function runCorpus({ files = [], rule }) {
+  if (typeof rule !== 'function') throw new TypeError('runCorpus: `rule` must be a function')
+  const rejected = []
+  const errored = []
+  for (const file of files) {
+    let verdict
+    try {
+      verdict = rule(file)
+    } catch (err) {
+      // A rule that THROWS on real input is a finding too — it would crash the gate in CI.
+      errored.push({ path: file.path, reason: err?.message || String(err) })
+      continue
+    }
+    if (verdict) rejected.push({ path: file.path, reason: typeof verdict === 'string' ? verdict : 'rejected' })
+  }
+  return { scanned: files.length, rejected, errored }
+}
+
+/** Human report. The scanned count is part of the verdict — "0 files, clean" is not clean. */
+export function formatReport(result, { glob } = {}) {
+  const lines = [`corpus-check: ${result.scanned} file(s) matched ${glob ? `\`${glob}\`` : 'the corpus'}`]
+  if (result.scanned === 0) {
+    lines.push('', '⚠️  MATCHED NOTHING — the glob is probably wrong. A rule that judged no files')
+    lines.push('    has proved nothing. Pass --allow-empty if the empty corpus is genuinely expected.')
+    return lines.join('\n')
+  }
+  for (const { path, reason } of result.errored) lines.push(`  💥 ${path} — rule threw: ${reason}`)
+  for (const { path, reason } of result.rejected) lines.push(`  ✖ ${path} — ${reason}`)
+  const bad = result.rejected.length + result.errored.length
+  lines.push('')
+  lines.push(
+    bad === 0
+      ? `✅ clean — the rule accepts all ${result.scanned} existing file(s).`
+      : `❌ ${bad}/${result.scanned} existing file(s) refused. Each one is either a real finding or a\n   false positive in the rule — decide per file before this gate merges (#1965).`,
+  )
+  return lines.join('\n')
+}
+
+function parseArgs(argv) {
+  const args = { glob: null, rule: null, json: false, allowEmpty: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--glob') args.glob = argv[++i]
+    else if (a === '--rule') args.rule = argv[++i]
+    else if (a === '--json') args.json = true
+    else if (a === '--allow-empty') args.allowEmpty = true
+  }
+  return args
+}
+
+const USAGE = `Usage: node scripts/corpus-check.mjs --glob '<pattern>' --rule <rule.mjs> [--json] [--allow-empty]
+
+  --glob         repo-relative glob of the files the gate would judge, e.g. 'apps/*/schemas/*.json'
+  --rule         .mjs exporting check({ path, text, json }) → falsy (accept) | string (reject reason)
+  --json         emit the result as JSON instead of a report
+  --allow-empty  do not fail when the glob matches nothing (rarely what you want)`
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.glob || !args.rule) {
+    console.error(USAGE)
+    process.exit(2)
+  }
+
+  const mod = await import(pathToFileURL(resolve(args.rule)).href)
+  const rule = mod.check || mod.default
+  if (typeof rule !== 'function') {
+    console.error(`corpus-check: ${args.rule} exports no \`check\` (or default) function.`)
+    process.exit(2)
+  }
+
+  const paths = findFiles(args.glob)
+  const result = runCorpus({ files: paths.map(p => readCorpusFile(p)), rule })
+
+  if (args.json) console.log(JSON.stringify({ glob: args.glob, ...result }, null, 2))
+  else console.log(formatReport(result, { glob: args.glob }))
+
+  if (result.scanned === 0) process.exit(args.allowEmpty ? 0 : 1)
+  process.exit(result.rejected.length + result.errored.length > 0 ? 1 : 0)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => { console.error(err); process.exit(2) })
+}

--- a/scripts/corpus-check.test.mjs
+++ b/scripts/corpus-check.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * #1965 contract — a gate's rule is run over every file it would judge BEFORE the gate merges,
+ * and the run cannot report "clean" without having actually looked at something.
+ *
+ *   node --test scripts/corpus-check.test.mjs
+ *
+ * The last two cases are themselves corpus runs against the REAL repo (the #1933 pattern:
+ * assert against the actual tree, not a fixture), replaying the #1957 near-miss.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { globToRegExp, findFiles, readCorpusFile, runCorpus, formatReport } from './corpus-check.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+test('globToRegExp anchors and respects directory boundaries', () => {
+  assert.ok(globToRegExp('apps/*/schemas/*.json').test('apps/velo/schemas/booking.json'))
+  // `*` must not cross a `/` — otherwise a one-level glob silently sweeps the whole tree
+  assert.equal(globToRegExp('apps/*/schemas/*.json').test('apps/velo/a/schemas/b.json'), false)
+  assert.equal(globToRegExp('*.json').test('apps/velo/package.json'), false)
+  assert.ok(globToRegExp('**/*.json').test('apps/velo/package.json'))
+  assert.ok(globToRegExp('scripts/**/*.mjs').test('scripts/lib/excalidraw.mjs'))
+  assert.ok(globToRegExp('scripts/**/*.mjs').test('scripts/corpus-check.mjs'), '`**/` must also match zero directories')
+})
+
+test('runCorpus separates accepts, rejects and rules that throw', () => {
+  const files = [
+    { path: 'a.json', json: { ok: true } },
+    { path: 'b.json', json: { ok: false } },
+    { path: 'c.json', json: null },
+  ]
+  const result = runCorpus({
+    files,
+    rule: ({ json }) => {
+      if (json === null) throw new Error('unparseable')
+      return json.ok ? null : 'not ok'
+    },
+  })
+  assert.equal(result.scanned, 3)
+  assert.deepEqual(result.rejected, [{ path: 'b.json', reason: 'not ok' }])
+  // A rule that throws on real input would crash the gate in CI — that is a finding, not a skip.
+  assert.equal(result.errored.length, 1)
+  assert.equal(result.errored[0].path, 'c.json')
+})
+
+test('an empty corpus reports loudly instead of reading as clean', () => {
+  // The whole point of #1966: a run that matched nothing must not look like a pass.
+  const report = formatReport(runCorpus({ files: [], rule: () => null }), { glob: 'nope/*.json' })
+  assert.match(report, /MATCHED NOTHING/)
+  assert.doesNotMatch(report, /clean/)
+})
+
+test('formatReport names every refused file', () => {
+  const report = formatReport(
+    { scanned: 47, rejected: [{ path: 'apps/velo/schemas/booking.json', reason: 'unknown target "locations"' }], errored: [] },
+    { glob: 'apps/*/schemas/*.json' },
+  )
+  assert.match(report, /apps\/velo\/schemas\/booking\.json/)
+  assert.match(report, /1\/47/)
+})
+
+// ── #1957 replay: the corpus catches what eight green unit tests did not ──────────────────────
+// `refTarget` names the generated DIRECTORY (plural); the config is keyed by the collection name
+// as written. velo configures `location` and correctly says `refTarget: "locations"`. The gate's
+// first version compared against config keys only — green tests, and it would have refused this.
+const VELO_BOOKING = 'apps/velo/schemas/booking.json'
+const CONFIGURED = ['location', 'booking'] // as the config keys them — singular
+const plural = (name) => (name.endsWith('s') ? name : `${name}s`)
+
+function refTargetsOf({ json }) {
+  return Object.values(json || {}).map(def => def?.refTarget).filter(Boolean)
+}
+
+test('the real velo schema still carries the plural refTarget this rule turns on', () => {
+  // Asserted, not skipped: if this file moves, the two cases below would quietly stop testing
+  // anything — a vacuous pass is the failure mode this whole issue is about.
+  assert.ok(existsSync(join(ROOT, VELO_BOOKING)), `${VELO_BOOKING} is the #1957 corpus case — update this test if it moves`)
+  assert.deepEqual(refTargetsOf(readCorpusFile(VELO_BOOKING)), ['locations'])
+})
+
+test('the config-keys-only rule refuses shipping schemas — the corpus says so, the tests did not', () => {
+  const naive = file => refTargetsOf(file).find(t => !CONFIGURED.includes(t)) ?? null
+  const result = runCorpus({ files: [readCorpusFile(VELO_BOOKING)], rule: f => naive(f) && `unknown target "${naive(f)}"` })
+  assert.equal(result.rejected.length, 1, 'the first #1957 version would have refused apps/velo')
+
+  // The shipped rule accepts both name forms, which is why velo generates today.
+  const fixed = file => refTargetsOf(file).find(t => !CONFIGURED.some(c => c === t || plural(c) === t)) ?? null
+  assert.equal(runCorpus({ files: [readCorpusFile(VELO_BOOKING)], rule: fixed }).rejected.length, 0)
+})
+
+test('findFiles reaches the real schema corpus', () => {
+  const files = findFiles('apps/*/schemas/*.json')
+  assert.ok(files.length > 0, 'the schema corpus is not empty — a zero match here means the walker is broken')
+  assert.ok(files.includes(VELO_BOOKING))
+})


### PR DESCRIPTION
Closes #1965
Closes #1966

Both #1751 postmortem proposals, done together because they converge on one question — *does this
rule/step actually do what its author thinks?* — from two sides. One new `AGENTS.md` section, one
review-checklist block, one small script.

## 👤 For humans

Two lessons from the last session, written down where the next gate author will hit them.

**A gate's tests only prove it does what its author imagined.** #1957's first version passed eight
green tests and would have refused four schemas that ship today — because it compared a reference
against the *configured* name while the schema legitimately names the *generated* one. Running it
over the real files caught that; no test could have. It also revealed the fallback branch it was
"fixing" was load-bearing for every plural reference in the repo.

**The most common defect isn't a crash — it's a step that does nothing and says nothing.** Three in
one session: a sign-off image that never committed, a worker that never woke, a summary that said
"No relationships" about the very fields it had just dropped. Each exits 0. Each looks fine. Each
was found days later by noticing an absence.

## 🤖 For agents

| Change | What it carries |
|---|---|
| `AGENTS.md` → new **Authoring a gate** section | Both rules, stack-neutral, after *Sign-off gates*. Advisory — a rule over one generated file has no corpus, and demanding a run there is its own false positive. |
| `.claude/skills/review/SKILL.md` → **Gates, Checks & Flow Steps** | Five checklist items: the two no-op questions, assert-the-effect, the corpus run, and "does no-matches mean clean or mean the query was wrong". |
| `scripts/corpus-check.mjs` + `.test.mjs` | `--glob` + `--rule <mjs exporting check({path,text,json})>` → per-file verdicts and a hit count. |

Notes on the script:
- **It refuses to exit 0 on a zero-file glob** (`--allow-empty` overrides). A corpus run that
  matched nothing and printed "clean" would be exactly the #1966 failure — the helper for that
  issue must not be an instance of it.
- A rule that **throws** on real input lands in `errored`, not silently skipped: it would crash the
  gate in CI, so it's a finding too.
- The test replays #1957 against the **real** `apps/velo/schemas/booking.json` (the #1933
  assert-against-the-actual-tree pattern) and *asserts the file exists* rather than skipping — a
  vacuous pass is the failure mode this whole PR is about.

**Deliberately not built:** a lint rule or CI enforcement for either. The three no-op cases share no
syntax (a shell exit code, an API semantic, an array filter), and #1965 asks for advisory. The value
is in the question being asked.

## Retro sweep (#1966 acceptance 4)

Every label-add in `.github/workflows/` and `scripts/` was checked. Already guarded:
`comment-dispatch`, `resume-on-comment`, `canary`, `fix-ci-on-failure` (all remove-then-add), and
`schedule-waves` (guarded upstream by `wave-gate.mjs`'s `isDispatched()`). One site left —
`decompose-on-issue.yml:65` adds `status:in-progress` without removing first, so an issue already
carrying it never moves on the board. **Filed as #1968**, not fixed inline, as the issue asks.

## 🧪 How to test

**The corpus check does what it claims** — reproduce the #1957 near-miss. Write the rule as it was
first written (target must match a *configured* collection name) and run it over the real schemas:

```bash
node scripts/corpus-check.mjs --glob 'apps/*/schemas/*.json' --rule ./rule.mjs
```

Expect a non-zero exit and named refusals — on this tree, 7 of 25 shipping schemas
(`apps/velo/schemas/booking.json` plus six in `apps/triage`). That is the output a gate author would
have seen before merging, instead of eight green tests.

**It can't silently pass:** `--glob 'nope/*.json'` prints `MATCHED NOTHING` and exits 1.

**The checklist catches all three no-ops:** walk #1933, #1750 and #1953 against the two questions in
`/review` → *Gates, Checks & Flow Steps*. Each is caught by "can this path exit 0 having done
nothing?" — and #1968 above is the same check applied to an un-reviewed gate, which is the second
half of the issue's test.

**Verified:** `node --test scripts/corpus-check.test.mjs` 7/7 · `pnpm typecheck` clean on velo,
triage, kassa · `npx fallow audit` clean on all 4 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdKNPsiNSjNpD4TNbu5Km6


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdKNPsiNSjNpD4TNbu5Km6)_