### PR TITLE
fix(root): re-add status:in-progress so the board card actually moves (#1968)

### DIFF
--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -51,6 +51,13 @@ jobs:
       # must *trigger* project-status.yml (which maps status:in-progress → the board's "In progress"
       # column) — and events from the default GITHUB_TOKEN do NOT trigger other workflows. A
       # default-token add would set the label but never move the board card. (#1218)
+      #
+      # And the ADD must be FRESH (#1968). project-status.yml fires on `issues: labeled`, and GitHub
+      # raises no such event when the label is already present — so on an issue that already carries
+      # `status:in-progress` (a re-dispatch, a resume, a human who set it before applying `delegate`)
+      # a bare add succeeds, warns nothing, and the card never moves. Remove first, exactly as
+      # comment-dispatch/resume-on-comment/canary/fix-ci-on-failure already do (the #1750 lesson).
+      # Still safe re: re-trigger — both events name `status:in-progress`, not `delegate`.
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
@@ -61,11 +68,19 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const issue_number = context.payload.issue.number
+            const LABEL = 'status:in-progress'
+            const had = (context.payload.issue.labels || [])
+              .some((l) => (typeof l === 'string' ? l : l.name) === LABEL)
+            if (had) {
+              // 404 here just means someone removed it between the event and now — the add still runs.
+              try { await github.rest.issues.removeLabel({ ...context.repo, issue_number, name: LABEL }) }
+              catch (e) { core.warning(`could not remove ${LABEL} before re-adding: ${e.message}`) }
+            }
             try {
-              await github.rest.issues.addLabels({
-                ...context.repo, issue_number: context.payload.issue.number, labels: ['status:in-progress'],
-              })
-            } catch (e) { core.warning(`could not add status:in-progress: ${e.message}`) }
+              await github.rest.issues.addLabels({ ...context.repo, issue_number, labels: [LABEL] })
+              core.info(`applied ${LABEL} to #${issue_number}${had ? ' (removed first, for a fresh labeled event)' : ''}`)
+            } catch (e) { core.warning(`could not add ${LABEL}: ${e.message}`) }
 
       # Timestamp the run start so the artifact-gate can tell "produced during this run"
       # from pre-existing comments/PRs.


### PR DESCRIPTION
Closes #1968

## 👤 For humans

`decompose-on-issue.yml` marks a delegated issue "in progress" so the board card moves. Adding a
label an issue already has fires no `labeled` event, so `project-status.yml` never woke and the card
stayed put — the step succeeded and warned nothing. Now it removes first.

## 🤖 For agents

- Remove-then-add, guarded on the label being present in the event payload; `core.info` names which
  path ran. Same pattern as `comment-dispatch` / `resume-on-comment` / `canary` /
  `fix-ci-on-failure`; #1750 is this defect on a different label.
- #535 re-fire guard unaffected — the job `if` keys on `delegate`, both events here name
  `status:in-progress`.
- **This site is currently dormant.** `vars.AGENT_HARNESS == 'pi'`, so `decompose-on-issue-pidev.yml`
  takes these events and never stamps the label at all — it only *reads* it, as the #1890 claim
  guard. So this is a latent fix for the flip back. Whether the pi flow should stamp
  `status:in-progress` is a separate question, deliberately not answered here.
- Found by the #1966 retro sweep.

## 🧪 How to test

Not testable while the pi harness is live. After a flip back (`AGENT_HARNESS` unset): take an issue
already labelled `status:in-progress`, apply `delegate`, and watch the board — the card moves to "In
progress". Before this, it did not. The run log shows `applied status:in-progress to #N (removed
first, for a fresh labeled event)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdKNPsiNSjNpD4TNbu5Km6


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdKNPsiNSjNpD4TNbu5Km6)_