### PR TITLE
fix(root): stop the status reporter cancelling itself into a red check

### DIFF
--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -50,9 +50,20 @@ permissions:
 # Key by head SHA (PR/check events) or issue number (issues events) so concurrent refreshes for
 # the SAME target collapse to one (each run recomputes full state, so the latest wins); distinct
 # targets never cancel each other.
+#
+# ⚠️ `cancel-in-progress` MUST stay false here (#1989). This group is keyed by the very SHA this
+# workflow reports ON, and a cancelled run leaves a check-run named `status` attached to that SHA.
+# Both readers treat `cancelled` as red — this file's own `ciState()` (:92) and, fatally,
+# `automerge-epic-subpr.yml`'s RED list (:89) — so self-cancellation marked the commit red and
+# every pipeline sub-PR silently stopped auto-merging into its epic, while a 🔴 ping told the
+# owner to go fix code that was never broken (observed on PR #1987).
+# The other cancelling workflows (a11y, frontend-review, red-team, simplify-review,
+# skill-freshness-pr) key on the PR *number*, so their cancelled run belongs to the superseded
+# SHA and is harmless — do NOT "align" this one back to them.
+# Queueing instead is safe: each run recomputes full state, so the last to finish still wins.
 concurrency:
   group: pipeline-status-${{ github.event.workflow_run.head_sha || github.event.check_suite.head_sha || github.event.pull_request.head.sha || github.event.issue.number || github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   status:


### PR DESCRIPTION
Closes #1989

## 👤 For humans

The workflow whose only job is to report whether CI passed was **failing itself**, reporting itself as the failure, and pinging the owner about code that was never broken. Because a red sub-PR is not allowed to auto-merge, the agent pipeline had quietly stopped landing any work into its epic branches — workers did the work, nothing merged.

One line: the status reporter no longer cancels its own concurrent runs.

## 🤖 For agents

`pipeline-pr-status.yml` keys its `concurrency` group on the **head SHA it reports on**, with `cancel-in-progress: true`. It has many triggers (`workflow_run` ×6, `check_suite`, `status`, `pull_request` ×4, `issues`); when two land within seconds for one SHA they resolve to the same group and cancel each other. The cancelled run leaves a check-run named `status` attached to that same SHA, and both readers class `cancelled` as red:

- `pipeline-pr-status.yml:92` — its own `ciState()`
- `automerge-epic-subpr.yml:89` — the merge gate's `RED` list

Neither classification is wrong in general. The defect is that the reporter cancels *itself, on the SHA it is judging*.

### Scoped to one file on purpose

`a11y`, `frontend-review`, `red-team`, `simplify-review` and `skill-freshness-pr` also use `cancel-in-progress: true`, but key on `github.event.pull_request.number` — their cancellation only fires when a new push supersedes them, so the cancelled check belongs to the **old** SHA while auto-merge evaluates the new one. Harmless. Do not "align" them.

### Why queueing is safe

Each run recomputes full state, so the last to finish still wins and the sticky comment stays correct. The job is seconds long and runs on `ubuntu-latest`, so it does not compete for the self-hosted agent runner.

## Evidence

Observed on #1987 — `🔴 @pmcp — CI failed on this pipeline PR (1 failing check): status`, on a branch whose code was fine. The run history for that SHA contains **no `failure` run at all**, only two `cancelled` ones at 21:45:59 and 21:46:00, seconds after the PR opened.

Refs #1971 — the "step succeeded, the work didn't happen" class this is an instance of.

## Note on already-affected PRs

Cancelled check-runs are immutable, so a PR already poisoned (#1987) stays red until a new commit gives it a fresh SHA. Any pushed follow-up clears it.

## 🧪 How to test

1. Merge, then let the pipeline open any new sub-PR.
2. On its head SHA, no check-run named `status` has conclusion `cancelled`.
3. The sticky reads ✅ once real checks finish, and the PR auto-merges into its epic unattended.
4. The sticky is still one edited-in-place comment, not one per refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_