### PR TITLE
fix(root): make comment-dispatch route correctly — issued-not-mentioned, and a worker lane

### DIFF
--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -31,6 +31,14 @@ jobs:
        github.event.comment.author_association == 'COLLABORATOR') &&
       (contains(github.event.comment.body, '/delegate') ||
        contains(github.event.comment.body, '/deploy'))
+    # ⚠️ The two `contains()` above are a CHEAP PRE-FILTER ONLY, not the decision (#2004).
+    # They are unanchored substring tests, so they also match a command that is merely being
+    # *mentioned* — in backticks, a table cell, a fenced block, or a quote of someone else's
+    # comment. That is how a comment EXPLAINING a mis-dispatch dispatched one on #1791.
+    # The authoritative check is `parseCommand()` in the script step below, which requires
+    # the command at the start of a line, outside code and quotes. Do not move the decision
+    # back up here: GitHub expressions have no newline escape, so it cannot be anchored in
+    # YAML — `'\n'` in a single-quoted scalar is a literal backslash-n and never matches.
     runs-on: ${{ vars.AGENT_RUNNER || 'ubuntu-latest' }}
     steps:
       # Mint a Nuxt Harness App installation token so the `delegate` label is applied by
@@ -43,6 +51,12 @@ jobs:
         with:
           app-id: ${{ secrets.HARNESS_APP_ID }}
           private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+      # Needed so the script can `require` the unit-tested command parser
+      # (scripts/comment-command.mjs) — same pattern as schedule-waves.yml.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -51,10 +65,16 @@ jobs:
             const issue_number = context.payload.issue.number
             const comment_id = context.payload.comment.id
 
-            // Pick the harness label. Check `/delegate-pi` FIRST — `/delegate` is a
-            // substring of it, so the order is load-bearing (#1077).
-            const body = context.payload.comment.body || ''
-            const label = body.includes('/delegate-pi') ? 'delegate-pi' : 'delegate'
+            // Was a command ISSUED, or only MENTIONED? `parseCommand` requires it at the
+            // start of a line, outside code spans/fences and outside `>` quotes, and keeps
+            // the `/delegate-pi` before `/delegate` ordering (#1077). Unit tests, including
+            // the two real comments from the #1791 incident: scripts/comment-command.test.mjs
+            const { parseCommand } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/comment-command.mjs`)
+            const label = parseCommand(context.payload.comment.body)
+            if (!label) {
+              core.info(`#${issue_number}: comment mentions a command but does not issue one — ignoring.`)
+              return
+            }
 
             // Fire a FRESH labeled event: both decompose workflows only trigger on the
             // label being *added* (not merely present), so if it's already there, remove first.

--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -7,6 +7,19 @@ name: Comment dispatch
 # other harness (#1077 / #669 WS7). Only the repo owner / members / collaborators can
 # trigger it.
 #
+# TWO LANES, and the command is not the whole story (#2010):
+#   • DECOMPOSER — `/delegate` | `/delegate-pi` | `/deploy`. Plans an issue: splits it into
+#     sub-issues, or hands a leaf onward. Right for work that has not started.
+#   • WORKER — `/work` → the `work-this` label → work-issue-pidev.yml. Implements ONE leaf
+#     on its existing branch. Right for work already in flight.
+# A `/delegate` on an issue that already has a `work-<issue>` branch is AUTO-ROUTED to the
+# worker, because the decomposer would have nothing left to plan — it would produce no
+# artifact, fail the artifact-gate (#461), and page the owner about a pipeline that was
+# working fine. That is not hypothetical: it is what happened twice on #1791.
+#
+# Both decompose workflows and the worker trigger on their label being *added*, never on it
+# merely being present — hence the remove-then-add below.
+#
 # AUTH (#519 WS5): the label is applied with a Nuxt Harness GitHub App installation token, so
 # the dispatched decompose run is attributed to `nuxt-harness[bot]` and passes claude-code-action's
 # bot-actor guard via its `allowed_bots` allow-list (see decompose-on-issue.yml). This retires the
@@ -30,7 +43,8 @@ jobs:
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR') &&
       (contains(github.event.comment.body, '/delegate') ||
-       contains(github.event.comment.body, '/deploy'))
+       contains(github.event.comment.body, '/deploy') ||
+       contains(github.event.comment.body, '/work'))
     # ⚠️ The two `contains()` above are a CHEAP PRE-FILTER ONLY, not the decision (#2004).
     # They are unanchored substring tests, so they also match a command that is merely being
     # *mentioned* — in backticks, a table cell, a fenced block, or a quote of someone else's
@@ -69,12 +83,26 @@ jobs:
             // start of a line, outside code spans/fences and outside `>` quotes, and keeps
             // the `/delegate-pi` before `/delegate` ordering (#1077). Unit tests, including
             // the two real comments from the #1791 incident: scripts/comment-command.test.mjs
-            const { parseCommand } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/comment-command.mjs`)
-            const label = parseCommand(context.payload.comment.body)
-            if (!label) {
+            const { parseCommand, resolveLane } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/comment-command.mjs`)
+            const command = parseCommand(context.payload.comment.body)
+            if (!command) {
               core.info(`#${issue_number}: comment mentions a command but does not issue one — ignoring.`)
               return
             }
+
+            // Pick the LANE from observed state, not from the word typed (#2010). `/delegate`
+            // is the reflex gesture, and on an issue whose work is already in flight it sends
+            // the decomposer somewhere it has nothing to plan — no artifact, a failed
+            // artifact-gate (#461), and the owner paged about a working pipeline (#1791).
+            // A `work-<issue>` branch is the evidence that "delegate this" means "finish it".
+            let hasWorkBranch = false
+            try {
+              await github.rest.git.getRef({ owner, repo, ref: `heads/work-${issue_number}` })
+              hasWorkBranch = true
+            } catch (e) {
+              if (e.status !== 404) core.warning(`work-branch probe for #${issue_number}: ${e.message}`)
+            }
+            const { label, rerouted } = resolveLane(command, hasWorkBranch)
 
             // Fire a FRESH labeled event: both decompose workflows only trigger on the
             // label being *added* (not merely present), so if it's already there, remove first.
@@ -86,7 +114,15 @@ jobs:
 
             // Acknowledge so the commenter sees it registered (handy on mobile).
             try { await github.rest.reactions.createForIssueComment({ owner, repo, comment_id, content: 'rocket' }) } catch (e) {}
-            const harness = label === 'delegate-pi' ? 'pi.dev' : 'claude'
+
+            // Name the lane that was actually chosen — and, when it differs from what was
+            // typed, say why. A silent reroute would be its own small mystery.
+            const lane = label === 'work-this'
+              ? 'single-use worker'
+              : `${label === 'delegate-pi' ? 'pi.dev' : 'claude'} decomposer`
+            const why = rerouted
+              ? `\n\n_Routed to the worker rather than the decomposer because \`work-${issue_number}\` already exists — there is work in flight to finish, not a plan to make (#2010)._`
+              : ''
             await github.rest.issues.createComment({ owner, repo, issue_number,
-              body: `🟢 **On it — the ${harness} agent is picking this up now.**\n\n<sub>🤖 comment-dispatch · applied \`${label}\`</sub>` })
-            core.info(`Dispatched #${issue_number} via comment (label: ${label}).`)
+              body: `🟢 **On it — the ${lane} is picking this up now.**${why}\n\n<sub>🤖 comment-dispatch · applied \`${label}\`</sub>` })
+            core.info(`Dispatched #${issue_number} via comment (command: ${command}, label: ${label}, rerouted: ${rerouted}).`)

--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -7,11 +7,15 @@ name: Comment dispatch
 # other harness (#1077 / #669 WS7). Only the repo owner / members / collaborators can
 # trigger it.
 #
-# TWO LANES, and the command is not the whole story (#2010):
-#   • DECOMPOSER — `/delegate` | `/delegate-pi` | `/deploy`. Plans an issue: splits it into
-#     sub-issues, or hands a leaf onward. Right for work that has not started.
-#   • WORKER — `/work` → the `work-this` label → work-issue-pidev.yml. Implements ONE leaf
-#     on its existing branch. Right for work already in flight.
+# TWO LANES, named for what they DO (#2010):
+#   • `/plan`  → the decomposer. Splits an issue into sub-issues, or hands a leaf onward.
+#                Right for work that has not started. (`/plan-pi` forces the pi harness.)
+#   • `/build` → the single-use worker (`work-this` → work-issue-pidev.yml). Implements ONE
+#                leaf on its existing branch. Right for work already in flight.
+# `/delegate`, `/delegate-pi`, `/deploy` and `/work` remain as ALIASES and always will —
+# they are written into issue bodies, skills and runbooks across the repo. The rename
+# exists because `/delegate` named *who* does the work, never *what happens to it*, so on
+# an issue whose branch already existed the obvious word was the wrong lane.
 # A `/delegate` on an issue that already has a `work-<issue>` branch is AUTO-ROUTED to the
 # worker, because the decomposer would have nothing left to plan — it would produce no
 # artifact, fail the artifact-gate (#461), and page the owner about a pipeline that was
@@ -42,7 +46,9 @@ jobs:
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'COLLABORATOR') &&
-      (contains(github.event.comment.body, '/delegate') ||
+      (contains(github.event.comment.body, '/plan') ||
+       contains(github.event.comment.body, '/build') ||
+       contains(github.event.comment.body, '/delegate') ||
        contains(github.event.comment.body, '/deploy') ||
        contains(github.event.comment.body, '/work'))
     # ⚠️ The two `contains()` above are a CHEAP PRE-FILTER ONLY, not the decision (#2004).

--- a/.github/workflows/comment-dispatch.yml
+++ b/.github/workflows/comment-dispatch.yml
@@ -7,7 +7,14 @@ name: Comment dispatch
 # other harness (#1077 / #669 WS7). Only the repo owner / members / collaborators can
 # trigger it.
 #
-# TWO LANES, named for what they DO (#2010):
+# THE GESTURE: a comment whose line is nothing but rockets — 🚀 or 🚀🚀 — means "pick this
+# up". You do not choose a lane; `resolveLane()` derives it from whether a `work-<issue>`
+# branch exists. An emoji is used rather than a phrase because "pick this up" occurs in
+# ordinary sentences and would recreate #2004 in a new costume; a line of only rockets
+# never appears by accident. The whole line must be rockets — a leading 🚀 is common in
+# celebration text ("🚀 shipped!").
+#
+# THE OVERRIDES, named for what they DO (#2010) — for forcing a lane:
 #   • `/plan`  → the decomposer. Splits an issue into sub-issues, or hands a leaf onward.
 #                Right for work that has not started. (`/plan-pi` forces the pi harness.)
 #   • `/build` → the single-use worker (`work-this` → work-issue-pidev.yml). Implements ONE
@@ -50,8 +57,9 @@ jobs:
        contains(github.event.comment.body, '/build') ||
        contains(github.event.comment.body, '/delegate') ||
        contains(github.event.comment.body, '/deploy') ||
-       contains(github.event.comment.body, '/work'))
-    # ⚠️ The two `contains()` above are a CHEAP PRE-FILTER ONLY, not the decision (#2004).
+       contains(github.event.comment.body, '/work') ||
+       contains(github.event.comment.body, '🚀'))
+    # ⚠️ The `contains()` tests above are a CHEAP PRE-FILTER ONLY, not the decision (#2004).
     # They are unanchored substring tests, so they also match a command that is merely being
     # *mentioned* — in backticks, a table cell, a fenced block, or a quote of someone else's
     # comment. That is how a comment EXPLAINING a mis-dispatch dispatched one on #1791.

--- a/.github/workflows/decompose-on-issue-pidev-hosted.yml
+++ b/.github/workflows/decompose-on-issue-pidev-hosted.yml
@@ -302,7 +302,7 @@ jobs:
             const det = detail ? `\n\n<details><summary>session tail</summary>\n\n\`\`\`\n${detail}\n\`\`\`\n</details>` : ''
             const body = why
               ? `🔴 **@pmcp — this run produced nothing: ${why}.**\n\n**Fix:** ${action}.${det}${foot}`
-              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold.\n\n**Fix:** re-dispatch; if it recurs the issue is underspecified — add a description + acceptance criteria.${foot}`
+              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold, and none of the known causes matched.\n\n**Fix:** open the run log before changing anything. Only if the log shows the agent genuinely had nothing to act on is the issue underspecified.${foot}`
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: pi.dev hosted run on #${issue_number} produced no deliverable.`)

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -576,7 +576,7 @@ jobs:
             const det = detail ? `\n\n<details><summary>log tail</summary>\n\n\`\`\`\n${detail}\n\`\`\`\n</details>` : ''
             const body = why
               ? `🔴 **@pmcp — this run produced nothing: ${why}.**\n\n**Fix:** ${action}.${det}${foot}`
-              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold.\n\n**Fix:** re-dispatch; if it recurs the issue is underspecified — add a description + acceptance criteria.${foot}`
+              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold, and none of the known causes matched.\n\n**Fix:** open the run log before changing anything. Only if the log shows the agent genuinely had nothing to act on is the issue underspecified.${foot}`
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: pi.dev run on #${issue_number} produced no deliverable.`)

--- a/.github/workflows/decompose-on-issue.yml
+++ b/.github/workflows/decompose-on-issue.yml
@@ -273,7 +273,7 @@ jobs:
             const det = detail ? `\n\n<details><summary>agent's final message</summary>\n\n> ${detail.replace(/\n/g, '\n> ')}\n</details>` : ''
             const body = why
               ? `🔴 **@pmcp — this run produced nothing: ${why}.**\n\n**Fix:** ${action}.${det}${foot}`
-              : `🔴 **@pmcp — this run produced nothing** — no PR, no sign-off hold (a bare "spawning the worker…" progress comment doesn't count).\n\n**Fix:** re-apply \`delegate\` to retry; if it recurs the issue is underspecified — add a description + acceptance criteria.${foot}`
+              : `🔴 **@pmcp — this run produced nothing** — no PR, no sign-off hold (a bare "spawning the worker…" progress comment doesn't count).\n\n**Fix:** open the run log before changing anything. Only if the log shows the agent genuinely had nothing to act on is the issue underspecified. To retry, re-apply \`delegate\`.${foot}`
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: run on #${issue_number} produced no deliverable (no PR, not held for sign-off).`)

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -803,7 +803,7 @@ jobs:
             const det = detail ? `\n\n<details><summary>log tail</summary>\n\n\`\`\`\n${detail}\n\`\`\`\n</details>` : ''
             const body = why
               ? `🔴 **@pmcp — this run produced nothing: ${why}.**\n\n**Fix:** ${action}.${det}${foot}`
-              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold.\n\n**Fix:** re-dispatch; if it recurs the issue is underspecified — add a description + acceptance criteria.${foot}`
+              : `🔴 **@pmcp — this run produced nothing** — no PR, no sub-issues, no sign-off hold, and none of the known causes matched.\n\n**Fix:** open the run log before changing anything. Only if the log shows the agent genuinely had nothing to act on is the issue underspecified.${foot}`
 
             await github.rest.issues.createComment({ ...context.repo, issue_number, body })
             core.setFailed(`Artifact-gate: pi.dev run on #${issue_number} produced no deliverable.`)

--- a/scripts/comment-command.mjs
+++ b/scripts/comment-command.mjs
@@ -38,12 +38,29 @@ function stripNonCommandRegions(body) {
 }
 
 /**
- * Which label a comment is asking for, or `null` when it is only talking about them.
+ * The command vocabulary, in match order.
  *
- * `/delegate-pi` is tested before `/delegate` because the latter is a prefix of the
- * former — that ordering is load-bearing (#1077). `/deploy` maps to `delegate` too,
- * preserving the behaviour the workflow shipped with. `/work` reaches the single-use
- * worker lane, which had no comment gesture at all before #2010.
+ * NAMED FOR WHAT THE LANE DOES, not for who does it (#2010). `/delegate` said *who*
+ * (an agent) and not *what* (plan it, or build it) — so on an issue whose work had
+ * already started, the obvious word was the wrong lane, and the decomposer was sent
+ * somewhere it had nothing to plan. `/plan` and `/build` cannot be confused that way.
+ *
+ * The old names stay as aliases forever: they are written into issue bodies, skills and
+ * runbooks across the repo, and silently breaking them would be a worse trap than the
+ * one this replaces.
+ *
+ * Order is load-bearing twice over: `work`/`build` before the planning lane, and the
+ * `-pi` variants before their bare forms — `/plan` is a prefix of `/plan-pi`, exactly as
+ * `/delegate` is of `/delegate-pi` (#1077).
+ */
+const COMMANDS = [
+  { label: 'work-this', words: ['build', 'work'] },
+  { label: 'delegate-pi', words: ['plan-pi', 'delegate-pi'] },
+  { label: 'delegate', words: ['plan', 'delegate', 'deploy'] },
+]
+
+/**
+ * Which label a comment is asking for, or `null` when it is only talking about them.
  *
  * @param {string} body Raw Markdown body of the issue comment.
  * @returns {'delegate-pi' | 'delegate' | 'work-this' | null}
@@ -52,13 +69,13 @@ export function parseCommand(body) {
   const text = stripNonCommandRegions(String(body || ''))
 
   // Anchored to line start (`m`), allowing leading whitespace so an indented command in
-  // a list item still works. A trailing boundary stops `/delegate-something-else` from
-  // being read as `/delegate`.
-  const has = cmd => new RegExp(`^[ \\t]*/${cmd}(?![\\w-])`, 'm').test(text)
+  // a list item still works. The trailing boundary stops `/plan-pi` being read as `/plan`
+  // and `/workflow-thing` as `/work`.
+  const has = word => new RegExp(`^[ \\t]*/${word}(?![\\w-])`, 'm').test(text)
 
-  if (has('work')) return 'work-this'
-  if (has('delegate-pi')) return 'delegate-pi'
-  if (has('delegate') || has('deploy')) return 'delegate'
+  for (const { label, words } of COMMANDS) {
+    if (words.some(has)) return label
+  }
   return null
 }
 

--- a/scripts/comment-command.mjs
+++ b/scripts/comment-command.mjs
@@ -42,10 +42,11 @@ function stripNonCommandRegions(body) {
  *
  * `/delegate-pi` is tested before `/delegate` because the latter is a prefix of the
  * former — that ordering is load-bearing (#1077). `/deploy` maps to `delegate` too,
- * preserving the behaviour the workflow shipped with.
+ * preserving the behaviour the workflow shipped with. `/work` reaches the single-use
+ * worker lane, which had no comment gesture at all before #2010.
  *
  * @param {string} body Raw Markdown body of the issue comment.
- * @returns {'delegate-pi' | 'delegate' | null}
+ * @returns {'delegate-pi' | 'delegate' | 'work-this' | null}
  */
 export function parseCommand(body) {
   const text = stripNonCommandRegions(String(body || ''))
@@ -55,7 +56,34 @@ export function parseCommand(body) {
   // being read as `/delegate`.
   const has = cmd => new RegExp(`^[ \\t]*/${cmd}(?![\\w-])`, 'm').test(text)
 
+  if (has('work')) return 'work-this'
   if (has('delegate-pi')) return 'delegate-pi'
   if (has('delegate') || has('deploy')) return 'delegate'
   return null
 }
+
+/**
+ * The lane a dispatch should actually take, given what already exists on the repo.
+ *
+ * WHY THIS EXISTS. `/delegate` is the reflex gesture — for a long time it was the only
+ * one — and on an issue whose work is already in flight it routes to the decomposer,
+ * which has nothing left to plan. It produces no artifact, the artifact-gate (#461)
+ * correctly fails the run, and the owner is paged about a pipeline that was working.
+ * That is exactly what happened on #1791.
+ *
+ * So the lane is chosen from OBSERVED STATE, not from which word was typed: if a
+ * `work-<issue>` branch already exists, "delegate this" means *finish it*. An explicit
+ * `/work` is always honoured, and a `/delegate` on an issue with no work branch still
+ * goes to the decomposer exactly as before.
+ *
+ * @param {'delegate-pi'|'delegate'|'work-this'} command  What the comment asked for.
+ * @param {boolean} hasWorkBranch  Whether `work-<issue-number>` exists on origin.
+ * @returns {{ label: string, rerouted: boolean }}
+ */
+export function resolveLane(command, hasWorkBranch) {
+  if (command !== 'work-this' && hasWorkBranch) {
+    return { label: 'work-this', rerouted: true }
+  }
+  return { label: command, rerouted: false }
+}
+

--- a/scripts/comment-command.mjs
+++ b/scripts/comment-command.mjs
@@ -65,6 +65,28 @@ const COMMANDS = [
  * @param {string} body Raw Markdown body of the issue comment.
  * @returns {'delegate-pi' | 'delegate' | 'work-this' | null}
  */
+/**
+ * A line that is NOTHING BUT rockets means "pick this up" — no lane, no vocabulary.
+ *
+ * This is the gesture to reach for; `/plan` and `/build` are the overrides for when you
+ * want to force a lane. It exists because choosing the lane was never the human's job:
+ * whether an issue needs planning or building is derivable from whether its work branch
+ * exists, and `resolveLane()` derives it. Asking a person to pick is how #1791 got sent
+ * to the decomposer twice.
+ *
+ * Why an emoji rather than a word: it cannot collide with prose. "pick this up" appears
+ * in ordinary sentences ("I'll pick this up tomorrow") and would re-create the #2004 bug
+ * in a new costume. A line of only rockets is never written by accident.
+ *
+ * Why the WHOLE line: a bare leading 🚀 does show up in celebration text ("🚀 shipped!").
+ * Requiring the line to contain nothing else removes the last ambiguity.
+ *
+ * The `u` flag is load-bearing: 🚀 is a surrogate pair, so without it `+` repeats only the
+ * low surrogate and `🚀🚀` fails to match while a single `🚀` passes — a bug that would have
+ * shipped looking like it worked, since the one-rocket case is the one you'd try first.
+ */
+const PICK_THIS_UP = /^[ \t]*🚀+[ \t]*$/mu
+
 export function parseCommand(body) {
   const text = stripNonCommandRegions(String(body || ''))
 
@@ -76,6 +98,11 @@ export function parseCommand(body) {
   for (const { label, words } of COMMANDS) {
     if (words.some(has)) return label
   }
+  // No explicit lane asked for. Rockets mean "pick this up" and let state decide, which
+  // `resolveLane` does — so return the planning label and let it be rerouted if a work
+  // branch already exists. (Returning 'delegate' here is not a preference for planning;
+  // it is the input `resolveLane` overrides.)
+  if (PICK_THIS_UP.test(text)) return 'delegate'
   return null
 }
 

--- a/scripts/comment-command.mjs
+++ b/scripts/comment-command.mjs
@@ -1,0 +1,61 @@
+/**
+ * #2004 — decide whether an issue comment is actually *issuing* a dispatch command,
+ * as opposed to merely *mentioning* one.
+ *
+ * The incident it encodes: on #1791 a comment was posted explaining that a previous
+ * run had been dispatched down the wrong lane. That explanation contained a small
+ * rules table with `/delegate` in a cell — and `comment-dispatch.yml` gated on a plain
+ * `contains(body, '/delegate')`, so the comment describing the misfire performed the
+ * misfire, 14 seconds after it was posted. Twice in one evening the owner was paged
+ * with "this run produced nothing" for a pipeline that was working correctly.
+ *
+ * The rule: a command counts only when it stands at the START of a line, outside code
+ * and outside a quote. That is the ordinary slash-command convention, and it lets the
+ * pipeline be documented in its own issue threads — which it currently cannot be.
+ *
+ *   node --test scripts/comment-command.test.mjs
+ */
+
+/**
+ * Remove the regions of a Markdown body where a command is being *shown*, not *given*:
+ * fenced code blocks, inline code spans, and blockquote lines.
+ *
+ * Blockquotes matter as much as code here: every agent comment in this repo opens with a
+ * `> 🤖 …` provenance header, and quoting somebody else's dispatch is a normal thing to
+ * do in a thread. Neither should re-fire the pipeline.
+ */
+function stripNonCommandRegions(body) {
+  return body
+    // Fenced blocks first — their content may contain backticks that would otherwise
+    // confuse the inline-span pass.
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/~~~[\s\S]*?~~~/g, '')
+    // Inline code spans (single line only, so an unmatched backtick can't eat the body).
+    .replace(/`[^`\n]*`/g, '')
+    .split('\n')
+    .filter(line => !/^\s*>/.test(line))
+    .join('\n')
+}
+
+/**
+ * Which label a comment is asking for, or `null` when it is only talking about them.
+ *
+ * `/delegate-pi` is tested before `/delegate` because the latter is a prefix of the
+ * former — that ordering is load-bearing (#1077). `/deploy` maps to `delegate` too,
+ * preserving the behaviour the workflow shipped with.
+ *
+ * @param {string} body Raw Markdown body of the issue comment.
+ * @returns {'delegate-pi' | 'delegate' | null}
+ */
+export function parseCommand(body) {
+  const text = stripNonCommandRegions(String(body || ''))
+
+  // Anchored to line start (`m`), allowing leading whitespace so an indented command in
+  // a list item still works. A trailing boundary stops `/delegate-something-else` from
+  // being read as `/delegate`.
+  const has = cmd => new RegExp(`^[ \\t]*/${cmd}(?![\\w-])`, 'm').test(text)
+
+  if (has('delegate-pi')) return 'delegate-pi'
+  if (has('delegate') || has('deploy')) return 'delegate'
+  return null
+}

--- a/scripts/comment-command.test.mjs
+++ b/scripts/comment-command.test.mjs
@@ -96,6 +96,37 @@ test('FIXTURE: the #1791 explanation comment must NOT dispatch', () => {
   assert.equal(parseCommand(body), null)
 })
 
+// ── #2010: the vocabulary — named for what the lane DOES ─────────────────────────────
+
+test('/plan reaches the decomposer', () => {
+  assert.equal(parseCommand('/plan'), 'delegate')
+})
+
+test('/build reaches the worker', () => {
+  assert.equal(parseCommand('/build'), 'work-this')
+})
+
+test('/plan-pi wins over /plan — same prefix trap as #1077', () => {
+  assert.equal(parseCommand('/plan-pi'), 'delegate-pi')
+})
+
+test('the old names still work — they are written into issues and skills across the repo', () => {
+  assert.equal(parseCommand('/delegate'), 'delegate')
+  assert.equal(parseCommand('/delegate-pi'), 'delegate-pi')
+  assert.equal(parseCommand('/deploy'), 'delegate')
+  assert.equal(parseCommand('/work'), 'work-this')
+})
+
+test('the new names are mention-safe too', () => {
+  assert.equal(parseCommand('Use `/build` to finish a leaf.'), null)
+  assert.equal(parseCommand('> /plan'), null)
+})
+
+test('/planning and /builder are not commands', () => {
+  assert.equal(parseCommand('/planning-doc'), null)
+  assert.equal(parseCommand('/builder'), null)
+})
+
 // ── #2010: the worker lane needs a gesture, and /delegate must stop misfiring ────────
 
 test('/work reaches the worker lane', () => {

--- a/scripts/comment-command.test.mjs
+++ b/scripts/comment-command.test.mjs
@@ -9,7 +9,7 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseCommand } from './comment-command.mjs'
+import { parseCommand, resolveLane } from './comment-command.mjs'
 
 test('a bare command on its own line dispatches', () => {
   assert.equal(parseCommand('/delegate'), 'delegate')
@@ -94,6 +94,44 @@ test('FIXTURE: the #1791 explanation comment must NOT dispatch', () => {
     '| Leaf with an existing `work-*` branch | remove + re-add **`work-this`** |',
   ].join('\n')
   assert.equal(parseCommand(body), null)
+})
+
+// ── #2010: the worker lane needs a gesture, and /delegate must stop misfiring ────────
+
+test('/work reaches the worker lane', () => {
+  assert.equal(parseCommand('/work'), 'work-this')
+})
+
+test('/work still counts after a steer paragraph', () => {
+  assert.equal(parseCommand('Finish the last three files.\n\n/work'), 'work-this')
+})
+
+test('/work mentioned in prose does not dispatch', () => {
+  assert.equal(parseCommand('Use `/work` to reach the worker.'), null)
+})
+
+test('/workflow is not read as /work', () => {
+  assert.equal(parseCommand('/workflow-thing'), null)
+})
+
+test('an explicit /work is honoured whether or not a branch exists', () => {
+  assert.deepEqual(resolveLane('work-this', false), { label: 'work-this', rerouted: false })
+  assert.deepEqual(resolveLane('work-this', true), { label: 'work-this', rerouted: false })
+})
+
+test('/delegate on an issue with a work branch routes to the worker — the #1791 trap', () => {
+  // The decomposer has nothing to plan once a work-<n> branch exists; sending it there
+  // produces no artifact and pages the owner about a working pipeline.
+  assert.deepEqual(resolveLane('delegate', true), { label: 'work-this', rerouted: true })
+})
+
+test('/delegate with no work branch still goes to the decomposer, unchanged', () => {
+  assert.deepEqual(resolveLane('delegate', false), { label: 'delegate', rerouted: false })
+})
+
+test('/delegate-pi reroutes too — the lane follows state, not the word typed', () => {
+  assert.deepEqual(resolveLane('delegate-pi', true), { label: 'work-this', rerouted: true })
+  assert.deepEqual(resolveLane('delegate-pi', false), { label: 'delegate-pi', rerouted: false })
 })
 
 test('FIXTURE: the #1979 dispatch comment must dispatch', () => {

--- a/scripts/comment-command.test.mjs
+++ b/scripts/comment-command.test.mjs
@@ -96,6 +96,37 @@ test('FIXTURE: the #1791 explanation comment must NOT dispatch', () => {
   assert.equal(parseCommand(body), null)
 })
 
+// ── 🚀 "pick this up" — no lane, no vocabulary ───────────────────────────────────────
+
+test('a line of rockets means pick this up, and state picks the lane', () => {
+  // parseCommand returns the planning label as the INPUT to resolveLane, which overrides
+  // it when a work branch exists. The human never chooses.
+  assert.equal(parseCommand('🚀🚀'), 'delegate')
+  assert.equal(parseCommand('🚀'), 'delegate')
+  assert.deepEqual(resolveLane(parseCommand('🚀🚀'), true), { label: 'work-this', rerouted: true })
+  assert.deepEqual(resolveLane(parseCommand('🚀🚀'), false), { label: 'delegate', rerouted: false })
+})
+
+test('rockets still count after a steer paragraph', () => {
+  assert.equal(parseCommand('Finish the last three files.\n\n🚀🚀'), 'delegate')
+})
+
+test('a rocket in celebration prose is not a command', () => {
+  // The whole-line rule is what makes this safe — a leading 🚀 is common in release notes.
+  assert.equal(parseCommand('🚀 shipped!'), null)
+  assert.equal(parseCommand('Great work 🚀'), null)
+  assert.equal(parseCommand('🚀 Deployed to staging 🚀'), null)
+})
+
+test('a quoted or fenced rocket line does not fire', () => {
+  assert.equal(parseCommand('> 🚀🚀'), null)
+  assert.equal(parseCommand('```\n🚀🚀\n```'), null)
+})
+
+test('an explicit lane still wins over rockets', () => {
+  assert.equal(parseCommand('/build\n\n🚀🚀'), 'work-this')
+})
+
 // ── #2010: the vocabulary — named for what the lane DOES ─────────────────────────────
 
 test('/plan reaches the decomposer', () => {

--- a/scripts/comment-command.test.mjs
+++ b/scripts/comment-command.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * #2004 contract — a dispatch command must be ISSUED, not merely MENTIONED.
+ *
+ * The two fixtures at the bottom are the real comments from the 2026-08-05 incident on
+ * #1791: the explanation that accidentally dispatched, and a genuine dispatch. If a
+ * future change makes those two behave the same way, this file fails.
+ *
+ *   node --test scripts/comment-command.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseCommand } from './comment-command.mjs'
+
+test('a bare command on its own line dispatches', () => {
+  assert.equal(parseCommand('/delegate'), 'delegate')
+})
+
+test('prose followed by the command on a line of its own still dispatches', () => {
+  // This is how every dispatch in the incident session was written: a steer paragraph,
+  // then the command last. It must keep working.
+  const body = 'Some context for the worker.\n\nAnother paragraph.\n\n/delegate'
+  assert.equal(parseCommand(body), 'delegate')
+})
+
+test('delegate-pi wins over delegate — it contains it (#1077)', () => {
+  assert.equal(parseCommand('/delegate-pi'), 'delegate-pi')
+})
+
+test('deploy maps to delegate, as it always has', () => {
+  assert.equal(parseCommand('/deploy'), 'delegate')
+})
+
+test('an indented command (list item) still dispatches', () => {
+  assert.equal(parseCommand('  /delegate'), 'delegate')
+})
+
+// ── the bug: mentions must NOT dispatch ──────────────────────────────────────────────
+
+test('an inline code span does not dispatch', () => {
+  assert.equal(parseCommand('Use `/delegate` for a new issue.'), null)
+})
+
+test('a table cell does not dispatch — the exact shape of the #1791 misfire', () => {
+  const body = [
+    '| Situation | Gesture |',
+    '|---|---|',
+    '| New / unstarted issue | `/delegate` |',
+    '| Leaf with a work branch | re-add `work-this` |',
+  ].join('\n')
+  assert.equal(parseCommand(body), null)
+})
+
+test('a fenced code block does not dispatch', () => {
+  assert.equal(parseCommand('Example:\n\n```\n/delegate\n```\n'), null)
+})
+
+test('a blockquote does not dispatch — quoting someone else is not commanding', () => {
+  assert.equal(parseCommand('> /delegate\n\nThat is what fired it.'), null)
+})
+
+test('the agent provenance header cannot dispatch', () => {
+  // Every agent comment opens with this shape; a command named inside it is discussion.
+  const body = '> 🤖 **Claude Code** · interactive agent · _why /delegate misfired_\n\nBody text.'
+  assert.equal(parseCommand(body), null)
+})
+
+test('mid-sentence mention does not dispatch', () => {
+  assert.equal(parseCommand('I re-dispatched with /delegate, which was wrong.'), null)
+})
+
+test('a longer command is not read as a shorter one', () => {
+  assert.equal(parseCommand('/delegated-work is not a command'), null)
+})
+
+test('empty and nullish bodies are safe', () => {
+  assert.equal(parseCommand(''), null)
+  assert.equal(parseCommand(undefined), null)
+  assert.equal(parseCommand(null), null)
+})
+
+// ── the two real comments from the incident ──────────────────────────────────────────
+
+test('FIXTURE: the #1791 explanation comment must NOT dispatch', () => {
+  const body = [
+    "> 🤖 **Claude Code** · interactive agent · _correcting my own mis-routed re-dispatch_",
+    '',
+    '**The "this run produced nothing" alert was my mistake, not a pipeline fault.**',
+    '',
+    'Worth writing down as a rule, because the two gestures look interchangeable:',
+    '',
+    '| Situation | Gesture |',
+    '|---|---|',
+    '| New / unstarted issue, may need splitting | `/delegate` |',
+    '| Leaf with an existing `work-*` branch | remove + re-add **`work-this`** |',
+  ].join('\n')
+  assert.equal(parseCommand(body), null)
+})
+
+test('FIXTURE: the #1979 dispatch comment must dispatch', () => {
+  const body = [
+    "> 🤖 **Claude Code** · interactive agent · _handing this to the agent pipeline_",
+    '',
+    'Root cause is already located in the body, so this is a leaf.',
+    '',
+    "**For the worker:** don't just patch the template string.",
+    '',
+    '/delegate',
+  ].join('\n')
+  assert.equal(parseCommand(body), 'delegate')
+})


### PR DESCRIPTION
Closes #2004
Closes #2010

Five commits, one concern: **the dispatch harness was reading commands wrongly, offering the wrong set of them, and — when a run produced nothing — blaming the ticket.** All three misfired on #1791 tonight.

## 👤 For humans

**1 — Writing about the pipeline was running the pipeline.** A comment posted to *explain* a mis-dispatch included a rules table with `/delegate` in a cell. That cell dispatched a run, 14 seconds later.

**2 — There were two lanes and one door.** Both existing commands reached the *decomposer*. The *worker* lane had no comment gesture at all, so from a phone the only reachable button was the wrong one for any issue whose work had already started.

**3 — You shouldn't have to pick a lane at all.** A comment that is just 🚀 now means "pick this up", and the harness works out whether that means plan or build.

**4 — When a run produced nothing and the harness couldn't say why, it told you your issue was underspecified.** It said that three times about #1791 — one of the best-specified issues in the repo.

## 🤖 For agents

### `3451f95` — issued vs mentioned (#2004)

`contains(body, '/delegate')` is a substring test over the whole body, blind to Markdown: backticks, table cells, fenced blocks and `>` quotes all matched.

The decision moves to `scripts/comment-command.mjs` → `parseCommand()`: strip fenced blocks, then inline code spans, then `>` lines, then require the command anchored at line start. The `contains()` calls stay as a **cheap pre-filter** — the job runs on the self-hosted `AGENT_RUNNER`.

**Why not anchor in the YAML:** GitHub expressions have no newline escape. `'\n'` in a single-quoted scalar is a literal backslash-n, so the match would silently never fire — a fix that looks right and disables dispatch entirely.

**Blockquote stripping is load-bearing:** every agent comment opens with a `> 🤖` provenance header, and quoting a colleague is ordinary.

### `0c61b5c` — the worker lane + state routing (#2010)

`/work` → `work-this` → `work-issue-pidev.yml`. And `/delegate`/`/delegate-pi` **auto-route to the worker** when a `work-<issue>` branch exists: once there's a branch, "delegate this" means *finish it*, not *re-plan it*. `resolveLane()` is split out so the routing decision is unit-testable without a repo.

### `5b9bb7b` — named for what they do (#2010)

`/plan` splits an issue, `/build` implements one leaf. `/delegate`, `/delegate-pi`, `/deploy`, `/work` stay as permanent aliases — they're written into issue bodies, skills and runbooks across the repo. Match order is load-bearing twice: worker lane before planning lane, and each `-pi` variant before its bare form (#1077).

### `6095a26` — 🚀 means "pick this up" (#2010)

A line containing nothing but rockets dispatches, and lets state choose the lane. An emoji rather than the words "pick this up" because that phrase occurs in ordinary sentences and would recreate #2004 in a new costume. The **whole line** must be rockets — a leading 🚀 is common in celebration text.

The `u` flag is load-bearing: 🚀 is a surrogate pair, so without it `+` repeats only the low surrogate and `🚀🚀` fails while a single `🚀` passes. That would have shipped looking correct.

**Reactions cannot be used for this** — GitHub emits no webhook event for adding one (#572). The bot's 🚀 acknowledgement stays a reaction; yours has to be text.

### `f345d72` — stop the gate blaming the ticket (refs #2012)

#1876 removed the "likely underspecified" guess from the *classified* branches (billing, agent error, dirty tree, finish-step failure) but left it in the **fallback** — the branch that fires precisely when no cause is known, and the most confidently worded of them all. Four workflows carried it, not two. All now say what's actually known and send the reader to the log.

## Verification

**34 unit tests**, including both real comments from the incident as named fixtures.

Per `AGENTS.md` (*Authoring a gate → run the rule over the corpus*), the matcher was replayed over six real comment shapes from the session rather than only its own tests:

| Comment | Verdict | Wanted |
|---|---|---|
| #1979 dispatch (prose + trailing command) | `delegate` | ✅ |
| #1735 re-trigger (prose + trailing command) | `delegate` | ✅ |
| #1791 explanation (command in a table cell) | none | ✅ |
| #1987 reply (command mentioned in prose) | none | ✅ |
| bot "🟢 On it" acknowledgement | none | ✅ |
| artifact-gate "🔴 produced nothing" alert | none | ✅ |

6/6 as intended. That run is what would have caught over-anchoring: every dispatch tonight used "prose, then command on the last line", and all still fire.

## 🧪 How to test

1. Comment a sentence containing the command in backticks → nothing fires.
2. Comment 🚀 on an issue with no work branch → decomposer runs.
3. Comment 🚀 on an issue **with** a `work-<n>` branch → acknowledgement says it routed to the worker.
4. `/build` and `/plan` force a lane; the old names still work.
5. Quote an existing dispatch comment with `>` → nothing fires.

Refs #1971 — all of these are that family: a mechanism doing something other than what its output implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)