### PR TITLE
fix(root): make the CI-failure ping carry the failure, not just its name

### DIFF
--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -101,14 +101,14 @@ jobs:
               for (const r of runs) {
                 if (r.status !== 'completed') { pending++; continue }
                 if (['success', 'neutral', 'skipped'].includes(r.conclusion)) success++
-                else { failure++; failing.push(r.name) } // failure, cancelled, timed_out, action_required, stale
+                else { failure++; failing.push({ name: r.name, id: r.id }) } // failure, cancelled, timed_out, action_required, stale
               }
               try {
                 const combined = (await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref })).data
                 for (const s of combined.statuses || []) {
                   if (s.state === 'pending') pending++
                   else if (s.state === 'success') success++
-                  else { failure++; failing.push(s.context) } // error, failure
+                  else { failure++; failing.push({ name: s.context }) } // error, failure — a commit status carries no annotations
                 }
               } catch (e) { core.warning(`combined status for ${ref}: ${e.message}`) }
               const total = success + pending + failure
@@ -151,18 +151,46 @@ jobs:
               const comments = await github.paginate(github.rest.issues.listComments,
                 { owner, repo, issue_number: pr.number, per_page: 100 })
               if (comments.some(c => (c.body || '').includes(marker))) return // already pinged this SHA
-              // Name the failing checks and say what is expected of the reader (#1909). The
-              // count alone ("1 failing check") told the owner they were needed without telling
-              // them what for, so the ping cost attention and returned none.
-              const names = (st.failing || []).slice(0, 5)
-              const more = (st.failing || []).length - names.length
+              // Name the failing checks (#1909) AND quote what actually went wrong (#2015).
+              // Names alone still meant leaving the notification, opening the checks tab, picking
+              // a job and scrolling a log — on a phone that is the entire task.
+              //
+              // `CI Gate` is the AGGREGATE (`if: always()` over 14 needs). It is never an
+              // independent cause; naming it beside the real failure doubles the apparent problem
+              // and sends the reader to a log that only says "not every job succeeded". Drop it
+              // whenever something else is red — but keep it when it is the ONLY red check, since
+              // that means something genuinely different (a needed job cancelled or stuck).
+              const ROLLUP = 'CI Gate'
+              const all = st.failing || []
+              const causes = all.length > 1 ? all.filter(f => f.name !== ROLLUP) : all
+              const names = causes.slice(0, 5)
+              const more = causes.length - names.length
               const list = names.length
-                ? names.map(n => `\`${n}\``).join(', ') + (more > 0 ? ` +${more} more` : '')
+                ? names.map(f => `\`${f.name}\``).join(', ') + (more > 0 ? ` +${more} more` : '')
                 : 'see the checks tab'
+
+              // The distilled failure: a step's `::error::` output becomes a check-run annotation,
+              // which is already the short form of the log. Two per check, truncated — enough to
+              // diagnose, collapsed so the notification itself stays scannable.
+              const excerpts = []
+              for (const f of names) {
+                if (!f.id) continue // a commit status has no annotations
+                try {
+                  const anns = (await github.rest.checks.listAnnotations(
+                    { owner, repo, check_run_id: f.id, per_page: 2 })).data
+                  for (const a of anns) {
+                    const msg = String(a.message || '').trim().slice(0, 400)
+                    if (msg) excerpts.push(`${f.name}: ${msg}`)
+                  }
+                } catch (e) { core.warning(`annotations for ${f.name}: ${e.message}`) }
+              }
+              const why = excerpts.length
+                ? `\n\n<details><summary>what failed</summary>\n\n\`\`\`\n${excerpts.join('\n\n')}\n\`\`\`\n</details>`
+                : ''
               const body =
                 `${marker}\n` +
-                `🔴 **@${OWNER} — CI failed on this pipeline PR** (${st.failure} failing ` +
-                `check${st.failure === 1 ? '' : 's'}): ${list}.\n\n` +
+                `🔴 **@${OWNER} — CI failed on this pipeline PR** (${causes.length} failing ` +
+                `check${causes.length === 1 ? '' : 's'}): ${list}.${why}\n\n` +
                 `**What's needed:** read the failure, then either push a fix to \`${pr.head.ref}\` ` +
                 `or reply here saying why it isn't yours. A red sub-PR won't auto-merge into its ` +
                 `epic, so it sits until one of those happens — **it does not mean the work is ` +


### PR DESCRIPTION
Closes #2015

## 👤 For humans

The ping told you *which* checks were red, then said "read the failure" — with nothing to read. Acting on it always meant leaving the notification, opening the checks tab, picking a job and scrolling a log. On a phone that's the entire task.

It also over-counted. On #2011 it reported **"2 failing checks: `CI Gate`, `Schema Drift Check`"** when there was one real failure; `CI Gate` is just the roll-up saying that the other one failed.

After this, that same ping reads:

> 🔴 **@pmcp — CI failed on this pipeline PR** (1 failing check): `Schema Drift Check`.
> <details><summary>what failed</summary>
>
> ```
> Schema Drift Check: ✗ apps/kassa/schemas/products.json vs packages/crouton-sales/schemas/products.json
>   undeclared drift: options.properties  consumer=null  package={label, priceModifier}
> ```
> </details>

Diagnosable without opening anything.

## 🤖 For agents

### Quote the failure

A step's `::error::` output becomes a check-run **annotation** — already the distilled form of the log. `pingOnRed` now fetches up to two per failing check via `checks.listAnnotations`, truncates each to 400 chars, and puts them in a collapsed `<details>` so the notification itself stays scannable.

`ciState()` now pushes `{ name, id }` instead of a bare name, so the annotations can be fetched. Commit statuses keep a name only — they carry no annotations, and the loop skips them on the missing `id`.

### Drop the roll-up

`CI Gate` is `if: always()` over 14 `needs` (`ci.yml:598`). It fails whenever any needed job did, so it is **never an independent cause**. Naming it beside the real failure doubles the apparent problem and points at a log whose only content is "not every job succeeded".

It's now filtered out whenever another check is red, and the headline count reflects real causes. When it is the **only** red check it is still named — that means something genuinely different (a needed job cancelled or stuck), and #1698's presence gate leans on it.

### Kept

The "push a fix or reply saying why it isn't yours" instruction, and the note that a red sub-PR won't auto-merge — that's what stops a red PR being mistaken for a finished one (#1815).

## Verification

The selection logic exercised against the real shapes:

| Failing checks | Reported |
|---|---|
| `CI Gate`, `Schema Drift Check` (the #2011 case) | 1 failing check: `Schema Drift Check` |
| `CI Gate` alone | 1 failing check: `CI Gate` |
| `CI Gate`, `E2E`, `A11y` | 2 failing checks: `E2E`, `A11y` |
| `Schema Drift Check` alone | 1 failing check: `Schema Drift Check` |

## 🧪 How to test

1. Break one check on a pipeline PR (e.g. reintroduce schema drift).
2. The ping names `Schema Drift Check`, **not** `CI Gate`, and shows the `✗ …undeclared drift…` lines.
3. It's diagnosable from the notification alone.
4. Make `CI Gate` itself the only red check → still named.

Refs #1909, which added the names; this is its next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_