### PR TITLE
fix(root): let auto-merge ask a second time

### DIFF
--- a/.github/workflows/automerge-epic-subpr.yml
+++ b/.github/workflows/automerge-epic-subpr.yml
@@ -48,10 +48,25 @@ name: Auto-merge epic sub-PRs
 # `pull_request: closed` event would not reach schedule-waves and the chain would stall
 # (#572). An App installation token cascades. Merge commit — NOT squash (merge policy).
 
+# RE-EVALUATION (#2013) — the trigger that makes every gate above mean anything.
+# `pull_request: opened` fires ~10s after the worker opens the PR, when ci.yml has barely
+# started, so `CI Gate` does not exist yet and the presence gate correctly declines. And
+# `check_suite` NEVER fires for our own CI: every check on a pipeline PR is created by
+# GitHub Actions under GITHUB_TOKEN, and GITHUB_TOKEN-triggered events never start a new
+# workflow run (the same recursion guard as #572/#626, documented for the sibling workflow
+# in #1884). A one-shot worker makes no second push, so `synchronize` never fires either.
+# Net effect: this workflow asked exactly once, always too early, and never again — every
+# green sub-PR sat unmerged forever, and the owner merged them by hand.
+# `workflow_run` DOES fire for Actions-generated completions. `CI` owns `CI Gate`, so its
+# completion is precisely the moment the answer can change. Same cure #1884 applied to
+# pipeline-pr-status.yml.
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
   check_suite:
+    types: [completed]
+  workflow_run:
+    workflows: ["CI"]
     types: [completed]
 
 permissions:
@@ -63,7 +78,8 @@ jobs:
     # (a red/again-pending suite will re-fire this when it next completes green).
     if: >
       github.event_name == 'pull_request' ||
-      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')
+      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
@@ -114,10 +130,16 @@ jobs:
             if (context.eventName === 'pull_request') {
               candidates.add(context.payload.pull_request.number)
             } else {
-              for (const p of (context.payload.check_suite.pull_requests || [])) candidates.add(p.number)
+              // check_suite and workflow_run carry the same two useful fields under
+              // different keys, and NEITHER carries `pull_request` — reading
+              // `github.event.pull_request` on these triggers yields undefined (#2013).
+              const src = context.payload.check_suite || context.payload.workflow_run
+              for (const p of (src.pull_requests || [])) candidates.add(p.number)
               if (!candidates.size) {
+                // `pull_requests` is routinely empty on workflow_run, so this fallback is
+                // the normal path there, not an edge case.
                 const assoc = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit,
-                  { owner, repo, commit_sha: context.payload.check_suite.head_sha, per_page: 100 })
+                  { owner, repo, commit_sha: src.head_sha, per_page: 100 })
                 assoc.forEach(p => candidates.add(p.number))
               }
             }


### PR DESCRIPTION
Closes #2013

## 👤 For humans

The pipeline produced a dozen green sub-PRs tonight and merged **none** of them. Each carried "Not auto-merged — `CI Gate` never reported", and each was in fact green a few minutes later. They sat until a human merged them by hand.

The workflow wasn't broken so much as **only ever asked once, and always too early**.

## 🤖 For agents

Three triggers, none of which can produce a second look:

| Trigger | Why it can't help |
|---|---|
| `pull_request: opened` | Fires ~10s after the worker opens the PR. `ci.yml` has barely started, so `CI Gate` doesn't exist and the presence gate (#1698) correctly declines. **This is the only evaluation most sub-PRs ever get.** |
| `check_suite: completed` | **Never fires.** Every check on a pipeline PR is created by Actions under `GITHUB_TOKEN`, and `GITHUB_TOKEN`-triggered events never start a workflow run — the same recursion guard as #572/#626, already documented for the sibling workflow in #1884. |
| `synchronize` | Needs another push. A one-shot worker never makes one. |

Adding `workflow_run` on `CI` completing fixes it — that trigger *does* fire for Actions-generated completions, and `CI` is the workflow that owns `CI Gate`, so its completion is precisely when the answer can change.

This is the same cure #1884 applied to `pipeline-pr-status.yml`, which had the identical disease: its status sticky froze at "2/11 checks passed" forever, on PRs that were green and mergeable.

### Candidate resolution

`workflow_run` carries **no** `pull_request` — reading `github.event.pull_request` on that trigger yields `undefined`. It shares `pull_requests` and `head_sha` with `check_suite` under a different key, so both now read from one `src`, and the `listPullRequestsAssociatedWithCommit` fallback becomes the **normal path** for `workflow_run` (its `pull_requests` array is routinely empty), not an edge case.

### Every gate is untouched

The presence gate (#1698), the red gate (#339), the `packages/` pause (#350) and the draft/non-draft split all still make the decisions. This only changes **how often they are asked**. A PR that shouldn't merge still doesn't.

## Verification

Candidate resolution exercised against all three payload shapes:

| Event | Resolves to |
|---|---|
| `pull_request` | the PR number directly |
| `check_suite` with `pull_requests` | that number |
| `workflow_run` with `pull_requests` | that number |
| `workflow_run` with empty `pull_requests` | falls back to `listPullRequestsAssociatedWithCommit(head_sha)` — the normal path |

## Note on the decline message

The comment it posts says *"GitHub intermittently drops `pull_request` events"*. That's the wrong diagnosis for the common case — nothing was dropped, CI simply hadn't finished. Corrected wording is tracked on #2013 rather than folded in here, so this PR stays one concern.

## 🧪 How to test

1. Let the pipeline open a sub-PR and do nothing at all.
2. When `CI` completes green, it merges into its epic branch unattended.
3. Force a red check → it stays open, as today.
4. Remove the `CI Gate` job on a branch → auto-merge still declines rather than treating absence as success (#1668/#1698).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_