### PR TITLE
docs(crouton-cli): document --poc and --out in the Init Options table

### DIFF
--- a/packages/crouton-cli/CLAUDE.md
+++ b/packages/crouton-cli/CLAUDE.md
@@ -214,7 +214,17 @@ crouton init my-app --dry-run
 | `-d, --dialect <type>` | `sqlite` or `pg` (default: sqlite) |
 | `--no-cf` | Skip Cloudflare-specific config |
 | `--domain <zone>` | CF zone for custom-domain routes → `<app>.<zone>` (prod) + `<app>-staging.<zone>` (staging); auto-bound on deploy. Omit → id-less `*.workers.dev` |
+| `--poc` | Scaffold into `pocs/<name>` (the incubator) instead of `apps/<name>` |
+| `--out <dir>` | Explicit target directory — overrides `--poc`; defaults to `apps/<name>` |
 | `--dry-run` | Preview without writing files |
+
+```bash
+# Scaffold into the pocs/ incubator instead of apps/
+crouton init quotes --poc
+
+# Explicit output directory (overrides --poc)
+crouton init scratch --out sandboxes/scratch
+```
 
 ### What `crouton init` Does
 


### PR DESCRIPTION
Closes #1895

Opened by hand — see the note at the bottom, this is #1976's failure mode recurring.

## 👤 For humans

`crouton init <name> --poc` is *the* documented recipe for scaffolding a POC, but the flag wasn't in the CLI's own options table — so an agent reading `packages/crouton-cli/CLAUDE.md` to learn `crouton init` couldn't find it.

Adds the two missing rows plus a worked example.

## 🤖 For agents

`packages/crouton-cli/CLAUDE.md` Init Options gains `--poc` and `--out <dir>`.

**Verified against the implementation, not the issue body.** `bin/crouton-generate.js:196`:

```js
const out = args.out || (args.poc ? `pocs/${args.name}` : undefined)
```

So `--out` really does win over `--poc`, and `--poc` really does resolve to `pocs/<name>` — which is what the new table says. Scope kept to that table; the recipe itself already lives in the `crouton` skill and `pocs/CLAUDE.md`, and duplicating it would create a second thing to drift.

## 🧪 How to test

Read the Init Options table in `packages/crouton-cli/CLAUDE.md` — `--poc` and `--out` are listed with descriptions matching `lib/init-app.ts` / `bin/crouton-generate.js`, followed by two example invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_