### PR TITLE
feat(root): give each PR its own preview environment

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -250,8 +250,26 @@ jobs:
           BETTER_AUTH_URL: ${{ inputs.environment == 'production' && inputs['production-url'] || inputs['staging-url'] }}
         run: |
           set -o pipefail
+          PR_NUM="${{ github.event.pull_request.number }}"
           if [ "${{ inputs.environment }}" = "production" ]; then
             pnpm run cf:deploy | tee deploy.log
+          elif [ -n "$PR_NUM" ]; then
+            # PER-PR PREVIEW (#2020). `cf:staging` targets the app's ONE staging Worker and its
+            # configured stagingUrl, so running it from a PR published over shared staging: two
+            # PRs clobbered each other, a merge to main overwrote both, and the PR comment still
+            # claimed the result was isolated. Same build, then the config is rewritten to a
+            # PR-scoped Worker with id-less bindings (wrangler auto-provisions fresh D1/KV, the
+            # way the app's own first deploy does) and no custom-domain route.
+            echo "PR preview for #$PR_NUM — rewriting the built config"
+            NITRO_PRESET=cloudflare_module npx nuxt build
+            node scripts/inject-wrangler-env.mjs
+            PREVIEW_OUT="$(node "$GITHUB_WORKSPACE/scripts/pr-preview-wrangler.mjs" \
+              .output/server/wrangler.json "${{ inputs.app }}" "$PR_NUM")"
+            PREVIEW_DB="$(printf '%s\n' "$PREVIEW_OUT" | sed -n 's/^db=//p')"
+            npx wrangler deploy --config .output/server/wrangler.json | tee deploy.log
+            # Fresh DB every time, so migrations are the whole schema — not incremental.
+            [ -n "$PREVIEW_DB" ] && npx wrangler d1 migrations apply "$PREVIEW_DB" --remote 2>&1 | tail -5
+            (pnpm db:seed:staging || true)
           else
             pnpm run cf:staging | tee deploy.log
           fi
@@ -264,6 +282,11 @@ jobs:
           # Fall back to the log-grep only when no URL was configured (#293).
           if [ "${{ inputs.environment }}" = "production" ]; then
             URL="${{ inputs['production-url'] }}"
+          elif [ -n "${{ github.event.pull_request.number }}" ]; then
+            # #2020: a preview must NEVER advertise the shared staging URL — that link would
+            # show whatever deployed last, which is the bug. Leave URL empty so the
+            # workers.dev fallback below (the hostname wrangler actually published) wins.
+            URL=""
           else
             URL="${{ inputs['staging-url'] }}"
           fi
@@ -578,7 +601,8 @@ jobs:
             const login = (email && password)
               ? `${oneClick}\n\n<details><summary>…or paste the creds</summary>\n\n\`\`\`\nEmail:    ${email}\nPassword: ${password}\n\`\`\`\n</details>\n_Disposable account on this isolated, throwaway staging DB._`
               : ''
-            const body = `${marker}\n🚀 **${app}** deployed to staging: ${url}${login}\n\n<sub>🤖 isolated, auto-provisioned Workers staging env (its own D1 + KV)</sub>`
+            const pr = context.issue.number
+            const body = `${marker}\n🚀 **${app}** preview for this PR: ${url}${login}\n\n<sub>🤖 \`${app}-pr${pr}\` — a Worker of its own, with its own auto-provisioned D1 + KV. Not shared staging; nothing else deploys over it, and it is deleted when this PR closes (#2020).</sub>`
             const { owner, repo } = context.repo
             const issue_number = context.issue.number
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number })

--- a/.github/workflows/teardown-pr-preview.yml
+++ b/.github/workflows/teardown-pr-preview.yml
@@ -1,0 +1,77 @@
+name: Teardown PR preview
+
+# Delete the per-PR preview environment when its PR closes (#2020).
+#
+# Every preview creates a Worker plus its own D1 and KV (deploy-app.yml rewrites the built
+# config to id-less bindings so wrangler provisions fresh ones). Without this, each PR leaves
+# three resources behind forever — and unlike a stale branch they are invisible until someone
+# opens the Cloudflare dashboard and finds hundreds.
+#
+# Deliberately NOT gated on `merged`: a closed-without-merging PR leaks exactly the same
+# resources as a merged one.
+#
+# Best-effort by design. A preview that was never deployed (no app change on the PR) has
+# nothing to delete, and `wrangler delete` on a missing resource is a normal, expected miss —
+# so each step tolerates failure and reports what it actually removed. The one thing this
+# must never do is fail the PR-close event.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  teardown:
+    # Fork PRs never got a preview (no secrets), so there is nothing to tear down.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # Which apps could this PR have deployed? Same source of truth as the deploy side —
+      # an app opts in with a deploy.config.json, so anything without one never had a preview.
+      - id: apps
+        run: |
+          set -uo pipefail
+          APPS=""
+          for cfg in apps/*/deploy.config.json pocs/*/deploy.config.json; do
+            [ -f "$cfg" ] || continue
+            APPS="$APPS $(basename "$(dirname "$cfg")")"
+          done
+          echo "list=$(echo $APPS | xargs)" >> "$GITHUB_OUTPUT"
+          echo "candidate apps:$APPS"
+
+      - name: Delete preview Worker + D1 + KV
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR: ${{ github.event.pull_request.number }}
+          APPS: ${{ steps.apps.outputs.list }}
+        run: |
+          set -uo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::warning::No Cloudflare token — skipping teardown (previews were never deployed either)."
+            exit 0
+          fi
+          REMOVED=0
+          for APP in $APPS; do
+            WORKER="${APP}-pr${PR}"
+            # `wrangler delete` exits non-zero for a Worker that doesn't exist. For most apps on
+            # most PRs that is the NORMAL case (the PR didn't touch that app), so it is noise,
+            # not an error — count what actually went away instead of trusting exit codes.
+            if npx wrangler delete --name "$WORKER" --force 2>&1 | tee /tmp/del.log | tail -2; then
+              grep -qi "deleted\|success" /tmp/del.log && { echo "  ✓ worker $WORKER"; REMOVED=$((REMOVED+1)); }
+            fi
+            for BINDING in db kv; do
+              RES="${WORKER}-${BINDING}"
+              case "$BINDING" in
+                db) npx wrangler d1 delete "$RES" --skip-confirmation 2>&1 | tail -1 && echo "  ✓ d1 $RES" || true ;;
+                kv) npx wrangler kv namespace delete --namespace-id "$RES" 2>&1 | tail -1 || true ;;
+              esac
+            done
+          done
+          echo "teardown for PR #${PR}: ${REMOVED} worker(s) removed"

--- a/scripts/lib/pr-preview-wrangler.mjs
+++ b/scripts/lib/pr-preview-wrangler.mjs
@@ -1,0 +1,82 @@
+/**
+ * Rewrite a built wrangler config into a PER-PR PREVIEW environment (#2020).
+ *
+ * THE BUG THIS FIXES. A PR deploy ran the app's own `cf:staging`, which targets the app's
+ * single staging Worker and its configured `stagingUrl`. So every PR — and every merge to
+ * `main` — published to the SAME place. Two PRs open on one app clobbered each other, a
+ * merge overwrote whatever preview was there, and the PR comment cheerfully described the
+ * result as "isolated, auto-provisioned … its own D1 + KV". A reviewer tapping that link
+ * had no way to know whose code they were looking at.
+ *
+ * WHAT ISOLATION ACTUALLY REQUIRES. Renaming the Worker is not enough: the bindings in the
+ * built config still carry the staging `database_id` / KV `id`, so a renamed Worker would
+ * quietly share staging's DATA. Three things have to change together:
+ *
+ *   1. `name`         → `<app>-pr<n>`, so it is a different Worker.
+ *   2. binding IDs    → dropped, so wrangler AUTO-PROVISIONS fresh D1/KV for this preview.
+ *                       This is the same id-less first-deploy path the app itself uses.
+ *   3. `routes`       → dropped, so it publishes to `*.workers.dev` instead of trying to
+ *                       bind the app's custom domain — which staging already owns, and
+ *                       which would either fail or steal the real hostname.
+ *
+ * Miss (2) and the preview writes to staging's database. Miss (3) and it fights staging for
+ * the domain. Renaming alone would look right and be worse than doing nothing, because the
+ * comment would finally be telling the truth about a Worker that still wasn't isolated.
+ */
+
+/** D1/KV/R2 id fields wrangler treats as "already provisioned — reuse this". */
+const ID_FIELDS = ['database_id', 'id', 'bucket_name', 'preview_database_id', 'preview_id']
+
+/**
+ * @param {object} config  Parsed wrangler config (the BUILT one, e.g. .output/server/wrangler.json).
+ * @param {string} app     App name, e.g. "kassa".
+ * @param {number|string} pr  PR number.
+ * @returns {{ config: object, name: string, changed: string[] }}
+ */
+export function toPrPreview(config, app, pr) {
+  if (!config || typeof config !== 'object') throw new TypeError('config must be an object')
+  if (!app) throw new TypeError('app is required')
+  if (!/^\d+$/.test(String(pr))) throw new TypeError(`pr must be a number, got ${JSON.stringify(pr)}`)
+
+  const out = structuredClone(config)
+  const name = `${app}-pr${pr}`
+  const changed = []
+
+  out.name = name
+  changed.push(`name=${name}`)
+
+  // Routes/custom domains belong to the real environments. A preview is workers.dev only.
+  for (const key of ['routes', 'route']) {
+    if (out[key]) { delete out[key]; changed.push(`dropped ${key}`) }
+  }
+  // The preset may leave an `env` block; a preview is its own top-level Worker, so any
+  // nested env would only reintroduce the staging bindings we are trying to escape.
+  if (out.env) { delete out.env; changed.push('dropped env') }
+
+  // Ensure it actually gets a workers.dev hostname — that URL is the whole deliverable.
+  if (out.workers_dev !== true) { out.workers_dev = true; changed.push('workers_dev=true') }
+
+  // Bindings: keep the BINDING name (the code refers to it) but drop the provisioned id and
+  // give the resource a per-PR name, so wrangler creates a fresh one.
+  for (const [section, nameField] of [['d1_databases', 'database_name'], ['kv_namespaces', null], ['r2_buckets', 'bucket_name']]) {
+    for (const b of out[section] || []) {
+      for (const f of ID_FIELDS) {
+        if (f in b) { delete b[f]; changed.push(`${section}.${b.binding}: dropped ${f}`) }
+      }
+      if (nameField) {
+        b[nameField] = `${name}-${b.binding}`.toLowerCase()
+        changed.push(`${section}.${b.binding}: ${nameField}=${b[nameField]}`)
+      }
+    }
+  }
+
+  return { config: out, name, changed }
+}
+
+/**
+ * The D1 database name this preview will provision for a given binding — the migrate step
+ * needs it, and deriving it in two places is how they drift.
+ */
+export function previewDbName(app, pr, binding = 'DB') {
+  return `${app}-pr${pr}-${binding}`.toLowerCase()
+}

--- a/scripts/lib/pr-preview-wrangler.mjs
+++ b/scripts/lib/pr-preview-wrangler.mjs
@@ -33,6 +33,44 @@ const ID_FIELDS = ['database_id', 'id', 'bucket_name', 'preview_database_id', 'p
  * @param {number|string} pr  PR number.
  * @returns {{ config: object, name: string, changed: string[] }}
  */
+/** Binding sections, and which field (if any) carries the resource's human name. */
+const BINDING_SECTIONS = [
+  ['d1_databases', 'database_name'],
+  ['kv_namespaces', null],
+  ['r2_buckets', 'bucket_name'],
+]
+
+/**
+ * Strip everything that ties the config to a REAL environment: the custom-domain route it
+ * would otherwise fight staging for, and any nested `env` block that would smuggle staging's
+ * bindings straight back in.
+ */
+function detachFromRealEnvs(out, changed) {
+  for (const key of ['routes', 'route', 'env']) {
+    if (out[key]) { delete out[key]; changed.push(`dropped ${key}`) }
+  }
+  // The workers.dev hostname IS the deliverable — without it there is no link to post.
+  if (out.workers_dev !== true) { out.workers_dev = true; changed.push('workers_dev=true') }
+}
+
+/**
+ * Make every binding provision fresh. The BINDING name is preserved (the app's code refers
+ * to it); only the provisioned id goes, plus a per-PR resource name so two previews cannot
+ * land on the same database.
+ */
+function scrubBindings(out, name, changed) {
+  for (const [section, nameField] of BINDING_SECTIONS) {
+    for (const b of out[section] || []) {
+      for (const f of ID_FIELDS) {
+        if (f in b) { delete b[f]; changed.push(`${section}.${b.binding}: dropped ${f}`) }
+      }
+      if (!nameField) continue
+      b[nameField] = `${name}-${b.binding}`.toLowerCase()
+      changed.push(`${section}.${b.binding}: ${nameField}=${b[nameField]}`)
+    }
+  }
+}
+
 export function toPrPreview(config, app, pr) {
   if (!config || typeof config !== 'object') throw new TypeError('config must be an object')
   if (!app) throw new TypeError('app is required')
@@ -40,35 +78,11 @@ export function toPrPreview(config, app, pr) {
 
   const out = structuredClone(config)
   const name = `${app}-pr${pr}`
-  const changed = []
-
+  const changed = [`name=${name}`]
   out.name = name
-  changed.push(`name=${name}`)
 
-  // Routes/custom domains belong to the real environments. A preview is workers.dev only.
-  for (const key of ['routes', 'route']) {
-    if (out[key]) { delete out[key]; changed.push(`dropped ${key}`) }
-  }
-  // The preset may leave an `env` block; a preview is its own top-level Worker, so any
-  // nested env would only reintroduce the staging bindings we are trying to escape.
-  if (out.env) { delete out.env; changed.push('dropped env') }
-
-  // Ensure it actually gets a workers.dev hostname — that URL is the whole deliverable.
-  if (out.workers_dev !== true) { out.workers_dev = true; changed.push('workers_dev=true') }
-
-  // Bindings: keep the BINDING name (the code refers to it) but drop the provisioned id and
-  // give the resource a per-PR name, so wrangler creates a fresh one.
-  for (const [section, nameField] of [['d1_databases', 'database_name'], ['kv_namespaces', null], ['r2_buckets', 'bucket_name']]) {
-    for (const b of out[section] || []) {
-      for (const f of ID_FIELDS) {
-        if (f in b) { delete b[f]; changed.push(`${section}.${b.binding}: dropped ${f}`) }
-      }
-      if (nameField) {
-        b[nameField] = `${name}-${b.binding}`.toLowerCase()
-        changed.push(`${section}.${b.binding}: ${nameField}=${b[nameField]}`)
-      }
-    }
-  }
+  detachFromRealEnvs(out, changed)
+  scrubBindings(out, name, changed)
 
   return { config: out, name, changed }
 }

--- a/scripts/lib/pr-preview-wrangler.test.mjs
+++ b/scripts/lib/pr-preview-wrangler.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * #2020 contract — a PR preview must be ISOLATED, not just renamed.
+ *
+ * The incident: PR deploys published to the app's single staging Worker and URL, so two PRs
+ * clobbered each other and a merge to main overwrote both — while the PR comment described
+ * the result as "isolated … its own D1 + KV". The dangerous near-fix is renaming the Worker
+ * and stopping there: it looks isolated and still writes to staging's database. These tests
+ * pin all three parts (name, bindings, routes) so that near-fix can't pass.
+ *
+ *   node --test scripts/lib/pr-preview-wrangler.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { toPrPreview, previewDbName } from './pr-preview-wrangler.mjs'
+
+/** Shaped like a real built config for an app with a custom domain + provisioned bindings. */
+const built = () => ({
+  name: 'kassa',
+  main: 'index.js',
+  compatibility_flags: ['nodejs_compat'],
+  routes: [{ pattern: 'kassa.pmcp.dev', custom_domain: true }],
+  d1_databases: [{ binding: 'DB', database_name: 'kassa-staging-db', database_id: 'REAL-STAGING-ID' }],
+  kv_namespaces: [{ binding: 'KV', id: 'REAL-KV-ID' }],
+  env: { staging: { name: 'kassa-staging' } },
+})
+
+test('the Worker is renamed per PR', () => {
+  const { config, name } = toPrPreview(built(), 'kassa', 2011)
+  assert.equal(name, 'kassa-pr2011')
+  assert.equal(config.name, 'kassa-pr2011')
+})
+
+test('D1 loses its provisioned id — otherwise the preview writes to STAGING data', () => {
+  const { config } = toPrPreview(built(), 'kassa', 2011)
+  const db = config.d1_databases[0]
+  assert.ok(!('database_id' in db), 'database_id must be dropped so wrangler provisions a new DB')
+  assert.equal(db.binding, 'DB', 'the binding name is what the code refers to — it must survive')
+  assert.equal(db.database_name, 'kassa-pr2011-db')
+})
+
+test('KV loses its id too', () => {
+  const { config } = toPrPreview(built(), 'kassa', 2011)
+  assert.ok(!('id' in config.kv_namespaces[0]))
+  assert.equal(config.kv_namespaces[0].binding, 'KV')
+})
+
+test('the custom domain is dropped — staging owns that hostname', () => {
+  const { config } = toPrPreview(built(), 'kassa', 2011)
+  assert.ok(!('routes' in config))
+  assert.ok(!('route' in config))
+  assert.equal(config.workers_dev, true, 'the workers.dev URL is the deliverable')
+})
+
+test('any nested env block is dropped — it would smuggle the staging bindings back in', () => {
+  const { config } = toPrPreview(built(), 'kassa', 2011)
+  assert.ok(!('env' in config))
+})
+
+test('no staging identifier survives anywhere in the output', () => {
+  // The blunt end-to-end assertion: if any real id or the staging DB name is still present,
+  // the preview is not isolated, however tidy the individual fields look.
+  const { config } = toPrPreview(built(), 'kassa', 2011)
+  const json = JSON.stringify(config)
+  for (const leak of ['REAL-STAGING-ID', 'REAL-KV-ID', 'kassa-staging-db', 'kassa.pmcp.dev']) {
+    assert.ok(!json.includes(leak), `preview config still references ${leak}`)
+  }
+})
+
+test('two PRs on one app never collide', () => {
+  const a = toPrPreview(built(), 'kassa', 2011)
+  const b = toPrPreview(built(), 'kassa', 2012)
+  assert.notEqual(a.name, b.name)
+  assert.notEqual(a.config.d1_databases[0].database_name, b.config.d1_databases[0].database_name)
+})
+
+test('the input config is not mutated', () => {
+  // The caller may still need the original (e.g. to report what staging looks like).
+  const original = built()
+  toPrPreview(original, 'kassa', 2011)
+  assert.equal(original.name, 'kassa')
+  assert.equal(original.d1_databases[0].database_id, 'REAL-STAGING-ID')
+})
+
+test('a config with no bindings or routes is handled', () => {
+  const { config } = toPrPreview({ name: 'poc', main: 'index.js' }, 'poc', 7)
+  assert.equal(config.name, 'poc-pr7')
+  assert.equal(config.workers_dev, true)
+})
+
+test('the migrate step derives the same DB name as the deploy', () => {
+  // Deriving this in two places is exactly how they drift.
+  const { config } = toPrPreview(built(), 'kassa', 2011)
+  assert.equal(previewDbName('kassa', 2011, 'DB'), config.d1_databases[0].database_name)
+})
+
+test('a non-numeric PR is refused rather than producing a junk Worker name', () => {
+  assert.throws(() => toPrPreview(built(), 'kassa', 'main'), TypeError)
+  assert.throws(() => toPrPreview(built(), 'kassa', '../evil'), TypeError)
+})

--- a/scripts/pr-preview-wrangler.mjs
+++ b/scripts/pr-preview-wrangler.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * CLI for the PR-preview config rewrite (#2020). Rewrites a BUILT wrangler config in place
+ * so the deploy lands in its own Worker with its own D1/KV, then prints the derived names
+ * for the workflow to reuse — deploy and migrate must agree on the DB name, and deriving it
+ * twice is how they drift.
+ *
+ *   node scripts/pr-preview-wrangler.mjs <built-wrangler.json> <app> <pr>
+ *
+ * Emits GITHUB_OUTPUT-style lines on stdout: worker=<name>, db=<database_name>.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { toPrPreview } from './lib/pr-preview-wrangler.mjs'
+
+const [file, app, pr] = process.argv.slice(2)
+if (!file || !app || !pr) {
+  console.error('usage: pr-preview-wrangler.mjs <built-wrangler.json> <app> <pr>')
+  process.exit(2)
+}
+
+const raw = readFileSync(file, 'utf8')
+const { config, name, changed } = toPrPreview(JSON.parse(raw), app, pr)
+writeFileSync(file, JSON.stringify(config, null, 2) + '\n')
+
+// Loud by design: this step silently doing nothing would ship a "preview" pointed at
+// staging, which is the exact failure #2020 is about.
+for (const c of changed) console.error(`  ${c}`)
+if (!changed.length) {
+  console.error('pr-preview-wrangler: NOTHING CHANGED — refusing to pretend this is isolated')
+  process.exit(1)
+}
+
+const db = (config.d1_databases || [])[0]?.database_name || ''
+console.log(`worker=${name}`)
+console.log(`db=${db}`)


### PR DESCRIPTION
Closes #2020

## 👤 For humans

A PR's "preview" link was the app's **shared staging URL**. Two PRs on one app published over each other, a merge to `main` overwrote both — and the comment described the result as *"isolated, auto-provisioned … its own D1 + KV"*. Tapping that link, you had no way to know whose code you were looking at.

Now each PR gets **`<app>-pr<n>`**: its own Worker, its own D1, its own KV, its own URL. Deleted when the PR closes.

## 🤖 For agents

### Renaming alone would have been worse than nothing

The built config still carries staging's `database_id` and KV `id`. A renamed Worker with those bindings quietly writes to **staging data** — while the comment finally tells the truth about an isolation it doesn't have. Three things change together in `toPrPreview()`:

1. `name` → `<app>-pr<n>`
2. **binding ids dropped** → wrangler auto-provisions fresh D1/KV, the same id-less path the app's own first deploy uses. The *binding name* (`DB`, `KV`) is preserved — that's what the code refers to.
3. `routes` and any nested `env` dropped → publishes to `workers.dev` instead of fighting staging for the custom domain it already owns.

### The URL logic inverts for PRs

`inputs['staging-url']` is deliberately **not** used on a PR, so the `workers.dev` hostname wrangler actually published wins. Advertising the shared URL *is* the bug, not a fallback.

### The CLI refuses to no-op

`scripts/pr-preview-wrangler.mjs` exits 1 if it changed nothing. A silent no-op here ships a "preview" pointed at staging — precisely the failure being fixed.

### Teardown

Not gated on `merged` — a closed-without-merging PR leaks the same three resources. Best-effort per app (most apps aren't touched by most PRs, so "not found" is the normal case), and it must never fail the PR-close event.

## Verification

**11 unit tests** on the transform. The one that matters most greps the entire rewritten config for any surviving staging identifier:

```js
for (const leak of ['REAL-STAGING-ID', 'REAL-KV-ID', 'kassa-staging-db', 'kassa.pmcp.dev'])
  assert.ok(!json.includes(leak), `preview config still references ${leak}`)
```

That's the assertion a rename-only near-fix fails. Also pinned: two PRs never collide, the input config isn't mutated, a non-numeric PR is refused rather than producing a junk Worker name, and the migrate step derives the same DB name as the deploy.

Exercised end to end on a realistic built config — output contained **zero** staging identifiers.

## ⚠️ What is NOT verified

**The Cloudflare path itself.** This sandbox has no CF credentials, so the transform is unit-tested and the deploy + teardown are not executed. The first PR that touches an app is the real test. Specific things to watch on that first run:

- does `wrangler deploy` with id-less bindings actually provision, or does it prompt?
- does the `workers.dev` URL appear in `deploy.log` for the grep to find?
- does `d1 migrations apply` against a brand-new DB apply the full schema?
- does teardown find and remove all three resources?

I'd rather say this plainly than let a green CI check imply the deploy works.

## 🧪 How to test

1. Open two PRs touching `apps/kassa`. Each comment shows a **different** `*.workers.dev` URL, each serving its own branch.
2. Merge something else to `main` → both PR links still serve their own PR.
3. Close one → its Worker, D1 and KV are gone.
4. Confirm the comment no longer claims isolation it doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_