### PR TITLE
fix(root): make the plan step fail loudly instead of hiding a crash

### DIFF
--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -437,7 +437,35 @@ jobs:
           # executable here.
           COMMITTED="$RUNNER_TEMP/committed-all.txt"
           cat "$RUNNER_TEMP/inputs.txt" "$RUNNER_TEMP/generated.txt" 2>/dev/null | grep . | sort -u > "$COMMITTED" || true
-          PLAN_OUT="$(node "$RUNNER_TEMP/pi-finish.mjs" plan "$COMMITTED" || true)"
+          # ⚠️ NO `|| true` HERE (#2012). It used to swallow the exit code, and on 2026-08-05 that
+          # cost four undiagnosable runs: `pi-finish.mjs` died with MODULE_NOT_FOUND (it imports a
+          # sibling relatively, and the sibling has to be stashed alongside it — see the stash step),
+          # `|| true` ate the crash, PLAN_OUT came back empty, every count read 0, nothing was staged
+          # and no PR opened. The artifact-gate then reported `FINISH_OUTCOME: success` with no
+          # deliverable — so #1876's harness-failed detector, which gates on FINISH_OUTCOME ==
+          # 'failure' and would have named this instantly, could never fire. Four runs said "none of
+          # the known causes matched" about a cause the harness was actively hiding.
+          #
+          # The distinction the old code lost: "the planner RAN and found nothing" (legitimate — a
+          # sign-off hold commits nothing) versus "the planner never ran" (a harness bug). Only the
+          # second is a failure, and it is the one that must be loud.
+          PLAN_ERR="$RUNNER_TEMP/plan-stderr.txt"
+          PLAN_OUT="$(node "$RUNNER_TEMP/pi-finish.mjs" plan "$COMMITTED" 2>"$PLAN_ERR")"
+          PLAN_RC=$?
+          if [ "$PLAN_RC" -ne 0 ]; then
+            echo "::error::pi-finish plan exited $PLAN_RC — the harness could not read this run's result. This is a WORKFLOW bug, not an underspecified issue."
+            tail -20 "$PLAN_ERR" || true
+            exit "$PLAN_RC"
+          fi
+          # Files were committed but the planner described none of them: it ran, yet its output is
+          # unusable, so anything downstream (the acceptance gate, the tests gate, the PR body)
+          # would be reasoning about an empty picture. Conditioned on $COMMITTED being non-empty so
+          # a legitimate sign-off hold — which commits nothing and plans nothing — still passes.
+          if [ -s "$COMMITTED" ] && [ -z "$(printf '%s' "$PLAN_OUT" | tr -d '[:space:]')" ]; then
+            echo "::error::plan is EMPTY while $(wc -l < "$COMMITTED") file(s) were committed — the planner produced no usable output. WORKFLOW bug, not an underspecified issue."
+            tail -20 "$PLAN_ERR" || true
+            exit 1
+          fi
           APP_DIR="$(printf '%s\n' "$PLAN_OUT" | sed -n 's/^APP_DIR=//p')"
           PKG_LOGIC="$(printf '%s\n' "$PLAN_OUT" | sed -n 's/^PKG_LOGIC=//p')"; PKG_LOGIC=${PKG_LOGIC:-0}
           TEST_FILES="$(printf '%s\n' "$PLAN_OUT" | sed -n 's/^TEST_FILES=//p')"; TEST_FILES=${TEST_FILES:-0}


### PR DESCRIPTION
Refs #2012

## 👤 For humans

Four worker runs last night produced nothing and told you *"none of the known causes matched"*. The cause was sitting in the log the whole time: the step that reads a run's result **crashed**, and a `|| true` swallowed it.

## 🤖 For agents

```bash
PLAN_OUT="$(node "$RUNNER_TEMP/pi-finish.mjs" plan "$COMMITTED" || true)"
```

`pi-finish.mjs` imports a sibling relatively, and both have to be stashed alongside each other. When the sibling is missing, node exits `MODULE_NOT_FOUND`. The `|| true` ate it, `PLAN_OUT` came back empty, every count read `0`, nothing was staged, no PR opened — **and the step still reported success**.

That last part is why four runs were undiagnosable. #1876 already has a detector for exactly this shape ("the harness failed after committing"), gated on `FINISH_OUTCOME == 'failure'`. The step lied about its outcome, so the detector could never fire, and every run fell through to the last-resort branch.

Evidence, run [31057096230](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/31057096230):

```
requireStack: []
Node.js v22.23.1
plan (#1904) — app=<none> packages-logic=0 test-files=0 tests-missing=0
```

### Two guards, and the distinction between them is the point

1. **Non-zero exit from the planner** → a workflow bug. Capture the code, print the stderr tail, exit with it. #1876 then names it correctly instead of shrugging.
2. **Empty plan while files *were* committed** → it ran but produced nothing usable, so the acceptance gate, tests gate and PR body would all reason about a blank picture.

Guard 2 is deliberately conditioned on `$COMMITTED` being non-empty. **A sign-off hold legitimately commits nothing and plans nothing** — failing that would break the hold path, which is precisely what the gates added in #1748 depend on. A naive "fail on empty plan" would have broken the feature shipped four hours ago.

stderr goes to a file rather than `2>&1`, so it can't pollute the sed-parsed stdout the downstream gates read.

## Verification

Simulated all four paths against the extracted shell logic:

| Case | Verdict |
|---|---|
| planner crashes (the #2012 case) | **FAIL** — planner exited 1 |
| normal run, files + plan | pass |
| ran but produced nothing, files committed | **FAIL** — empty plan |
| sign-off hold: no files, no plan | **pass** ← the one a naive fix breaks |

Plus `bash -n` on the extracted step.

## What this does NOT fix

**The missing module itself.** That's third in priority and still unidentified — the error's opening lines were above the retrievable log window, and I've been wrong twice already guessing at this bug's cause, so I'm not naming a file on a hunch.

With this merged, the next occurrence names it in one line instead of an hour. That trade — fix the blindness before the bug — is deliberate: had guard 1 existed at 22:23, the first no-op would have been diagnosed immediately instead of the fourth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_