### PR TITLE
fix(root): let the gate report a finish-step failure it can already see (#2012)

### DIFF
--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -839,6 +839,20 @@ jobs:
               }
             } catch (e) { core.warning(`artifact-gate: could not read pi run log: ${e.message}`) }
 
+            // #2012 — the finish step FAILED, and that verdict must not depend on pi's log
+            // existing. This same check also lives inside the `if (logFile && exists(logFile))`
+            // chain above, which is exactly where it cannot help: when the harness dies early pi
+            // never runs, so PI_EXEC_LOG is empty, the whole chain is skipped, and the branch that
+            // would name this is unreachable. That is how run 31057590885 reported "none of the
+            // known causes matched" while its own env said FINISH_OUTCOME=failure. #1876's detector
+            // misses it too — that one requires a commit made THIS run, and a harness that dies
+            // before committing has none by definition.
+            if (!why && process.env.FINISH_OUTCOME === 'failure') {
+              why = 'the finish step FAILED — the harness could not process this run'
+              action = 'open the run log at the `finish` step and read its error (a non-zero plan exit prints the stderr tail there). '
+                + 'This is a WORKFLOW bug, not an underspecified issue — do not edit the ticket'
+            }
+
             // #1764 fallback — an uncommitted tree is a definite cause even if the log is unreadable.
             if (!why && process.env.PI_LEFT_DIRTY === '1') {
               why = 'the deterministic finish step could not persist pi\'s edits — the working tree is still dirty (#1764)'


### PR DESCRIPTION
## 👤 Humans

When a pi run dies before doing anything, the notification you get says *"none of the known causes matched"* — which reads like the ticket is underspecified. It isn't. The workflow already knows the finish step failed; it just never says so.

Five no-op runs on #1791 all looked like a mystery for this reason.

#2024 made the plan step **fail loudly** instead of swallowing its error, so the gate's environment now carries `FINISH_OUTCOME: failure`. This PR makes the gate actually **read** it.

## 🤖 Agents

`.github/workflows/work-issue-pidev.yml` — the `FINISH_OUTCOME === 'failure'` classifier branch is nested inside:

```js
if (!why && logFile && fs.existsSync(logFile)) { … }
```

`PI_EXEC_LOG` is empty precisely when the harness dies early (pi never ran long enough to write one), so on exactly the runs that need explaining the branch is unreachable and the classifier falls through to the generic message.

#1876's detector misses it too: it requires `workBranch` — a commit made *this* run — which a harness dying before committing never has.

Fix: hoist an unconditional check next to the other two fallbacks, guarded by `!why` so a normal pi failure *with* a log still classifies as "pi step failed" (higher-fidelity cause wins).

```js
if (!why && process.env.FINISH_OUTCOME === 'failure') {
  why = 'the finish step FAILED — the harness could not process this run'
  action = 'open the run log at the `finish` step and read its error … '
    + 'This is a WORKFLOW bug, not an underspecified issue — do not edit the ticket'
}
```

**Verification:** replayed the classifier over the four env shapes observed on #1791 tonight. Run `31057590885` (the one that produced the generic message) now classifies as "finish failed"; a normal pi failure with a log present is unchanged. YAML validated.

**Not fixed here:** the underlying `MODULE_NOT_FOUND` in `pi-finish.mjs` is still unidentified — this PR is about the gate telling the truth about it, so the next occurrence points at the workflow instead of at the ticket.

Refs #2012

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_