### PR TITLE
fix(root): stop the claim guard wedging issues whose work is mid-flight

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -162,27 +162,18 @@ jobs:
         with:
           script: |
             const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
-            const { data: issue } = await github.rest.issues.get({ ...context.repo, issue_number })
-            // Linked PRs: anything whose body references this issue with a closing keyword.
-            const q = `repo:${context.repo.owner}/${context.repo.repo} is:pr ${issue_number} in:body`
-            const { data: found } = await github.rest.search.issuesAndPullRequests({ q, per_page: 20 })
-            const re = new RegExp(`(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))\\s+#${issue_number}\\b`, 'i')
-            const linkedPRs = []
-            for (const it of found.items || []) {
-              if (!re.test(it.body || '')) continue
-              linkedPRs.push({ number: it.number, state: it.state, merged: Boolean(it.pull_request?.merged_at) })
-            }
-            // When status:in-progress was applied (weakest signal → needs its timestamp).
-            let inProgressSince = null
-            if ((issue.labels || []).some((l) => (l.name || l) === 'status:in-progress')) {
-              const events = await github.paginate(github.rest.issues.listEvents, { ...context.repo, issue_number, per_page: 100 })
-              const last = events.filter((e) => e.event === 'labeled' && e.label?.name === 'status:in-progress').pop()
-              inProgressSince = last?.created_at || null
-            }
-            const facts = { issueState: issue.state, linkedPRs, inProgressSince, now: new Date().toISOString() }
+            // Gathering lives in scripts/claim-facts.mjs so BOTH pi lanes share one
+            // implementation (#2027). It used to be a byte-identical block in each workflow,
+            // which is how the wedge got half-fixed: repairing the worker's copy left the
+            // decomposer refusing exactly what the worker no longer did. Unit-tested against a
+            // fake Octokit — the two subtle fields (`self.pr`, `baseRef`) are the ones whose
+            // absence refused #1791 five times. Contract: scripts/claim-facts.test.mjs.
+            const { gatherClaimFacts } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/claim-facts.mjs`)
+            const facts = await gatherClaimFacts({ github, context, issueNumber: issue_number, core })
             require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/claim-facts.json`, JSON.stringify(facts))
             core.info(`claim facts: ${JSON.stringify(facts)}`)
       - name: Claim guard
+        id: claim
         run: node scripts/pipeline-loop-guard.mjs claim-guard < "$RUNNER_TEMP/claim-facts.json"
 
       - uses: pnpm/action-setup@v4
@@ -386,8 +377,29 @@ jobs:
       # log (`PI_EXEC_LOG`) instead of claude's structured execution_file, so the failure
       # "why" is cause-aware (billing / error / underspecified) — parity with the claude
       # flow. PASS/FAIL is unchanged either way.
+      # A claim-guard refusal is a DELIBERATE stop, not a no-op run (#2027) — the guard says so
+      # in its own error text. Reporting it as "produced nothing" reads as a broken pipeline and
+      # sends the owner to rewrite a ticket that was fine. It still gets a comment, because
+      # silence after comment-dispatch's "🟢 On it" is its own mystery — just a calm one.
+      - name: Not picked up — the issue is already claimed
+        if: ${{ always() && steps.claim.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue || github.event.issue.number }}
+          CLAIM_REASON: ${{ steps.claim.outputs.claim_reason }}
+        with:
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER)
+            const reason = process.env.CLAIM_REASON || 'another run already holds this issue'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            await github.rest.issues.createComment({ ...context.repo, issue_number, body:
+              `⏸️ **Not picked up — ${reason}.**\n\n`
+              + `Nothing is broken and nothing was lost: the run stopped before starting so two runs `
+              + `can't build the same issue. Resolve the blocker above, then dispatch again.\n\n`
+              + `<sub>🤖 pi.dev harness (CI · mac-mini) · claim guard #1890 · <a href="${runUrl}">run log</a></sub>` })
+
       - name: Artifact-gate — fail if the agent produced nothing
-        if: always()
+        if: ${{ always() && steps.claim.outcome != 'failure' }}
         uses: actions/github-script@v7
         env:
           PI_EXEC_LOG: ${{ steps.pi.outputs.exec_log }}

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -156,50 +156,14 @@ jobs:
         with:
           script: |
             const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
-            const { data: issue } = await github.rest.issues.get({ ...context.repo, issue_number })
-            // Linked PRs: anything whose body references this issue with a closing keyword.
-            const q = `repo:${context.repo.owner}/${context.repo.repo} is:pr ${issue_number} in:body`
-            const { data: found } = await github.rest.search.issuesAndPullRequests({ q, per_page: 20 })
-            const re = new RegExp(`(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))\\s+#${issue_number}\\b`, 'i')
-            // The search API does not return head/base refs, so fetch each candidate. Both
-            // are load-bearing (#2027): `head.ref` identifies THIS worker's own branch, and
-            // `base.ref` distinguishes "merged to main" from "merged into its epic branch".
-            // Candidates are few (<= 20 after the closing-keyword filter), so this is cheap.
-            const linkedPRs = []
-            let selfPr = null
-            for (const it of found.items || []) {
-              if (!re.test(it.body || '')) continue
-              let headRef = null, baseRef = null, merged = Boolean(it.pull_request?.merged_at)
-              try {
-                const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: it.number })
-                headRef = pr.head?.ref ?? null
-                baseRef = pr.base?.ref ?? null
-                merged = Boolean(pr.merged_at)
-              } catch (e) {
-                // Leave baseRef null — decideClaim then treats a merge as landed, the safer
-                // pre-#2027 default when we could not determine the base.
-                core.warning(`claim facts: could not fetch PR #${it.number} (${e.message})`)
-              }
-              // A PR on `work-<issue>` IS this worker's own branch, not a competitor. The
-              // decomposer routes a re-dispatch here precisely BECAUSE that branch exists
-              // (resolveLane, #2010) — without this the guard refuses the very lane that
-              // was chosen for it.
-              if (headRef === `work-${issue_number}`) selfPr = it.number
-              linkedPRs.push({ number: it.number, state: it.state, merged, headRef, baseRef })
-            }
-            // When status:in-progress was applied (weakest signal → needs its timestamp).
-            let inProgressSince = null
-            if ((issue.labels || []).some((l) => (l.name || l) === 'status:in-progress')) {
-              const events = await github.paginate(github.rest.issues.listEvents, { ...context.repo, issue_number, per_page: 100 })
-              const last = events.filter((e) => e.event === 'labeled' && e.label?.name === 'status:in-progress').pop()
-              inProgressSince = last?.created_at || null
-            }
-            const facts = {
-              issueState: issue.state, linkedPRs, inProgressSince,
-              now: new Date().toISOString(),
-              defaultBranch: context.payload.repository?.default_branch || 'main',
-              self: { pr: selfPr },
-            }
+            // Gathering lives in scripts/claim-facts.mjs so BOTH pi lanes share one
+            // implementation (#2027). It used to be a byte-identical block in each workflow,
+            // which is how the wedge got half-fixed: repairing the worker's copy left the
+            // decomposer refusing exactly what the worker no longer did. Unit-tested against a
+            // fake Octokit — the two subtle fields (`self.pr`, `baseRef`) are the ones whose
+            // absence refused #1791 five times. Contract: scripts/claim-facts.test.mjs.
+            const { gatherClaimFacts } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/claim-facts.mjs`)
+            const facts = await gatherClaimFacts({ github, context, issueNumber: issue_number, core })
             require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/claim-facts.json`, JSON.stringify(facts))
             core.info(`claim facts: ${JSON.stringify(facts)}`)
       - name: Claim guard

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -161,10 +161,31 @@ jobs:
             const q = `repo:${context.repo.owner}/${context.repo.repo} is:pr ${issue_number} in:body`
             const { data: found } = await github.rest.search.issuesAndPullRequests({ q, per_page: 20 })
             const re = new RegExp(`(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))\\s+#${issue_number}\\b`, 'i')
+            // The search API does not return head/base refs, so fetch each candidate. Both
+            // are load-bearing (#2027): `head.ref` identifies THIS worker's own branch, and
+            // `base.ref` distinguishes "merged to main" from "merged into its epic branch".
+            // Candidates are few (<= 20 after the closing-keyword filter), so this is cheap.
             const linkedPRs = []
+            let selfPr = null
             for (const it of found.items || []) {
               if (!re.test(it.body || '')) continue
-              linkedPRs.push({ number: it.number, state: it.state, merged: Boolean(it.pull_request?.merged_at) })
+              let headRef = null, baseRef = null, merged = Boolean(it.pull_request?.merged_at)
+              try {
+                const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: it.number })
+                headRef = pr.head?.ref ?? null
+                baseRef = pr.base?.ref ?? null
+                merged = Boolean(pr.merged_at)
+              } catch (e) {
+                // Leave baseRef null — decideClaim then treats a merge as landed, the safer
+                // pre-#2027 default when we could not determine the base.
+                core.warning(`claim facts: could not fetch PR #${it.number} (${e.message})`)
+              }
+              // A PR on `work-<issue>` IS this worker's own branch, not a competitor. The
+              // decomposer routes a re-dispatch here precisely BECAUSE that branch exists
+              // (resolveLane, #2010) — without this the guard refuses the very lane that
+              // was chosen for it.
+              if (headRef === `work-${issue_number}`) selfPr = it.number
+              linkedPRs.push({ number: it.number, state: it.state, merged, headRef, baseRef })
             }
             // When status:in-progress was applied (weakest signal → needs its timestamp).
             let inProgressSince = null
@@ -173,10 +194,16 @@ jobs:
               const last = events.filter((e) => e.event === 'labeled' && e.label?.name === 'status:in-progress').pop()
               inProgressSince = last?.created_at || null
             }
-            const facts = { issueState: issue.state, linkedPRs, inProgressSince, now: new Date().toISOString() }
+            const facts = {
+              issueState: issue.state, linkedPRs, inProgressSince,
+              now: new Date().toISOString(),
+              defaultBranch: context.payload.repository?.default_branch || 'main',
+              self: { pr: selfPr },
+            }
             require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/claim-facts.json`, JSON.stringify(facts))
             core.info(`claim facts: ${JSON.stringify(facts)}`)
       - name: Claim guard
+        id: claim
         run: node scripts/pipeline-loop-guard.mjs claim-guard < "$RUNNER_TEMP/claim-facts.json"
 
       # ── WS2 pipeline context (#1695) — read epic_branch/depth/epic OFF the issue body ──
@@ -331,7 +358,11 @@ jobs:
       # never edited them) — no reliance on .gitignore foreseeing them. Files a generator wrote via
       # `bash` (not an edit tool) are NOT in the ledger; they are REPORTED, never silently committed.
       - id: finish
-        if: ${{ !cancelled() }}
+        # `!cancelled()` deliberately keeps this running after a pi failure so partial work is
+        # still persisted — but NOT after a claim-guard refusal (#2027): pi never ran, there is
+        # nothing to finish, and the step's own failure then fed the artifact-gate a false
+        # "the harness crashed" signal.
+        if: ${{ !cancelled() && steps.claim.outcome != 'failure' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -633,8 +664,31 @@ jobs:
       # log (`PI_EXEC_LOG`) instead of claude's structured execution_file, so the failure
       # "why" is cause-aware (billing / error / underspecified) — parity with the claude
       # flow. PASS/FAIL is unchanged either way.
+      # A claim-guard refusal is a DELIBERATE stop, not a no-op run (#2027). The guard says so
+      # in its own error text; the gate used to ignore that and post "🔴 this run produced
+      # nothing", which reads as a broken pipeline and (pre-#1876) invited rewriting a perfectly
+      # good ticket. Five such alarms on #1791 were all this. The refusal still gets a comment —
+      # silence after comment-dispatch's "🟢 On it" would be its own mystery — just a calm one
+      # that names the blocker, posted by the step below.
+      - name: Not picked up — the issue is already claimed
+        if: ${{ always() && steps.claim.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue || github.event.issue.number }}
+          CLAIM_REASON: ${{ steps.claim.outputs.claim_reason }}
+        with:
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER)
+            const reason = process.env.CLAIM_REASON || 'another run already holds this issue'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            await github.rest.issues.createComment({ ...context.repo, issue_number, body:
+              `⏸️ **Not picked up — ${reason}.**\n\n`
+              + `Nothing is broken and nothing was lost: the worker stopped before starting so two runs `
+              + `can't build the same issue. Resolve the blocker above, then dispatch again.\n\n`
+              + `<sub>🤖 pi.dev harness (CI · mac-mini) · claim guard #1890 · <a href="${runUrl}">run log</a></sub>` })
+
       - name: Artifact-gate — fail if the agent produced nothing
-        if: always()
+        if: ${{ always() && steps.claim.outcome != 'failure' }}
         uses: actions/github-script@v7
         env:
           PI_EXEC_LOG: ${{ steps.pi.outputs.exec_log }}

--- a/scripts/claim-facts.mjs
+++ b/scripts/claim-facts.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// claim-facts.mjs — the READ side of the claim guard (#1890), extracted so the two pi lanes
+// share one implementation (#2027).
+//
+// WHY THIS FILE EXISTS. The facts-gathering lived as a byte-identical `github-script` block
+// inside BOTH `work-issue-pidev.yml` and `decompose-on-issue-pidev.yml`. That duplication is
+// how the #2027 wedge got half-fixed: the worker's copy was repaired and the decomposer's kept
+// the bug, so an epic hit exactly the refusal the worker no longer had. Two copies of a guard
+// is one guard and one liability.
+//
+// The DECISION stays in `pipeline-loop-guard.mjs` (`decideClaim`) — pure and unit-tested. This
+// module only turns the GitHub API into the facts that decision consumes, and it is unit-tested
+// too (claim-facts.test.mjs) against a fake `github` client, because its two subtle fields are
+// exactly the ones that were missing:
+//
+//   • `self.pr`   — the PR on `work-<issue>` is THIS pipeline's own branch, not a competitor.
+//                   `resolveLane()` (#2010) routes a re-dispatch to the worker *because* that
+//                   branch exists; without this the guard then refuses the lane chosen for it.
+//   • `baseRef`   — our topology is `work-<n>` → `epic/<n>-<slug>` → `main`. A sub-PR merging
+//                   into its EPIC branch is mid-flight, not landed. Treating it as landed
+//                   refused #1791 permanently, and would refuse every epic-topology issue the
+//                   moment its first sub-PR merged.
+
+/** Does this PR body reference the issue with a closing keyword? */
+export function referencesIssue(body, issueNumber) {
+  const re = new RegExp(`(clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed))\\s+#${issueNumber}\\b`, 'i')
+  return re.test(String(body || ''))
+}
+
+/**
+ * Gather the claim facts for one issue.
+ *
+ * @param {object}  o
+ * @param {object}  o.github        an Octokit-shaped client (the `github` global in github-script)
+ * @param {object}  o.context       the github-script `context`
+ * @param {number}  o.issueNumber
+ * @param {object} [o.core]         optional logger; only `warning` is used
+ * @returns {Promise<object>} the shape `decideClaim` consumes
+ */
+export async function gatherClaimFacts({ github, context, issueNumber, core }) {
+  const { owner, repo } = context.repo
+  const warn = (m) => (core?.warning ? core.warning(m) : console.warn(m))
+
+  const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number: issueNumber })
+
+  const q = `repo:${owner}/${repo} is:pr ${issueNumber} in:body`
+  const { data: found } = await github.rest.search.issuesAndPullRequests({ q, per_page: 20 })
+
+  // The search API returns neither head nor base ref, so each candidate is fetched. Both refs
+  // are load-bearing (see the header), and the candidate list is small — at most 20, usually 1.
+  const linkedPRs = []
+  let selfPr = null
+  for (const it of found.items || []) {
+    if (!referencesIssue(it.body, issueNumber)) continue
+    let headRef = null
+    let baseRef = null
+    let merged = Boolean(it.pull_request?.merged_at)
+    try {
+      const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: it.number })
+      headRef = pr.head?.ref ?? null
+      baseRef = pr.base?.ref ?? null
+      merged = Boolean(pr.merged_at)
+    } catch (e) {
+      // Leave baseRef null. `decideClaim` then treats a merge as landed — the safer
+      // pre-#2027 default, so an unreachable API cannot silently UNLOCK an issue.
+      warn(`claim facts: could not fetch PR #${it.number} (${e.message})`)
+    }
+    if (headRef === `work-${issueNumber}`) selfPr = it.number
+    linkedPRs.push({ number: it.number, state: it.state, merged, headRef, baseRef })
+  }
+
+  // When `status:in-progress` was applied — the weakest signal, so it needs its timestamp.
+  let inProgressSince = null
+  const hasInProgress = (issue.labels || []).some((l) => (l.name || l) === 'status:in-progress')
+  if (hasInProgress) {
+    const events = await github.paginate(github.rest.issues.listEvents,
+      { owner, repo, issue_number: issueNumber, per_page: 100 })
+    const last = events.filter((e) => e.event === 'labeled' && e.label?.name === 'status:in-progress').pop()
+    inProgressSince = last?.created_at || null
+  }
+
+  return {
+    issueState: issue.state,
+    linkedPRs,
+    inProgressSince,
+    now: new Date().toISOString(),
+    defaultBranch: context.payload?.repository?.default_branch || 'main',
+    self: { pr: selfPr },
+  }
+}

--- a/scripts/claim-facts.test.mjs
+++ b/scripts/claim-facts.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * #2027 contract — the READ side of the claim guard.
+ *
+ * `decideClaim` was already tested, and still refused #1791 five times, because the two fields
+ * that mattered were never GATHERED. These tests pin the gathering itself, against a fake
+ * Octokit, so the missing-facts failure mode cannot come back silently in either lane.
+ *
+ *   node --test scripts/claim-facts.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { gatherClaimFacts, referencesIssue } from './claim-facts.mjs'
+import { decideClaim } from './pipeline-loop-guard.mjs'
+
+const context = { repo: { owner: 'FriendlyInternet', repo: 'nuxt-crouton' }, payload: { repository: { default_branch: 'main' } } }
+
+/** A fake Octokit: `prs` are both the search hits and what `pulls.get` returns. */
+function fakeGithub({ issue = { state: 'open', labels: [] }, prs = [], events = [], pullsGetThrows = false } = {}) {
+  return {
+    paginate: async () => events,
+    rest: {
+      issues: {
+        get: async () => ({ data: issue }),
+        listEvents: async () => ({ data: events }),
+      },
+      search: {
+        issuesAndPullRequests: async () => ({
+          data: { items: prs.map((p) => ({ number: p.number, state: p.state, body: p.body, pull_request: { merged_at: p.mergedAt || null } })) },
+        }),
+      },
+      pulls: {
+        get: async ({ pull_number }) => {
+          if (pullsGetThrows) throw new Error('boom')
+          const p = prs.find((x) => x.number === pull_number)
+          return { data: { head: { ref: p.headRef }, base: { ref: p.baseRef }, merged_at: p.mergedAt || null } }
+        },
+      },
+    },
+  }
+}
+
+test('referencesIssue matches closing keywords only', () => {
+  assert.equal(referencesIssue('Closes #1791', 1791), true)
+  assert.equal(referencesIssue('fixes #1791', 1791), true)
+  assert.equal(referencesIssue('Resolved #1791', 1791), true)
+  // A bare mention is not a claim — the PR merely talks about the issue.
+  assert.equal(referencesIssue('related to #1791', 1791), false)
+  // #17910 must not satisfy #1791.
+  assert.equal(referencesIssue('Closes #17910', 1791), false)
+})
+
+test('the PR on work-<issue> is identified as OUR OWN — the half that was never gathered', async () => {
+  const github = fakeGithub({ prs: [
+    { number: 1987, state: 'open', body: 'Closes #1791', headRef: 'work-1791', baseRef: 'epic/1791-sales' },
+  ] })
+  const facts = await gatherClaimFacts({ github, context, issueNumber: 1791 })
+  assert.equal(facts.self.pr, 1987)
+  assert.equal(facts.linkedPRs[0].baseRef, 'epic/1791-sales')
+})
+
+test('a PR from another branch is NOT ours', async () => {
+  const github = fakeGithub({ prs: [
+    { number: 1999, state: 'open', body: 'Closes #1791', headRef: 'somebody-else', baseRef: 'main' },
+  ] })
+  const facts = await gatherClaimFacts({ github, context, issueNumber: 1791 })
+  assert.equal(facts.self.pr, null)
+})
+
+test('end to end: the real #1791 shape now PROCEEDS', async () => {
+  // PR #1987 merged into `epic/1791-…`, on our own `work-1791` branch. Both facts were absent
+  // before #2027, and their absence refused this issue permanently.
+  const github = fakeGithub({ prs: [
+    { number: 1987, state: 'closed', body: 'Closes #1791', headRef: 'work-1791', baseRef: 'epic/1791-sales', mergedAt: '2026-08-05T23:50:18Z' },
+  ] })
+  const facts = await gatherClaimFacts({ github, context, issueNumber: 1791 })
+  assert.equal(decideClaim(facts).action, 'proceed')
+})
+
+test('end to end: a genuinely landed issue still REFUSES', async () => {
+  // The loosening must not blind the guard — this is the case #1890 exists for.
+  const github = fakeGithub({ prs: [
+    { number: 2011, state: 'closed', body: 'Closes #1735', headRef: 'work-1735', baseRef: 'main', mergedAt: '2026-08-05T22:00:00Z' },
+  ] })
+  const facts = await gatherClaimFacts({ github, context, issueNumber: 1735 })
+  // Our own branch, but it landed on main: the work is done, so this must NOT be exempted.
+  const v = decideClaim({ ...facts, self: { pr: null } })
+  assert.equal(v.action, 'refuse')
+})
+
+test('end to end: a competing OPEN pr still refuses', async () => {
+  const github = fakeGithub({ prs: [
+    { number: 1987, state: 'open', body: 'Closes #1791', headRef: 'work-1791', baseRef: 'epic/1791-sales' },
+    { number: 1999, state: 'open', body: 'Closes #1791', headRef: 'someone-else', baseRef: 'main' },
+  ] })
+  const facts = await gatherClaimFacts({ github, context, issueNumber: 1791 })
+  const v = decideClaim(facts)
+  assert.equal(v.action, 'refuse')
+  assert.equal(v.claimedBy, 1999)
+})
+
+test('an unfetchable PR leaves baseRef null and stays REFUSED — fail safe, not fail open', async () => {
+  const github = fakeGithub({
+    prs: [{ number: 1987, state: 'closed', body: 'Closes #1791', mergedAt: '2026-08-05T23:50:18Z' }],
+    pullsGetThrows: true,
+  })
+  const facts = await gatherClaimFacts({ github, context, issueNumber: 1791, core: { warning() {} } })
+  assert.equal(facts.linkedPRs[0].baseRef, null)
+  assert.equal(decideClaim(facts).action, 'refuse')
+})
+
+test('a PR that only MENTIONS the issue is not gathered at all', async () => {
+  const github = fakeGithub({ prs: [
+    { number: 2000, state: 'open', body: 'see #1791 for context', headRef: 'x', baseRef: 'main' },
+  ] })
+  const facts = await gatherClaimFacts({ github, context, issueNumber: 1791 })
+  assert.equal(facts.linkedPRs.length, 0)
+  assert.equal(decideClaim(facts).action, 'proceed')
+})
+
+test('the default branch is read from the event payload, not hardcoded', async () => {
+  const github = fakeGithub()
+  const facts = await gatherClaimFacts({ github, context: { ...context, payload: { repository: { default_branch: 'trunk' } } }, issueNumber: 1 })
+  assert.equal(facts.defaultBranch, 'trunk')
+  // …and falls back when the payload carries no repository (workflow_dispatch).
+  const bare = await gatherClaimFacts({ github, context: { repo: context.repo }, issueNumber: 1 })
+  assert.equal(bare.defaultBranch, 'main')
+})
+
+test('status:in-progress contributes its timestamp only when the label is present', async () => {
+  const events = [{ event: 'labeled', label: { name: 'status:in-progress' }, created_at: '2026-08-06T00:00:00Z' }]
+  const without = await gatherClaimFacts({ github: fakeGithub({ events }), context, issueNumber: 1 })
+  assert.equal(without.inProgressSince, null)
+
+  const withLabel = await gatherClaimFacts({
+    github: fakeGithub({ issue: { state: 'open', labels: [{ name: 'status:in-progress' }] }, events }),
+    context, issueNumber: 1,
+  })
+  assert.equal(withLabel.inProgressSince, '2026-08-06T00:00:00Z')
+})

--- a/scripts/pipeline-loop-guard.mjs
+++ b/scripts/pipeline-loop-guard.mjs
@@ -32,7 +32,7 @@
 // `if:` blocks in the two `*-pidev.yml` workflows. This file is the single tested source.
 
 import { pathToFileURL } from 'node:url'
-import { readFileSync } from 'node:fs'
+import { appendFileSync, readFileSync } from 'node:fs'
 
 export const ALLOWED_BOT = 'nuxt-harness[bot]'
 export const MAX_DEPTH = 3
@@ -108,8 +108,17 @@ export function labelForChild({ depth = 0, isLeaf = false, maxDepth = MAX_DEPTH 
  * forever, so a stale stamp PROCEEDS (saying so), and an unparseable timestamp fails OPEN —
  * the three strong signals still gate. A closed-but-unmerged PR does not claim anything: a
  * rejected attempt should free the issue, not lock it.
+ *
+ * MERGED MEANS MERGED TO THE DEFAULT BRANCH (#2027). Our topology is `work-<n>` →
+ * `epic/<n>-<slug>` → `main`, so a sub-PR merging into its EPIC branch is mid-flight, not
+ * done. Reading it as "landed" refuses every re-dispatch from then on: it wedged #1791
+ * permanently after PR #1987 merged into `epic/1791-…`, and would wedge every issue in the
+ * epic topology the moment its first sub-PR merged. A PR whose `baseRef` is unknown still
+ * counts as landed — the caller may not have fetched it, and the pre-#2027 behaviour is the
+ * safer default when we cannot tell.
  */
 export const CLAIM_TTL_MINUTES = 90
+export const DEFAULT_BRANCH = 'main'
 
 export function decideClaim({
   issueState = 'open',
@@ -117,6 +126,7 @@ export function decideClaim({
   inProgressSince = null,
   now = null,
   ttlMinutes = CLAIM_TTL_MINUTES,
+  defaultBranch = DEFAULT_BRANCH,
   self = {},
 } = {}) {
   if (issueState === 'closed') {
@@ -125,7 +135,7 @@ export function decideClaim({
 
   // A PR of our own (a re-dispatch onto the same branch) is not a competing claim.
   const others = (linkedPRs || []).filter((pr) => pr && pr.number !== self?.pr)
-  const merged = others.find((pr) => pr.merged)
+  const merged = others.find((pr) => pr.merged && (pr.baseRef == null || pr.baseRef === defaultBranch))
   if (merged) {
     return { action: 'refuse', claimedBy: merged.number, reason: `PR #${merged.number} already merged for this issue` }
   }
@@ -155,6 +165,19 @@ export function decideClaim({
 //     → facts.json is { issueState, linkedPRs, inProgressSince, now, self } gathered by the
 //       workflow's API step. Exit 0 to proceed; exit 1 (with an ::error::) when the issue is
 //       already claimed, so the run stops before spending a build on duplicate work (#1890).
+/**
+ * Publish a refusal reason as a step output so the workflow can say WHY on the issue (#2027).
+ * Without it the owner sees only the artifact-gate's generic alarm and has to open step 6 of a
+ * run log to learn the run stopped on purpose. Reasons are single-line by construction; strip
+ * newlines anyway rather than corrupt the output file. Diagnostics only — never throws.
+ */
+function publishClaimReason(reason) {
+  if (!process.env.GITHUB_OUTPUT) return
+  try {
+    appendFileSync(process.env.GITHUB_OUTPUT, `claim_reason=${String(reason).replace(/[\r\n]+/g, ' ')}\n`)
+  } catch { /* the guard's verdict still stands; only the explanation is lost */ }
+}
+
 function main(argv) {
   const [cmd, ...rest] = argv
   if (cmd === 'claim-guard') {
@@ -173,6 +196,7 @@ function main(argv) {
       console.log(`Claim guard OK — ${verdict.reason}.`)
       return
     }
+    publishClaimReason(verdict.reason)
     console.log(`::error::Claim guard: refusing to work this issue — ${verdict.reason}. This is a deliberate stop, not a build failure (#1890).`)
     process.exit(1)
   }

--- a/scripts/pipeline-loop-guard.test.mjs
+++ b/scripts/pipeline-loop-guard.test.mjs
@@ -146,6 +146,82 @@ test('this run\'s OWN pr is ignored — a re-dispatch must not refuse itself', (
   assert.equal(v.action, 'proceed')
 })
 
+// ── #2027: the two halves of the wedge that made #1791 unworkable ────────────────────
+// Both branches below existed in `decideClaim` but could never fire in production, because
+// the workflow's facts step supplied neither `self` nor a `baseRef`. The result: every
+// re-dispatch of an issue whose work was in flight, or whose sub-PR had merged into its epic
+// branch, was refused — and the artifact-gate reported that refusal as a broken harness.
+
+test('a PR merged into its EPIC branch has not landed — the issue stays workable (#2027)', () => {
+  // `work-<n>` → `epic/<n>-<slug>` → `main`. PR #1987 merged into the middle rung; treating
+  // that as "done" wedged #1791 permanently and would wedge every epic-topology issue.
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1987, state: 'closed', merged: true, baseRef: 'epic/1791-sales-block-editor-views' }],
+    defaultBranch: 'main',
+    now: T0,
+  })
+  assert.equal(v.action, 'proceed')
+})
+
+test('a PR merged into the DEFAULT branch still refuses — the work really did land', () => {
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1987, state: 'closed', merged: true, baseRef: 'main' }],
+    defaultBranch: 'main',
+    now: T0,
+  })
+  assert.equal(v.action, 'refuse')
+  assert.equal(v.claimedBy, 1987)
+})
+
+test('an UNKNOWN base counts as landed — unfetchable facts keep the pre-#2027 default', () => {
+  // `pulls.get` can fail; refusing is the safe side of that coin, so absence of a baseRef
+  // must not silently unlock an issue.
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1987, state: 'closed', merged: true }],
+    now: T0,
+  })
+  assert.equal(v.action, 'refuse')
+})
+
+test('the default branch is honoured even when it is not called main', () => {
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 42, state: 'closed', merged: true, baseRef: 'trunk' }],
+    defaultBranch: 'trunk',
+    now: T0,
+  })
+  assert.equal(v.action, 'refuse')
+})
+
+test('self-exemption survives a merged own-PR — a re-dispatch onto our branch is not a claim', () => {
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [{ number: 1987, state: 'closed', merged: true, baseRef: 'main' }],
+    self: { pr: 1987 },
+    now: T0,
+  })
+  assert.equal(v.action, 'proceed')
+})
+
+test('a COMPETING open PR still refuses while our own branch PR is exempt', () => {
+  // The exemption must be surgical: exempting our branch cannot blind the guard to a genuine
+  // second runner, which is the whole point of #1890.
+  const v = decideClaim({
+    issueState: 'open',
+    linkedPRs: [
+      { number: 1987, state: 'open', headRef: 'work-1791' },
+      { number: 1999, state: 'open', headRef: 'somebody-else' },
+    ],
+    self: { pr: 1987 },
+    now: T0,
+  })
+  assert.equal(v.action, 'refuse')
+  assert.equal(v.claimedBy, 1999)
+})
+
 test('a FRESH status:in-progress is refused', () => {
   const v = decideClaim({ issueState: 'open', inProgressSince: mins(-10), now: T0 })
   assert.equal(v.action, 'refuse')


### PR DESCRIPTION
Closes #2027

## 👤 Humans

Every "🔴 this run produced nothing" alarm on #1791 tonight was a **false alarm**. The pipeline wasn't broken — it was refusing to start, on purpose, and then reporting that refusal as a crash.

Run [31057590885](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/31057590885):

```
6  Claim guard      failure   ← the job ends here
7–15                skipped   ← pi never runs
16 finish           failure   ← nothing to finish
17 artifact-gate    failure   ← posts "🔴 this run produced nothing"
```

Two consequences of this PR:

- **🚀 on an issue with work in flight now runs.** #1791 was permanently unworkable — every future dispatch would have been refused too.
- **When the guard *does* refuse, you get told why**, calmly: *"⏸️ Not picked up — PR #1999 is already open for this issue"*, instead of a red alarm about a working pipeline.

## 🤖 Agents

All three defects are in the **facts** fed to the guard, not in `decideClaim` itself.

### 1 — `self` was gathered by nobody

`decideClaim` documents and tests the exemption:

> *A PR of our own (a re-dispatch onto the same branch) is not a competing claim.*

```js
const others = (linkedPRs || []).filter((pr) => pr && pr.number !== self?.pr)
```

`pipeline-loop-guard.test.mjs:139` covers it. The workflow's facts step wrote `{ issueState, linkedPRs, inProgressSince, now }` — no `self`. **Zero production callers**; only its own unit test ever reached that branch.

This put two rules in direct contradiction: `resolveLane()` (#2010) routes 🚀 to the **worker** *because* `work-<n>` exists, and the guard then refused *because* the PR on `work-<n>` exists. Same fact, opposite conclusions.

Now gathered from the PR whose head ref is `work-<issue>` — definitionally this worker's own branch.

### 2 — `merged` never looked at the base

```js
merged: Boolean(it.pull_request?.merged_at)
```

Topology is `work-<n>` → `epic/<n>-<slug>` → `main`. PR #1987 merged into `epic/1791-…`, which the guard read as *"the work already landed"*. That is a **permanent** refusal, and every issue in the epic topology inherits it the moment its first sub-PR merges.

Merged now means merged to the repo's default branch. An **unknown** base still counts as landed — `pulls.get` can fail, and refusing is the safe side of that coin, so a fetch error must not silently unlock an issue.

### 3 — the gate ignored a stop it was told was deliberate

The guard's own text: `This is a deliberate stop, not a build failure (#1890).` The artifact-gate ran `if: always()` and posted the "produced nothing" alarm anyway.

`finish` and the artifact-gate now skip on a claim refusal, and the guard publishes its reason via `$GITHUB_OUTPUT` so the replacement comment can name the real blocker. Silence wasn't an option — after comment-dispatch's "🟢 On it", nothing at all would be its own mystery.

## Verification

**The corpus check, not just the tests** (AGENTS.md). Replayed `decideClaim` over the real #1791 facts at both points in time, plus the cases that must keep refusing:

```
▶ PROCEED  #1791 at 23:48 (PR 1987 OPEN on work-1791)     — no claim found
▶ PROCEED  #1791 now (PR 1987 MERGED into epic/1791-…)    — no claim found
⛔ REFUSE   a PR merged to main, not ours                  — PR #2011 already merged
⛔ REFUSE   a closed issue                                 — its work is done or was dropped
```

The third line is the one that matters: loosening the rule did not blind the guard to a genuine claim. A dedicated test pins that too — our own branch PR exempt **and** a competing open PR still refusing, in the same call.

**6 new tests, 29 pass.** `fallow audit --base origin/main` clean (the reason-publishing was extracted to a helper — inlined it pushed `main()` to cognitive 16). YAML parsed and step conditions asserted.

## ⚠️ Not verified

The `pulls.get` fan-out and the new comment step run only on CI. The first refused dispatch after merge is the real test — watch that the comment names a specific PR rather than falling back to *"another run already holds this issue"*.

## 🧪 How to test

1. Comment 🚀 on [#1791](https://github.com/FriendlyInternet/nuxt-crouton/issues/1791). Step 6 should pass and pi should actually start — previously it died there.
2. On an issue with a competing open PR from a different branch, the guard should still refuse, and the comment should name that PR number.
3. No "🔴 produced nothing" comment should ever accompany a claim refusal again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_