### PR TITLE
fix(root): quote what actually failed, and keep the red ping current

### DIFF
--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -150,7 +150,13 @@ jobs:
               const marker = `<!-- ci-fail-ping:${pr.head.sha} -->`
               const comments = await github.paginate(github.rest.issues.listComments,
                 { owner, repo, issue_number: pr.number, per_page: 100 })
-              if (comments.some(c => (c.body || '').includes(marker))) return // already pinged this SHA
+              // Already pinged this SHA? The @MENTION stays one-shot (a mention doesn't re-fire on
+              // an edit, so re-creating would be pure spam) — but the BODY is refreshed below if
+              // more checks have gone red since (#2029). Checks finish minutes apart: on PR #2025
+              // the ping fired naming one failure and `Type Check Apps` went red 42s later, so the
+              // owner was left reading a permanently understated count while the sticky comment
+              // said three. A stale loud signal is worse than a quiet accurate one.
+              const existing = comments.find(c => (c.body || '').includes(marker))
               // Name the failing checks (#1909) AND quote what actually went wrong (#2015).
               // Names alone still meant leaving the notification, opening the checks tab, picking
               // a job and scrolling a log — on a phone that is the entire task.
@@ -172,15 +178,26 @@ jobs:
               // The distilled failure: a step's `::error::` output becomes a check-run annotation,
               // which is already the short form of the log. Two per check, truncated — enough to
               // diagnose, collapsed so the notification itself stays scannable.
+              //
+              // FILTER BY LEVEL (#2029). `listAnnotations` returns `notice`/`warning`/`failure`
+              // together, in creation order — and CI emits its noise first (the Node-20
+              // deprecation notice, "no files found for playwright-report/"). Taking the first two
+              // of ANY level therefore quoted two things that did not fail, under a heading that
+              // said "what failed". Fetch a page, keep the failures. Fall back to any level only
+              // when a check produced no failure annotation at all, and say so, so a reader is
+              // never told a warning is the cause.
               const excerpts = []
               for (const f of names) {
                 if (!f.id) continue // a commit status has no annotations
                 try {
                   const anns = (await github.rest.checks.listAnnotations(
-                    { owner, repo, check_run_id: f.id, per_page: 2 })).data
-                  for (const a of anns) {
+                    { owner, repo, check_run_id: f.id, per_page: 50 })).data
+                  const hard = anns.filter(a => a.annotation_level === 'failure')
+                  const use = hard.length ? hard : anns
+                  const label = hard.length ? f.name : `${f.name} (no error annotation — showing context)`
+                  for (const a of use.slice(0, 2)) {
                     const msg = String(a.message || '').trim().slice(0, 400)
-                    if (msg) excerpts.push(`${f.name}: ${msg}`)
+                    if (msg) excerpts.push(`${label}: ${msg}`)
                   }
                 } catch (e) { core.warning(`annotations for ${f.name}: ${e.message}`) }
               }
@@ -197,6 +214,12 @@ jobs:
                 `finished and waiting on your approval**.\n\n` +
                 `[Checks](${pr.html_url}/checks) · \`${pr.head.ref}\` → \`${pr.base.ref}\`.\n\n` +
                 `<sub>🤖 agent pipeline (CI) · failure notify (#1815/#1909)</sub>`
+              if (existing) {
+                if ((existing.body || '').trim() === body.trim()) return // nothing new to say
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+                core.info(`Refreshed the red ping on #${pr.number} (${causes.length} failing now).`)
+                return
+              }
               await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body })
               core.info(`Pinged @${OWNER} on red #${pr.number} (${pr.head.sha.slice(0, 7)}).`)
             }


### PR DESCRIPTION
Closes #2029

## 👤 Humans

The "what failed" box I shipped a few hours ago in #2015 was showing things that hadn't failed.

[On #2025](https://github.com/FriendlyInternet/nuxt-crouton/pull/2025#issuecomment-5198722766):

```
🔴 @pmcp — CI failed (1 failing check): E2E (with-pages).

what failed
  Node.js 20 is deprecated. …
  No files were found with the provided path: playwright-report/.
```

Both quoted lines are warnings. And the check that actually mattered — **`Type Check Apps`** — wasn't named at all, while the sticky comment right beside it said *"3 failing"*.

## 🤖 Agents

### 1 — annotations were never filtered by level

`checks.listAnnotations` returns `notice` / `warning` / `failure` interleaved in creation order, and CI emits its noise first (Node-20 deprecation, upload-artifact's "no files found"). `per_page: 2` therefore took two non-failures and printed them under a heading promising the opposite.

Now: fetch a page, keep `annotation_level === 'failure'`. Fall back to any level **only** when a check produced no failure annotation, and label that case `(no error annotation — showing context)` so a warning is never passed off as the cause.

### 2 — the ping was one-shot over a set that keeps growing

It fired on the first red check and never revised. `Type Check Apps` went red at 23:52:48 — 42 seconds after the ping posted at 23:52:06 — so the count was permanently understated, and the loud signal disagreed with the quiet one.

The **@mention** stays one-shot: a mention doesn't re-fire on an edit, so re-creating would be spam. The **body** is now refreshed in place when the failing set changes, and skipped when it hasn't (an unchanged body writes nothing).

The #2015 `CI Gate` roll-up filtering is unchanged, so the ping still legitimately names one fewer check than the sticky.

## ⚠️ What is NOT verified

I could not read the actual annotations for those two check runs — no API surface available here exposes them, and `get_check_run` returned an empty `output`. So the level-filter is reasoned from how the Actions runner maps `##[error]` → `failure` and `##[warning]` → `warning`, not confirmed against that run.

A related honest limit: a job whose only failure annotation is `Process completed with exit code 1` will quote exactly that. Strictly better than quoting a deprecation notice, but not a diagnosis — the Playwright detail lives in the log, not an annotation. Improving that means a log-tail fetch, which is a bigger change than this fix.

## 🧪 How to test

Push a commit that fails typecheck **and** e2e:

1. The ping should name both checks — not whichever went red first.
2. The "what failed" box should contain error text, never a Node-20 deprecation notice.
3. When the second check fails after the ping posted, the existing comment updates rather than a second one appearing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_