### PR TITLE
fix(root): an already-decomposed issue is not a leaf

### DIFF
--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -53,6 +53,15 @@ children that aren't yet worked, and stop (idempotent).
 
 ## Step 2 — Apply the LEAF TEST (all must be true)
 
+> **First, a hard precondition — an issue that already has OPEN sub-issues is never a
+> leaf (#2048).** Its children *are* the decomposition; the job is to resume the tree
+> (dispatch the open, unblocked children), not to re-plan it. This is a **lookup, not a
+> judgement**, and it is easy to miss because `gh issue view` does **not** list
+> sub-issues — so the four criteria below get applied to a well-written epic's *prose*
+> and it reads as "one coherent change". That is exactly how epic #515, with three open
+> ready children, was classified a leaf and handed to the single-leaf worker, which spent
+> eleven minutes on it and produced nothing. Check `/sub_issues` before judging.
+
 An issue is **leaf-sized** when:
 
 1. **Single coherent change** — one concern, one PR's worth of work.

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -176,22 +176,103 @@ jobs:
         id: claim
         run: node scripts/pipeline-loop-guard.mjs claim-guard < "$RUNNER_TEMP/claim-facts.json"
 
+      # ── ALREADY DECOMPOSED? (#2048) ───────────────────────────────────────────────
+      # An issue with OPEN sub-issues is not a leaf — its children ARE the decomposition.
+      # The LEAF TEST is applied to the issue's PROSE and never to its sub-issues (and the
+      # prompt reads the issue with `gh issue view`, which does not list them), so epic #515
+      # — three open ready children — was classified a leaf and handed to the single-leaf
+      # worker, which burned eleven minutes and produced nothing.
+      #
+      # "Does this have open children" is a LOOKUP, not a judgement, so it is answered here
+      # rather than asked of pi. The same state was already paginated twice in this file by
+      # the artifact-gate's #1074 child-deliverable scan — just too late to affect anything.
+      # The DECISION is the pure, unit-tested `planResume` (scripts/resume-decomposed.mjs);
+      # this step is I/O only. Contract: scripts/resume-decomposed.test.mjs.
+      - name: Gather sub-issues
+        id: subs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
+            let children = []
+            try {
+              const subs = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                { ...context.repo, issue_number, per_page: 100 })
+              // `hasOpenChildren` decides worker-vs-decomposer per child, so it needs each
+              // grandchild's state — one extra call per open child, and trees are small.
+              children = await Promise.all(subs.map(async (s) => {
+                let hasOpenChildren = false
+                if (s.state === 'open') {
+                  try {
+                    const g = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                      { ...context.repo, issue_number: s.number, per_page: 100 })
+                    hasOpenChildren = g.some((x) => x.state === 'open')
+                  } catch (e) { core.warning(`grandchild probe #${s.number}: ${e.message}`) }
+                }
+                return { number: s.number, state: s.state, body: s.body || '', hasOpenChildren }
+              }))
+            } catch (e) {
+              // Fail OPEN into normal classification — a gather glitch must not stop the pipeline.
+              core.warning(`sub-issue gather failed (${e.message}) — classifying normally.`)
+            }
+            require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/sub-issues.json`, JSON.stringify(children))
+            core.info(`sub-issues: ${children.length} (${children.filter(c => c.state === 'open').length} open)`)
+      - name: Resume an already-decomposed tree
+        id: resume
+        run: node scripts/resume-decomposed.mjs < "$RUNNER_TEMP/sub-issues.json"
+
+      - name: Dispatch the open children
+        if: ${{ steps.resume.outputs.resume == '1' }}
+        uses: actions/github-script@v7
+        env:
+          DISPATCH: ${{ steps.resume.outputs.dispatch }}
+          REASON: ${{ steps.resume.outputs.reason }}
+          ISSUE_NUMBER: ${{ inputs.issue || github.event.issue.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER)
+            const pairs = String(process.env.DISPATCH || '').split(',').filter(Boolean)
+              .map((p) => { const [n, label] = p.split(':'); return { number: Number(n), label } })
+            const done = []
+            for (const { number, label } of pairs) {
+              // Fire a FRESH `labeled` event — the workers trigger on the label being ADDED,
+              // never on it merely being present, so a re-dispatch must remove it first.
+              try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: number, name: label }) } catch (e) {}
+              await github.rest.issues.addLabels({ ...context.repo, issue_number: number, labels: [label] })
+              done.push(`#${number} → \`${label}\``)
+            }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            await github.rest.issues.createComment({ ...context.repo, issue_number, body:
+              `🌳 **Already decomposed — resumed the tree instead of re-planning it.**\n\n`
+              + (done.length ? `Dispatched: ${done.join(' · ')}\n\n` : `Nothing dispatchable right now — every open child is waiting on a sibling.\n\n`)
+              + `_${process.env.REASON}_\n\n`
+              + `<sub>🤖 pi.dev harness (CI · mac-mini) · resume-decomposed #2048 · <a href="${runUrl}">run log</a></sub>` })
+            core.info(`Resumed #${issue_number}: ${done.join(', ') || '(all blocked)'}`)
+
+      # Everything below is the CLASSIFY path — skipped entirely once the tree was
+      # resumed (#2048), so a decomposed epic costs a few API calls instead of an
+      # install, a package warm and an eleven-minute pi run that cannot succeed.
       - uses: pnpm/action-setup@v4
+        if: ${{ steps.resume.outputs.resume != '1' }}
         with:
           # per-job dest — the default ~/setup-pnpm collides between the two
           # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
           dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v4
+        if: ${{ steps.resume.outputs.resume != '1' }}
         with:
           node-version: 22
           cache: pnpm
       - name: Install
+        if: ${{ steps.resume.outputs.resume != '1' }}
         run: pnpm install --frozen-lockfile
 
       # Warm @fyit/* dist so the agent's `crouton init`/generate/migrate doesn't cold-build
       # ~30 packages one-at-a-time mid-run (the #1213/#1247 tax — ~15-20 min). Content-addressed
       # cache + build-all on miss; a warm cache makes this ~seconds. (#1222)
       - name: Warm @fyit package builds
+        if: ${{ steps.resume.outputs.resume != '1' }}
         uses: ./.github/actions/warm-packages
 
       # Timestamp the run start so the artifact-gate distinguishes "produced this run"
@@ -204,6 +285,7 @@ jobs:
       # the worker PR) act as the Harness App and cascade. ANTHROPIC_API_KEY = the
       # funded metered key (NOT a subscription — subscription OAuth must not back CI).
       - id: pi
+        if: ${{ steps.resume.outputs.resume != '1' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -245,7 +327,7 @@ jobs:
             cat >> "$PROMPT_FILE" <<'PI_ED'
           EVENT-DRIVEN DECOMPOSE — PLAN ONLY. You are the task-decomposer. Do NOT run `/task-decompose`, do NOT spawn any subagent, and do NOT run any `gh`, `git`, or issue-mutating command. Your ONLY output is a plan file that a deterministic step will apply. Concretely:
           1. READ the target issue (use `gh issue view` to read only — reading is fine, mutating is not).
-          2. Apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, one focused run.
+          2. Apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, one focused run. AN ISSUE THAT ALREADY HAS OPEN SUB-ISSUES IS NEVER A LEAF (#2048) — its children ARE the decomposition, and `gh issue view` does NOT list them, so check explicitly before you judge. (A deterministic step normally intercepts this case before you are invoked; if you are seeing it anyway, that step failed open — emit a split plan for the remaining open children rather than {"leaf": true}.)
           3. Using your file-writing tool (NOT a shell heredoc — bodies contain emoji/backticks and shell quoting breaks, #1001), write a file named exactly `decompose-plan.json` in the current working directory, as valid JSON — ONE of these three shapes:
              - Single leaf: {"leaf": true}
              - Split: {"leaf": false, "children": [ {"title": "...", "body": "...markdown with ## 👤 For humans / ## 🤖 For agents / ## 🧪 How to test...", "labels": ["type:...","<component>"], "needsSplit": false, "blockedBy": []}, ... ]} — 2 to 6 children, one coherent concern each. Set needsSplit=true for a child that itself still needs decomposing, false for a ready leaf. Exactly one `type:*` label plus a real component label per child (unknown labels are dropped). Do NOT put a pipeline block or Dedup line in the body.
@@ -295,7 +377,7 @@ jobs:
       # .github/labels.yml, creates + links (sub-issues API) + labels each child. A missing/empty
       # plan is a loud, honest failure the artifact-gate then reports.
       - name: Apply decompose plan
-        if: ${{ env.PIPELINE_MODE == 'event-driven' }}
+        if: ${{ env.PIPELINE_MODE == 'event-driven' && steps.resume.outputs.resume != '1' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -399,7 +481,10 @@ jobs:
               + `<sub>🤖 pi.dev harness (CI · mac-mini) · claim guard #1890 · <a href="${runUrl}">run log</a></sub>` })
 
       - name: Artifact-gate — fail if the agent produced nothing
-        if: ${{ always() && steps.claim.outcome != 'failure' }}
+        # Also skipped on a resumed tree (#2048): that path reports its own
+        # deliverable, and its comment lands BEFORE t0 so the since-t0 scan
+        # would never see it and would false-fail a successful run.
+        if: ${{ always() && steps.claim.outcome != 'failure' && steps.resume.outputs.resume != '1' }}
         uses: actions/github-script@v7
         env:
           PI_EXEC_LOG: ${{ steps.pi.outputs.exec_log }}

--- a/scripts/resume-decomposed.mjs
+++ b/scripts/resume-decomposed.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// resume-decomposed.mjs — an issue that is ALREADY decomposed is not a leaf (#2048).
+//
+// THE BUG THIS CLOSES. The decomposer's LEAF TEST is applied to the issue's *prose*
+// ("single coherent change, bounded file set, …") and never to its *sub-issues* — and
+// step 1 of the prompt reads the issue with `gh issue view`, which does not list them.
+// So epic #515, which has three open, ready children (#516/#517/#518), was classified
+// as a single leaf and labelled `work-this`. The single-leaf worker then spent eleven
+// minutes trying to implement an entire epic on one branch, produced nothing, and the
+// owner was paged about a pipeline doing exactly what it was told.
+//
+// WHY THIS IS DETERMINISTIC AND NOT A PROMPT LINE. "Does this issue have open children"
+// is a lookup, not a judgement. Asking a probabilistic runtime to re-derive a fact the
+// API answers directly is how the fact gets ignored. The same state was already being
+// paginated twice elsewhere in the very same workflow (the artifact-gate's #1074 child
+// -deliverable scan) — just too late to affect the decision. So: check first, and only
+// fall through to the LLM classification when there is genuinely nothing to resume.
+//
+// The correct behaviour for an already-decomposed tree is "resume the tree, work the
+// remaining open leaves" — a deliverable the artifact-gate already understands (#1074).
+
+import { pathToFileURL } from 'node:url'
+import { appendFileSync, readFileSync } from 'node:fs'
+// Both are already the tested source of truth for these two facts — the trigger label the
+// worker fires on, and the `Blocked-by: #NN` body format. Importing beats restating them.
+import { WORKER_TRIGGER } from './pipeline-loop-guard.mjs'
+import { parseBlockedBy } from './apply-decompose-plan.mjs'
+
+/**
+ * Which of an already-decomposed issue's children should be dispatched now?
+ *
+ * @param {Array} children  `[{ number, state, body?, hasOpenChildren? }]` — the target's
+ *                          sub-issues, as returned by the sub_issues API.
+ * @returns {{ resume: boolean, dispatch: Array<{number:number,label:string}>, waiting:number[], reason:string }}
+ *
+ * `resume:false` means "not decomposed — classify normally". That covers BOTH an issue
+ * with no children at all and one whose children are ALL CLOSED (a finished tree is not
+ * a tree to resume; the issue may legitimately have new leaf work).
+ */
+export function planResume(children = []) {
+  const kids = (children || []).filter(Boolean)
+  const open = kids.filter((c) => c.state === 'open')
+  if (!open.length) {
+    return {
+      resume: false,
+      dispatch: [],
+      waiting: [],
+      reason: kids.length
+        ? `all ${kids.length} sub-issue(s) are closed — nothing to resume`
+        : 'no sub-issues — not decomposed',
+    }
+  }
+
+  // A child waits until every blocker it names is closed (#1750). Blockers are issue
+  // NUMBERS in the child's body (`Blocked-by: #NN`), unlike a plan's sibling indices.
+  const closed = new Set(kids.filter((c) => c.state === 'closed').map((c) => c.number))
+  const openNumbers = new Set(open.map((c) => c.number))
+  const dispatch = []
+  const waiting = []
+  for (const c of open) {
+    const blockers = parseBlockedBy(c.body || '')
+    // Only a blocker that is still OPEN holds a child back. A blocker outside this tree
+    // (or already gone) must not wedge it — an unresolvable reference would otherwise
+    // park the child forever with nothing to close it.
+    const live = blockers.filter((n) => openNumbers.has(n) && !closed.has(n))
+    if (live.length) { waiting.push(c.number); continue }
+    // A child that is itself decomposed needs the decomposer again, not a code worker.
+    dispatch.push({ number: c.number, label: c.hasOpenChildren ? 'delegate-pi' : WORKER_TRIGGER })
+  }
+
+  return {
+    resume: true,
+    dispatch,
+    waiting,
+    reason: dispatch.length
+      ? `already decomposed — resuming ${dispatch.length} of ${open.length} open child(ren)`
+      : `already decomposed — all ${open.length} open child(ren) are blocked by siblings`,
+  }
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────────
+//   node scripts/resume-decomposed.mjs < children.json
+// children.json is the sub_issues array (with `body`), gathered by the workflow.
+// Prints `resume=<0|1>`, `dispatch=<n:label,...>` and `reason=<text>` to $GITHUB_OUTPUT.
+function main() {
+  let children = []
+  try {
+    const raw = readFileSync(0, 'utf8').trim()
+    children = raw ? JSON.parse(raw) : []
+  } catch (err) {
+    // Fail OPEN into normal classification: a gather glitch must not stop the pipeline.
+    console.log(`::warning::resume-decomposed could not read its input (${err.message}) — classifying normally.`)
+    return
+  }
+  const v = planResume(children)
+  console.log(`resume-decomposed: ${v.reason}`)
+  if (v.waiting.length) console.log(`  waiting on siblings: ${v.waiting.map((n) => `#${n}`).join(', ')}`)
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, [
+      `resume=${v.resume ? 1 : 0}`,
+      `dispatch=${v.dispatch.map((d) => `${d.number}:${d.label}`).join(',')}`,
+      `reason=${v.reason.replace(/[\r\n]+/g, ' ')}`,
+      '',
+    ].join('\n'))
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) main()

--- a/scripts/resume-decomposed.test.mjs
+++ b/scripts/resume-decomposed.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * #2048 contract — an already-decomposed issue is never a leaf.
+ *
+ * The case that minted this: epic #515 had three open, ready children (#516/#517/#518)
+ * and was classified as a single leaf, so the single-leaf worker spent eleven minutes
+ * on an epic and produced nothing. The classification never looked at the sub-issues.
+ *
+ *   node --test scripts/resume-decomposed.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { planResume } from './resume-decomposed.mjs'
+
+const open = (number, body = '') => ({ number, state: 'open', body })
+const closed = (number, body = '') => ({ number, state: 'closed', body })
+
+test('the real #515 shape resumes instead of classifying', () => {
+  const v = planResume([open(516), open(517), open(518)])
+  assert.equal(v.resume, true)
+  assert.deepEqual(v.dispatch.map(d => d.number), [516, 517, 518])
+  assert.ok(v.dispatch.every(d => d.label === 'work-this'))
+})
+
+test('no sub-issues → classify normally (the common case must not regress)', () => {
+  const v = planResume([])
+  assert.equal(v.resume, false)
+  assert.equal(v.dispatch.length, 0)
+  assert.match(v.reason, /not decomposed/)
+})
+
+test('a FINISHED tree classifies normally — a closed tree is not a tree to resume', () => {
+  // Otherwise an epic whose children all merged could never take new leaf work.
+  const v = planResume([closed(516), closed(517)])
+  assert.equal(v.resume, false)
+  assert.match(v.reason, /closed/)
+})
+
+test('a partially-finished tree resumes only what is still open', () => {
+  const v = planResume([closed(516), open(517), open(518)])
+  assert.equal(v.resume, true)
+  assert.deepEqual(v.dispatch.map(d => d.number), [517, 518])
+})
+
+test('a child blocked by an OPEN sibling waits (#1750 ordering is respected)', () => {
+  const v = planResume([open(516), open(517, 'Blocked-by: #516')])
+  assert.deepEqual(v.dispatch.map(d => d.number), [516])
+  assert.deepEqual(v.waiting, [517])
+})
+
+test('a child whose blocker has CLOSED is dispatched', () => {
+  const v = planResume([closed(516), open(517, 'Blocked-by: #516')])
+  assert.deepEqual(v.dispatch.map(d => d.number), [517])
+  assert.deepEqual(v.waiting, [])
+})
+
+test('a blocker OUTSIDE this tree does not wedge the child forever', () => {
+  // Nothing in this tree can ever close #999, so treating it as live would park the
+  // child permanently with no event able to release it.
+  const v = planResume([open(517, 'Blocked-by: #999')])
+  assert.deepEqual(v.dispatch.map(d => d.number), [517])
+})
+
+test('a child that is itself decomposed goes back to the DECOMPOSER, not a code worker', () => {
+  const v = planResume([{ ...open(517), hasOpenChildren: true }, open(518)])
+  assert.equal(v.dispatch.find(d => d.number === 517).label, 'delegate-pi')
+  assert.equal(v.dispatch.find(d => d.number === 518).label, 'work-this')
+})
+
+test('an all-blocked tree still reports resume=true — it must not fall through to the LEAF TEST', () => {
+  // This is the subtle one: "nothing to dispatch right now" is NOT "this is a leaf".
+  // Falling through here would recreate the exact #515 bug on a cycle-free but fully
+  // serialised tree.
+  const v = planResume([open(516, 'Blocked-by: #517'), open(517, 'Blocked-by: #516')])
+  assert.equal(v.resume, true)
+  assert.equal(v.dispatch.length, 0)
+  assert.deepEqual(v.waiting, [516, 517])
+})
+
+test('null/garbage entries are tolerated, not thrown on', () => {
+  assert.equal(planResume([null, undefined, open(516)]).dispatch.length, 1)
+  assert.equal(planResume(undefined).resume, false)
+})


### PR DESCRIPTION
Closes #2048

## 👤 Humans

That "this run produced nothing" on #515 was the pipeline doing exactly what it was told.

#515 is an epic with **three open, ready children** (#516, #517, #518). The decomposer classified it as a **single leaf** and handed the whole epic to the single-leaf worker. The worker spent **eleven minutes** trying to implement an epic on one branch, produced nothing, and you got paged.

After this, dispatching an epic that already has children works *the children*.

## 🤖 Agents

### The cause

The LEAF TEST is applied to the issue's **prose**:

> single coherent change, bounded file set, clear/testable acceptance, one focused run

None of those four mention sub-issues — and step 1 tells pi to read the issue with `gh issue view`, **which does not list them**. So pi judged a well-written epic body as "one coherent change" and was never shown the three issues that contradict it.

### The fix is a lookup, not a better prompt

"Does this issue have open children" is not a judgement call. Asking a probabilistic runtime to re-derive a fact the API answers is how the fact gets ignored — the same shape as #2027's claim guard.

The state was **already being paginated twice in this very file** by the artifact-gate's #1074 child-deliverable scan. It just ran too late to affect the decision.

New `scripts/resume-decomposed.mjs` — pure, unit-tested `planResume()`:

- returns `resume:false` (classify normally) when there are no children **or** all children are closed
- otherwise dispatches the open, unblocked children, honouring #1750 `Blocked-by:` ordering
- picks each child's label by its own state — a child that is *itself* decomposed goes back to `delegate-pi`, not to a code worker
- imports `WORKER_TRIGGER` and `parseBlockedBy` rather than restating them

The whole classify path — pnpm setup, install, package warm, pi, apply — and the artifact-gate now **skip** on a resumed tree. A decomposed epic costs a few API calls instead of an eleven-minute run that cannot succeed.

The prompt and `.claude/agents/task-decomposer.md` are hardened too, as a second line of defence that names *why* it's easy to miss.

### Two tests that matter more than the happy path

Both pin cases that would silently reintroduce the bug:

```js
test('a FINISHED tree classifies normally — a closed tree is not a tree to resume')
// else an epic whose children all merged could never take new leaf work

test('an all-blocked tree still reports resume=true — it must not fall through to the LEAF TEST')
// "nothing to dispatch right now" is NOT "this is a leaf" — falling through here
// recreates #515 exactly, on a fully serialised tree
```

10 tests, all pass (49 across the three guard suites). `fallow audit --base origin/main` clean. YAML validated and every step's `if:` asserted — including catching that `Apply decompose plan` already had one, which would have been a duplicate mapping key.

## ⚠️ Not verified

The workflow path itself runs only on CI. The first dispatch of an epic-with-children after merge is the real test — I've verified the *decision* against #515's exact shape (three open children, no blockers → all three dispatched as `work-this`), not the labelling round-trip.

Also: the `hasOpenChildren` probe adds one API call per open child. Trees are small (≤6 by `MAX_CHILDREN`), so this is bounded, but it is a new per-child call.

## 🧪 How to test

1. 🚀 on #515 → the run should dispatch #516/#517/#518 and comment *"Already decomposed — resumed the tree"*, **not** label #515 `work-this`.
2. 🚀 on a childless issue → unchanged, pi classifies as before.
3. 🚀 on an epic whose children are all closed → unchanged.
4. An epic with a `Blocked-by:` chain → only the unblocked children dispatch; the rest are named as waiting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_