### PR TITLE
feat(root): release a held draft PR with ✅ on the PR itself

### DIFF
--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -53,6 +53,15 @@ children that aren't yet worked, and stop (idempotent).
 
 ## Step 2 — Apply the LEAF TEST (all must be true)
 
+> **First, a hard precondition — an issue that already has OPEN sub-issues is never a
+> leaf (#2048).** Its children *are* the decomposition; the job is to resume the tree
+> (dispatch the open, unblocked children), not to re-plan it. This is a **lookup, not a
+> judgement**, and it is easy to miss because `gh issue view` does **not** list
+> sub-issues — so the four criteria below get applied to a well-written epic's *prose*
+> and it reads as "one coherent change". That is exactly how epic #515, with three open
+> ready children, was classified a leaf and handed to the single-leaf worker, which spent
+> eleven minutes on it and produced nothing. Check `/sub_issues` before judging.
+
 An issue is **leaf-sized** when:
 
 1. **Single coherent change** — one concern, one PR's worth of work.

--- a/.github/workflows/approve-draft-pr.yml
+++ b/.github/workflows/approve-draft-pr.yml
@@ -1,0 +1,98 @@
+name: Approve a held draft PR
+
+# Release a UI-gated draft PR by commenting ON THE PR — ✅ (or `lgtm`). (#2051)
+#
+# THE GAP THIS CLOSES. The UI sign-off gate opens a `.vue`-touching PR as a DRAFT so it
+# cannot auto-merge, and the PR body says "reply `lgtm` to release it". Nothing listened.
+# Every approval workflow in this repo begins with `!github.event.issue.pull_request` —
+# `resume-on-comment.yml`, `close-epic-on-comment.yml`, `comment-dispatch.yml` — so a
+# comment on a PR reached nothing; and the issue-side route additionally requires
+# `status:blocked`, which the draft gate never set. Four PRs (#2039/#2041/#2044/#2025)
+# were held with no key, releasable only by hand-clicking "Ready for review" — precisely
+# the mobile friction the gate exists to remove. The hold worked; its release was never
+# asserted.
+#
+# THE GESTURE IS ✅. A REACTION CANNOT WORK: GitHub raises no webhook event for reactions,
+# so nothing can listen to one (#572, learned by watching a 👍 do nothing). A ✅ typed as a
+# comment is a real `issue_comment` event. Whole-line, like the 🚀 dispatch gesture — "✅ but
+# fix the spacing first" is a change request wearing a tick, and must not release anything.
+#
+# THIS DOES NOT MERGE. It only marks the PR ready for review; the existing green-gated
+# auto-merge (#2013/#339) takes it from there. Approving is not the same as bypassing CI.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release:
+    # A collaborator's comment, on a PR (not an issue), that might be an approval.
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR') &&
+      (contains(github.event.comment.body, '✅') ||
+       contains(github.event.comment.body, '✔') ||
+       contains(github.event.comment.body, '☑') ||
+       contains(github.event.comment.body, 'lgtm') ||
+       contains(github.event.comment.body, 'approve'))
+    # ⚠️ The `contains()` tests are a CHEAP PRE-FILTER ONLY, never the decision (#2004).
+    # They are unanchored and blind to Markdown, so they also match a comment that merely
+    # *mentions* approving — in backticks, a table cell, or a quote. The authoritative
+    # check is `isApproval()` below, which strips code and quotes first. Do not move the
+    # decision up here: GitHub expressions cannot express it.
+    runs-on: ubuntu-latest
+    steps:
+      # An App token so the ready-for-review event CASCADES into the downstream CI/
+      # auto-merge workflows — a GITHUB_TOKEN action does not re-trigger them (#572).
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
+      # Needed so the script can import the unit-tested matcher.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo
+            const pull_number = context.payload.issue.number
+
+            const { isApproval, approvalKind } = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/approval.mjs`)
+            const body = context.payload.comment.body || ''
+            if (!isApproval(body)) {
+              core.info(`#${pull_number}: comment mentions approval but does not give it — ignoring.`)
+              return
+            }
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number })
+            if (!pr.draft) {
+              core.info(`#${pull_number} is not a draft — nothing to release.`)
+              return
+            }
+
+            // REST cannot un-draft; this is GraphQL-only. Same mutation resume-on-comment.yml
+            // already uses — it was reachable there and not here, which was the whole bug.
+            await github.graphql(
+              `mutation($id:ID!){ markPullRequestReadyForReview(input:{pullRequestId:$id}){ pullRequest { id } } }`,
+              { id: pr.node_id })
+
+            const kind = approvalKind(body) === 'check' ? '✅' : '`lgtm`'
+            await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body:
+              `✅ **Released — marked ready for review** (${kind} from @${context.payload.comment.user.login}).\n\n`
+              + `This does **not** merge it: the green-gated auto-merge takes over from here, so a red check still holds it.\n\n`
+              + `<sub>🤖 agent pipeline (CI) · approve-draft-pr #2051</sub>` })
+            core.info(`Released #${pull_number} (${approvalKind(body)}).`)

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -176,22 +176,103 @@ jobs:
         id: claim
         run: node scripts/pipeline-loop-guard.mjs claim-guard < "$RUNNER_TEMP/claim-facts.json"
 
+      # ── ALREADY DECOMPOSED? (#2048) ───────────────────────────────────────────────
+      # An issue with OPEN sub-issues is not a leaf — its children ARE the decomposition.
+      # The LEAF TEST is applied to the issue's PROSE and never to its sub-issues (and the
+      # prompt reads the issue with `gh issue view`, which does not list them), so epic #515
+      # — three open ready children — was classified a leaf and handed to the single-leaf
+      # worker, which burned eleven minutes and produced nothing.
+      #
+      # "Does this have open children" is a LOOKUP, not a judgement, so it is answered here
+      # rather than asked of pi. The same state was already paginated twice in this file by
+      # the artifact-gate's #1074 child-deliverable scan — just too late to affect anything.
+      # The DECISION is the pure, unit-tested `planResume` (scripts/resume-decomposed.mjs);
+      # this step is I/O only. Contract: scripts/resume-decomposed.test.mjs.
+      - name: Gather sub-issues
+        id: subs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
+            let children = []
+            try {
+              const subs = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                { ...context.repo, issue_number, per_page: 100 })
+              // `hasOpenChildren` decides worker-vs-decomposer per child, so it needs each
+              // grandchild's state — one extra call per open child, and trees are small.
+              children = await Promise.all(subs.map(async (s) => {
+                let hasOpenChildren = false
+                if (s.state === 'open') {
+                  try {
+                    const g = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
+                      { ...context.repo, issue_number: s.number, per_page: 100 })
+                    hasOpenChildren = g.some((x) => x.state === 'open')
+                  } catch (e) { core.warning(`grandchild probe #${s.number}: ${e.message}`) }
+                }
+                return { number: s.number, state: s.state, body: s.body || '', hasOpenChildren }
+              }))
+            } catch (e) {
+              // Fail OPEN into normal classification — a gather glitch must not stop the pipeline.
+              core.warning(`sub-issue gather failed (${e.message}) — classifying normally.`)
+            }
+            require('fs').writeFileSync(`${process.env.RUNNER_TEMP}/sub-issues.json`, JSON.stringify(children))
+            core.info(`sub-issues: ${children.length} (${children.filter(c => c.state === 'open').length} open)`)
+      - name: Resume an already-decomposed tree
+        id: resume
+        run: node scripts/resume-decomposed.mjs < "$RUNNER_TEMP/sub-issues.json"
+
+      - name: Dispatch the open children
+        if: ${{ steps.resume.outputs.resume == '1' }}
+        uses: actions/github-script@v7
+        env:
+          DISPATCH: ${{ steps.resume.outputs.dispatch }}
+          REASON: ${{ steps.resume.outputs.reason }}
+          ISSUE_NUMBER: ${{ inputs.issue || github.event.issue.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER)
+            const pairs = String(process.env.DISPATCH || '').split(',').filter(Boolean)
+              .map((p) => { const [n, label] = p.split(':'); return { number: Number(n), label } })
+            const done = []
+            for (const { number, label } of pairs) {
+              // Fire a FRESH `labeled` event — the workers trigger on the label being ADDED,
+              // never on it merely being present, so a re-dispatch must remove it first.
+              try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: number, name: label }) } catch (e) {}
+              await github.rest.issues.addLabels({ ...context.repo, issue_number: number, labels: [label] })
+              done.push(`#${number} → \`${label}\``)
+            }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            await github.rest.issues.createComment({ ...context.repo, issue_number, body:
+              `🌳 **Already decomposed — resumed the tree instead of re-planning it.**\n\n`
+              + (done.length ? `Dispatched: ${done.join(' · ')}\n\n` : `Nothing dispatchable right now — every open child is waiting on a sibling.\n\n`)
+              + `_${process.env.REASON}_\n\n`
+              + `<sub>🤖 pi.dev harness (CI · mac-mini) · resume-decomposed #2048 · <a href="${runUrl}">run log</a></sub>` })
+            core.info(`Resumed #${issue_number}: ${done.join(', ') || '(all blocked)'}`)
+
+      # Everything below is the CLASSIFY path — skipped entirely once the tree was
+      # resumed (#2048), so a decomposed epic costs a few API calls instead of an
+      # install, a package warm and an eleven-minute pi run that cannot succeed.
       - uses: pnpm/action-setup@v4
+        if: ${{ steps.resume.outputs.resume != '1' }}
         with:
           # per-job dest — the default ~/setup-pnpm collides between the two
           # self-hosted runners on the mac mini box (ENOTEMPTY, #1255)
           dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v4
+        if: ${{ steps.resume.outputs.resume != '1' }}
         with:
           node-version: 22
           cache: pnpm
       - name: Install
+        if: ${{ steps.resume.outputs.resume != '1' }}
         run: pnpm install --frozen-lockfile
 
       # Warm @fyit/* dist so the agent's `crouton init`/generate/migrate doesn't cold-build
       # ~30 packages one-at-a-time mid-run (the #1213/#1247 tax — ~15-20 min). Content-addressed
       # cache + build-all on miss; a warm cache makes this ~seconds. (#1222)
       - name: Warm @fyit package builds
+        if: ${{ steps.resume.outputs.resume != '1' }}
         uses: ./.github/actions/warm-packages
 
       # Timestamp the run start so the artifact-gate distinguishes "produced this run"
@@ -204,6 +285,7 @@ jobs:
       # the worker PR) act as the Harness App and cascade. ANTHROPIC_API_KEY = the
       # funded metered key (NOT a subscription — subscription OAuth must not back CI).
       - id: pi
+        if: ${{ steps.resume.outputs.resume != '1' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -245,7 +327,7 @@ jobs:
             cat >> "$PROMPT_FILE" <<'PI_ED'
           EVENT-DRIVEN DECOMPOSE — PLAN ONLY. You are the task-decomposer. Do NOT run `/task-decompose`, do NOT spawn any subagent, and do NOT run any `gh`, `git`, or issue-mutating command. Your ONLY output is a plan file that a deterministic step will apply. Concretely:
           1. READ the target issue (use `gh issue view` to read only — reading is fine, mutating is not).
-          2. Apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, one focused run.
+          2. Apply the LEAF TEST: single coherent change, bounded file set, clear/testable acceptance, one focused run. AN ISSUE THAT ALREADY HAS OPEN SUB-ISSUES IS NEVER A LEAF (#2048) — its children ARE the decomposition, and `gh issue view` does NOT list them, so check explicitly before you judge. (A deterministic step normally intercepts this case before you are invoked; if you are seeing it anyway, that step failed open — emit a split plan for the remaining open children rather than {"leaf": true}.)
           3. Using your file-writing tool (NOT a shell heredoc — bodies contain emoji/backticks and shell quoting breaks, #1001), write a file named exactly `decompose-plan.json` in the current working directory, as valid JSON — ONE of these three shapes:
              - Single leaf: {"leaf": true}
              - Split: {"leaf": false, "children": [ {"title": "...", "body": "...markdown with ## 👤 For humans / ## 🤖 For agents / ## 🧪 How to test...", "labels": ["type:...","<component>"], "needsSplit": false, "blockedBy": []}, ... ]} — 2 to 6 children, one coherent concern each. Set needsSplit=true for a child that itself still needs decomposing, false for a ready leaf. Exactly one `type:*` label plus a real component label per child (unknown labels are dropped). Do NOT put a pipeline block or Dedup line in the body.
@@ -295,7 +377,7 @@ jobs:
       # .github/labels.yml, creates + links (sub-issues API) + labels each child. A missing/empty
       # plan is a loud, honest failure the artifact-gate then reports.
       - name: Apply decompose plan
-        if: ${{ env.PIPELINE_MODE == 'event-driven' }}
+        if: ${{ env.PIPELINE_MODE == 'event-driven' && steps.resume.outputs.resume != '1' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -399,7 +481,10 @@ jobs:
               + `<sub>🤖 pi.dev harness (CI · mac-mini) · claim guard #1890 · <a href="${runUrl}">run log</a></sub>` })
 
       - name: Artifact-gate — fail if the agent produced nothing
-        if: ${{ always() && steps.claim.outcome != 'failure' }}
+        # Also skipped on a resumed tree (#2048): that path reports its own
+        # deliverable, and its comment lands BEFORE t0 so the since-t0 scan
+        # would never see it and would false-fail a successful run.
+        if: ${{ always() && steps.claim.outcome != 'failure' && steps.resume.outputs.resume != '1' }}
         uses: actions/github-script@v7
         env:
           PI_EXEC_LOG: ${{ steps.pi.outputs.exec_log }}

--- a/scripts/approval.mjs
+++ b/scripts/approval.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// approval.mjs — is this comment an APPROVAL? One definition, used everywhere (#2051).
+//
+// WHY THIS IS ITS OWN MODULE. `lgtm` was matched by a bare `/\b(approve|approved|lgtm)\b/i`
+// in two places in resume-on-comment.yml. That is the #2004 bug in a new costume — the
+// pattern is unanchored and blind to Markdown, so "I wouldn't lgtm this yet", a quoted
+// `` `lgtm` ``, and a `>`-quote of someone else's approval all match. On the dispatch side
+// that mis-fired a pipeline; here it would RELEASE CODE FOR MERGE, so the same bug is
+// strictly more expensive. Two copies of a rule is one rule and one liability (#2027).
+//
+// WHY ✅ AND NOT A REACTION. GitHub raises NO webhook event for reactions, so nothing can
+// listen to one — settled in #572 after a 👍 silently did nothing. A ✅ typed as a COMMENT
+// is a real `issue_comment` event. This is the same reasoning that made the dispatch
+// gesture a rocket line rather than the phrase "pick this up".
+
+import { pathToFileURL } from 'node:url'
+import { stripNonCommandRegions } from './comment-command.mjs'
+
+/**
+ * A line that is NOTHING BUT check marks means "approved".
+ *
+ * Whole-line, like the rocket: `✅ nice work, but change X first` must NOT approve, and a
+ * stray ✅ in prose ("✅ shipped the other one") is common enough to matter. Accepts the
+ * three check emoji a phone keyboard actually offers, each with an optional variation
+ * selector (U+FE0F) — ✔️ and ☑️ are normally typed WITH it and ✅ normally without, and a
+ * pattern that assumed either way would reject half the real inputs.
+ *
+ * Unlike 🚀 these are BMP code points, so `u` is not load-bearing here the way it was for
+ * the rocket (#2010) — it is kept for consistency and because ️ handling is clearer
+ * under it.
+ */
+const CHECK_ONLY_LINE = /^[ \t]*(?:[✅✔☑]️?[ \t]*)+$/mu
+
+/** The word form. Kept because it is written into issue bodies and skills across the repo. */
+const APPROVAL_WORD = /^[ \t]*(?:lgtm|approved?)\b|(?<![\w-])(?:lgtm|approved?)(?![\w-])/im
+
+/**
+ * Is `body` an approval?
+ *
+ * Code spans, fenced blocks and `>` quotes are stripped FIRST, so a comment that merely
+ * *discusses* approving — or quotes someone else's — never approves.
+ *
+ * @param {string} body Raw Markdown of the comment.
+ * @returns {boolean}
+ */
+export function isApproval(body) {
+  const text = stripNonCommandRegions(String(body || ''))
+  if (CHECK_ONLY_LINE.test(text)) return true
+  return APPROVAL_WORD.test(text)
+}
+
+/** Which form was used — for the acknowledgement, so the reply mirrors the gesture. */
+export function approvalKind(body) {
+  const text = stripNonCommandRegions(String(body || ''))
+  if (CHECK_ONLY_LINE.test(text)) return 'check'
+  if (APPROVAL_WORD.test(text)) return 'word'
+  return null
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────────
+//   node scripts/approval.mjs "<comment body>"   → exit 0 if approval, 1 if not
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  const ok = isApproval(process.argv.slice(2).join(' '))
+  console.log(ok ? `approval (${approvalKind(process.argv.slice(2).join(' '))})` : 'not an approval')
+  process.exit(ok ? 0 : 1)
+}

--- a/scripts/approval.test.mjs
+++ b/scripts/approval.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * #2051 contract — what counts as an approval.
+ *
+ * A false positive here RELEASES CODE FOR MERGE, so the discussing-vs-issuing distinction
+ * matters more than it did for dispatch (#2004), where the cost was a mis-fired pipeline.
+ *
+ *   node --test scripts/approval.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isApproval, approvalKind } from './approval.mjs'
+
+// ── the check gesture ─────────────────────────────────────────────────────────
+test('a line of only check marks approves', () => {
+  assert.equal(isApproval('✅'), true)
+  assert.equal(isApproval('✅✅'), true)
+  assert.equal(isApproval('✅ ✅ ✅'), true)
+  assert.equal(approvalKind('✅'), 'check')
+})
+
+test('the other check emoji a phone keyboard offers also work, with or without VS16', () => {
+  assert.equal(isApproval('✔️'), true)
+  assert.equal(isApproval('✔'), true)
+  assert.equal(isApproval('☑️'), true)
+})
+
+test('a check line inside a longer comment still approves — but only if it is its own line', () => {
+  assert.equal(isApproval('Looks good to me.\n\n✅'), true)
+})
+
+test('a check with prose on the same line does NOT approve', () => {
+  // "✅ but change X first" is a change request wearing a tick.
+  assert.equal(isApproval('✅ but fix the spacing first'), false)
+  assert.equal(isApproval('✅ shipped the other one'), false)
+})
+
+// ── the word form ─────────────────────────────────────────────────────────────
+test('the word forms still approve', () => {
+  assert.equal(isApproval('lgtm'), true)
+  assert.equal(isApproval('LGTM!'), true)
+  assert.equal(isApproval('approve'), true)
+  assert.equal(isApproval('approved, thanks'), true)
+  assert.equal(approvalKind('lgtm'), 'word')
+})
+
+// ── the #2004 class: discussing is not issuing ────────────────────────────────
+test('a quoted lgtm in a code span does NOT approve', () => {
+  assert.equal(isApproval('reply with `lgtm` to release it'), false)
+})
+
+test('a fenced block mentioning lgtm does NOT approve', () => {
+  assert.equal(isApproval('```\nRULES: reply lgtm to approve\n```'), false)
+  assert.equal(isApproval('~~~\napproved\n~~~'), false)
+})
+
+test('a > quote of someone else approving does NOT approve', () => {
+  assert.equal(isApproval('> lgtm\n\nI disagree, hold on.'), false)
+})
+
+test('a table cell documenting the gesture does NOT approve', () => {
+  // The exact shape that mis-fired the dispatcher on #1791 — an explanation of the
+  // mechanism, posted on the very thread the mechanism watches.
+  assert.equal(isApproval('| Approval signal | `lgtm` |\n|---|---|'), false)
+})
+
+test('lgtm as part of a bigger word does not approve', () => {
+  assert.equal(isApproval('lgtmm'), false)
+  assert.equal(isApproval('not-lgtm'), false)
+  assert.equal(isApproval('disapproved'), false)
+})
+
+// ── negatives that must stay negative ─────────────────────────────────────────
+test('ordinary review prose does not approve', () => {
+  assert.equal(isApproval('can you add a test for the empty case?'), false)
+  assert.equal(isApproval('👍'), false)          // a thumbs-up is not the gesture
+  assert.equal(isApproval('🚀'), false)          // that is the DISPATCH gesture, not approval
+  assert.equal(isApproval(''), false)
+  assert.equal(isApproval(null), false)
+  assert.equal(isApproval(undefined), false)
+})
+
+test('"I would not lgtm this yet" is the sentence that must never approve', () => {
+  // The one that would be caught by the old bare /\blgtm\b/i and merge unreviewed code.
+  // It is a plain sentence — no code span to strip — so the word form DOES match it.
+  // Recorded as a KNOWN LIMIT rather than pretended away: the check gesture is the safe
+  // signal, and this is the argument for preferring it.
+  assert.equal(isApproval('I would not lgtm this yet'), true)
+})

--- a/scripts/comment-command.mjs
+++ b/scripts/comment-command.mjs
@@ -24,7 +24,7 @@
  * `> 🤖 …` provenance header, and quoting somebody else's dispatch is a normal thing to
  * do in a thread. Neither should re-fire the pipeline.
  */
-function stripNonCommandRegions(body) {
+export function stripNonCommandRegions(body) {
   return body
     // Fenced blocks first — their content may contain backticks that would otherwise
     // confuse the inline-span pass.

--- a/scripts/resume-decomposed.mjs
+++ b/scripts/resume-decomposed.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// resume-decomposed.mjs — an issue that is ALREADY decomposed is not a leaf (#2048).
+//
+// THE BUG THIS CLOSES. The decomposer's LEAF TEST is applied to the issue's *prose*
+// ("single coherent change, bounded file set, …") and never to its *sub-issues* — and
+// step 1 of the prompt reads the issue with `gh issue view`, which does not list them.
+// So epic #515, which has three open, ready children (#516/#517/#518), was classified
+// as a single leaf and labelled `work-this`. The single-leaf worker then spent eleven
+// minutes trying to implement an entire epic on one branch, produced nothing, and the
+// owner was paged about a pipeline doing exactly what it was told.
+//
+// WHY THIS IS DETERMINISTIC AND NOT A PROMPT LINE. "Does this issue have open children"
+// is a lookup, not a judgement. Asking a probabilistic runtime to re-derive a fact the
+// API answers directly is how the fact gets ignored. The same state was already being
+// paginated twice elsewhere in the very same workflow (the artifact-gate's #1074 child
+// -deliverable scan) — just too late to affect the decision. So: check first, and only
+// fall through to the LLM classification when there is genuinely nothing to resume.
+//
+// The correct behaviour for an already-decomposed tree is "resume the tree, work the
+// remaining open leaves" — a deliverable the artifact-gate already understands (#1074).
+
+import { pathToFileURL } from 'node:url'
+import { appendFileSync, readFileSync } from 'node:fs'
+// Both are already the tested source of truth for these two facts — the trigger label the
+// worker fires on, and the `Blocked-by: #NN` body format. Importing beats restating them.
+import { WORKER_TRIGGER } from './pipeline-loop-guard.mjs'
+import { parseBlockedBy } from './apply-decompose-plan.mjs'
+
+/**
+ * Which of an already-decomposed issue's children should be dispatched now?
+ *
+ * @param {Array} children  `[{ number, state, body?, hasOpenChildren? }]` — the target's
+ *                          sub-issues, as returned by the sub_issues API.
+ * @returns {{ resume: boolean, dispatch: Array<{number:number,label:string}>, waiting:number[], reason:string }}
+ *
+ * `resume:false` means "not decomposed — classify normally". That covers BOTH an issue
+ * with no children at all and one whose children are ALL CLOSED (a finished tree is not
+ * a tree to resume; the issue may legitimately have new leaf work).
+ */
+export function planResume(children = []) {
+  const kids = (children || []).filter(Boolean)
+  const open = kids.filter((c) => c.state === 'open')
+  if (!open.length) {
+    return {
+      resume: false,
+      dispatch: [],
+      waiting: [],
+      reason: kids.length
+        ? `all ${kids.length} sub-issue(s) are closed — nothing to resume`
+        : 'no sub-issues — not decomposed',
+    }
+  }
+
+  // A child waits until every blocker it names is closed (#1750). Blockers are issue
+  // NUMBERS in the child's body (`Blocked-by: #NN`), unlike a plan's sibling indices.
+  const closed = new Set(kids.filter((c) => c.state === 'closed').map((c) => c.number))
+  const openNumbers = new Set(open.map((c) => c.number))
+  const dispatch = []
+  const waiting = []
+  for (const c of open) {
+    const blockers = parseBlockedBy(c.body || '')
+    // Only a blocker that is still OPEN holds a child back. A blocker outside this tree
+    // (or already gone) must not wedge it — an unresolvable reference would otherwise
+    // park the child forever with nothing to close it.
+    const live = blockers.filter((n) => openNumbers.has(n) && !closed.has(n))
+    if (live.length) { waiting.push(c.number); continue }
+    // A child that is itself decomposed needs the decomposer again, not a code worker.
+    dispatch.push({ number: c.number, label: c.hasOpenChildren ? 'delegate-pi' : WORKER_TRIGGER })
+  }
+
+  return {
+    resume: true,
+    dispatch,
+    waiting,
+    reason: dispatch.length
+      ? `already decomposed — resuming ${dispatch.length} of ${open.length} open child(ren)`
+      : `already decomposed — all ${open.length} open child(ren) are blocked by siblings`,
+  }
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────────
+//   node scripts/resume-decomposed.mjs < children.json
+// children.json is the sub_issues array (with `body`), gathered by the workflow.
+// Prints `resume=<0|1>`, `dispatch=<n:label,...>` and `reason=<text>` to $GITHUB_OUTPUT.
+function main() {
+  let children = []
+  try {
+    const raw = readFileSync(0, 'utf8').trim()
+    children = raw ? JSON.parse(raw) : []
+  } catch (err) {
+    // Fail OPEN into normal classification: a gather glitch must not stop the pipeline.
+    console.log(`::warning::resume-decomposed could not read its input (${err.message}) — classifying normally.`)
+    return
+  }
+  const v = planResume(children)
+  console.log(`resume-decomposed: ${v.reason}`)
+  if (v.waiting.length) console.log(`  waiting on siblings: ${v.waiting.map((n) => `#${n}`).join(', ')}`)
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, [
+      `resume=${v.resume ? 1 : 0}`,
+      `dispatch=${v.dispatch.map((d) => `${d.number}:${d.label}`).join(',')}`,
+      `reason=${v.reason.replace(/[\r\n]+/g, ' ')}`,
+      '',
+    ].join('\n'))
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) main()

--- a/scripts/resume-decomposed.test.mjs
+++ b/scripts/resume-decomposed.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * #2048 contract — an already-decomposed issue is never a leaf.
+ *
+ * The case that minted this: epic #515 had three open, ready children (#516/#517/#518)
+ * and was classified as a single leaf, so the single-leaf worker spent eleven minutes
+ * on an epic and produced nothing. The classification never looked at the sub-issues.
+ *
+ *   node --test scripts/resume-decomposed.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { planResume } from './resume-decomposed.mjs'
+
+const open = (number, body = '') => ({ number, state: 'open', body })
+const closed = (number, body = '') => ({ number, state: 'closed', body })
+
+test('the real #515 shape resumes instead of classifying', () => {
+  const v = planResume([open(516), open(517), open(518)])
+  assert.equal(v.resume, true)
+  assert.deepEqual(v.dispatch.map(d => d.number), [516, 517, 518])
+  assert.ok(v.dispatch.every(d => d.label === 'work-this'))
+})
+
+test('no sub-issues → classify normally (the common case must not regress)', () => {
+  const v = planResume([])
+  assert.equal(v.resume, false)
+  assert.equal(v.dispatch.length, 0)
+  assert.match(v.reason, /not decomposed/)
+})
+
+test('a FINISHED tree classifies normally — a closed tree is not a tree to resume', () => {
+  // Otherwise an epic whose children all merged could never take new leaf work.
+  const v = planResume([closed(516), closed(517)])
+  assert.equal(v.resume, false)
+  assert.match(v.reason, /closed/)
+})
+
+test('a partially-finished tree resumes only what is still open', () => {
+  const v = planResume([closed(516), open(517), open(518)])
+  assert.equal(v.resume, true)
+  assert.deepEqual(v.dispatch.map(d => d.number), [517, 518])
+})
+
+test('a child blocked by an OPEN sibling waits (#1750 ordering is respected)', () => {
+  const v = planResume([open(516), open(517, 'Blocked-by: #516')])
+  assert.deepEqual(v.dispatch.map(d => d.number), [516])
+  assert.deepEqual(v.waiting, [517])
+})
+
+test('a child whose blocker has CLOSED is dispatched', () => {
+  const v = planResume([closed(516), open(517, 'Blocked-by: #516')])
+  assert.deepEqual(v.dispatch.map(d => d.number), [517])
+  assert.deepEqual(v.waiting, [])
+})
+
+test('a blocker OUTSIDE this tree does not wedge the child forever', () => {
+  // Nothing in this tree can ever close #999, so treating it as live would park the
+  // child permanently with no event able to release it.
+  const v = planResume([open(517, 'Blocked-by: #999')])
+  assert.deepEqual(v.dispatch.map(d => d.number), [517])
+})
+
+test('a child that is itself decomposed goes back to the DECOMPOSER, not a code worker', () => {
+  const v = planResume([{ ...open(517), hasOpenChildren: true }, open(518)])
+  assert.equal(v.dispatch.find(d => d.number === 517).label, 'delegate-pi')
+  assert.equal(v.dispatch.find(d => d.number === 518).label, 'work-this')
+})
+
+test('an all-blocked tree still reports resume=true — it must not fall through to the LEAF TEST', () => {
+  // This is the subtle one: "nothing to dispatch right now" is NOT "this is a leaf".
+  // Falling through here would recreate the exact #515 bug on a cycle-free but fully
+  // serialised tree.
+  const v = planResume([open(516, 'Blocked-by: #517'), open(517, 'Blocked-by: #516')])
+  assert.equal(v.resume, true)
+  assert.equal(v.dispatch.length, 0)
+  assert.deepEqual(v.waiting, [516, 517])
+})
+
+test('null/garbage entries are tolerated, not thrown on', () => {
+  assert.equal(planResume([null, undefined, open(516)]).dispatch.length, 1)
+  assert.equal(planResume(undefined).resume, false)
+})


### PR DESCRIPTION
Closes #2051

## 👤 Humans

You asked whether approval could be a check icon instead of `lgtm`. Two answers:

**A reaction can't work.** GitHub raises no webhook event for reactions, so nothing can listen to one — settled in #572 after a 👍 silently did nothing. But **✅ typed as a comment** is a real event and works exactly like the 🚀 dispatch gesture.

**And `lgtm` wasn't working either.** You already commented `lgtm` on #2039 and #2041 — I found both while scanning real comments. Nothing happened, because nothing was listening.

After this: comment **✅** on a held draft PR and it goes ready for review.

## 🤖 Agents

### The hold worked; its release was never asserted

The UI gate opens a `.vue`-touching PR as a draft whose body says *"reply `lgtm` to release it"*. Neither route reached anything:

| Route | Why it did nothing |
|---|---|
| on the **PR** | every approval workflow starts with `!github.event.issue.pull_request` — `resume-on-comment`, `close-epic-on-comment`, `comment-dispatch`. PR comments are excluded by design. |
| on the **issue** | `resume-on-comment` also requires `status:blocked`; the draft gate never set it. |

Four PRs held with no key, releasable only by hand-clicking "Ready for review" — the exact mobile friction the gate exists to remove. The `markPullRequestReadyForReview` mutation already existed at `resume-on-comment.yml:280`; it was simply unreachable from here.

This is the `AGENTS.md` question — *can this path exit 0 having done nothing?* — applied to a **hold**. I shipped the draft flag last night without checking anything could undo it.

### One tested matcher

`lgtm` was matched by a bare `/\b(approve|approved|lgtm)\b/i` in two places. That's #2004 in a costume — unanchored, blind to Markdown, so a quoted `` `lgtm` `` matches. On the dispatch side that mis-fired a pipeline; **here it would release code for merge**, so the same bug is strictly more expensive.

`scripts/approval.mjs` strips code spans, fences and `>` quotes first (reusing `comment-command.mjs`'s helper rather than a second copy — the #2027 lesson).

### The gesture

Whole-line, like the rocket: `✅`, `✅✅`, also `✔️`/`☑️` with or without the variation selector (phone keyboards differ). `✅ but fix the spacing first` is a change request wearing a tick and must not release anything.

**It does not merge.** It only un-drafts; the green-gated auto-merge takes over, so a red check still holds the PR.

## Verification

**12 unit tests — and the corpus run, which is the real check.** Replayed over **45 genuine comments** from the four held PRs plus #1791/#1641:

```
WOULD APPROVE  #2039 pmcp :: lgtm
WOULD APPROVE  #2041 pmcp :: lgtm
scanned 45 real comments → 2 would approve
```

Exactly the two real approvals. Every comment that merely *quotes* the word is ignored — including this repo's own `` reply `lgtm` to release it `` instructions, which appear on those same threads and would have fired the old matcher.

`fallow audit --base origin/main` clean; the `comment-command` suite still passes (46 total) after exporting its strip helper.

## ⚠️ Known limit, not papered over

`"I would not lgtm this yet"` still matches the word form. It's a plain sentence with no code span to strip. I left the word semantics **unchanged** rather than bolting a negation heuristic onto a gate that merges code — a wrong refusal costs too, and the corpus of real approvals is small. It's recorded in a test that asserts the current behaviour, and it's the argument for ✅ being the primary gesture.

Also unverified: the workflow itself runs only on CI. The first ✅ after merge is the real test.

## 🧪 How to test

1. Comment `✅` on #2039 → leaves draft, CI runs, auto-merge takes over.
2. Comment ``I wouldn't `lgtm` this yet`` → nothing happens.
3. Comment `✅ nice, but change X` → nothing; the line must be only checks.
4. A bot or non-collaborator comment → never approves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_