### PR TITLE
fix(root): attach the log tail on the path where it is the only evidence

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -574,10 +574,28 @@ jobs:
                   // detections above; on the worker twin that guess sent the owner to rewrite two
                   // well-specified tickets while the actual bug was in the workflow's own shell.
                   why = 'pi ran to completion but no PR, sub-issues, or sign-off hold appeared — and none of the known causes matched'
-                  action = 'open the run log before changing anything. Only if the log shows pi genuinely had nothing to act on is the issue underspecified'
+                  action = 'read the log tail below first — it is what pi actually said. Only if it shows pi genuinely had nothing to act on is the issue underspecified'
+                  // ATTACH THE TAIL HERE ABOVE ALL (#2065). This branch means "I cannot explain
+                  // this run", and it was the ONLY branch that withheld the log — while sitting
+                  // inside `if (exists(logFile))`, so the log was read and then dropped. Three
+                  // alarms (#2055/#2056/#2058) were undiagnosable from outside the runner for
+                  // exactly this reason, each telling the owner to "open the run log" while the
+                  // relevant slice of it sat in `tail`.
+                  if (tail.trim()) detail = tail.trim()
                 }
               }
             } catch (e) { core.warning(`artifact-gate: could not read pi run log: ${e.message}`) }
+
+            // No log at all (#2065). "Open the run log" is misleading advice when the run
+            // never wrote one — and an empty PI_EXEC_LOG is itself evidence: the harness
+            // stopped before pi produced any output. Distinguish the two situations.
+            let hadLog = false
+            try { hadLog = Boolean(process.env.PI_EXEC_LOG) && fs.existsSync(process.env.PI_EXEC_LOG) } catch (e) { hadLog = false }
+            if (!why && !hadLog) {
+              why = 'pi produced NO run log at all — the harness stopped before pi wrote any output'
+              action = 'do not edit the issue. Open the run log and read the steps BEFORE the agent step; '
+                + 'an absent `PI_EXEC_LOG` means the failure is upstream of pi, in the workflow'
+            }
 
             // Fallback when the log is unreadable but the step itself failed.
             if (!why && failed) {

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -846,13 +846,21 @@ jobs:
                   // The finish step failed but pushed nothing — still a harness fault, not the ticket.
                   why = 'the finish step failed before it could commit anything'
                   action = 'open the run log at the `finish` step — a workflow bug, not an underspecified issue'
+                  if (tail.trim()) detail = tail.trim()
                 } else {
                   // LAST RESORT — no known cause matched. Say exactly that (#1876). The old text
                   // asserted "the issue is likely underspecified", which is a GUESS printed in the
                   // same confident voice as the real detections above; it sent the owner to rewrite
                   // two well-specified tickets while the actual bug was in this workflow.
                   why = 'pi ran to completion but no PR, sub-issues, or sign-off hold appeared — and none of the known causes matched'
-                  action = 'open the run log before changing anything. Only if the log shows pi genuinely had nothing to act on is the issue underspecified'
+                  action = 'read the log tail below first — it is what pi actually said. Only if it shows pi genuinely had nothing to act on is the issue underspecified'
+                  // ATTACH THE TAIL HERE ABOVE ALL (#2065). This branch means "I cannot explain
+                  // this run", and it was the ONLY branch that withheld the log — while sitting
+                  // inside `if (exists(logFile))`, so the log was read and then dropped. Three
+                  // alarms (#2055/#2056/#2058) were undiagnosable from outside the runner for
+                  // exactly this reason, each telling the owner to "open the run log" while the
+                  // relevant slice of it sat in `tail`.
+                  if (tail.trim()) detail = tail.trim()
                 }
               }
             } catch (e) { core.warning(`artifact-gate: could not read pi run log: ${e.message}`) }
@@ -875,6 +883,17 @@ jobs:
             if (!why && process.env.PI_LEFT_DIRTY === '1') {
               why = 'the deterministic finish step could not persist pi\'s edits — the working tree is still dirty (#1764)'
               action = 'open the run log for the finish step git error; not an underspecified issue (see #1764)'
+            }
+
+            // No log at all (#2065). "Open the run log" is misleading advice when the run
+            // never wrote one — and an empty PI_EXEC_LOG is itself evidence: the harness
+            // stopped before pi produced any output. Distinguish the two situations.
+            let hadLog = false
+            try { hadLog = Boolean(process.env.PI_EXEC_LOG) && fs.existsSync(process.env.PI_EXEC_LOG) } catch (e) { hadLog = false }
+            if (!why && !hadLog) {
+              why = 'pi produced NO run log at all — the harness stopped before pi wrote any output'
+              action = 'do not edit the issue. Open the run log and read the steps BEFORE the agent step; '
+                + 'an absent `PI_EXEC_LOG` means the failure is upstream of pi, in the workflow'
             }
 
             // Fallback when the log is unreadable but the step itself failed.


### PR DESCRIPTION
Closes #2065

## 👤 Humans

You got three more *"this run produced nothing — none of the known causes matched"* alarms this morning. Each one told you to open the run log. Each one had already **read** the relevant slice of that log and thrown it away.

Now that slice is in the comment.

## 🤖 Agents

The gate reads pi's log, runs a chain of regexes, and attaches the tail on exactly one branch:

```js
} else if (failed) {
  why = 'the pi agent step errored before it built anything'
  if (tail.trim()) detail = tail.trim()          // ← attached ONLY here
} else if (FINISH_OUTCOME === 'failure') { … }   // no detail
} else {
  why = '… none of the known causes matched'     // ← the "I don't know" branch. No detail.
}
```

**The one branch meaning "I cannot explain this run" was the only one withholding the explanation** — and it lives inside `if (exists(logFile))`, so reaching it *proves* the log was read. `tail` (last 600 chars) is computed two lines above.

### The run that made this concrete

[Run 31084971583](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/31084971583) on #2055 — the gate's own env:

```
PI_EXEC_LOG:       decompose-pidev-exec-31084971583.log
CLAUDE_CONCLUSION: success     ← pi exited cleanly
PI_LEFT_DIRTY:     0           ← it edited nothing at all
FINISH_OUTCOME:    success
```

pi ran **84 seconds**, changed zero files, exited 0. Not a crash, not the claim guard, not out of credit. I could not diagnose it from outside the runner — and neither could you — because the only artifact that could say why was discarded by the message telling us to go find it.

### Changes

1. `detail` attached on the unknown-cause branch in **both** pi workflows, and on `work-issue-pidev`'s finish-failure branch.
2. **A new explicit branch for "no log at all".** An absent `PI_EXEC_LOG` is itself evidence — the harness stopped before pi ran — so "open the run log" is actively misleading. It now says to read the steps *before* the agent step.

### What this deliberately does not do

**No new regex buckets.** That treadmill is what this replaces: the goal is to make an *unrecognised* failure diagnosable, not to keep enumerating recognised ones. The 600-char cap and collapsed `<details>` stay, so the comment remains phone-readable (#1336).

## Verification

Both workflows YAML-validated; `fallow audit --base origin/main` clean. Verified by reading the gate source that `tail` is in scope at every branch it is now attached to.

## ⚠️ Not verified

The gate runs only in CI, so the rendered comment is unverified — the next no-op run is the real test. Specifically worth checking: that the tail is non-empty in practice on the unknown-cause path (if pi's log is genuinely empty, the new no-log branch should catch it first and this one should never be reached).

**This does not explain #2055.** It makes the *next* #2055 explainable. The three alarms remain open and undiagnosed; my one hypothesis — that #2056/#2058 target `.github/workflows/**`, which the pi token cannot write — does **not** cover #2055, which targets `scripts/app-shots.mjs` and is perfectly writable. I'd rather say that than dress a partial theory as the cause.

## 🧪 How to test

Dispatch an issue whose work is already done, so pi exits 0 having edited nothing. The alarm should carry a collapsed `log tail` section showing what pi actually said.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_