### PR TITLE
fix(root): make a review preview actually serve the review overlay

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -248,6 +248,15 @@ jobs:
           # BETTER_AUTH_* are only needed by the prerender pass at build time.
           BETTER_AUTH_SECRET: prerender-placeholder
           BETTER_AUTH_URL: ${{ inputs.environment == 'production' && inputs['production-url'] || inputs['staging-url'] }}
+          # REVIEW OVERLAY (#2070) — set HERE, not in each app's cf:staging script.
+          # The flag existed only in the CLI's scaffold template (scaffold-app.ts), so the
+          # three apps that predate it never had it: 0 of 3. The bridge-wiring steps below
+          # would then push their secrets to a Worker serving no overlay, the deploy would
+          # succeed, and every "walk the preview" ask had nothing behind it (#2037 sat
+          # unrunnable for weeks on exactly this). One place, so it cannot drift per app.
+          # Gated on `review-pr`: an ordinary staging deploy is the trunk preview and must
+          # stay overlay-free — and the bridge needs a PR to post to anyway.
+          NUXT_PUBLIC_CROUTON_REVIEW: ${{ (inputs.environment == 'staging' && inputs['review-pr'] != '') && 'true' || '' }}
         run: |
           set -o pipefail
           PR_NUM="${{ github.event.pull_request.number }}"
@@ -405,6 +414,29 @@ jobs:
           npx wrangler secret bulk "$RUNNER_TEMP/review-secrets.json" --env staging
           rm -f "$RUNNER_TEMP/review-secrets.json"
           echo "✓ Wired preview-review bridge → PR #$PR on $REPOSITORY (posts as nuxt-harness[bot])"
+
+      # ── PROVE the overlay is actually there (#2070) ─────────────────────────────
+      # Wiring the bridge's secrets says nothing about whether the deployed build SERVES
+      # the overlay — and for two years it didn't, silently: deploy green, secrets set,
+      # `/api/_review` 404, every "walk the preview" link inert. Same class as #2045's
+      # blank screenshot: an artifact that looks like a deliverable and isn't. Probe the
+      # live URL and FAIL, so a preview that can't be reviewed never gets handed over as
+      # one. Report-only would just re-create the silence.
+      - name: Verify the review overlay is live
+        if: ${{ inputs.environment == 'staging' && inputs['review-pr'] != '' }}
+        env:
+          URL: ${{ steps.deploy.outputs.url || inputs['staging-url'] }}
+        run: |
+          set -o pipefail
+          [ -z "$URL" ] && { echo "::error::review deploy has no URL to probe"; exit 1; }
+          code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$URL/api/_review" || echo 000)"
+          if [ "$code" = "404" ] || [ "$code" = "000" ]; then
+            echo "::error::The review overlay is NOT live at $URL (/api/_review → $code)."
+            echo "::error::This preview cannot be reviewed — do not hand out the link. Check that"
+            echo "::error::NUXT_PUBLIC_CROUTON_REVIEW reached the build (#2070)."
+            exit 1
+          fi
+          echo "✓ review overlay live at $URL (/api/_review → $code)"
 
       # Guarantee a new app can AUTHENTICATE on first deploy with ZERO per-app setup.
       # A freshly provisioned Worker has no secrets, so member login 500s with


### PR DESCRIPTION
Closes #2070

## 👤 Humans

Every *"walk the preview"* ask you've had has been unwalkable. No existing app could serve a review overlay, and nothing anywhere said so — the deploy went green, the bridge secrets were written, and the link did nothing.

Measured against live staging before this change:

```
https://velo.pmcp.dev             → 200   (app is up)
https://velo.pmcp.dev/api/_review → 404   (bridge absent)
```

## 🤖 Agents

### Why no app had it

`NUXT_PUBLIC_CROUTON_REVIEW=true` lives in **`crouton-cli/lib/scaffold-app.ts:168`** — the template for **new** apps. velo, kassa and triage all predate it: **0 of 3** have it in `cf:staging`.

And `deploy-app.yml`'s own comment says the overlay is turned on "at build" — but it never set the variable. It relied on the app script that doesn't have it. The comment described behaviour that existed for no current app.

### 1 · Set it once, in the workflow

Gated on `review-pr`, at the deploy step's `env`. **Deliberately not backfilled into the three apps' `cf:staging`** — three copies of a flag that must agree is exactly how this happened.

Ordinary staging deploys stay overlay-free: shared staging is the trunk preview, and the bridge needs a PR to post to anyway.

### 2 · Prove it, don't assume it

Wiring the bridge's secrets says nothing about whether the *build* serves the overlay. That gap is the whole bug — deploy green, secrets set, `/api/_review` 404, preview inert. Same class as #2045's blank screenshot: **an artifact that looks like a deliverable and isn't.**

So the run now probes `/api/_review` on the deployed URL and **fails** on 404. Report-only would just re-create the silence.

## Verification

`fallow audit` clean; YAML validated (24 steps); confirmed `steps.deploy.outputs.url` is a real output (set at `:330`) before depending on it.

I also **dispatched a `review_pr=2039` staging deploy of velo and cancelled it** — without the flag it would have published a preview with no overlay and handed over a URL that silently does nothing. That's the failure this PR exists to stop, so I wasn't going to demonstrate it.

## ⚠️ Not verified

**The fix runs only in CI and I could not execute it** — this sandbox has no Cloudflare credentials. So the claim "the overlay is now served" is *reasoned* (the flag reaches `nuxt build` via step env, and the app's own template proves that's the right variable), **not observed**.

The new probe is what makes that safe: if the reasoning is wrong, the next review deploy **fails loudly** instead of handing out another dead link. That's the honest state — the probe is the verification, deferred to the first real run.

Also unverified: whether the overlay alone is sufficient for the pin→comment round trip, or whether the bridge needs more than the #607 secrets. #2037 is the end-to-end walk that answers that, and it's blocked on this.

## 🧪 How to test

Dispatch `deploy-apps.yml` with `app=velo, environment=staging, review_pr=<an open PR>`:

1. The run should pass its new **Verify the review overlay is live** step.
2. `curl https://velo.pmcp.dev/api/_review` → not 404.
3. Open the URL, pin a comment on an element → it should arrive on that PR.
4. An ordinary merge-to-`main` staging deploy should still have **no** overlay.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_