### PR TITLE
fix(root): make a review preview actually serve the overlay (#2073)

### DIFF
--- a/.claude/skills/poc-deploy/SKILL.md
+++ b/.claude/skills/poc-deploy/SKILL.md
@@ -23,7 +23,7 @@ PR touches pocs/<name>/** (POC has a deploy.config.json)  →  deploy-pocs.yml (
 
 > **Review overlay is ON by default for all POC staging deploys (#596).** `deploy-pocs.yml` passes
 > `enable-review: true` to `deploy-app.yml`, so every POC preview is built with
-> `NUXT_PUBLIC_CROUTON_REVIEW=true` (the `@fyit/crouton-devtools` overlay + source stamper + `/api/_review`
+> `NUXT_PUBLIC_CROUTON_REVIEW=true` (the `@fyit/crouton-devtools` overlay + source stamper + `/api/_feedback`
 > bridge). The PR comment includes overlay usage instructions. For the bridge to post `🎯 Preview feedback`
 > comments, set the `NUXT_CROUTON_REVIEW_GITHUB_APP_*` repo-level secrets (see
 > `writeups/setup/review-bridge-token-setup.md`); the overlay still renders without them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,22 +309,15 @@ jobs:
       - name: Build better-sqlite3's native binding
         run: pnpm rebuild better-sqlite3
 
-      - name: Cache layer builds
-        id: layer-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            packages/crouton-auth/dist
-            packages/crouton-core/dist
-            packages/crouton/dist
-          key: layer-builds-${{ hashFiles('packages/crouton-auth/**/*.ts', 'packages/crouton-core/**/*.ts', 'packages/crouton/**/*.ts') }}
-
-      - name: Build layer packages
-        if: steps.layer-cache.outputs.cache-hit != 'true'
-        run: |
-          pnpm --filter '@fyit/crouton-auth' build
-          pnpm --filter '@fyit/crouton-core' build
-          pnpm --filter '@fyit/crouton' build
+      # Build ALL @fyit packages, not a hand-listed three (#2073). This step used to name
+      # crouton-auth / crouton-core / crouton explicitly, which silently assumed no app ever
+      # consumes another dist-built package. Adding `@fyit/crouton-devtools` to the apps broke
+      # `nuxt prepare` below with "Could not load `@fyit/crouton-devtools`. Is it installed?" —
+      # the exact failure `warm-packages` was written for ("a subset can miss a package the app
+      # transitively extends", #1222). Using the shared action means the next dist-consumed
+      # package needs no edit here, and it shares the content-addressed cache with the deploy
+      # jobs instead of maintaining a second, narrower one.
+      - uses: ./.github/actions/warm-packages
 
       - name: Prepare apps
         run: |

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -371,7 +371,8 @@ jobs:
 
       # ── Preview-review bridge wiring (#607, part of #488) ───────────────────────
       # The live-preview comment loop turns the overlay ON at build (NUXT_PUBLIC_CROUTON_REVIEW)
-      # but the bridge (`/api/_review`, @fyit/crouton-devtools) also needs RUNTIME config to
+      # but the bridge (`POST /api/_feedback`, installed by @fyit/crouton-devtools via
+      # @fyit/crouton-feedback — it was `/api/_review` before the #960 extraction) also needs RUNTIME config to
       # know which PR to post to and how to auth — which no deploy ever set, so every overlay
       # comment 4xx'd "Review bridge not configured". These two steps inject it on staging,
       # PR-tied deploys: routing (repo + PR) + the Nuxt Harness App creds (so the bridge mints
@@ -415,13 +416,28 @@ jobs:
           rm -f "$RUNNER_TEMP/review-secrets.json"
           echo "✓ Wired preview-review bridge → PR #$PR on $REPOSITORY (posts as nuxt-harness[bot])"
 
-      # ── PROVE the overlay is actually there (#2070) ─────────────────────────────
+      # ── PROVE the overlay is actually there (#2070, corrected in #2073) ────────
       # Wiring the bridge's secrets says nothing about whether the deployed build SERVES
-      # the overlay — and for two years it didn't, silently: deploy green, secrets set,
-      # `/api/_review` 404, every "walk the preview" link inert. Same class as #2045's
-      # blank screenshot: an artifact that looks like a deliverable and isn't. Probe the
-      # live URL and FAIL, so a preview that can't be reviewed never gets handed over as
-      # one. Report-only would just re-create the silence.
+      # the overlay — and it didn't, silently: deploy green, secrets set, no overlay,
+      # every "walk the preview" link inert. Same class as #2045's blank screenshot: an
+      # artifact that looks like a deliverable and isn't. So probe the live URL and FAIL,
+      # rather than hand over a preview that can't be reviewed.
+      #
+      # #2073 — the FIRST version of this probe checked `/api/_review`, a route that does
+      # not exist anywhere in the repo (the real handler is `/api/_feedback`, registered by
+      # @fyit/crouton-feedback). It would have failed on a perfectly good preview too, which
+      # is the "run the rule over the corpus, not just its tests" lesson in miniature: a
+      # gate authored from an imagined interface refuses correct builds. Both assertions
+      # below were run against a real app before landing.
+      #
+      # TWO independent signals, because each catches a different half:
+      #   • POST /api/_feedback   — the module is INSTALLED (the app must consume
+      #                             @fyit/crouton-devtools; velo/kassa/triage did not).
+      #                             POST, not GET: the handler is method-scoped, so a GET
+      #                             falls through to 404 even when it's registered.
+      #   • croutonReview in HTML — the review FLAG reached the build
+      #                             (`runtimeConfig.public.croutonReview = true`, set only
+      #                             when NUXT_PUBLIC_CROUTON_REVIEW === 'true').
       - name: Verify the review overlay is live
         if: ${{ inputs.environment == 'staging' && inputs['review-pr'] != '' }}
         env:
@@ -429,14 +445,32 @@ jobs:
         run: |
           set -o pipefail
           [ -z "$URL" ] && { echo "::error::review deploy has no URL to probe"; exit 1; }
-          code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$URL/api/_review" || echo 000)"
+          fail=0
+
+          code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
+                    -X POST -H 'content-type: application/json' -d '{}' \
+                    "$URL/api/_feedback" || echo 000)"
           if [ "$code" = "404" ] || [ "$code" = "000" ]; then
-            echo "::error::The review overlay is NOT live at $URL (/api/_review → $code)."
-            echo "::error::This preview cannot be reviewed — do not hand out the link. Check that"
-            echo "::error::NUXT_PUBLIC_CROUTON_REVIEW reached the build (#2070)."
+            echo "::error::No feedback endpoint at $URL (POST /api/_feedback → $code)."
+            echo "::error::The app does not install the overlay — add '@fyit/crouton-devtools'"
+            echo "::error::to its nuxt.config modules + dependencies (#2073)."
+            fail=1
+          else
+            echo "✓ feedback endpoint live (POST /api/_feedback → $code)"
+          fi
+
+          if curl -s --max-time 30 "$URL/" | grep -q 'croutonReview'; then
+            echo "✓ review flag present in the served HTML"
+          else
+            echo "::error::The review flag did not reach the build at $URL."
+            echo "::error::NUXT_PUBLIC_CROUTON_REVIEW must be 'true' at BUILD time (#2070)."
+            fail=1
+          fi
+
+          if [ "$fail" = "1" ]; then
+            echo "::error::This preview cannot be reviewed — do not hand out the link."
             exit 1
           fi
-          echo "✓ review overlay live at $URL (/api/_review → $code)"
 
       # Guarantee a new app can AUTHENTICATE on first deploy with ZERO per-app setup.
       # A freshly provisioned Worker has no secrets, so member login 500s with

--- a/apps/kassa/nuxt.config.ts
+++ b/apps/kassa/nuxt.config.ts
@@ -12,7 +12,11 @@ const isCloudflare = preset.startsWith('cloudflare')
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  modules: ['@fyit/crouton'],
+  // See apps/velo/nuxt.config.ts — crouton-devtools is what installs the review
+  // overlay under the `NUXT_PUBLIC_CROUTON_REVIEW` gate; without it a review
+  // preview has nothing to pin a comment on (#2073). Gates itself off in a
+  // normal production build.
+  modules: ['@fyit/crouton', '@fyit/crouton-devtools'],
   css: ['~/assets/css/main.css'],
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },

--- a/apps/kassa/package.json
+++ b/apps/kassa/package.json
@@ -27,6 +27,7 @@
     "@fyit/crouton": "workspace:*",
     "@fyit/crouton-charts": "workspace:*",
     "@fyit/crouton-core": "workspace:*",
+    "@fyit/crouton-devtools": "workspace:*",
     "@fyit/crouton-email": "workspace:*",
     "@fyit/crouton-i18n": "workspace:*",
     "@fyit/crouton-pages": "workspace:*",

--- a/apps/triage/nuxt.config.ts
+++ b/apps/triage/nuxt.config.ts
@@ -26,7 +26,12 @@ export default defineNuxtConfig({
   ],
 
   modules: [
-    '@fyit/crouton'
+    '@fyit/crouton',
+    // See apps/velo/nuxt.config.ts — crouton-devtools is what installs the review
+    // overlay under the `NUXT_PUBLIC_CROUTON_REVIEW` gate; without it a review
+    // preview has nothing to pin a comment on (#2073). Gates itself off in a
+    // normal production build.
+    '@fyit/crouton-devtools'
   ],
 
   croutonAuth: {

--- a/apps/triage/package.json
+++ b/apps/triage/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@fyit/crouton": "workspace:*",
     "@fyit/crouton-charts": "workspace:*",
+    "@fyit/crouton-devtools": "workspace:*",
     "@fyit/crouton-triage": "workspace:*",
     "@vue-flow/core": "^1.41.2",
     "@vue-flow/node-resizer": "^1.5.1",

--- a/apps/velo/nuxt.config.ts
+++ b/apps/velo/nuxt.config.ts
@@ -6,7 +6,13 @@ const cfStubs = resolve(__dirname, 'server/utils/_cf-stubs')
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  modules: ['@fyit/crouton'],
+  // crouton-devtools is what INSTALLS the review overlay (it gates + installs
+  // @fyit/crouton-feedback). Without it, `NUXT_PUBLIC_CROUTON_REVIEW=true` sets a
+  // flag no module reads and a "review preview" serves nothing to pin a comment on
+  // (#2073). In a production build the module gates itself off entirely — it
+  // returns before installing anything unless dev / the devtools flag / the review
+  // flag is set — so this costs a normal deploy nothing.
+  modules: ['@fyit/crouton', '@fyit/crouton-devtools'],
   css: ['~/assets/css/main.css'],
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },

--- a/apps/velo/package.json
+++ b/apps/velo/package.json
@@ -27,6 +27,7 @@
     "@fyit/crouton-assets": "workspace:*",
     "@fyit/crouton-bookings": "workspace:*",
     "@fyit/crouton-core": "workspace:*",
+    "@fyit/crouton-devtools": "workspace:*",
     "@fyit/crouton-email": "workspace:*",
     "@fyit/crouton-i18n": "workspace:*",
     "@fyit/crouton-pages": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@fyit/crouton-core':
         specifier: workspace:*
         version: link:../../packages/crouton-core
+      '@fyit/crouton-devtools':
+        specifier: workspace:*
+        version: link:../../packages/crouton-devtools
       '@fyit/crouton-email':
         specifier: workspace:*
         version: link:../../packages/crouton-email
@@ -172,6 +175,9 @@ importers:
       '@fyit/crouton-charts':
         specifier: workspace:*
         version: link:../../packages/crouton-charts
+      '@fyit/crouton-devtools':
+        specifier: workspace:*
+        version: link:../../packages/crouton-devtools
       '@fyit/crouton-triage':
         specifier: workspace:*
         version: link:../../packages/crouton-triage
@@ -215,6 +221,9 @@ importers:
       '@fyit/crouton-core':
         specifier: workspace:*
         version: link:../../packages/crouton-core
+      '@fyit/crouton-devtools':
+        specifier: workspace:*
+        version: link:../../packages/crouton-devtools
       '@fyit/crouton-email':
         specifier: workspace:*
         version: link:../../packages/crouton-email

--- a/pocs/crouton-builder-demo/nuxt.config.ts
+++ b/pocs/crouton-builder-demo/nuxt.config.ts
@@ -7,7 +7,7 @@ const cfStubs = resolve(__dirname, 'server/utils/_cf-stubs')
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   // @fyit/crouton-devtools registers the dev/review launcher — Console (eruda) + Annotate (pin
-  // feedback → /api/_review → PR comment). Activated on staging by NUXT_PUBLIC_CROUTON_REVIEW=true
+  // feedback → /api/_feedback → PR comment). Activated on staging by NUXT_PUBLIC_CROUTON_REVIEW=true
   // (set in cf:staging); zero production footprint. Supersedes the deprecated /eruda extends layer.
   modules: ['@fyit/crouton', '@fyit/crouton-devtools'],
   css: ['~/assets/css/main.css'],

--- a/scripts/scaffold-poc-deploy.mjs
+++ b/scripts/scaffold-poc-deploy.mjs
@@ -22,7 +22,7 @@
 // nuxt.config `modules` (scaffold-app.ts), so the overlay is active on every POC staging
 // preview — every preview URL is review-ready. deploy-app.yml always builds the devtools
 // dist before `nuxt prepare` (#745), so it loads regardless of this script's layerPackages
-// default. A PR-tied deploy also gets the /api/_review bridge wired (deploy-app.yml's
+// default. A PR-tied deploy also gets the /api/_feedback bridge wired (deploy-app.yml's
 // review-pr input + the NUXT_CROUTON_REVIEW_GITHUB_APP_* repo secrets → GitHub App PR
 // commenting as nuxt-harness[bot]).
 

--- a/writeups/setup/crouton-github-app.md
+++ b/writeups/setup/crouton-github-app.md
@@ -155,7 +155,7 @@ not-found failure message keeps a one-line hint pointing back at this permission
   subscribe to events. This is also #515's "appoint the App to release" signal.
 - **GitHub Checks (WS4):** the gates (artifact-gate / schema-review / UI sign-off / deploy) become
   Check Runs instead of bot comments.
-- **review-bridge (other half of WS2):** the `/api/_review` endpoint (#491, in `packages/crouton-devtools`)
+- **review-bridge (other half of WS2):** the `/api/_feedback` endpoint (#491, in `packages/crouton-devtools`)
   swaps its PAT for an App installation token the same way — tracked separately (package HARD GATE).
 - **Provenance:** once comments post as `nuxt-harness[bot]`, the `require-comment-provenance` hook
   band-aid (#497) can be retired for App-posted comments.

--- a/writeups/setup/review-bridge-token-setup.md
+++ b/writeups/setup/review-bridge-token-setup.md
@@ -21,7 +21,7 @@
   live in the Worker; the central mint is the teams-era step (#519).
 - **App permission used:** *Pull requests: write* (PR conversation comment). The App also holds
   *Contents: write* for the ticket-editor (#503) — not used here.
-- **Consumer:** `@fyit/crouton-devtools` → `POST /api/_review`
+- **Consumer:** `@fyit/crouton-devtools` → `POST /api/_feedback`
   (`packages/crouton-devtools/src/runtime/server/api/review.post.ts`).
 - **Action:** `POST /repos/{owner}/{repo}/issues/{pr}/comments` (a `🎯 Preview feedback` comment).
 - **Gate:** staging only — behind `NUXT_PUBLIC_CROUTON_REVIEW=true`; absent from production builds.

--- a/writeups/setup/secrets-and-tokens.md
+++ b/writeups/setup/secrets-and-tokens.md
@@ -74,7 +74,7 @@ When a **deployed staging Worker** needs to talk to GitHub *by itself* (no human
 | Feature (component) | Worker secret name | Action | Minimal scope |
 |---|---|---|---|
 | **ticket-editor** (`workers/ticket-editor`) — commits an edited Excalidraw diagram back | `GITHUB_TOKEN` | commit files via Contents API | fine-grained PAT, repo-only · **Contents: R/W** |
-| **review-bridge** (`@fyit/crouton-devtools` → `POST /api/_review`) — posts a `🎯 Preview feedback` PR comment | `NUXT_CROUTON_REVIEW_GITHUB_TOKEN` | comment on a PR | fine-grained PAT, repo-only · **Pull requests: write** · **staging only** |
+| **review-bridge** (`@fyit/crouton-devtools` → `POST /api/_feedback`) — posts a `🎯 Preview feedback` PR comment | `NUXT_CROUTON_REVIEW_GITHUB_TOKEN` | comment on a PR | fine-grained PAT, repo-only · **Pull requests: write** · **staging only** |
 
 Rules for **every** Tier-2 token:
 - **Cloudflare Worker secret only** — `wrangler secret put <NAME> --env staging`. Never bake into the bundle, never expose to the client, **never on a production Worker**.
@@ -82,7 +82,7 @@ Rules for **every** Tier-2 token:
 - Prefer a **dedicated bot/machine account** over a person's PAT (attributable; doesn't impersonate a human's full access).
 - **Interim by design** — provision as disposable; do not adopt as "the credential."
 
-> ⚠️ Security note (review-bridge): `/api/_review` is currently **unauthenticated** — anyone who reaches the staging URL can trigger a comment. Keep staging behind login, treat the token as low-trust, and rotate aggressively until the App/OAuth model lands.
+> ⚠️ Security note (review-bridge): `/api/_feedback` is currently **unauthenticated** — anyone who reaches the staging URL can trigger a comment. Keep staging behind login, treat the token as low-trust, and rotate aggressively until the App/OAuth model lands.
 
 ---
 
@@ -156,7 +156,7 @@ Swapping two PATs is the least of it. The App is a GitHub-native **identity + we
 
 **Fixes things we currently do wrong**
 - **Posts as `nuxt-harness[bot]`, not @pmcp** — the *real* fix for the provenance problem we band-aided with the `require-comment-provenance` hook. Bot comments become unmistakable at the source.
-- **Retires the scattered per-feature PATs** and the **unauthenticated `/api/_review`** (actions tie to a real installation, not an open URL + shared low-trust token).
+- **Retires the scattered per-feature PATs** and the **unauthenticated `/api/_feedback`** (actions tie to a real installation, not an open URL + shared low-trust token).
 - **Exact permissions** — no more "the bot token lacks `workflows`/`actions`" walls; grant only what's chosen.
 
 **New capabilities**


### PR DESCRIPTION
Closes #2073

## 👤 What this fixes

You asked for a preview link you can click. The last fix (#2072) deployed one and it still had no overlay — the probe it added caught that, then failed for its own reason too. Both are fixed here.

**1. No launched app installs `@fyit/crouton-devtools`.** That module is what installs the overlay. #2072 set the flag that turns it on; nothing was there to read it. 8 pocs have it, 0 apps do — which is why the overlay has only ever worked on pocs.

**2. The probe checked `/api/_review`, a route that exists nowhere in the repo.** The real handler is `POST /api/_feedback` (renamed in the #960 extraction). The old name still lives in `writeups/setup/*.md` and the poc-deploy skill — that's where I got it. So the gate would have refused a *working* preview too.

## 🤖 What changed

| file | change |
|---|---|
| `apps/{velo,kassa,triage}/nuxt.config.ts` + `package.json` | add `@fyit/crouton-devtools` to `modules` + `dependencies` |
| `.github/workflows/deploy-app.yml` | probe two real signals instead of one imaginary one |
| `writeups/setup/*.md`, `.claude/skills/poc-deploy/SKILL.md`, `scripts/scaffold-poc-deploy.mjs`, `pocs/crouton-builder-demo/nuxt.config.ts` | `/api/_review` → `/api/_feedback` |

The module gates itself off in a production build (returns before `installModule` unless dev / devtools flag / review flag), so an ordinary deploy is unchanged.

**The probe now checks two independent signals**, because each catches a different half:

- `POST /api/_feedback` ≠ 404 → the **module is installed**
- `croutonReview` in the served HTML → the **flag reached the build**

POST, not GET: the handler is `method: 'post'`, so a GET falls through to 404 *even when registered* — a GET probe cannot tell "absent" from "wrong verb".

## Evidence

Both assertions run against a real app before landing, rather than written from an imagined interface.

Deployed velo (before):
```
POST https://velo.pmcp.dev/api/_feedback → 404
grep croutonReview in the HTML           → nothing
```

Local velo with the module wired in and the flag set:
```
POST http://localhost:3006/api/_feedback → 200
grep croutonReview in the HTML           → croutonReview:true
```

`pnpm typecheck` green on all three apps · `npx fallow audit --base origin/main` → no issues in 14 changed files.

## 🧪 How to test

Dispatch `deploy-apps.yml` with `app=velo, environment=staging, review_pr=<a PR number>`. The **Verify the review overlay is live** step must pass with both ✓ lines. Then open `https://velo.pmcp.dev`, click the glasses launcher, pin a comment — it should land on that PR as `🎯 Preview feedback`.

Refs #2070, #2072, #2037, #960

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_