### PR TITLE
fix(root): make the pi telemetry probe able to report anything but "none found" (#2056)

### DIFF
--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -280,6 +280,11 @@ jobs:
       - id: t0
         run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      # Stash the telemetry capture in RUNNER_TEMP BEFORE pi runs — pi creates and checks out
+      # the epic branch mid-run, which may not carry scripts/, and the capture step runs after
+      # pi. Same Pattern B as the worker lane's parser stash (#1764/#1782, #2056).
+      - run: cp scripts/pi-telemetry-capture.sh "$RUNNER_TEMP/pi-telemetry-capture.sh"
+
       # ── The agent: pi.dev (replaces claude-code-action) ──────────────────────────
       # GH_TOKEN = the App token → pi's `gh`/git operations (sub-issues, epic branch,
       # the worker PR) act as the Harness App and cascade. ANTHROPIC_API_KEY = the
@@ -495,7 +500,17 @@ jobs:
           script: |
             const issue_number = Number(process.env.ISSUE_NUMBER)
             const since = '${{ steps.t0.outputs.ts }}'
+            // #2056 — an empty/unparseable `since` makes this gate FAIL OPEN, silently. The
+            // whole gate is "did anything appear AFTER the run started": with `since: ''` the
+            // comments API returns the issue's ENTIRE history, so `newComment` is true for any
+            // issue anyone ever commented on, and a run that produced nothing is waved through
+            // as a deliverable. That is worse than no gate, so refuse to run rather than guess.
             const sinceMs = new Date(since).getTime()
+            if (!since || Number.isNaN(sinceMs)) {
+              core.setFailed(`Artifact-gate cannot run: the run-start timestamp is ${since ? `unparseable (${since})` : 'empty'}. `
+                + 'Without it the gate would treat pre-existing comments as this run\'s output and pass a no-op (#2056).')
+              return
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo, issue_number, since,
@@ -684,38 +699,20 @@ jobs:
 
       # ── Telemetry convergence capture (#944) — REAL data from this pi run ──────────
       # Proves the "one feed → both consumers" loop on a live run: locate this run's pi
-      # subagent telemetry (~/.pi/agent/sessions/.../subagent-artifacts) and run the
+      # subagent telemetry (a `subagent-artifacts` dir under the session root) and run the
       # adapter to emit BOTH a Loop Station WS2 trace AND the #883 ledger-row slice.
       # Non-fatal + artifact-only on purpose: it must never fail the headline code-writing
       # proof, and committing rows to the ledger file from CI is a separate follow-up — here
       # we surface them as an artifact + in the log so the convergence is verifiable.
+      #
+      # The body lives in scripts/pi-telemetry-capture.sh — SHARED with the worker lane, which
+      # carried a byte-identical copy of the same three defects (#2056). Read that file for
+      # what was broken and why it now says PROBE BROKEN instead of "none found".
       - name: Capture pi telemetry → WS2 trace + #883 ledger slice (artifacts; non-fatal)
         if: always()
         env:
           SINCE: ${{ steps.t0.outputs.ts }}
-        run: |
-          set +e
-          mkdir -p pi-telemetry-out
-          SESS_ROOT="$HOME/.pi/agent/sessions"
-          # The most-recently-modified subagent-artifacts dir MODIFIED DURING THIS RUN (#1019):
-          # `-newermt "$SINCE"` scopes to dirs touched at/after the run-start timestamp, so we
-          # never mis-attribute a PRIOR run's telemetry (the #839 stale-row bug). `-newermt`
-          # works on both BSD find (the mac-mini) and GNU find (ubuntu fallback).
-          # shellcheck disable=SC2038 # -I{} consumes whole LINES, so a path with spaces survives
-          TELE_DIR="$(find "$SESS_ROOT" -type d -name subagent-artifacts -newermt "$SINCE" 2>/dev/null \
-            | xargs -I{} stat -f '%m {}' {} 2>/dev/null | sort -rn | head -n1 | cut -d' ' -f2-)"
-          if [ -z "$TELE_DIR" ]; then
-            TELE_DIR="$(find "$SESS_ROOT" -type d -name subagent-artifacts -newermt "$SINCE" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -n1 | cut -d' ' -f2-)"
-          fi
-          if [ -n "$TELE_DIR" ] && [ -d "$TELE_DIR" ]; then
-            echo "pi telemetry dir: $TELE_DIR"
-            node .claude/skills/loop-station/pi-telemetry.mjs "$TELE_DIR"          > pi-telemetry-out/pi-trace.jsonl  2>/dev/null
-            node .claude/skills/loop-station/pi-telemetry.mjs "$TELE_DIR" --ledger > pi-telemetry-out/ledger-rows.jsonl 2>/dev/null
-            echo "── #883 ledger-row slice from THIS pi run (model · cost · turns · wall) ──"
-            cat pi-telemetry-out/ledger-rows.jsonl || true
-          else
-            echo "no pi subagent telemetry found — a decompose-only run (sub-issues, no worker) writes none. Skipping."
-          fi
+        run: bash "$RUNNER_TEMP/pi-telemetry-capture.sh"
 
       - name: Upload pi telemetry artifact
         if: always()

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -229,6 +229,9 @@ jobs:
           # The finish step's DECISION core (#1893/#1904) — stashed for the same reason as the two
           # above: pi may check out a work branch mid-run that doesn't carry scripts/.
           cp scripts/pi-finish.mjs "$RUNNER_TEMP/pi-finish.mjs"
+          # Same reason again (#2056): the telemetry capture runs AFTER pi, so it cannot read
+          # scripts/ out of a working tree pi may have switched.
+          cp scripts/pi-telemetry-capture.sh "$RUNNER_TEMP/pi-telemetry-capture.sh"
 
       # ── The agent: pi.dev (replaces claude-code-action) ──────────────────────────
       # GH_TOKEN = the App token → pi's `gh`/git operations (sub-issues, epic branch,
@@ -669,7 +672,17 @@ jobs:
           script: |
             const issue_number = Number(process.env.ISSUE_NUMBER)
             const since = '${{ steps.t0.outputs.ts }}'
+            // #2056 — an empty/unparseable `since` makes this gate FAIL OPEN, silently. The
+            // whole gate is "did anything appear AFTER the run started": with `since: ''` the
+            // comments API returns the issue's ENTIRE history, so `newComment` is true for any
+            // issue anyone ever commented on, and a run that produced nothing is waved through
+            // as a deliverable. That is worse than no gate, so refuse to run rather than guess.
             const sinceMs = new Date(since).getTime()
+            if (!since || Number.isNaN(sinceMs)) {
+              core.setFailed(`Artifact-gate cannot run: the run-start timestamp is ${since ? `unparseable (${since})` : 'empty'}. `
+                + 'Without it the gate would treat pre-existing comments as this run\'s output and pass a no-op (#2056).')
+              return
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo, issue_number, since,
@@ -897,38 +910,20 @@ jobs:
 
       # ── Telemetry convergence capture (#944) — REAL data from this pi run ──────────
       # Proves the "one feed → both consumers" loop on a live run: locate this run's pi
-      # subagent telemetry (~/.pi/agent/sessions/.../subagent-artifacts) and run the
+      # subagent telemetry (a `subagent-artifacts` dir under the session root) and run the
       # adapter to emit BOTH a Loop Station WS2 trace AND the #883 ledger-row slice.
       # Non-fatal + artifact-only on purpose: it must never fail the headline code-writing
       # proof, and committing rows to the ledger file from CI is a separate follow-up — here
       # we surface them as an artifact + in the log so the convergence is verifiable.
+      #
+      # The body lives in scripts/pi-telemetry-capture.sh — SHARED with the decomposer lane,
+      # which carried a byte-identical copy of the same three defects (#2056). Read that file
+      # for what was broken and why it now says PROBE BROKEN instead of "none found".
       - name: Capture pi telemetry → WS2 trace + #883 ledger slice (artifacts; non-fatal)
         if: always()
         env:
           SINCE: ${{ steps.t0.outputs.ts }}
-        run: |
-          set +e
-          mkdir -p pi-telemetry-out
-          SESS_ROOT="$HOME/.pi/agent/sessions"
-          # The most-recently-modified subagent-artifacts dir MODIFIED DURING THIS RUN (#1019):
-          # `-newermt "$SINCE"` scopes to dirs touched at/after the run-start timestamp, so we
-          # never mis-attribute a PRIOR run's telemetry (the #839 stale-row bug). `-newermt`
-          # works on both BSD find (the mac-mini) and GNU find (ubuntu fallback).
-          # shellcheck disable=SC2038 # -I{} consumes whole LINES, so a path with spaces survives
-          TELE_DIR="$(find "$SESS_ROOT" -type d -name subagent-artifacts -newermt "$SINCE" 2>/dev/null \
-            | xargs -I{} stat -f '%m {}' {} 2>/dev/null | sort -rn | head -n1 | cut -d' ' -f2-)"
-          if [ -z "$TELE_DIR" ]; then
-            TELE_DIR="$(find "$SESS_ROOT" -type d -name subagent-artifacts -newermt "$SINCE" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -n1 | cut -d' ' -f2-)"
-          fi
-          if [ -n "$TELE_DIR" ] && [ -d "$TELE_DIR" ]; then
-            echo "pi telemetry dir: $TELE_DIR"
-            node .claude/skills/loop-station/pi-telemetry.mjs "$TELE_DIR"          > pi-telemetry-out/pi-trace.jsonl  2>/dev/null
-            node .claude/skills/loop-station/pi-telemetry.mjs "$TELE_DIR" --ledger > pi-telemetry-out/ledger-rows.jsonl 2>/dev/null
-            echo "── #883 ledger-row slice from THIS pi run (model · cost · turns · wall) ──"
-            cat pi-telemetry-out/ledger-rows.jsonl || true
-          else
-            echo "no pi subagent telemetry found — a decompose-only run (sub-issues, no worker) writes none. Skipping."
-          fi
+        run: bash "$RUNNER_TEMP/pi-telemetry-capture.sh"
 
       - name: Upload pi telemetry artifact
         if: always()

--- a/scripts/pi-telemetry-capture.sh
+++ b/scripts/pi-telemetry-capture.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# pi-telemetry-capture.sh — locate THIS pi run's telemetry, run the adapter, and preserve
+# the raw session. Shared by both pi lanes (#2056).
+#
+# WHY THIS FILE EXISTS. This lived as a byte-identical block inside BOTH
+# `work-issue-pidev.yml` and `decompose-on-issue-pidev.yml` — the same duplication that let
+# the #2027 claim-guard wedge get half-fixed. Two copies of a diagnostic is one diagnostic
+# and one liability, and here BOTH copies carried all three defects below.
+#
+# WHAT IT USED TO DO, AND WHY THAT WAS WORSE THAN NOTHING. Every run printed "no pi subagent
+# telemetry found" and it was structurally unable to print anything else:
+#
+#   1. WRONG ROOT. It searched only `$HOME/.pi/agent/sessions`, but the WORKER lane passes
+#      `--session-dir "$RUNNER_TEMP/pi-session"`. Nothing was ever written where it looked,
+#      for any worker run, successful or not. (The decomposer lane passes no --session-dir,
+#      so `$HOME` is right for it — which is why one wrong root looked plausible.)
+#   2. EMPTY `SINCE`. `find -newermt ""` errors on GNU find and silently matches everything
+#      on BSD — and the whole pipeline was `2>/dev/null`, so a probe that could not run and a
+#      genuine "nothing found" printed the same reassuring sentence.
+#   3. NO RAW CAPTURE. Only the adapter's output was uploaded, so when the adapter found
+#      nothing there was nothing left to inspect — and `$RUNNER_TEMP` is wiped when the job
+#      ends, taking the session jsonl with it. That is exactly why #2055's 84-second no-op
+#      could not be explained afterwards.
+#
+# EXIT CODE. Always 0. A broken diagnostic must not turn a successful worker run red — that
+# trades a silent diagnostic for a misleading verdict. Instead a broken probe emits an
+# `::error::` annotation and says PROBE BROKEN, so it can never again read as "all clear".
+# The three outcomes are deliberately distinguishable: PROBE BROKEN ≠ "ran cleanly, found
+# none" ≠ "found telemetry".
+#
+# Inputs (env): SINCE (run-start ISO timestamp), RUNNER_TEMP, HOME.
+# Output: ./pi-telemetry-out/ (uploaded as a build artifact by the caller).
+
+set +e
+mkdir -p pi-telemetry-out
+
+if [ -z "${SINCE:-}" ]; then
+  echo "::error::PROBE BROKEN — the run-start timestamp (steps.t0.outputs.ts) is empty, so this"
+  echo "::error::run's telemetry cannot be distinguished from a previous run's. NOT reporting"
+  echo "::error::'no telemetry found': that would be a guess. (#2056)"
+  exit 0
+fi
+
+# Both roots: the per-run session dir the worker lane passes to pi, plus pi's own default
+# (what the decomposer lane uses). Searching both means a future change to either side
+# degrades to "found via the other" rather than to silence.
+SESS_ROOTS=""
+[ -d "$RUNNER_TEMP/pi-session" ] && SESS_ROOTS="$RUNNER_TEMP/pi-session"
+[ -d "$HOME/.pi/agent/sessions" ] && SESS_ROOTS="$SESS_ROOTS $HOME/.pi/agent/sessions"
+if [ -z "$SESS_ROOTS" ]; then
+  echo "::error::PROBE BROKEN — no pi session root exists at either $RUNNER_TEMP/pi-session"
+  echo "::error::or $HOME/.pi/agent/sessions. pi wrote no session at all this run. (#2056)"
+  exit 0
+fi
+echo "searching session roots: $SESS_ROOTS"
+
+# The most-recently-modified subagent-artifacts dir MODIFIED DURING THIS RUN (#1019):
+# `-newermt "$SINCE"` scopes to dirs touched at/after the run-start timestamp, so we never
+# mis-attribute a PRIOR run's telemetry (the #839 stale-row bug). `-newermt` works on both
+# BSD find (the mac-mini) and GNU find (ubuntu fallback). Errors are KEPT (not `2>/dev/null`)
+# so a find that cannot run says so instead of looking empty.
+# shellcheck disable=SC2086 # word-splitting SESS_ROOTS into multiple find roots is intended
+FIND_ERR="$(find $SESS_ROOTS -type d -name subagent-artifacts -newermt "$SINCE" 2>&1 >"$RUNNER_TEMP/tele-dirs.txt")"
+if [ -n "$FIND_ERR" ]; then
+  echo "::error::PROBE BROKEN — find failed while scanning for telemetry: $FIND_ERR (#2056)"
+  exit 0
+fi
+
+# Newest-first by mtime via `ls -dt`, which means the same thing on BSD and GNU.
+# NOT `stat`: the two platforms give `-f` opposite meanings — on GNU it prints FILESYSTEM
+# stats and EXITS 0, so the old "BSD form, then GNU fallback" resolved to a line of
+# free-space numbers and the fallback never ran. Verified on a real runner.
+# The non-empty guard is load-bearing: `xargs` with no input still runs `ls -dt`, which
+# prints `.` — a real directory, so an empty result would have been handed to the adapter
+# as if it were the session.
+TELE_DIR=""
+if [ -s "$RUNNER_TEMP/tele-dirs.txt" ]; then
+  TELE_DIR="$(tr '\n' '\0' < "$RUNNER_TEMP/tele-dirs.txt" | xargs -0 ls -dt 2>/dev/null | head -n1)"
+fi
+
+if [ -n "$TELE_DIR" ] && [ -d "$TELE_DIR" ]; then
+  echo "pi telemetry dir: $TELE_DIR"
+  node .claude/skills/loop-station/pi-telemetry.mjs "$TELE_DIR"          > pi-telemetry-out/pi-trace.jsonl    2>pi-telemetry-out/adapter.err
+  node .claude/skills/loop-station/pi-telemetry.mjs "$TELE_DIR" --ledger > pi-telemetry-out/ledger-rows.jsonl 2>>pi-telemetry-out/adapter.err
+  [ -s pi-telemetry-out/adapter.err ] && echo "::warning::pi-telemetry adapter wrote to stderr — see the adapter.err artifact"
+  echo "── #883 ledger-row slice from THIS pi run (model · cost · turns · wall) ──"
+  cat pi-telemetry-out/ledger-rows.jsonl || true
+else
+  echo "probe ran cleanly; no subagent-artifacts dir was touched during this run."
+  echo "(A decompose-only run — sub-issues, no worker — legitimately writes none.)"
+fi
+
+# ALWAYS keep the raw session, whatever the adapter made of it. $RUNNER_TEMP is wiped when
+# the job ends, so this is the only chance to preserve the one file that can explain a
+# no-op run after the fact (#2055).
+if [ -d "$RUNNER_TEMP/pi-session" ]; then
+  mkdir -p pi-telemetry-out/session
+  cp -R "$RUNNER_TEMP/pi-session/." pi-telemetry-out/session/ 2>/dev/null
+  echo "captured raw pi session ($(find pi-telemetry-out/session -type f | wc -l | tr -d ' ') files)"
+else
+  echo "::warning::no raw pi session at $RUNNER_TEMP/pi-session to capture (#2055)"
+fi


### PR DESCRIPTION
Closes #2056

pi held this one as `Needs: action` — the fix is entirely in `.github/workflows/**`, which its token can't write. Doing it from an interactive session instead.

## 👤 What was wrong

When a pi run does nothing, the step meant to explain it printed **"no pi subagent telemetry found"** — on every run, including successful ones. It was structurally incapable of printing anything else. That's why #2055's 84-second no-op couldn't be explained afterwards.

## 🤖 Three stacked defects

Each exits 0 having done nothing, in a block duplicated byte-for-byte across both pi lanes.

| # | defect | fix |
|---|---|---|
| 1 | **Wrong root** — searched `$HOME/.pi/agent/sessions` while the worker lane passes `--session-dir "$RUNNER_TEMP/pi-session"`. Nothing was ever written where it looked, for any worker run. | search both roots |
| 2 | **Empty `SINCE`** — `find -newermt ""` errors on GNU, matches everything on BSD, and the pipeline was `2>/dev/null`, so a broken probe and a genuine "nothing found" printed the same sentence | assert it; keep find's stderr |
| 3 | **No raw capture** — only the adapter's output was uploaded, and `$RUNNER_TEMP` is wiped at job end | preserve the session jsonl as an artifact |

The decomposer lane passes no `--session-dir`, so `$HOME` *is* right for it — which is how one wrong root looked plausible for years.

### Two more found while fixing it

**The newest-dir resolution never worked on Linux.** It used `stat -f` with a `stat -c` fallback — but GNU `stat -f` prints **filesystem** stats and **exits 0**, so it resolved to a line of free-space numbers and the fallback never ran:

```
bsd->  [Total: 16777216   Free: 16397158]
```

Replaced with `ls -dt` (same meaning on both platforms), plus a non-empty guard — `xargs` with no input still runs `ls -dt`, which prints `.`, a real directory that would have been handed to the adapter as if it were the session.

**The artifact-gate failed open on the same empty timestamp.** With `since: ''` the comments API returns the issue's *entire* history, so `newComment` is true for any issue anyone ever commented on — a run that produced nothing gets waved through as a deliverable. That's worse than no gate. It now refuses to run rather than guess. (Both lanes.)

## Structure

Extracted to `scripts/pi-telemetry-capture.sh` so the two lanes share one implementation — the duplication is *why* both copies carried all three defects, the same shape as the #2027 claim-guard wedge. Stashed in `RUNNER_TEMP` before pi runs (Pattern B, #1764/#1782): pi may switch branches and the capture runs afterwards.

## Evidence

Ran the extracted script over four scenarios. Previously **all four** printed "none found":

| scenario | now prints |
|---|---|
| empty `SINCE` | `::error::PROBE BROKEN — the run-start timestamp … is empty` |
| real telemetry dir | `pi telemetry dir: …/abc/subagent-artifacts` + `captured raw pi session` |
| session, no telemetry | `probe ran cleanly; no subagent-artifacts dir was touched during this run.` |
| no session root | `::error::PROBE BROKEN — no pi session root exists at either …` |

Both workflows parse (`yaml.safe_load`), both artifact-gate scripts pass `node --check`, `npx fallow audit --base origin/main` → no issues in 17 changed files.

**It still exits 0** — a broken diagnostic must not turn a successful worker run red, which would trade a silent diagnostic for a misleading verdict. A broken probe emits an `::error::` annotation instead, so it can never again read as "all clear".

## 🧪 How to test

Next pi worker run: the telemetry step should print `searching session roots: …` and either a real telemetry dir or `probe ran cleanly; no subagent-artifacts dir was touched`. Download the `pi-telemetry-<run_id>` artifact — it now contains a `session/` folder with the raw jsonl.

Refs #2012, #2055, #1904

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_