### PR TITLE
fix(root): migrate the per-PR preview's own database, not the committed one (#2078)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -277,7 +277,20 @@ jobs:
             PREVIEW_DB="$(printf '%s\n' "$PREVIEW_OUT" | sed -n 's/^db=//p')"
             npx wrangler deploy --config .output/server/wrangler.json | tee deploy.log
             # Fresh DB every time, so migrations are the whole schema — not incremental.
-            [ -n "$PREVIEW_DB" ] && npx wrangler d1 migrations apply "$PREVIEW_DB" --remote 2>&1 | tail -5
+            # --config is REQUIRED here (#2078). The PR-scoped database name exists ONLY in the
+            # rewritten built config; the committed wrangler.jsonc carries <app>-db /
+            # <app>-staging-db and structurally cannot know about <app>-pr<n>-db. Without it
+            # wrangler read the committed file and died with "Couldn't find a D1 DB with the name
+            # or binding '<app>-pr<n>-db'", so EVERY per-PR preview since #2020 served an
+            # unmigrated, empty database. pr-preview-wrangler.mjs makes migrations_dir absolute
+            # first, so passing --config cannot re-create #138's doubled path (a green step that
+            # migrates nothing) — the silent version of the same bug.
+            if [ -z "$PREVIEW_DB" ]; then
+              echo "::error::pr-preview-wrangler produced no db name — the preview would have NO schema."
+              exit 1
+            fi
+            npx wrangler d1 migrations apply "$PREVIEW_DB" \
+              --config .output/server/wrangler.json --remote
             (pnpm db:seed:staging || true)
           else
             pnpm run cf:staging | tee deploy.log

--- a/scripts/lib/pr-preview-wrangler.mjs
+++ b/scripts/lib/pr-preview-wrangler.mjs
@@ -71,7 +71,46 @@ function scrubBindings(out, name, changed) {
   }
 }
 
-export function toPrPreview(config, app, pr) {
+/**
+ * Make `migrations_dir` ABSOLUTE so the built config can be handed to
+ * `wrangler d1 migrations apply --config` (#2078).
+ *
+ * WHY THIS IS NEEDED AT ALL. The per-PR database name exists ONLY in this rewritten config —
+ * the committed `wrangler.jsonc` carries `<app>-db` / `<app>-staging-db` and structurally
+ * cannot know about `<app>-pr<n>-db`. So the migrate step must read THIS file. It didn't: it
+ * ran with no `--config`, wrangler fell back to the committed one, and every per-PR preview
+ * since #2020 shipped an unmigrated, empty database while the deploy went green.
+ *
+ * WHY ABSOLUTE AND NOT JUST `--config`. `migrations_dir` resolves relative to the config file
+ * that declares it. The source config sits in the app root, so `server/db/migrations/sqlite`
+ * is right there — but the BUILT config sits in `.output/server/`, where the same relative
+ * path resolves to `.output/server/server/db/migrations/sqlite`. That is #138 exactly: wrangler
+ * finds no migrations, reports success, and migrates nothing. A silent no-op replacing a loud
+ * failure is not a fix, so the path is rewritten absolute at the one moment we still know the
+ * app root.
+ */
+function absolutizeMigrations(out, base, changed) {
+  if (!base) return
+  for (const b of out.d1_databases || []) {
+    const dir = b.migrations_dir
+    if (typeof dir !== 'string' || !dir || isAbsolutePath(dir)) continue
+    b.migrations_dir = joinPath(base, dir)
+    changed.push(`d1_databases.${b.binding}: migrations_dir=${b.migrations_dir}`)
+  }
+}
+
+const isAbsolutePath = (p) => p.startsWith('/')
+const joinPath = (a, b) => `${a.replace(/\/+$/, '')}/${b.replace(/^\.\//, '')}`
+
+/**
+ * @param {object} config  Parsed wrangler config (the BUILT one, e.g. .output/server/wrangler.json).
+ * @param {string} app     App name, e.g. "kassa".
+ * @param {number|string} pr  PR number.
+ * @param {{ migrationsBase?: string }} [opts]  Absolute app root; relative `migrations_dir`
+ *   values are rewritten against it so the built config is usable with `--config` (#2078).
+ * @returns {{ config: object, name: string, changed: string[] }}
+ */
+export function toPrPreview(config, app, pr, opts = {}) {
   if (!config || typeof config !== 'object') throw new TypeError('config must be an object')
   if (!app) throw new TypeError('app is required')
   if (!/^\d+$/.test(String(pr))) throw new TypeError(`pr must be a number, got ${JSON.stringify(pr)}`)
@@ -83,6 +122,7 @@ export function toPrPreview(config, app, pr) {
 
   detachFromRealEnvs(out, changed)
   scrubBindings(out, name, changed)
+  absolutizeMigrations(out, opts.migrationsBase, changed)
 
   return { config: out, name, changed }
 }

--- a/scripts/lib/pr-preview-wrangler.test.mjs
+++ b/scripts/lib/pr-preview-wrangler.test.mjs
@@ -97,3 +97,60 @@ test('a non-numeric PR is refused rather than producing a junk Worker name', () 
   assert.throws(() => toPrPreview(built(), 'kassa', 'main'), TypeError)
   assert.throws(() => toPrPreview(built(), 'kassa', '../evil'), TypeError)
 })
+
+/**
+ * #2078 contract — a preview must be MIGRATABLE, not just isolated.
+ *
+ * The incident: the per-PR database name exists only in the rewritten config, but the migrate
+ * step ran with no `--config`, so wrangler read the committed `wrangler.jsonc` and errored
+ * "Couldn't find a D1 DB with the name or binding '<app>-pr<n>-db'". Every per-PR preview since
+ * #2020 came up with an empty database. The dangerous near-fix is passing `--config` alone:
+ * `migrations_dir` is relative to the config that declares it, and the built config lives in
+ * `.output/server/`, so the path doubles and wrangler reports success having migrated nothing
+ * (#138) — a silent no-op replacing a loud failure. These tests pin the absolute rewrite.
+ */
+const builtWithMigrations = () => ({
+  name: 'kassa',
+  d1_databases: [{
+    binding: 'DB',
+    database_name: 'kassa-staging-db',
+    database_id: 'REAL-STAGING-ID',
+    migrations_dir: 'server/db/migrations/sqlite',
+  }],
+})
+
+test('#2078: migrations_dir is made absolute against the app root', () => {
+  const { config } = toPrPreview(builtWithMigrations(), 'kassa', 2074, { migrationsBase: '/repo/apps/kassa' })
+  assert.equal(config.d1_databases[0].migrations_dir, '/repo/apps/kassa/server/db/migrations/sqlite')
+})
+
+test('#2078: an already-absolute migrations_dir is left alone', () => {
+  const cfg = builtWithMigrations()
+  cfg.d1_databases[0].migrations_dir = '/somewhere/else/migrations'
+  const { config } = toPrPreview(cfg, 'kassa', 2074, { migrationsBase: '/repo/apps/kassa' })
+  assert.equal(config.d1_databases[0].migrations_dir, '/somewhere/else/migrations')
+})
+
+test('#2078: a `./`-prefixed migrations_dir does not produce a doubled separator', () => {
+  const cfg = builtWithMigrations()
+  cfg.d1_databases[0].migrations_dir = './server/db/migrations/sqlite'
+  const { config } = toPrPreview(cfg, 'kassa', 2074, { migrationsBase: '/repo/apps/kassa/' })
+  assert.equal(config.d1_databases[0].migrations_dir, '/repo/apps/kassa/server/db/migrations/sqlite')
+})
+
+test('#2078: without migrationsBase the config is untouched — callers that never migrate are unaffected', () => {
+  const { config } = toPrPreview(builtWithMigrations(), 'kassa', 2074)
+  assert.equal(config.d1_databases[0].migrations_dir, 'server/db/migrations/sqlite')
+})
+
+test('#2078: the rewrite is reported, so a silent no-op is visible in the log', () => {
+  const { changed } = toPrPreview(builtWithMigrations(), 'kassa', 2074, { migrationsBase: '/repo/apps/kassa' })
+  assert.ok(changed.some((c) => c.includes('migrations_dir=/repo/apps/kassa/')), changed.join(' | '))
+})
+
+test('#2078: the isolation guarantees still hold alongside the rewrite', () => {
+  const { config } = toPrPreview(builtWithMigrations(), 'kassa', 2074, { migrationsBase: '/repo/apps/kassa' })
+  const db = config.d1_databases[0]
+  assert.ok(!('database_id' in db), 'still must provision fresh')
+  assert.equal(db.database_name, 'kassa-pr2074-db')
+})

--- a/scripts/pr-preview-wrangler.mjs
+++ b/scripts/pr-preview-wrangler.mjs
@@ -9,8 +9,28 @@
  *
  * Emits GITHUB_OUTPUT-style lines on stdout: worker=<name>, db=<database_name>.
  */
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import { toPrPreview } from './lib/pr-preview-wrangler.mjs'
+import { parseJsonc } from './lib/wrangler-d1.mjs'
+
+/** The app's committed config, or null when it can't be read (backfill is then a no-op). */
+function readSourceWrangler(appDir) {
+  const p = join(appDir, 'wrangler.jsonc')
+  if (!existsSync(p)) return null
+  try { return parseJsonc(readFileSync(p, 'utf8')) } catch { return null }
+}
+
+/** `migrations_dir` for a binding, from the top level or any named env — first match wins. */
+function sourceMigrationsDir(source, binding) {
+  if (!source) return null
+  const scopes = [source, ...Object.values(source.env || {})]
+  for (const s of scopes) {
+    const hit = (s?.d1_databases || []).find((d) => d.binding === binding && d.migrations_dir)
+    if (hit) return hit.migrations_dir
+  }
+  return null
+}
 
 const [file, app, pr] = process.argv.slice(2)
 if (!file || !app || !pr) {
@@ -19,7 +39,9 @@ if (!file || !app || !pr) {
 }
 
 const raw = readFileSync(file, 'utf8')
-const { config, name, changed } = toPrPreview(JSON.parse(raw), app, pr)
+// cwd is the app root (the workflow runs this with working-directory: <workspace>/<app>), which
+// is what a source-config `migrations_dir` is relative to. See absolutizeMigrations (#2078).
+const { config, name, changed } = toPrPreview(JSON.parse(raw), app, pr, { migrationsBase: process.cwd() })
 writeFileSync(file, JSON.stringify(config, null, 2) + '\n')
 
 // Loud by design: this step silently doing nothing would ship a "preview" pointed at
@@ -28,6 +50,41 @@ for (const c of changed) console.error(`  ${c}`)
 if (!changed.length) {
   console.error('pr-preview-wrangler: NOTHING CHANGED — refusing to pretend this is isolated')
   process.exit(1)
+}
+
+// The migrate step runs against THIS config, so a D1 binding whose migrations can't be located
+// means the preview comes up with an empty schema — green deploy, no tables: the #2078 failure.
+//
+// Nitro regenerates the built config on every build and is already known to DROP fields the
+// source declares (it drops the whole `env` block — nitro#3429, which is why inject-wrangler-env
+// exists). Rather than assume `migrations_dir` survives, backfill it from the source
+// `wrangler.jsonc` when it's absent, then assert the directory is really there. Backfilling is
+// strictly better than failing: it fixes the case instead of blocking every preview on it.
+const dbs = config.d1_databases || []
+if (dbs.length) {
+  const source = readSourceWrangler(process.cwd())
+  let patched = false
+  for (const b of dbs) {
+    if (!b.migrations_dir) {
+      const fromSource = sourceMigrationsDir(source, b.binding)
+      if (fromSource) {
+        b.migrations_dir = resolve(process.cwd(), fromSource)
+        console.error(`  d1_databases.${b.binding}: migrations_dir backfilled from wrangler.jsonc = ${b.migrations_dir}`)
+        patched = true
+      }
+    }
+    if (!b.migrations_dir) {
+      console.error(`pr-preview-wrangler: d1 binding ${b.binding} has NO migrations_dir, in the built config`)
+      console.error('  or in wrangler.jsonc. The preview would deploy an unmigrated database (#2078).')
+      process.exit(1)
+    }
+    if (!existsSync(b.migrations_dir)) {
+      console.error(`pr-preview-wrangler: migrations_dir does not exist: ${b.migrations_dir}`)
+      console.error('  The preview would migrate nothing while reporting success (#138/#2078).')
+      process.exit(1)
+    }
+  }
+  if (patched) writeFileSync(file, JSON.stringify(config, null, 2) + '\n')
 }
 
 const db = (config.d1_databases || [])[0]?.database_name || ''


### PR DESCRIPTION
Closes #2078

## 👤 What this fixes

**Every per-PR preview deploy since #2020 has been serving an unmigrated, empty database.** The Worker deploys fine, wrangler provisions a fresh D1, then:

```
✨ DB provisioned 🎉  →  kassa-pr2074-db
✘ [ERROR] Couldn't find a D1 DB with the name or binding
  'kassa-pr2074-db' in your wrangler.jsonc file.
```

It also fails the whole deploy step, which is why **all four** preview deploys on #2074 are red — apps and poc alike.

## 🤖 Why

The migrate ran with **no `--config`**, so wrangler read the app's *committed* `wrangler.jsonc` — which carries `<app>-db` / `<app>-staging-db` and structurally cannot know about `<app>-pr<n>-db`. That name exists only in the rewritten built config.

**Passing `--config` alone would have been worse.** `migrations_dir` resolves relative to the config that declares it. The built config lives in `.output/server/`, so `server/db/migrations/sqlite` would resolve to `.output/server/server/db/migrations/sqlite` — **#138 exactly**, where wrangler reports success having migrated nothing. That trades a loud failure for a silent one.

So `pr-preview-wrangler.mjs` rewrites `migrations_dir` **absolute** at the one moment it still knows the app root, and the migrate passes `--config`.

**And it doesn't assume the field survives the build.** Nitro is already known to drop things the source declares — it drops the entire `env` block (nitro#3429), which is the whole reason `inject-wrangler-env` exists. So rather than guess about `migrations_dir`, the CLI backfills it from `wrangler.jsonc` when absent, then asserts the directory actually exists. Backfilling beats failing: it fixes the case instead of blocking every preview on it.

Two silent-no-op paths removed while here: an empty `PREVIEW_DB` short-circuited the entire migrate line with no message, and `| tail -5` hid the output.

## Evidence

Ran the CLI over **all 12 real app/poc configs**, in both built-config shapes — `migrations_dir` kept, and dropped by the build:

```
✅ apps/kassa [keep] → /…/apps/kassa/server/db/migrations/sqlite
✅ apps/kassa [drop] → /…/apps/kassa/server/db/migrations/sqlite
✅ apps/triage [keep] / [drop]      ✅ apps/velo [keep] / [drop]
✅ pocs/crouton-builder-demo [keep] / [drop]
✅ pocs/notes [keep] / [drop]       ✅ pocs/pins [keep] / [drop]
=== pass=12 fail=0 ===
```

Each resolved path was asserted to be a real directory — not just a non-empty string. `pocs/loop-station` has no D1 binding at all, so nothing fires for it.

Six new unit tests pin the absolute rewrite, the already-absolute and `./`-prefixed cases, the no-`migrationsBase` no-op, the log line, and that #2020's isolation guarantees still hold alongside it. 17/17 green. `npx fallow audit --base origin/main` → no issues.

## 🧪 How to test

Open a PR touching any `apps/**` or `pocs/**` path and let the preview deploy. The migrate step should apply migrations against `<app>-pr<N>-db`. Then:

```
npx wrangler d1 execute <app>-pr<N>-db --remote \
  --command "SELECT name FROM sqlite_master WHERE type='table'"
```

Tables should be listed. Today this returns nothing.

Refs #2020, #138, #2074

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_