### PR TITLE
fix(root): resolve the preview's provisioned D1 id before migrating (#2085)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -289,6 +289,11 @@ jobs:
               echo "::error::pr-preview-wrangler produced no db name — the preview would have NO schema."
               exit 1
             fi
+            # The deploy above just PROVISIONED that database, but the built config still
+            # carries no `database_id` — it is stripped on purpose so wrangler auto-provisions
+            # (#2020). Remote D1 operations need the id, so resolve it by name now that it
+            # exists. Without this the migrate fails "missing a database_id" (#2085).
+            node "$GITHUB_WORKSPACE/scripts/pr-preview-db-id.mjs" .output/server/wrangler.json
             npx wrangler d1 migrations apply "$PREVIEW_DB" \
               --config .output/server/wrangler.json --remote
             (pnpm db:seed:staging || true)

--- a/scripts/lib/pr-preview-db-id.mjs
+++ b/scripts/lib/pr-preview-db-id.mjs
@@ -1,0 +1,45 @@
+/**
+ * Resolve the PR-preview's provisioned D1 ids into its BUILT wrangler config (#2085).
+ *
+ * WHY THIS EXISTS. Per-PR previews deliberately strip `database_id` from the built config
+ * so `wrangler deploy` AUTO-PROVISIONS a fresh database per PR (#2020) — keeping the
+ * preview off staging's data. #2079 then pointed `d1 migrations apply` at that same built
+ * config, because it is the only place the PR-scoped `database_name` exists. Both moves are
+ * right, and together they leave a gap: remote D1 operations need the **id**, and the id
+ * does not exist until the deploy that creates it has run.
+ *
+ *     ✘ Found a database with name or binding velo-pr2080-db but it is missing a
+ *       database_id, which is needed for operations on remote resources.
+ *
+ * So this runs BETWEEN deploy and migrate: ask wrangler which databases exist, match by the
+ * name already in the config, and write the id in.
+ *
+ * IT FAILS LOUDLY ON A MISS. A preview that quietly skips its migrations is exactly the
+ * #2078 failure — an empty database behind a link that looks like a working preview — and
+ * that one went unnoticed for weeks precisely because nothing complained.
+ */
+
+/**
+ * @param {object}   config      parsed built wrangler config (mutated in place)
+ * @param {Array<{name?:string, uuid?:string, id?:string}>} d1List  `wrangler d1 list --json`
+ * @returns {{ resolved: string[], missing: string[], alreadySet: string[] }}
+ */
+export function applyD1Ids(config, d1List) {
+  const resolved = []
+  const missing = []
+  const alreadySet = []
+
+  for (const b of config?.d1_databases || []) {
+    if (b.database_id) { alreadySet.push(b.database_name || b.binding); continue }
+    const name = b.database_name
+    if (!name) { missing.push(`<binding ${b.binding} has no database_name>`); continue }
+    const hit = (d1List || []).find((d) => d.name === name)
+    // wrangler has used both keys across versions; take whichever is present rather than
+    // betting on one and silently resolving to `undefined`.
+    const id = hit && (hit.uuid || hit.id)
+    if (!id) { missing.push(name); continue }
+    b.database_id = id
+    resolved.push(`${name} → ${id}`)
+  }
+  return { resolved, missing, alreadySet }
+}

--- a/scripts/lib/pr-preview-db-id.test.mjs
+++ b/scripts/lib/pr-preview-db-id.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * #2085 contract — the preview must migrate its OWN database, or say why it can't.
+ *
+ * The gap: #2020 strips `database_id` so wrangler auto-provisions a fresh DB per PR, and
+ * #2079 points the migrate at that same built config because it is the only place the
+ * PR-scoped name lives. Both correct; together they leave the migrate with a name and no
+ * id, which remote D1 operations require. This resolves it between the two.
+ *
+ * The failure mode to protect against is NOT the error — it is the quiet success: a
+ * preview whose migrations were skipped serves an empty database behind a link that looks
+ * fine. That is #2078, which went unnoticed for weeks. So an unresolved name must be loud.
+ *
+ *   node --test scripts/lib/pr-preview-db-id.test.mjs
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { applyD1Ids } from './pr-preview-db-id.mjs'
+
+const built = () => ({
+  name: 'velo-pr2080',
+  d1_databases: [{ binding: 'DB', database_name: 'velo-pr2080-db', migrations_dir: '/abs/migrations' }],
+})
+
+test('the provisioned id is written in, matched by name', () => {
+  const cfg = built()
+  const r = applyD1Ids(cfg, [{ name: 'velo-pr2080-db', uuid: 'UUID-1' }])
+  assert.equal(cfg.d1_databases[0].database_id, 'UUID-1')
+  assert.deepEqual(r.missing, [])
+  assert.deepEqual(r.resolved, ['velo-pr2080-db → UUID-1'])
+})
+
+test('`id` is accepted as well as `uuid` — wrangler has used both', () => {
+  const cfg = built()
+  applyD1Ids(cfg, [{ name: 'velo-pr2080-db', id: 'ID-1' }])
+  assert.equal(cfg.d1_databases[0].database_id, 'ID-1')
+})
+
+test('THE LOUD CASE — an unmatched name is reported, not silently skipped', () => {
+  const cfg = built()
+  const r = applyD1Ids(cfg, [{ name: 'some-other-db', uuid: 'x' }])
+  assert.deepEqual(r.missing, ['velo-pr2080-db'])
+  assert.equal(cfg.d1_databases[0].database_id, undefined, 'must not invent an id')
+})
+
+test('an empty d1 list is a miss, not a pass', () => {
+  assert.deepEqual(applyD1Ids(built(), []).missing, ['velo-pr2080-db'])
+  assert.deepEqual(applyD1Ids(built(), null).missing, ['velo-pr2080-db'])
+})
+
+test('a binding that already has an id is left alone — never overwritten', () => {
+  const cfg = built()
+  cfg.d1_databases[0].database_id = 'PRE-EXISTING'
+  const r = applyD1Ids(cfg, [{ name: 'velo-pr2080-db', uuid: 'DIFFERENT' }])
+  assert.equal(cfg.d1_databases[0].database_id, 'PRE-EXISTING')
+  assert.deepEqual(r.resolved, [])
+  assert.deepEqual(r.alreadySet, ['velo-pr2080-db'])
+})
+
+test('a binding with no database_name is a miss and names the binding', () => {
+  const cfg = { d1_databases: [{ binding: 'DB' }] }
+  assert.match(applyD1Ids(cfg, [{ name: 'x', uuid: 'y' }]).missing[0], /binding DB/)
+})
+
+test('multiple bindings resolve independently, and one miss still reports', () => {
+  const cfg = { d1_databases: [
+    { binding: 'DB', database_name: 'a-db' },
+    { binding: 'DB2', database_name: 'b-db' },
+  ] }
+  const r = applyD1Ids(cfg, [{ name: 'a-db', uuid: 'A' }])
+  assert.equal(cfg.d1_databases[0].database_id, 'A')
+  assert.deepEqual(r.missing, ['b-db'])
+})
+
+test('no d1 bindings at all is a clean no-op (pocs/loop-station has none)', () => {
+  const r = applyD1Ids({ name: 'x' }, [])
+  assert.deepEqual(r, { resolved: [], missing: [], alreadySet: [] })
+})

--- a/scripts/lib/sync-wrangler-ids.mjs
+++ b/scripts/lib/sync-wrangler-ids.mjs
@@ -55,8 +55,14 @@ function parseJsonc(text) {
  * Run a wrangler subcommand and parse its JSON output. Pass the FULL arg list —
  * note the two list commands differ: `d1 list` needs an explicit `--json` flag,
  * but `kv namespace list` already emits a JSON array and REJECTS `--json`.
+ *
+ * EXPORTED (#2085) so the per-PR preview path can ask the same question the same way.
+ * It needs the provisioned D1 id too, but writes it into the BUILT config rather than
+ * the source `wrangler.jsonc`, so it can't reuse `syncWranglerIds` wholesale — this is
+ * the one piece worth sharing, and a second copy of "how do we ask wrangler" is exactly
+ * the duplication that let one bug live in two places twice already (#2027, #2056).
  */
-function wranglerJson(appDir, args, injectEnvVar) {
+export function wranglerJson(appDir, args, injectEnvVar) {
   const injected = process.env[injectEnvVar]
   const raw = injected !== undefined
     ? injected

--- a/scripts/pr-preview-db-id.mjs
+++ b/scripts/pr-preview-db-id.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * CLI: write the provisioned D1 ids into a per-PR preview's BUILT wrangler config (#2085).
+ * Runs BETWEEN `wrangler deploy` (which provisions) and `d1 migrations apply` (which needs
+ * the id). See scripts/lib/pr-preview-db-id.mjs for why the gap exists.
+ *
+ *   node scripts/pr-preview-db-id.mjs <built-wrangler.json>
+ *
+ * cwd must be the app dir, so `wrangler` resolves the same account the deploy used.
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { wranglerJson } from './lib/sync-wrangler-ids.mjs'
+import { applyD1Ids } from './lib/pr-preview-db-id.mjs'
+
+const [file] = process.argv.slice(2)
+if (!file) {
+  console.error('usage: pr-preview-db-id.mjs <built-wrangler.json>')
+  process.exit(2)
+}
+if (!existsSync(file)) {
+  console.error(`pr-preview-db-id: ${file} not found — run the build + deploy first.`)
+  process.exit(1)
+}
+
+const config = JSON.parse(readFileSync(file, 'utf8'))
+if (!(config.d1_databases || []).length) {
+  console.log('pr-preview-db-id: no d1 bindings — nothing to resolve.')
+  process.exit(0)
+}
+
+// PR_PREVIEW_D1_LIST lets this be exercised without Cloudflare (the same injection hook
+// sync-wrangler-ids uses); in CI it is unset and the real `wrangler d1 list` runs.
+const d1List = wranglerJson(process.cwd(), ['d1', 'list', '--json'], 'PR_PREVIEW_D1_LIST')
+const { resolved, missing, alreadySet } = applyD1Ids(config, d1List)
+
+for (const r of resolved) console.log(`  resolved ${r}`)
+for (const a of alreadySet) console.log(`  ${a} already had an id — left alone`)
+
+if (missing.length) {
+  console.error(`::error::No provisioned D1 found for: ${missing.join(', ')}`)
+  console.error(`::error::Available: ${(d1List || []).map((d) => d.name).join(', ') || '(none)'}`)
+  console.error('::error::Refusing to continue — migrating nothing would leave the preview')
+  console.error('::error::with an empty database behind a link that looks fine (#2078/#2085).')
+  process.exit(1)
+}
+
+if (resolved.length) writeFileSync(file, JSON.stringify(config, null, 2) + '\n')
+console.log(`pr-preview-db-id: ${resolved.length} id(s) written to ${file}`)


### PR DESCRIPTION
Closes #2085

## 👤 My regression, from #2079

Preview deploys now get past *"couldn't find a D1 with that name"* and die on *"missing a database_id"* instead. Both fail — the error just moved one step later. This is what's red on #2080.

```
env.DB (velo-pr2080-db)      D1 Database
Uploaded velo-pr2080 (21.31 sec)
✘ Found a database with name or binding velo-pr2080-db but it is
  missing a database_id, which is needed for operations on remote resources.
```

## 🤖 Two correct decisions with a gap between them

- **#2020** strips `database_id` from the built config so wrangler **auto-provisions** a fresh DB per PR — that's what keeps the preview off staging's data.
- **#2079** points the migrate at that same built config, because it's the only place the PR-scoped `database_name` exists.

Both right. Together they leave the migrate with a name and no id — and the id doesn't exist until the deploy that creates it has run.

So: a step **between** deploy and migrate. Ask wrangler which databases exist, match by the name already in the config, write the id in.

**It fails loudly on a miss.** A preview that quietly skips migrations is #2078 returning — an empty database behind a link that looks fine — and that went unnoticed for weeks precisely because nothing complained.

Exports `wranglerJson` from `scripts/lib/sync-wrangler-ids.mjs` rather than writing a second *"how do we ask wrangler"*. That duplication let one bug live in two places in both #2027 and #2056.

## What I should have caught

#2079 **was** corpus-checked, over 12 real configs. But the assertion was *"does `migrations_dir` resolve to a real directory"* — the half I had reasoned about. Nothing exercised the **post-deploy** half, because that needs Cloudflare.

**A corpus run only covers what it actually asserts.** Breadth of inputs doesn't compensate for a check aimed at the wrong half.

This one *is* testable without Cloudflare, via the `injectEnvVar` hook `sync-wrangler-ids` already had — so it is.

## Evidence

8 unit tests, plus the real CLI driven end-to-end on both paths:

```
=== happy path (injected d1 list) ===
  resolved velo-pr2080-db → 11111111-2222-3333-4444-555555555555
  pr-preview-db-id: 1 id(s) written        exit=0

=== miss path ===
  ::error::No provisioned D1 found for: velo-pr2080-db
  ::error::Available: velo-staging-db
  ::error::Refusing to continue — migrating nothing would leave the preview
  ::error::with an empty database behind a link that looks fine.   exit=1
```

25/25 tests across both preview suites. YAML parses. Fallow reports no new findings on the changed files (the duplication warn is inherited).

## 🧪 How to test

This PR's own preview deploys are the test — they should now reach the migrate and pass. Then:

```
npx wrangler d1 execute <app>-pr<N>-db --remote \
  --command "SELECT name FROM sqlite_master WHERE type='table'"
```

Refs #2079, #2078, #2020

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_