### PR TITLE
fix(root): a PR's changed files are the merge-base diff, not a tree diff (#2087)

### DIFF
--- a/scripts/deploy-detect.mjs
+++ b/scripts/deploy-detect.mjs
@@ -101,7 +101,27 @@ export function resolveChangedFiles({ event, baseSha, headSha, git }) {
     // A PR's base.sha is always a real, fetched commit — if it won't resolve, something is
     // genuinely wrong; don't paper over it.
     if (!git.isResolvable(baseSha)) throw new DetectError(`PR base sha not resolvable: ${baseSha || '(empty)'}`)
-    return { files: git.diff(baseSha, headSha), source: 'pr:base..head' }
+    // THREE-dot (#2087). `git diff A B` is the symmetric difference of two TREES, so a branch
+    // that has fallen behind `main` reports everything that landed on main meanwhile as its
+    // own change — in reverse. #2080 changed two files under packages/crouton-cli and the
+    // two-dot diff reported 21, including apps/{kassa,triage,velo}/nuxt.config.ts (which
+    // #2074 had just added to main). That scheduled all three app deploys for a PR that
+    // touches no app, and they went red — the visible cost is spurious failures on unrelated
+    // PRs. `A...B` diffs from the MERGE BASE, which is what "what did this PR change" means.
+    //
+    // It can only ever over-deploy, never under — so nothing was silently skipped, and the
+    // fix cannot introduce a missed deploy either.
+    if (!git.hasMergeBase(baseSha, headSha)) {
+      // No merge base (a shallow checkout that doesn't reach it). Fail loud rather than
+      // silently falling back to two-dot — that fallback IS this bug, and #1499's rule is
+      // that an unresolvable diff must never quietly become a wrong answer.
+      throw new DetectError(
+        `PR merge-base not resolvable for ${baseSha}...${headSha} — the checkout is probably too `
+        + `shallow. Refusing to fall back to a two-dot diff, which reports every commit that `
+        + `landed on the base branch since this one forked as if this PR made it (#2087).`,
+      )
+    }
+    return { files: git.diffFrom(baseSha, headSha), source: 'pr:base...head' }
   }
   // push-to-main: prefer the tip's first-parent diff — for a merge commit that IS the net PR
   // change, and it doesn't depend on github.event.before (which is wrong under concurrent
@@ -128,6 +148,26 @@ function realGit() {
     },
     diff(a, b) {
       return run(['diff', '--name-only', a, b]).split('\n').map(s => s.trim()).filter(Boolean)
+    },
+    // THREE-dot: from the merge base of a and b (#2087). A separate method, not a flag on
+    // `diff`, so the injected fake can answer the two differently — the old fake returned one
+    // canned list for `diff(a, b)` and therefore could not express the distinction at all,
+    // which is why every existing test passed against the wrong diff form.
+    diffFrom(a, b) {
+      return run(['diff', '--name-only', `${a}...${b}`]).split('\n').map(s => s.trim()).filter(Boolean)
+    },
+    // `git merge-base` is the only honest way to ask this. NOT `isResolvable('a...b')` —
+    // that runs `rev-parse --verify 'a...b^{commit}'`, which a RANGE can never satisfy, so
+    // the guard threw on every PR. The unit fake happily declared the range resolvable, so
+    // the tests agreed with the code and both were wrong; only running it against the real
+    // repo showed it. Twice in one change, the same lesson.
+    hasMergeBase(a, b) {
+      try {
+        run(['merge-base', a, b])
+        return true
+      } catch {
+        return false
+      }
     }
   }
 }

--- a/scripts/deploy-detect.test.mjs
+++ b/scripts/deploy-detect.test.mjs
@@ -14,9 +14,20 @@ import {
 } from './deploy-detect.mjs'
 
 // A stand-in for the injected git: declared-resolvable refs + canned diffs.
-const fakeGit = ({ resolvable = [], diffs = {} }) => ({
+//
+// `diffs` keys are the literal ref expression, so a test can give DIFFERENT answers for
+// `a..b` and `a...b` (#2087). The old fake had only `diff(a, b)` keyed `a..b`, so two-dot
+// and three-dot were indistinguishable to it — every test passed against the wrong diff
+// form because the fake shared the code's assumption. `isResolvable` covers `a...b` too,
+// which is how the merge-base guard is exercised.
+const fakeGit = ({ resolvable = [], diffs = {}, mergeBase = true }) => ({
   isResolvable: ref => resolvable.includes(ref),
-  diff: (a, b) => diffs[`${a}..${b}`] || []
+  diff: (a, b) => diffs[`${a}..${b}`] || [],
+  diffFrom: (a, b) => diffs[`${a}...${b}`] || [],
+  // Its own knob, because it is its own git question (`git merge-base`). The first cut of
+  // this fix expressed it as isResolvable('a...b'); the fake said yes, real git says no —
+  // a range is not a commit — and the guard threw on every PR (#2087).
+  hasMergeBase: () => mergeBase
 })
 
 const APPS = [
@@ -110,14 +121,94 @@ test('push with the all-zero before-sha and no HEAD~1 throws rather than emittin
   assert.throws(() => resolveChangedFiles({ event: 'push', baseSha: ZERO_SHA, headSha: 'head', git }), DetectError)
 })
 
-test('pull_request uses base..head', () => {
-  const git = fakeGit({ resolvable: ['prbase'], diffs: { 'prbase..prhead': ['apps/triage/x.vue'] } })
+// Was `pull_request uses base..head`, asserting the two-dot form — the test pinned the bug
+// (#2087). It passed because the old fake keyed everything as `a..b`, so it could not have
+// noticed the difference it was asserting. Now it pins the merge-base diff.
+test('pull_request uses base...head (merge base)', () => {
+  const git = fakeGit({
+    resolvable: ['prbase', 'prbase...prhead'],
+    diffs: { 'prbase...prhead': ['apps/triage/x.vue'] },
+  })
   const r = resolveChangedFiles({ event: 'pull_request', baseSha: 'prbase', headSha: 'prhead', git })
-  assert.equal(r.source, 'pr:base..head')
+  assert.equal(r.source, 'pr:base...head')
   assert.deepEqual(r.files, ['apps/triage/x.vue'])
 })
 
 test('pull_request throws when the PR base sha will not resolve (no silent empty)', () => {
   const git = fakeGit({ resolvable: [] })
   assert.throws(() => resolveChangedFiles({ event: 'pull_request', baseSha: 'ghost', headSha: 'head', git }), DetectError)
+})
+
+
+/* ── #2087: a PR that has fallen behind its base must not inherit the base's changes ──
+ *
+ * THE INCIDENT. #2080 changed two files under packages/crouton-cli. `git diff BASE HEAD`
+ * (two-dot) reported 21, including apps/{kassa,triage,velo}/nuxt.config.ts — files #2074 had
+ * just added to main, which this branch simply didn't have yet. That scheduled all three app
+ * deploys for a PR touching no app, and they failed, putting a red X on unrelated work.
+ *
+ * Two-dot is the symmetric difference of two TREES. "What did this PR change" is the diff
+ * from the MERGE BASE — three-dot. These pin that, and the fake above is what makes them
+ * capable of failing.
+ */
+test('#2087: a PR uses the THREE-dot diff, not two-dot', () => {
+  const r = resolveChangedFiles({
+    event: 'pull_request', baseSha: 'BASE', headSha: 'HEAD',
+    git: fakeGit({
+      resolvable: ['BASE', 'BASE...HEAD'],
+      diffs: {
+        // What main gained meanwhile (must NOT be attributed to this PR) …
+        'BASE..HEAD': ['apps/velo/nuxt.config.ts', 'apps/kassa/package.json', 'packages/crouton-cli/lib/x.ts'],
+        // … versus what the PR actually changed.
+        'BASE...HEAD': ['packages/crouton-cli/lib/x.ts'],
+      },
+    }),
+  })
+  assert.deepEqual(r.files, ['packages/crouton-cli/lib/x.ts'])
+  assert.equal(r.source, 'pr:base...head')
+})
+
+test('#2087 end to end: the stale-branch shape schedules NO deploys', () => {
+  const { files } = resolveChangedFiles({
+    event: 'pull_request', baseSha: 'BASE', headSha: 'HEAD',
+    git: fakeGit({
+      resolvable: ['BASE', 'BASE...HEAD'],
+      diffs: {
+        'BASE..HEAD': ['apps/velo/nuxt.config.ts', 'apps/triage/nuxt.config.ts', 'packages/crouton-cli/lib/x.ts'],
+        'BASE...HEAD': ['packages/crouton-cli/lib/x.ts'],
+      },
+    }),
+  })
+  const { include, any } = computeMatrix({ event: 'pull_request', changedFiles: files, apps: APPS })
+  assert.deepEqual(include, [], 'a crouton-cli-only PR must deploy nothing')
+  assert.equal(any, false)
+})
+
+test('#2087: an unresolvable merge base FAILS rather than falling back to two-dot', () => {
+  assert.throws(
+    () => resolveChangedFiles({
+      event: 'pull_request', baseSha: 'BASE', headSha: 'HEAD',
+      git: fakeGit({ resolvable: ['BASE'], diffs: { 'BASE..HEAD': ['apps/velo/x.ts'] }, mergeBase: false }),
+    }),
+    DetectError,
+    'silently using two-dot IS the bug — a shallow checkout must be loud',
+  )
+})
+
+test('#2087: a PR that really does touch an app still deploys it', () => {
+  const { files } = resolveChangedFiles({
+    event: 'pull_request', baseSha: 'BASE', headSha: 'HEAD',
+    git: fakeGit({ resolvable: ['BASE', 'BASE...HEAD'], diffs: { 'BASE...HEAD': ['apps/velo/app/x.vue'] } }),
+  })
+  const { include } = computeMatrix({ event: 'pull_request', changedFiles: files, apps: APPS })
+  assert.deepEqual(include.map(i => i.app), ['velo'])
+})
+
+test('#2087: the push path is untouched — still first-parent two-dot', () => {
+  const r = resolveChangedFiles({
+    event: 'push', baseSha: 'BEFORE', headSha: 'HEAD',
+    git: fakeGit({ resolvable: ['HEAD~1'], diffs: { 'HEAD~1..HEAD': ['apps/velo/x.ts'] } }),
+  })
+  assert.equal(r.source, 'push:first-parent')
+  assert.deepEqual(r.files, ['apps/velo/x.ts'])
 })


### PR DESCRIPTION
Closes #2087

## 👤 Why #2080 is red

It shouldn't have deployed anything. #2080 changes two files under `packages/crouton-cli/**`, which is in **no** app's `watchPaths` — and on a PR the matcher narrows further to `apps/<app>/**`. It scheduled all three apps, and they failed.

```
two-dot  (what detect did):  21 files      three-dot (what a PR IS):  2 files
  apps/kassa/nuxt.config.ts                  packages/crouton-cli/lib/utils/validate-config.ts
  apps/triage/nuxt.config.ts                 packages/crouton-cli/tests/…/validate-config.test.ts
  apps/velo/nuxt.config.ts
```

Those `apps/**` files are what **#2074 added to `main`** after this branch was cut. `git diff A B` is the symmetric difference of two **trees**, so a branch that's fallen behind reports everything that landed meanwhile as its own change — in reverse. `A...B` diffs from the **merge base**, which is what "what did this PR change" means.

**Direction matters:** it can only ever over-deploy, never under. Nothing was silently skipped. The cost is wasted deploys, runner contention, and red checks on unrelated PRs.

## Two things running it caught that testing it didn't

**1. The existing test pinned the bug.** It asserted `pr:base..head`. It passed because the fake keyed every diff as `a..b` — so two-dot and three-dot were *indistinguishable to it*. The test and the code shared the same wrong assumption. The fake now answers the two forms separately, which is what makes these tests capable of failing at all.

**2. My first merge-base guard threw on every PR.** I wrote it as `isResolvable('a...b')` — which runs `rev-parse --verify 'a...b^{commit}'`, and a **range is not a commit**, so it can never succeed. The unit fake declared the range resolvable and cheerfully agreed with me. Only running the real script against #2080's real refs showed it:

```
::error::PR merge-base not resolvable for 40a79435e...d35cf0acd
```

Same lesson twice inside one change. The guard is now `git merge-base`, with its own knob on the fake.

An uncomputable merge base **fails loud** rather than falling back to two-dot — that fallback *is* this bug (#1499's rule).

## Evidence — the real script, on the real refs

```
=== #2080 (crouton-cli only) ===
Changed files (pr:base...head):
  packages/crouton-cli/lib/utils/validate-config.ts
  packages/crouton-cli/tests/unit/utils/validate-config.test.ts
Detected matrix: {"include":[]}
any=false

=== control: #2074 (really touched apps/) ===
Detected matrix: {"include":[{"app":"kassa"…},{"app":"triage"…},{"app":"velo"…}]}
any=true
```

20/20 tests · fallow clean.

## What this means for the queue

**#2080 goes green on a re-run once this lands** — it needs no deploy at all. It does not need #2086 (the preview D1 id fix); that one is still correct and needed for PRs that *do* deploy.

## 🧪 How to test

Re-run `Deploy Apps` on #2080 → `any=false`, no deploy jobs. Open a PR touching `apps/velo/**` → velo still deploys.

Refs #1499, #1477, #1297, #2080, #2086

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_