### PR TITLE
fix(root): ask again on a clock — auto-merge was edge-triggered only (#2091)

### DIFF
--- a/.github/workflows/automerge-epic-subpr.yml
+++ b/.github/workflows/automerge-epic-subpr.yml
@@ -60,7 +60,23 @@ name: Auto-merge epic sub-PRs
 # `workflow_run` DOES fire for Actions-generated completions. `CI` owns `CI Gate`, so its
 # completion is precisely the moment the answer can change. Same cure #1884 applied to
 # pipeline-pr-status.yml.
+# LEVEL-TRIGGERED BACKSTOP (#2091). Everything above is EDGE-triggered — a PR event, or a
+# workflow completing. A PR held at a moment when the answer was legitimately "not yet" is
+# therefore never re-asked, because its edges have all already fired: the pi worker pushes
+# exactly once (no `synchronize`), `check_suite` never fires for our own CI, and its `CI` run
+# completed long ago. Ten green sub-PRs sat stranded that way — CI went green in the 39-minute
+# window before #2013's re-evaluation existed, and nothing retroactively re-asks. Nothing was
+# red; the stale "CI Gate never reported" comment even read like an explanation.
+#
+# #1698 also measured GitHub intermittently DROPPING `pull_request` events (1 in 16). Under a
+# purely edge-triggered design every dropped event is a permanent strand.
+#
+# So: ask again, on a clock. The sweep only supplies CANDIDATES — every gate below (draft,
+# green, presence, shared-code, App-token merge) applies identically, so a PR that should be
+# held is re-asked and held again, not waved through.
 on:
+  schedule:
+    - cron: '17 * * * *'   # hourly, off-the-hour so it doesn't pile onto :00 with everything else
   pull_request:
     types: [opened, ready_for_review, synchronize]
   check_suite:
@@ -76,7 +92,9 @@ jobs:
   automerge:
     # On a PR event, evaluate it directly; on a check_suite, only when it went green
     # (a red/again-pending suite will re-fire this when it next completes green).
+    # `schedule` always runs — it carries no conclusion to filter on; it IS the "ask again".
     if: >
+      github.event_name == 'schedule' ||
       github.event_name == 'pull_request' ||
       (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success') ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
@@ -127,7 +145,25 @@ jobs:
 
             // Resolve candidate PR numbers from whatever event fired.
             const candidates = new Set()
-            if (context.eventName === 'pull_request') {
+            if (context.eventName === 'schedule') {
+              // The level-triggered sweep (#2091): there is no event payload to read from, so
+              // enumerate the population directly — every open, non-draft PR targeting an epic
+              // branch. Drafts are the sign-off gates and are merged by resume-on-comment on
+              // approval, never here.
+              //
+              // The cap is stated out loud rather than silently truncating: a sweep that
+              // quietly stops halfway would strand exactly the PRs it exists to rescue, which
+              // is the bug in a new costume.
+              const SWEEP_MAX = 100
+              const open = await github.paginate(github.rest.pulls.list,
+                { owner, repo, state: 'open', per_page: 100 })
+              const subPrs = open.filter(p => !p.draft && p.base.ref.startsWith('epic/'))
+              for (const p of subPrs.slice(0, SWEEP_MAX)) candidates.add(p.number)
+              core.info(`Sweep: ${open.length} open PRs, ${subPrs.length} open non-draft sub-PRs on epic branches.`)
+              if (subPrs.length > SWEEP_MAX) {
+                core.warning(`Sweep cap ${SWEEP_MAX} reached — ${subPrs.length - SWEEP_MAX} sub-PR(s) NOT evaluated this tick. They will be picked up next hour, but if this recurs the cap needs raising.`)
+              }
+            } else if (context.eventName === 'pull_request') {
               candidates.add(context.payload.pull_request.number)
             } else {
               // check_suite and workflow_run carry the same two useful fields under


### PR DESCRIPTION
Closes #2091

## 👤 Why ten green PRs are stuck

Nothing is broken. Nothing ever re-asked.

```
22:18  automerge holds them: "CI Gate never reported"   ← correct at that moment
22:17–22:55  CI Gate SUCCEEDS for all ten
22:57  #2013 lands the workflow_run re-evaluation
23:02  first workflow_run-triggered automerge run       ← works, 71 times since
```

All ten had CI complete inside the **39-minute window before #2013 existed**. `workflow_run` fires when a workflow *completes* — theirs already had. Their other edges are gone too: the pi worker pushes exactly once (no `synchronize`), and `check_suite` never fires for our own CI.

So they were stranded permanently, and *silently*: green, unlabelled, carrying a stale comment that reads like an explanation.

**This is the shape, not the exception.** #1698 measured GitHub intermittently **dropping** `pull_request` events (1 in 16). Under a purely edge-triggered design, every dropped event is a permanent strand.

## 🤖 The fix

An hourly sweep (`17 * * * *`, off-the-hour) that re-asks. It **only supplies candidates** — every existing gate applies identically:

| gate | still applies |
|---|---|
| draft | ✅ drafts are the sign-off gates; merged by `resume-on-comment` on approval, never here |
| green | ✅ |
| presence (`CI Gate` reported) | ✅ |
| shared-code `packages/` hold | ✅ |
| App-token merge, no squash | ✅ |

A PR that should be held is **re-asked and held again**, not waved through.

The cap is `core.warning`'d rather than silently truncating — a sweep that quietly stops halfway would strand exactly the PRs it exists to rescue, which is the bug in a new costume.

## Evidence — simulated against the live repo

```
11 open PRs → 9 open non-draft sub-PRs on epic branches
  #2014 #2009 #2007 #2006 #2005 #2002 #2001 #2000 #1998

stranded set covered: [1998, 2000, 2001, 2002, 2005, 2006, 2007, 2009, 2014]
stranded MISSED     : [1999]   ← a draft sign-off gate, correctly excluded
extra picked up     : []
```

Exactly the stranded set, nothing else.

## A correction to my own earlier reading

I first reported these were *"evaluated once and never again"*, based on a search filtered on `head_branch == work-*`. That filter **cannot see the re-evaluations at all** — a `workflow_run`-triggered run reports `head_branch=main`. The conclusion happened to be right; the evidence for it wasn't, and I'd have missed a working mechanism if the timeline hadn't independently confirmed it.

## 🧪 How to test

Wait one tick after merge and re-read the nine. Each should either be merged into its epic branch, or carry `status:needs-merge` with the shared-code comment — they each touch one `packages/**` file, so expect the latter. **Neither outcome should require a push.**

Refs #2013, #1698, #339

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7VAe5PrcMss1beL8VEHq1)_