### PR TITLE
Make holds actionable end to end: issue-side blocked state, ✅ everywhere, and a link to the ask

### DIFF
--- a/.github/workflows/approve-draft-pr.yml
+++ b/.github/workflows/approve-draft-pr.yml
@@ -90,6 +90,16 @@ jobs:
               `mutation($id:ID!){ markPullRequestReadyForReview(input:{pullRequestId:$id}){ pullRequest { id } } }`,
               { id: pr.node_id })
 
+            // #2054: release the issue-side status:blocked the draft-open step (work-issue-pidev.yml)
+            // may have set. Resolve the issue from "Closes #NN" in the PR body — same pattern
+            // resume-on-comment.yml uses. Best-effort: a PR with no Closes line just has nothing to clear.
+            const closesMatch = (pr.body || '').match(/\bCloses\s+#(\d+)/i)
+            if (closesMatch) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: Number(closesMatch[1]), name: 'status:blocked' })
+              } catch (e) { /* label may not have been set (non-UI PR) — fine */ }
+            }
+
             const kind = approvalKind(body) === 'check' ? '✅' : '`lgtm`'
             await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body:
               `✅ **Released — marked ready for review** (${kind} from @${context.payload.comment.user.login}).\n\n`

--- a/.github/workflows/clear-blocked-on-pr-close.yml
+++ b/.github/workflows/clear-blocked-on-pr-close.yml
@@ -1,0 +1,49 @@
+name: Clear status:blocked when a held PR closes unmerged
+
+# #2054 acceptance criterion 5 — the last leg of the issue-side hold state.
+# work-issue-pidev.yml labels the ISSUE `status:blocked` when it opens a UI-held
+# draft; approve-draft-pr.yml clears it on release. But a held PR can also be
+# CLOSED WITHOUT MERGING (superseded, abandoned, re-dispatched) — and then the
+# label would stick forever, leaving a permanently-"blocked" issue whose blocker
+# no longer exists (the same one-way-door shape as #1665).
+#
+# Deliberately narrow so it can never clear a legitimate block:
+#   • fires only on close-without-merge (a merged PR's `Closes #NN` closes the
+#     issue itself — no label left to worry about);
+#   • only for pipeline worker branches (`work-<N>`), and the issue is resolved
+#     from the BRANCH NAME — the same coupling work-issue-pidev.yml used to SET
+#     the label — never from body prose, so an unrelated PR mentioning an issue
+#     can't strip that issue's real hold.
+# Removing a label raises no `labeled` event and triggers nothing (#572) — this
+# is state cleanup, not a dispatch.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  clear:
+    if: |
+      !github.event.pull_request.merged &&
+      startsWith(github.event.pull_request.head.ref, 'work-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const head = context.payload.pull_request.head.ref
+            const m = head.match(/^work-(\d+)$/)
+            if (!m) { core.info(`head ${head} is not a work-<issue> branch — nothing to clear.`); return }
+            const issue_number = Number(m[1])
+            try {
+              await github.rest.issues.removeLabel({ ...context.repo, issue_number, name: 'status:blocked' })
+              core.info(`Cleared status:blocked from #${issue_number} (PR #${context.payload.pull_request.number} closed unmerged).`)
+            } catch (e) {
+              // 404 = the label wasn't set (non-UI PR, or already cleared) — the normal case.
+              core.info(`No status:blocked to clear on #${issue_number} (${e.status || e.message}).`)
+            }

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -558,8 +558,11 @@ jobs:
             // push (#1076), which needs the owner to ACT, not to answer.
             // The `**Needs:** answer | action | approval` line is the explicit discriminator.
             // Absent ⇒ 'answer', which is exactly today's behaviour, so older holds are unaffected.
-            const holdBody = comments.map(c => c.body || '')
-              .find(b => /^##\s*🔀\s*Blocked\b/m.test(b)) || ''
+            // Keep the COMMENT OBJECT, not just its body (#2096): the notification below
+            // links the ask directly, so the owner is one tap from it instead of scroll-
+            // hunting a long thread on a phone for "the 🔀 comment above".
+            const holdComment = comments.find(c => /^##\s*🔀\s*Blocked\b/m.test(c.body || '')) || null
+            const holdBody = holdComment ? (holdComment.body || '') : ''
             const needs = (holdBody.match(/^\s*\*\*Needs:\*\*\s*(answer|action|approval)\b/mi) || [])[1]
             const holdKind = holdBody ? (needs ? needs.toLowerCase() : 'answer') : null
             const askedQuestion = signoffHeld && holdKind === 'answer'
@@ -574,10 +577,12 @@ jobs:
                 const freshPR = prRefs
                   .filter(e => new Date(e.created_at).getTime() >= sinceMs)
                   .map(e => e.source.issue.number)[0]
+                // Link the ask itself (#2096) — holdComment is guaranteed non-null on both
+                // hold branches (holdKind requires a non-empty holdBody).
                 const what = freshPR
                   ? `done → PR #${freshPR}`
-                  : needsAction ? '**needs you to APPLY something** — not an answer, not an approval. The 🔀 comment above says what to do and why the agent could not; the patch is collapsed under it. Comment here when applied and the work resumes in a fresh run.'
-                  : askedQuestion ? '**asked you a question** — it needs an *answer*, not an approval. The 🔀 comment above leads with the recommendation; reply with your pick and the work resumes in a fresh run.'
+                  : needsAction ? `**needs you to APPLY something** — not an answer, not an approval. **[→ the ask](${holdComment.html_url})** says what to do and why the agent could not; the patch is collapsed under it. Comment here when applied and the work resumes in a fresh run.`
+                  : askedQuestion ? `**asked you a question** — it needs an *answer*, not an approval. **[→ the ask](${holdComment.html_url})** leads with the recommendation; reply with your pick and the work resumes in a fresh run.`
                   : (createdSubIssues ? 'decomposed → sub-issues created (see the tree)'
                     : leafDispatched ? 'classified as a leaf → handed to the `work-this` worker (its PR lands in a separate run)'
                     : signoffHeld ? 'held for sign-off (`status:blocked` + a review)'

--- a/.github/workflows/resume-on-comment.yml
+++ b/.github/workflows/resume-on-comment.yml
@@ -210,7 +210,12 @@ jobs:
             const issue_number = context.payload.issue.number
             const body = context.payload.comment.body || ''
             // Approval only — a change-request reply must NOT merge anything.
-            if (!/\b(approve|approved|lgtm)\b/i.test(body)) {
+            // ONE definition of "approval" (#2051/#2094): isApproval() understands the
+            // whole-line ✅ gesture and strips code/quotes first, so a quoted or backticked
+            // `lgtm` can no longer merge a PR (the #2004 shape). The repo is checked out at
+            // the top of this job, so the tested module is importable here.
+            const { isApproval } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/approval.mjs`)
+            if (!isApproval(body)) {
               core.info('Comment is not an approval — nothing to merge.'); return
             }
 
@@ -482,24 +487,39 @@ jobs:
   # approval AND the issue actually has a pending gate PR (open, into an `epic/*`
   # branch). An approval word on an ordinary issue is ignored.
   explain-skipped-approval:
+    # The contains() tests are a CHEAP PRE-FILTER ONLY (#2004) — the decision is
+    # isApproval() below. The check emoji are listed too (#2094): a bare ✅ used to
+    # slip past this prefilter entirely, so a wasted check-approval got no explainer.
     if: |
       !github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot' &&
       !contains(github.event.issue.labels.*.name, 'status:blocked') &&
-      (contains(github.event.comment.body, 'lgtm') || contains(github.event.comment.body, 'approve'))
+      (contains(github.event.comment.body, 'lgtm') ||
+       contains(github.event.comment.body, 'approve') ||
+       contains(github.event.comment.body, '✅') ||
+       contains(github.event.comment.body, '✔') ||
+       contains(github.event.comment.body, '☑'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      contents: read
       issues: write
       pull-requests: read
     steps:
+      # Needed so the script can import the unit-tested matcher (scripts/approval.mjs) —
+      # same pattern as approve-draft-pr.yml (#2051/#2094).
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - uses: actions/github-script@v7
         with:
           script: |
             const issue_number = context.payload.issue.number
             const body = context.payload.comment.body || ''
-            // Re-check precisely — the job `if` is a coarse prefilter.
-            if (!/\b(approve|approved|lgtm)\b/i.test(body)) return
+            // Re-check precisely — the job `if` is a coarse prefilter; one definition of
+            // "approval" everywhere (#2051/#2094), including the whole-line ✅ gesture.
+            const { isApproval } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/approval.mjs`)
+            if (!isApproval(body)) return
 
             // Is there really a gate waiting? Only then is silence a bug worth explaining.
             let gatePR = null

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -566,6 +566,14 @@ jobs:
             { [ "$ACCEPT" = "fail" ] || [ "$TESTS_MISSING" = "1" ] || [ "$UI_TOUCHED" = "1" ]; } && DRAFT_FLAG="--draft"
             HOLD_NOTE=""
             [ "$UI_TOUCHED" = "1" ] && HOLD_NOTE="$(printf '\n\n👁 **Visual change — held for sign-off.** This PR touches a surface you have to LOOK at, so it opens as a draft and does not auto-merge. Reply `lgtm` to release it. Evidence should be attached above; if it is missing, that is a harness bug (#1748), not a reason to approve blind.')"
+            # #2054: a UI-held draft is invisible everywhere except the PR's draft flag —
+            # the board, the epic digest, and the issue-side `resume-on-comment.yml` route
+            # (which requires status:blocked) can't see it. Label the ISSUE too. State only —
+            # nothing triggers off this label (#572); the PR-side ✅/`lgtm` route (#2052)
+            # remains primary since that's where the reviewer is looking.
+            if [ "$UI_TOUCHED" = "1" ]; then
+              gh issue edit "$ISSUE" --add-label status:blocked 2>&1 | tail -1 || true
+            fi
             if [ -z "$EXISTING" ]; then
               gh pr create $DRAFT_FLAG --base "$BASE" --head "$BR" \
                 --title "$(git log -1 --format=%s)" \

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -726,8 +726,11 @@ jobs:
             // push (#1076), which needs the owner to ACT, not to answer.
             // The `**Needs:** answer | action | approval` line is the explicit discriminator.
             // Absent ⇒ 'answer', which is exactly today's behaviour, so older holds are unaffected.
-            const holdBody = comments.map(c => c.body || '')
-              .find(b => /^##\s*🔀\s*Blocked\b/m.test(b)) || ''
+            // Keep the COMMENT OBJECT, not just its body (#2096): the notification below
+            // links the ask directly, so the owner is one tap from it instead of scroll-
+            // hunting a long thread on a phone for "the 🔀 comment above".
+            const holdComment = comments.find(c => /^##\s*🔀\s*Blocked\b/m.test(c.body || '')) || null
+            const holdBody = holdComment ? (holdComment.body || '') : ''
             const needs = (holdBody.match(/^\s*\*\*Needs:\*\*\s*(answer|action|approval)\b/mi) || [])[1]
             const holdKind = holdBody ? (needs ? needs.toLowerCase() : 'answer') : null
             const askedQuestion = signoffHeld && holdKind === 'answer'
@@ -742,10 +745,12 @@ jobs:
                 const freshPR = prRefs
                   .filter(e => new Date(e.created_at).getTime() >= sinceMs)
                   .map(e => e.source.issue.number)[0]
+                // Link the ask itself (#2096) — holdComment is guaranteed non-null on both
+                // hold branches (holdKind requires a non-empty holdBody).
                 const what = freshPR
                   ? `done → PR #${freshPR}`
-                  : needsAction ? '**needs you to APPLY something** — not an answer, not an approval. The 🔀 comment above says what to do and why the agent could not; the patch is collapsed under it. Comment here when applied and the work resumes in a fresh run.'
-                  : askedQuestion ? '**asked you a question** — it needs an *answer*, not an approval. The 🔀 comment above leads with the recommendation; reply with your pick and the work resumes in a fresh run.'
+                  : needsAction ? `**needs you to APPLY something** — not an answer, not an approval. **[→ the ask](${holdComment.html_url})** says what to do and why the agent could not; the patch is collapsed under it. Comment here when applied and the work resumes in a fresh run.`
+                  : askedQuestion ? `**asked you a question** — it needs an *answer*, not an approval. **[→ the ask](${holdComment.html_url})** leads with the recommendation; reply with your pick and the work resumes in a fresh run.`
                   : (createdSubIssues ? 'decomposed → sub-issues created (see the tree)'
                     : signoffHeld ? 'held for sign-off (`status:blocked` + a review)'
                     : 'produced a deliverable — see the run')


### PR DESCRIPTION
Closes #2054
Closes #2094
Closes #2096

Three workflow-only fixes from today's live test of the ✅ flow + the owner's feedback that hold notifications weren't actionable. All three sit behind the #1076 wall (the pipeline's App token can't push `.github/workflows/**`), so they land via this interactive-session PR instead. One commit per issue.

## 👤 For humans

- **Held work is now visible as *waiting on you*** — a UI-held draft labels its issue `status:blocked`, and the label is cleared however the hold ends: ✅/`lgtm` release, or the PR closing unmerged (#2054, incl. acceptance criterion 5 that the reviewed patch had deferred).
- **✅ means the same thing everywhere** — on a blocked issue it now merges the gate PR exactly like `lgtm`; a quoted/backticked approval no longer counts; and a wasted ✅ gets the "here's why nothing happened" explainer instead of silence (#2094).
- **Hold notifications link the ask** — "**[→ the ask](…)**" replaces "the 🔀 comment above", so you're one tap from the thing the notification is about (#2096).

## 🤖 For agents

| Commit | Files | Change |
|---|---|---|
| #2054 | `work-issue-pidev.yml`, `approve-draft-pr.yml`, `clear-blocked-on-pr-close.yml` (new) | label on draft-open · unlabel on release · unlabel on unmerged close (issue resolved from the `work-<N>` branch name, never body prose) |
| #2094 | `resume-on-comment.yml` | mergegate + explain-skipped-approval decide via `isApproval()` from `scripts/approval.mjs`; prefilter widened with ✅/✔/☑; checkout added to the explainer job |
| #2096 | `work-issue-pidev.yml`, `decompose-on-issue-pidev.yml` | artifact-gate keeps the hold **comment object** and embeds its `html_url` in the needsAction/askedQuestion notifications (twins kept in sync) |

Verified: YAML parses (all 5 files), `node --test scripts/approval.test.mjs` green, `npx fallow audit` clean on the diff, no private `\b(approve|approved|lgtm)\b` decision regex remains in any workflow (grep-proven; surviving mentions are prose and `contains()` prefilters).

## 🧪 How to test

1. Comment a whole-line ✅ on a `status:blocked` issue that has an open gate PR into `epic/*` → the PR merges and the block clears (before: agent resumed, PR stayed open).
2. Dispatch a `.vue`-touching leaf → the draft PR opens **and** its issue shows `status:blocked`; ✅ the PR → both clear.
3. Close a held `work-N` PR without merging → the issue's label clears.
4. Next pipeline hold → the notification contains "**→ the ask**" linking the 🔀 comment directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pt5N8ru5FJUK2YHnwuUNSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pt5N8ru5FJUK2YHnwuUNSS)_