### PR TITLE
fix(crouton-sales): negative price modifiers now visible + negative product price allowed

### DIFF
--- a/packages/crouton-sales/app/components/Client/ProductList.vue
+++ b/packages/crouton-sales/app/components/Client/ProductList.vue
@@ -213,7 +213,7 @@
               <template #label="{ item }">
                 <span class="flex items-center justify-between w-full">
                   <span>{{ item.label }}</span>
-                  <span v-if="item.priceModifier > 0" class="text-xs text-muted ml-2">+{{ format(item.priceModifier) }}</span>
+                  <span v-if="item.priceModifier" class="text-xs text-muted ml-2">{{ item.priceModifier > 0 ? '+' : '' }}{{ format(item.priceModifier) }}</span>
                 </span>
               </template>
             </UCheckboxGroup>
@@ -232,7 +232,7 @@
               <template #label="{ item }">
                 <span class="flex items-center justify-between w-full">
                   <span>{{ item.label }}</span>
-                  <span v-if="item.priceModifier > 0" class="text-xs text-muted ml-2">+{{ format(item.priceModifier) }}</span>
+                  <span v-if="item.priceModifier" class="text-xs text-muted ml-2">{{ item.priceModifier > 0 ? '+' : '' }}{{ format(item.priceModifier) }}</span>
                 </span>
               </template>
             </URadioGroup>
@@ -249,8 +249,8 @@
                 class="flex items-center gap-2"
               >
                 <span class="flex-1 min-w-0 truncate text-sm">{{ option.label }}</span>
-                <span v-if="option.priceModifier > 0" class="shrink-0 text-xs text-muted">
-                  +{{ format(option.priceModifier) }}
+                <span v-if="option.priceModifier" class="shrink-0 text-xs text-muted">
+                  {{ option.priceModifier > 0 ? '+' : '' }}{{ format(option.priceModifier) }}
                 </span>
                 <UFieldGroup v-if="lineForOption(product, option.id)" size="sm">
                   <UButton

--- a/packages/crouton-sales/app/components/ProductForm.vue
+++ b/packages/crouton-sales/app/components/ProductForm.vue
@@ -66,7 +66,6 @@
               <UInputNumber
                 v-model="state.price"
                 class="w-full"
-                :min="0"
                 :step="0.01"
                 :format-options="{ style: 'currency', currency: 'EUR' }"
               />


### PR DESCRIPTION
## Summary
- Discount (negative) option price modifiers now show a `-€x,xx` badge in the POS — previously invisible, which made the subtraction look broken even though the cart total was already correct.
- Removed the hardcoded `:min="0"` on the product price field, so a product can now be saved with a negative price (manual discount line).

Closes #2116

## 🧪 How to test
1. Boot `apps/kassa`, open the kassa event workspace, enable edit mode on a product, add an option with price `-1.00`.
2. Expand the product in the POS — the option row shows the negative badge (`€ -1,00`).
3. Add it to cart — cart line + Bestel total already reflected the subtraction (unchanged behavior, confirmed via live repro before this fix).
4. Edit the product's own price field, enter `-1.00`, save — it persists.

Verified locally: typecheck green, fallow audit clean (no new findings on the diff).