### PR TITLE
feat(root): nudge open status:blocked holds when their cited blocker closes

### DIFF
--- a/.github/workflows/refresh-blocked-on-close.yml
+++ b/.github/workflows/refresh-blocked-on-close.yml
@@ -1,0 +1,60 @@
+name: Refresh status:blocked holds when the cited blocker closes
+
+# #2112 (epic #2108 WS5) — the write side of #2104. #2104 taught a fresh run to check whether a
+# blocker it cites is still open before trusting an old thread. This is the push side: the moment
+# an issue closes, every OTHER open `status:blocked` issue that cites it by number gets a one-line
+# nudge, so the owner (and the next agent run) doesn't have to notice the closure on their own.
+#
+# Deliberately narrow:
+#   • Matches `#<n>` as a DISTINCT token in the body or in comments — not a substring match, so
+#     `#210` never matches an issue that only mentions `#2104`.
+#   • Never removes `status:blocked` or resolves the hold — that stays a human / resume-on-comment.yml
+#     call. This only surfaces that the cited state changed.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const closedNumber = context.payload.issue.number
+            const tokenRe = new RegExp(`(^|[^\\d#])#${closedNumber}(?!\\d)`)
+
+            const blocked = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              state: 'open',
+              labels: 'status:blocked',
+              per_page: 100,
+            })
+
+            for (const issue of blocked) {
+              if (issue.number === closedNumber) continue
+              if (issue.pull_request) continue
+
+              let cites = tokenRe.test(issue.body || '')
+              if (!cites) {
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  ...context.repo,
+                  issue_number: issue.number,
+                  per_page: 100,
+                })
+                cites = comments.some(c => tokenRe.test(c.body || ''))
+              }
+              if (!cites) continue
+
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: `🔄 the blocker this was waiting on (#${closedNumber}) has since closed — re-check whether this hold still applies.`,
+              })
+              core.info(`Posted refresh nudge on #${issue.number} (cites closed #${closedNumber}).`)
+            }


### PR DESCRIPTION
Closes #2112

## 👤 For humans

The pipeline agent working #2112 (epic #2108 WS5) couldn't write `.github/workflows/**` with its token, so it posted the finished workflow as a patch and held. This PR applies that patch verbatim — merging it is the "apply" step the hold is waiting on, and it closes #2112 directly.

What it does once on `main`: the moment any issue closes, every *other* open `status:blocked` issue that cites the closed number gets a one-line 🔄 "re-check this hold" comment. It never removes the label or resolves the hold — that stays a human / resume-on-comment.yml call.

## 🤖 For agents

- New `.github/workflows/refresh-blocked-on-close.yml` — `issues: closed` trigger, `issues: write` permission, inline `actions/github-script@v7` (mirrors `clear-blocked-on-pr-close.yml`'s style; no separate script file).
- Citation match is a distinct-token regex `(^|[^\d#])#<n>(?!\d)` over the blocked issue's body, falling back to its comments — so `#210` never matches an issue that only mentions `#2104`. Verified locally: matches `#2109`, rejects `#21090` and `##2109`.
- Skips the closed issue itself and PRs; posts exactly one comment per citing issue.
- This is the write side of #2104's read-side check. Patch source: [issue comment](https://github.com/FriendlyInternet/nuxt-crouton/issues/2112#issuecomment-5225755720), applied unmodified apart from being written to disk.

## 🧪 How to test

1. Open a test issue A, label it `status:blocked`, with a body containing `Blocked-by: #<B>` (or any prose mentioning `#<B>`).
2. Close issue B.
3. Confirm exactly one `🔄 the blocker this was waiting on (#<B>) has since closed…` comment lands on A, and A's `status:blocked` label is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkaF7hPmxhC1pwAtFegVv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkaF7hPmxhC1pwAtFegVv3)_