### PR TITLE
fix(ci): headless subscription auth for pi-claude-cli on the mac-mini (#2119)

### DIFF
--- a/.github/workflows/a11y-daily-pidev.yml
+++ b/.github/workflows/a11y-daily-pidev.yml
@@ -102,6 +102,10 @@ jobs:
         env:
           PI_MODEL: ${{ inputs.model || 'claude-haiku-4-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
+          # Headless subscription auth: the mini's runner runs `claude` in a session that can't
+          # reach the macOS Keychain, so pass a long-lived OAuth token (claude setup-token, 1y)
+          # the CLI reads from env instead of the keychain login (#2119).
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           set -uo pipefail
           command -v pi >/dev/null 2>&1 || npm i -g @earendil-works/pi-coding-agent

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -291,9 +291,12 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Everything on the Claude SUBSCRIPTION (#1669). delegate-hard still escalates,
           # but now by MODEL (sonnet → opus) on the same subscription provider — no metered
-          # lane. NO ANTHROPIC_API_KEY: pi-claude-cli uses the mini's `claude` login.
+          # lane. Headless subscription auth: the mini's runner runs `claude` in a session that
+          # can't reach the macOS Keychain, so CLAUDE_CODE_OAUTH_TOKEN (claude setup-token, 1y)
+          # authenticates the CLI from env instead of the keychain login (#2119).
           PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
           # PIPELINE_MODE=event-driven is inherited from the JOB-level env (above). The pi prompt
           # branches on it to the PLAN-ONLY directive (#1696); the apply step gates on it too.

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -239,10 +239,13 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Everything on the Claude SUBSCRIPTION (#1669). delegate-hard still escalates,
-          # but now by MODEL (sonnet → opus) on the same subscription provider — no metered
-          # lane. NO ANTHROPIC_API_KEY: pi-claude-cli uses the mini's `claude` login.
+          # but now by MODEL (sonnet → opus) on the same provider — no metered lane.
+          # Headless subscription auth: the mini's runner runs `claude` in a session that
+          # can't reach the macOS Keychain, so CLAUDE_CODE_OAUTH_TOKEN (claude setup-token, 1y)
+          # authenticates the CLI from env instead of the keychain login (#2119).
           PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
           # WS2 (#1695): the integration branch parsed off the issue's pipeline block (empty → main).
           EPIC_BRANCH: ${{ steps.ctx.outputs.epic_branch }}


### PR DESCRIPTION
## Root cause
The mac-mini self-hosted runners are launchd services. They run `claude` in a process session that **cannot reach the macOS login Keychain**. After Claude Code moved credential storage into the Keychain (~the `2.1.198 → 2.1.222` update), `pi-claude-cli` runs on the mini report `Claude CLI is not authenticated` and produce nothing — every run ends with `complete-work cap 4 reached`.

Reproduced locally: `env -i HOME=… PATH=… claude -p` → `Not logged in`. Same machine, same unlocked keychain; only the process *session* differs.

## Fix (subscription only — no metered key)
Keep `pi-claude-cli` (everything-on-the-subscription, #1669), but authenticate the `claude` subprocess **from env** with a long-lived `claude setup-token` (1y) in `CLAUDE_CODE_OAUTH_TOKEN`. The CLI prioritizes this env var over the keychain, so it works headlessly.

Verified end-to-end: minimal-env `claude -p` with the token → `TOKEN_OK`.

Adds the secret export to the three `pi-claude-cli` workflows that lacked it:
- `a11y-daily-pidev.yml`
- `decompose-on-issue-pidev.yml` (the failing lane, run 31424027705)
- `work-issue-pidev.yml`

`decompose-on-issue-pidev-hosted.yml` is untouched (it uses 0 `pi-claude-cli` refs).

## Secret
`CLAUDE_CODE_OAUTH_TOKEN` already exists in repo secrets; updated to a fresh `setup-token`. **Note:** the token value was pasted in the issue thread during diagnosis — rotate it (re-run `claude setup-token`, update the secret) once this is stable.