### PR TITLE
Epic #2118: crouton-sales: align the "in bereiding" badge and make its click behavior self-evident

### DIFF
--- a/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
+++ b/packages/crouton-sales/app/components/EventWorkspace/OrdersTab.vue
@@ -431,40 +431,47 @@ function toggleExpand(id: string) {
     <!-- The backlog, stated plainly. Deliberately ABOVE the filters: it is the
          one number that does NOT follow them, and putting it below would imply
          it did. Zero is worth showing too — "nothing waiting" is the answer
-         someone walked over to get. -->
-    <UButton
-      v-if="outstanding > 0"
-      :color="outstandingOnly ? 'warning' : 'neutral'"
-      :variant="outstandingOnly ? 'subtle' : 'ghost'"
-      size="sm"
-      icon="i-lucide-hourglass"
-      :label="t('sales.workspace.outstanding', { count: outstanding })"
-      :aria-pressed="outstandingOnly"
-      :title="outstandingOnly ? t('sales.workspace.outstandingFilterClear') : t('sales.workspace.outstandingFilter')"
-      class="-ms-2"
-      :ui="{ leadingIcon: outstandingOnly ? '' : 'text-warning' }"
-      @click="toggleOutstandingOnly"
-    >
-      <template #trailing>
-        <UIcon
-          v-if="outstandingOnly"
-          name="i-lucide-x"
-          class="size-3.5 opacity-70"
-        />
-      </template>
-    </UButton>
+         someone walked over to get.
 
-    <!-- Nothing outstanding: a statement, not a control — there is no slice to
-         filter to, so offering a button would be a dead end. -->
-    <div
-      v-else
-      class="flex items-center gap-2 text-sm text-muted"
-    >
-      <UIcon
-        name="i-lucide-check-check"
-        class="size-4 text-success"
-      />
-      {{ t('sales.workspace.outstandingNone') }}
+         Wrapped in the same px-4 as the pane header / order rows below (#2118):
+         previously this sat outside that padding with a `-ms-2` offset trying
+         to compensate, which drifted out of alignment. -->
+    <div class="px-4">
+      <UButton
+        v-if="outstanding > 0"
+        :color="outstandingOnly ? 'warning' : 'neutral'"
+        :variant="outstandingOnly ? 'subtle' : 'soft'"
+        size="sm"
+        icon="i-lucide-hourglass"
+        :label="outstandingOnly
+          ? t('sales.workspace.outstandingActive', { count: outstanding })
+          : t('sales.workspace.outstanding', { count: outstanding })"
+        :aria-pressed="outstandingOnly"
+        :title="outstandingOnly ? t('sales.workspace.outstandingFilterClear') : t('sales.workspace.outstandingFilter')"
+        :ui="{ leadingIcon: outstandingOnly ? '' : 'text-warning' }"
+        @click="toggleOutstandingOnly"
+      >
+        <template #trailing>
+          <UIcon
+            v-if="outstandingOnly"
+            name="i-lucide-x"
+            class="size-3.5 opacity-70"
+          />
+        </template>
+      </UButton>
+
+      <!-- Nothing outstanding: a statement, not a control — there is no slice to
+           filter to, so offering a button would be a dead end. -->
+      <div
+        v-else
+        class="flex items-center gap-2 text-sm text-muted"
+      >
+        <UIcon
+          name="i-lucide-check-check"
+          class="size-4 text-success"
+        />
+        {{ t('sales.workspace.outstandingNone') }}
+      </div>
     </div>
 
     <!-- Filters live behind a toggle (in the pane header when the parent

--- a/packages/crouton-sales/i18n/locales/en.json
+++ b/packages/crouton-sales/i18n/locales/en.json
@@ -607,6 +607,7 @@
         "settingsStat": "printers"
       },
       "outstanding": "{count} in progress",
+      "outstandingActive": "{count} in progress (filtered)",
       "outstandingNone": "Nothing in progress",
       "outstandingFilter": "Show only these",
       "outstandingFilterClear": "Show all orders"

--- a/packages/crouton-sales/i18n/locales/fr.json
+++ b/packages/crouton-sales/i18n/locales/fr.json
@@ -606,6 +606,7 @@
         "settingsStat": "imprimantes"
       },
       "outstanding": "{count} en préparation",
+      "outstandingActive": "{count} en préparation (filtré)",
       "outstandingNone": "Rien en préparation",
       "outstandingFilter": "Afficher seulement celles-ci",
       "outstandingFilterClear": "Afficher toutes les commandes"

--- a/packages/crouton-sales/i18n/locales/nl.json
+++ b/packages/crouton-sales/i18n/locales/nl.json
@@ -607,6 +607,7 @@
         "settingsStat": "printers"
       },
       "outstanding": "{count} in bereiding",
+      "outstandingActive": "{count} in bereiding (gefilterd)",
       "outstandingNone": "Niets in bereiding",
       "outstandingFilter": "Toon alleen deze",
       "outstandingFilterClear": "Toon alle bestellingen"


### PR DESCRIPTION
Assembles #2118 — closed and merged into `epic/2118-crouton-sales-align-the-in-bereiding-bad`, ready for `main`.

## 🧪 How to test
Review the assembled diff; CI runs on this PR.

Packages-approved: sub-PR #2133 already reviewed, `lgtm`'d, and merged into the epic branch by the owner (packages/crouton-sales UI-only change, CI green throughout).
