### PR TITLE
Epic #2119: Per-product view in the Data pane: show column totals for the filtered list

### DIFF
--- a/packages/crouton-sales/app/components/Dashboard/PerProductTotals.vue
+++ b/packages/crouton-sales/app/components/Dashboard/PerProductTotals.vue
@@ -96,6 +96,11 @@ const totalOutstanding = computed(() =>
   visibleRows.value.reduce((s, r) => s + (r.outstanding ?? 0), 0)
 )
 
+/** Sum of Verkocht for the rows currently visible (respects the location filter). */
+const totalSold = computed(() =>
+  visibleRows.value.reduce((s, r) => s + r.sold, 0)
+)
+
 /**
  * How each row reads, decided here so the template stays a flat list.
  * The null case is the meaningful one — see the block comment above.
@@ -195,6 +200,12 @@ watch(() => props.personnel, () => fetchTotals())
           >{{ r.outstandingText }}</span>
         </li>
       </ul>
+
+      <div class="flex items-center gap-3 pt-2 mt-1 border-t border-default text-sm font-semibold">
+        <span class="flex-1">{{ t('sales.dashboard.perProduct.total') }}</span>
+        <span class="w-12 shrink-0 text-right tabular-nums">{{ totalSold }}</span>
+        <span class="w-12 shrink-0 text-right tabular-nums">{{ totalOutstanding }}</span>
+      </div>
     </template>
   </div>
 </template>

--- a/packages/crouton-sales/i18n/locales/en.json
+++ b/packages/crouton-sales/i18n/locales/en.json
@@ -214,7 +214,8 @@
         "outstanding": "Still out",
         "allLocations": "All",
         "stillOut": "{count} still out",
-        "directHandover": "This location hands over directly — nothing can be outstanding here"
+        "directHandover": "This location hands over directly — nothing can be outstanding here",
+        "total": "Total"
       }
     },
     "common": {

--- a/packages/crouton-sales/i18n/locales/nl.json
+++ b/packages/crouton-sales/i18n/locales/nl.json
@@ -214,7 +214,8 @@
         "outstanding": "Nog uit",
         "allLocations": "Alles",
         "stillOut": "{count} nog uit",
-        "directHandover": "Deze locatie geeft direct mee — hier kan niets blijven staan"
+        "directHandover": "Deze locatie geeft direct mee — hier kan niets blijven staan",
+        "total": "Totaal"
       }
     },
     "common": {


### PR DESCRIPTION
Assembles #2119 — closed and merged into `epic/2119-per-product-view-in-the-data-pane-show-c`, ready for `main`.

## 🧪 How to test
Review the assembled diff; CI runs on this PR.

Packages-approved: sub-PR #2132 already reviewed, `lgtm`'d, and merged into the epic branch by the owner (packages/crouton-sales UI-only change, CI green throughout).
