### PR TITLE
Epic #2146: Data pane filter (1/2): thread productIds/categoryIds through the backing endpoints

### DIFF
--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/per-product-totals.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/per-product-totals.get.ts
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId, personnel } = getQuery(event)
+  const { eventId, personnel, productIds, categoryIds } = getQuery(event)
   if (!eventId) {
     // Unlike the other chart endpoints this is event-scoped by nature: a
     // backlog is a property of one running event, and summing "still to
@@ -45,7 +45,7 @@ export default defineEventHandler(async (event) => {
       locations: salesLocations,
       kdsbumps: salesKdsbumps
     },
-    { teamId: team.id, eventId: String(eventId), personnel }
+    { teamId: team.id, eventId: String(eventId), personnel, productIds, categoryIds }
   )
 
   return { items }

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/product-day-matrix.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/product-day-matrix.get.ts
@@ -13,10 +13,11 @@
  * The table renders both measures and toggles client-side, so this returns
  * units and revenue together rather than one measure.
  */
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
 import { chartOrderScope, salesOrderDay } from '../../../../../utils/chart-scope'
 import { buildProductDayMatrix } from '../../../../../utils/product-day-matrix'
+import { productCategoryCondition } from '../../../../../utils/product-category-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -26,7 +27,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId, personnel } = getQuery(event)
+  const { eventId, personnel, productIds, categoryIds } = getQuery(event)
 
   const dateExpr = salesOrderDay(salesOrders)
 
@@ -47,7 +48,10 @@ export default defineEventHandler(async (event) => {
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
     .leftJoin(salesCategories, eq(salesProducts.categoryId, salesCategories.id))
-    .where(chartOrderScope(salesOrders, { teamId: team.id, eventId, personnel }))
+    .where(and(
+      chartOrderScope(salesOrders, { teamId: team.id, eventId, personnel }),
+      productCategoryCondition(salesProducts.id, salesProducts.categoryId, { productIds, categoryIds })
+    ))
     .groupBy(dateExpr, salesProducts.title, salesCategories.title)
     .orderBy(dateExpr)
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-day.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/revenue-by-day.get.ts
@@ -5,17 +5,19 @@
  * Optional ?eventId= narrows to a single event; omitted ⇒ team-wide.
  * Used by the salesChartBlock's `revenue-by-day` chart kind.
  */
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
 import { chartOrderScope, salesOrderDay } from '../../../../../utils/chart-scope'
+import { productCategoryCondition } from '../../../../../utils/product-category-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
+import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
 
 export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId, personnel } = getQuery(event)
+  const { eventId, personnel, productIds, categoryIds } = getQuery(event)
 
   const dateExpr = salesOrderDay(salesOrders)
 
@@ -26,7 +28,11 @@ export default defineEventHandler(async (event) => {
     })
     .from(salesOrderitems)
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
-    .where(chartOrderScope(salesOrders, { teamId: team.id, eventId, personnel }))
+    .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
+    .where(and(
+      chartOrderScope(salesOrders, { teamId: team.id, eventId, personnel }),
+      productCategoryCondition(salesProducts.id, salesProducts.categoryId, { productIds, categoryIds })
+    ))
     .groupBy(dateExpr)
     .orderBy(dateExpr)
 

--- a/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/top-products.get.ts
+++ b/packages/crouton-sales/server/api/crouton-sales/teams/[id]/charts/top-products.get.ts
@@ -5,9 +5,10 @@
  * Optional ?eventId= narrows to a single event; omitted ⇒ team-wide.
  * Used by the salesChartBlock's `top-products` chart kind.
  */
-import { desc, eq } from 'drizzle-orm'
+import { and, desc, eq } from 'drizzle-orm'
 import { resolveTeamAndCheckMembership } from '@fyit/crouton-auth/server/utils/team'
 import { chartOrderScope } from '../../../../../utils/chart-scope'
+import { productCategoryCondition } from '../../../../../utils/product-category-filter'
 import { salesOrders } from '~~/layers/sales/collections/orders/server/database/schema'
 import { salesOrderitems } from '~~/layers/sales/collections/orderitems/server/database/schema'
 import { salesProducts } from '~~/layers/sales/collections/products/server/database/schema'
@@ -16,7 +17,7 @@ export default defineEventHandler(async (event) => {
   const { team } = await resolveTeamAndCheckMembership(event)
   const db = useDB()
 
-  const { eventId, personnel } = getQuery(event)
+  const { eventId, personnel, productIds, categoryIds } = getQuery(event)
 
   // quantity is stored as TEXT → cast to a number before summing.
   const quantityExpr = sql<number>`sum(cast(${salesOrderitems.quantity} as real))`
@@ -29,7 +30,10 @@ export default defineEventHandler(async (event) => {
     .from(salesOrderitems)
     .innerJoin(salesOrders, eq(salesOrderitems.orderId, salesOrders.id))
     .innerJoin(salesProducts, eq(salesOrderitems.productId, salesProducts.id))
-    .where(chartOrderScope(salesOrders, { teamId: team.id, eventId, personnel }))
+    .where(and(
+      chartOrderScope(salesOrders, { teamId: team.id, eventId, personnel }),
+      productCategoryCondition(salesProducts.id, salesProducts.categoryId, { productIds, categoryIds })
+    ))
     .groupBy(salesProducts.title)
     .orderBy(desc(quantityExpr))
     .limit(10)

--- a/packages/crouton-sales/server/utils/per-product-totals.ts
+++ b/packages/crouton-sales/server/utils/per-product-totals.ts
@@ -38,6 +38,7 @@ import { and, desc, eq, sql } from 'drizzle-orm'
 import { locationBlocksDeliverySql } from './location-handover'
 import { excludesCancelledOrders } from './order-status'
 import { personnelConditionOn } from './personnel-condition'
+import { productCategoryCondition } from './product-category-filter'
 
 export interface PerProductTables {
   orders: any
@@ -67,6 +68,9 @@ export interface PerProductTotalsInput {
   eventId: string
   /** `all` | `exclude` | `only` — the Data pane's staff toggle. */
   personnel?: unknown
+  /** Optional product/category narrowing (#2146) — see `product-category-filter.ts`. */
+  productIds?: unknown
+  categoryIds?: unknown
 }
 
 export async function buildPerProductTotals(
@@ -87,7 +91,11 @@ export async function buildPerProductTotals(
     eq(orders.teamId, input.teamId),
     eq(orders.eventId, input.eventId),
     excludesCancelledOrders(orders),
-    personnelConditionOn(orders.isPersonnel, input.personnel)
+    personnelConditionOn(orders.isPersonnel, input.personnel),
+    productCategoryCondition(products.id, products.categoryId, {
+      productIds: input.productIds,
+      categoryIds: input.categoryIds
+    })
   )
 
   // --- sold -----------------------------------------------------------------

--- a/packages/crouton-sales/server/utils/product-category-filter.ts
+++ b/packages/crouton-sales/server/utils/product-category-filter.ts
@@ -1,0 +1,54 @@
+/**
+ * Product / category filter for the Data pane (#2146).
+ *
+ * A product matches when its id is in `productIds`, OR its category is in
+ * `categoryIds` — a category selection is shorthand for "all its products".
+ * Mirrors `personnelConditionOn()`'s contract (`personnel-condition.ts`):
+ * `undefined` when no filter is set, safe to drop straight into `and(...)`,
+ * which ignores undefined args — so every endpoint's existing WHERE
+ * composition inherits this filter without special-casing the empty case.
+ *
+ * Takes the product-id / category-id COLUMNS rather than a table, so it works
+ * whether the caller already has `salesProducts` joined in (product-day-matrix,
+ * per-product-totals) or needs to join it in for this filter alone
+ * (revenue-by-day, top-products, which previously had no reason to touch
+ * `salesProducts` at all).
+ */
+import { inArray, or, type AnyColumn, type SQL } from 'drizzle-orm'
+
+export interface ProductCategoryFilter {
+  productIds?: unknown
+  categoryIds?: unknown
+}
+
+/**
+ * A query-string id list, as either a comma-separated string (`?productIds=a,b`)
+ * or an array (repeated `?productIds=a&productIds=b`) — coerced to a clean
+ * array of non-empty string ids.
+ */
+function toIdList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String).map(v => v.trim()).filter(Boolean)
+  if (typeof value === 'string' && value) return value.split(',').map(v => v.trim()).filter(Boolean)
+  return []
+}
+
+/**
+ * Drizzle condition for `productIdColumn IN productIds OR categoryIdColumn IN
+ * categoryIds`, or `undefined` when both filters are empty/omitted.
+ */
+export function productCategoryCondition(
+  productIdColumn: AnyColumn,
+  categoryIdColumn: AnyColumn,
+  filter: ProductCategoryFilter
+): SQL | undefined {
+  const productIds = toIdList(filter.productIds)
+  const categoryIds = toIdList(filter.categoryIds)
+
+  if (!productIds.length && !categoryIds.length) return undefined
+
+  const conditions: SQL[] = []
+  if (productIds.length) conditions.push(inArray(productIdColumn, productIds))
+  if (categoryIds.length) conditions.push(inArray(categoryIdColumn, categoryIds))
+
+  return or(...conditions)
+}

--- a/packages/crouton-sales/test/product-category-filter.test.ts
+++ b/packages/crouton-sales/test/product-category-filter.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Product/category filter — behaviour contract for `productCategoryCondition`
+ * (#2146). DB-free: it builds a drizzle SQL fragment, so the assertions check
+ * the fragment's shape (via `toSQL`-free string rendering) and the pure
+ * id-list parsing, mirroring `order-filters.test.ts`'s style.
+ */
+import { describe, it, expect } from 'vitest'
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { productCategoryCondition } from '../server/utils/product-category-filter'
+
+const products = sqliteTable('sales_products', {
+  id: text('id').primaryKey(),
+  categoryId: text('categoryId')
+})
+
+describe('productCategoryCondition', () => {
+  it('returns undefined when both filters are omitted (no-op, drops out of and())', () => {
+    expect(productCategoryCondition(products.id, products.categoryId, {})).toBeUndefined()
+  })
+
+  it('returns undefined when both filters are empty strings/arrays', () => {
+    expect(productCategoryCondition(products.id, products.categoryId, {
+      productIds: '',
+      categoryIds: []
+    })).toBeUndefined()
+  })
+
+  it('builds a condition for productIds alone', () => {
+    const cond = productCategoryCondition(products.id, products.categoryId, { productIds: 'p1,p2' })
+    expect(cond).toBeDefined()
+  })
+
+  it('builds a condition for categoryIds alone', () => {
+    const cond = productCategoryCondition(products.id, products.categoryId, { categoryIds: 'c1' })
+    expect(cond).toBeDefined()
+  })
+
+  it('ORs productIds and categoryIds together when both are set', () => {
+    const cond = productCategoryCondition(products.id, products.categoryId, {
+      productIds: 'p1',
+      categoryIds: 'c1'
+    })
+    expect(cond).toBeDefined()
+    // or() with 2 conditions renders both id lists in the same fragment.
+    const sql = cond!.queryChunks.map(String).join(' ')
+    expect(sql.length).toBeGreaterThan(0)
+  })
+
+  it('accepts an array of ids (repeated ?productIds=a&productIds=b)', () => {
+    const cond = productCategoryCondition(products.id, products.categoryId, {
+      productIds: ['p1', 'p2']
+    })
+    expect(cond).toBeDefined()
+  })
+
+  it('trims whitespace and drops empty entries from a comma-separated list', () => {
+    const a = productCategoryCondition(products.id, products.categoryId, { productIds: ' p1 , , p2 ' })
+    const b = productCategoryCondition(products.id, products.categoryId, { productIds: 'p1,p2' })
+    expect(a).toBeDefined()
+    expect(b).toBeDefined()
+  })
+})


### PR DESCRIPTION
Assembles #2146 — closed and merged into `epic/2146-data-pane-filter-1-2-thread-productids-c`, ready for `main`.

## 🧪 How to test
Review the assembled diff; CI runs on this PR.

Packages-approved: sub-PR #2148 already reviewed and merged into the epic branch by the owner (packages/crouton-sales server-only change — new `product-category-filter.ts` helper + unit test, wired into 4 existing endpoints; CI green throughout).


---
_Generated by [Claude Code](https://claude.ai/code/session_01C9opGHdwoo2YMAJZWYtcpA)_