### PR TITLE
fix(root): three completion/notification gaps in the pipeline flow

### DIFF
--- a/.github/workflows/automerge-epic-subpr.yml
+++ b/.github/workflows/automerge-epic-subpr.yml
@@ -107,11 +107,14 @@ jobs:
           private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
           owner: FriendlyInternet
       - uses: actions/github-script@v7
+        env:
+          OWNER_LOGIN: ${{ vars.PIPELINE_OWNER || 'pmcp' }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo
             const BOTS = ['claude[bot]', 'nuxt-harness[bot]']
+            const OWNER = process.env.OWNER_LOGIN || 'pmcp'
 
             // The check that must have REPORTED before we merge (#1698). ci.yml's `gate`
             // job — its display name, which is what the checks API returns.
@@ -235,6 +238,13 @@ jobs:
               const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number })
               const sharedCode = files.filter(f => f.filename.startsWith('packages/'))
               if (sharedCode.length) {
+                // #2150: announce this hold ONCE. The hourly sweep re-evaluates every open sub-PR
+                // on an epic branch, and without this guard it re-posted the identical "held for a
+                // human" comment every hour (observed twice, 7 minutes apart, on PR #2148) and
+                // would re-request review just as repeatedly. The label added below (first time
+                // only) is the durable "already held" marker for later sweeps to check.
+                const alreadyHeld = (pr.labels || []).some(l => l.name === 'status:needs-merge')
+                if (alreadyHeld) { core.info(`#${pull_number} already held for shared-code review — not re-announcing.`); continue }
                 core.info(`#${pull_number} touches packages/ (${sharedCode.length} file(s)) — holding for a human.`)
                 // `status:needs-merge`, NOT `status:blocked` (#2083). The two holds ask for
                 // different things and used to share a label: a sign-off gate means "I asked
@@ -244,10 +254,15 @@ jobs:
                 // (#2039/#2041/#2044), and this guard's own "held for a human" comment landed
                 // under a label implying an open question.
                 try { await github.rest.issues.addLabels({ owner, repo, issue_number: pull_number, labels: ['status:needs-merge'] }) } catch (e) { core.warning(`addLabel #${pull_number}: ${e.message}`) }
+                // #2150: request review so the PR surfaces in the owner's native "Review
+                // requested" list — a plain comment produces neither a push notification nor a
+                // native GitHub surface pointing at the owner (confirmed absent from both, live,
+                // on PR #2148 — it showed up under neither "Created by me" nor "Review requested").
+                try { await github.rest.pulls.requestReviewers({ owner, repo, pull_number, reviewers: [OWNER] }) } catch (e) { core.warning(`requestReviewers #${pull_number}: ${e.message}`) }
                 const list = sharedCode.slice(0, 10).map(f => `- \`${f.filename}\``).join('\n')
                 const more = sharedCode.length > 10 ? `\n…and ${sharedCode.length - 10} more.` : ''
                 await github.rest.issues.createComment({ owner, repo, issue_number: pull_number,
-                  body: '⏸️ **Held for a human — this build PR changes shared code under `packages/`.**\n\n'
+                  body: `⏸️ **Held for a human — this build PR changes shared code under \`packages/\`.** @${OWNER}\n\n`
                     + '**Fix:** a change here ripples across every consuming app (the `packages/` HARD GATE, #350), so it is not auto-merged — review it, confirm `pnpm typecheck` across apps, then merge.\n\n'
                     + `<details><summary>shared-code files (${sharedCode.length})</summary>\n\n${list}${more}\n</details>\n\n`
                     + '<sub>🤖 agent pipeline (CI) · auto-merge shared-code guard (#339)</sub>' })

--- a/.github/workflows/epic-ready-pr.yml
+++ b/.github/workflows/epic-ready-pr.yml
@@ -57,25 +57,31 @@ jobs:
             const OWNER = process.env.OWNER_LOGIN || 'pmcp'
             const ws = process.env.GITHUB_WORKSPACE
             const { parsePipelineBlock } = await import(`${ws}/scripts/pipeline-context.mjs`)
-            const { parseEpicNumber, decideOpen } = await import(`${ws}/scripts/epic-ready.mjs`)
+            const { parseEpicNumber, decideOpen, resolveEpicTarget } = await import(`${ws}/scripts/epic-ready.mjs`)
 
             // Resolve (epicNumber, epicBranch) from either the closed child's pipeline block
-            // or a manual dispatch's branch input.
-            let epicNumber, epicBranch
+            // or a manual dispatch's branch input. When no block/epic is recorded, default
+            // epicNumber to the closed issue's OWN number — mirrors the EPIC="${EPIC:-$ISSUE}"
+            // convention every other pipeline step uses for a solo leaf dispatched directly via
+            // `work-this` (#1686) rather than through a real multi-child epic. Resolution must
+            // not depend on the pipeline block surviving to close-time — empirically it often
+            // doesn't (#2152).
+            let epicNumber, epicBranch, closedIssueNumber = null, blockEpicNumber = null
             if (context.eventName === 'workflow_dispatch') {
               epicBranch = process.env.DISPATCH_BRANCH
               epicNumber = parseEpicNumber(epicBranch)
+              if (!epicNumber) { core.info(`could not resolve an epic number from ${epicBranch}; skip.`); return }
             } else {
               const closed = context.payload.issue
+              closedIssueNumber = closed.number
               const block = parsePipelineBlock(closed.body || '')
-              epicNumber = block.epic
+              blockEpicNumber = block.epic
+              epicNumber = block.epic ?? closed.number
               epicBranch = block.epic_branch
-              if (!epicNumber) { core.info(`#${closed.number} has no pipeline block — not a pipeline child; skip.`); return }
-              if (epicNumber === closed.number) { core.info(`#${closed.number} is the epic itself — closed via /close-epic, not here; skip.`); return }
             }
-            if (!epicNumber) { core.info(`could not resolve an epic number from ${epicBranch}; skip.`); return }
 
-            // Fall back to matching-refs if the block carried no branch (older children).
+            // Fall back to matching-refs if the block carried no branch (older children, or a
+            // solo leaf whose block never persisted).
             if (!epicBranch) {
               try {
                 const refs = await github.paginate('GET /repos/{owner}/{repo}/git/matching-refs/heads/{prefix}',
@@ -91,6 +97,21 @@ jobs:
               subIssues = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues',
                 { owner, repo, issue_number: epicNumber, per_page: 100 })
             } catch (e) { core.warning(`sub-issues for #${epicNumber}: ${e.message}`); return }
+
+            // #2152: a genuine multi-child epic that closed directly (not via a sub-issue's PR
+            // merging) is NOT this workflow's job — it closes via /close-epic (#856), so keep the
+            // original skip. But a SOLO leaf using itself as its own integration branch (#1686)
+            // also resolves epicNumber to its own number, with zero real sub-issues — that used to
+            // be indistinguishable from the genuine-epic case and always skipped. Treat it as its
+            // epic's one completed child instead.
+            if (closedIssueNumber !== null) {
+              const { isSolo } = resolveEpicTarget({ closedIssueNumber, blockEpicNumber, subIssueCount: subIssues.length })
+              if (epicNumber === closedIssueNumber) {
+                if (!isSolo) { core.info(`#${closedIssueNumber} is a genuine epic (${subIssues.length} sub-issue(s)) — closed via /close-epic, not here; skip.`); return }
+                core.info(`#${closedIssueNumber} is a solo leaf (its own epic branch, no real sub-issues) — treating its own closure as the completion signal.`)
+                subIssues = [{ number: closedIssueNumber, state: 'closed' }]
+              }
+            }
 
             // 2) any existing OPEN epic→main PR (idempotency guard)
             const existing = await github.paginate(github.rest.pulls.list,

--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -224,6 +224,31 @@ jobs:
               core.info(`Pinged @${OWNER} on red #${pr.number} (${pr.head.sha.slice(0, 7)}).`)
             }
 
+            // #2135: one-shot @mention the moment an epic shows "Awaiting your sign-off" — the
+            // rollup card above is silent otherwise, so a fresh sign-off hold produced ZERO signal
+            // an owner would notice (three real PRs — #2132/#2133/#2134 — sat unpinged until asked
+            // about directly). Keyed by epic number only, deduped like pingOnRed's SHA marker: a
+            // repeat status refresh on the SAME still-held epic must never re-ping. Known
+            // limitation, accepted deliberately: if this epic is unblocked and later blocked again
+            // by a second, unrelated hold, it will NOT re-ping — pingOnRed's per-SHA key can afford
+            // per-instance precision because a SHA changes; a sign-off hold has no equally cheap
+            // "which instance" signal, and a false skip here is safe (the rollup card still shows
+            // it), while spamming on every sweep re-evaluation would not be.
+            async function pingOnSignoffHold(epicNumber, title) {
+              const marker = `<!-- signoff-ping:${epicNumber} -->`
+              const comments = await github.paginate(github.rest.issues.listComments,
+                { owner, repo, issue_number: epicNumber, per_page: 100 })
+              if (comments.some(c => (c.body || '').includes(marker))) return // already pinged this hold
+              const body =
+                `${marker}\n` +
+                `🎨 **@${OWNER} — this needs your sign-off** (${title}).\n\n` +
+                `A draft PR is waiting on your \`lgtm\`/\`approve\` reply before it can build or ` +
+                `merge — open this issue's latest comment (or its PR) to see what changed.\n\n` +
+                `<sub>🤖 agent pipeline (CI) · sign-off notify (#1815/#2135)</sub>`
+              await github.rest.issues.createComment({ owner, repo, issue_number: epicNumber, body })
+              core.info(`Pinged @${OWNER} on fresh sign-off hold for epic #${epicNumber}.`)
+            }
+
             // A live flow-status CARD on the epic (#1838) — stage + child tree + current activity,
             // computed deterministically from sub-issue state + each child's work-<n> PR. Replaces
             // the old thin count line. Renders even with 0 children (the sign-off / decompose stages).
@@ -281,6 +306,7 @@ jobs:
               if (total === 0) {
                 head = epicBlocked ? `## 🎨 Awaiting your sign-off — ${title}` : `## ⏳ Decomposing — ${title}`
                 activity = epicBlocked ? '_now: waiting for your `lgtm` / answer on the design_' : '_now: the decomposer is planning this epic_'
+                if (epicBlocked) await pingOnSignoffHold(epicNumber, title)
               } else if (done < total) {
                 head = `## 🔨 Building — ${title}  (${done}/${total})`
                 activity = `_now: ${total - done} of ${total} in flight — reply here or on a PR to steer_`

--- a/scripts/epic-ready.mjs
+++ b/scripts/epic-ready.mjs
@@ -16,6 +16,32 @@ export function parseEpicNumber(ref) {
 }
 
 /**
+ * Resolve which issue number to treat as "the epic" for a just-closed pipeline issue, and
+ * whether it's a genuine multi-child epic or a SOLO LEAF using itself as its own integration
+ * branch (#1686's single-use worker: `EPIC="${EPIC:-$ISSUE}"`, the same default every other
+ * pipeline step already applies when a target has no parent). PURE — #2152.
+ *
+ * A solo leaf's pipeline-block `epic=` field (when it survives to close-time at all — often
+ * absent, #2152) equals its OWN issue number, exactly like a genuine multi-child epic closing
+ * directly instead of via `/close-epic`. The only thing that tells them apart is whether the
+ * resolved epic number actually has real GitHub sub-issues — a solo leaf never does.
+ *
+ *   closedIssueNumber: number        — the issue whose `issues: closed` event fired this
+ *   blockEpicNumber:   number|null   — `epic=` from its pipeline block, if any
+ *   subIssueCount:     number        — real sub-issues already fetched for the resolved epic number
+ *
+ * Returns { epicNumber, isSolo }. When isSolo is true, the caller should treat the closed issue
+ * itself as its epic's one completed child (`subIssues = [{ state: 'closed' }]`) rather than
+ * skipping — that's the #2152 fix. When isSolo is false and epicNumber === closedIssueNumber,
+ * the caller should keep the original #1815 behaviour: skip, defer to `/close-epic` (#856).
+ */
+export function resolveEpicTarget({ closedIssueNumber, blockEpicNumber = null, subIssueCount = 0 }) {
+  const epicNumber = blockEpicNumber ?? closedIssueNumber
+  const isSolo = epicNumber === closedIssueNumber && subIssueCount === 0
+  return { epicNumber, isSolo }
+}
+
+/**
  * Decide whether to open the epic→main PR. PURE.
  *   subIssues:           [{ state: 'open'|'closed' }]  — the epic's DIRECT sub-issues
  *   existingEpicMainPrs: [ ... ]                        — OPEN PRs already head=epic-branch base=main

--- a/scripts/epic-ready.test.mjs
+++ b/scripts/epic-ready.test.mjs
@@ -3,7 +3,7 @@
 //   node --test scripts/epic-ready.test.mjs
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseEpicNumber, decideOpen } from './epic-ready.mjs'
+import { parseEpicNumber, decideOpen, resolveEpicTarget } from './epic-ready.mjs'
 
 test('parseEpicNumber pulls the number from an epic branch, else null', () => {
   assert.equal(parseEpicNumber('epic/1701-cold-scaffold-first-run'), 1701)
@@ -48,4 +48,30 @@ test('does NOT open when the branch is not ahead of main (nothing to land)', () 
 
 test('defaults are safe — empty call never opens', () => {
   assert.equal(decideOpen().open, false)
+})
+
+// ── resolveEpicTarget (#2152: solo leaf vs genuine epic) ──────────────────────
+test('a real child of a distinct epic: epicNumber from the block, never solo', () => {
+  const r = resolveEpicTarget({ closedIssueNumber: 42, blockEpicNumber: 10, subIssueCount: 0 })
+  assert.deepEqual(r, { epicNumber: 10, isSolo: false })
+})
+
+test('a solo leaf with no pipeline block at all defaults epicNumber to its own number', () => {
+  const r = resolveEpicTarget({ closedIssueNumber: 2146, blockEpicNumber: null, subIssueCount: 0 })
+  assert.deepEqual(r, { epicNumber: 2146, isSolo: true })
+})
+
+test('a solo leaf whose block DID survive (epic=self) is still solo when it has no real sub-issues', () => {
+  const r = resolveEpicTarget({ closedIssueNumber: 2146, blockEpicNumber: 2146, subIssueCount: 0 })
+  assert.deepEqual(r, { epicNumber: 2146, isSolo: true })
+})
+
+test('a genuine multi-child epic closing directly (epic=self, real sub-issues) is NOT solo', () => {
+  const r = resolveEpicTarget({ closedIssueNumber: 100, blockEpicNumber: 100, subIssueCount: 5 })
+  assert.deepEqual(r, { epicNumber: 100, isSolo: false })
+})
+
+test('a genuine epic with no block at all (defaults to self) but real sub-issues is NOT solo', () => {
+  const r = resolveEpicTarget({ closedIssueNumber: 100, blockEpicNumber: null, subIssueCount: 3 })
+  assert.deepEqual(r, { epicNumber: 100, isSolo: false })
 })


### PR DESCRIPTION
Closes #2152
Closes #2150
Closes #2135

## 👤 For humans

Three separate, real gaps surfaced back-to-back today while running actual work through the pipeline (the Data-pane-filter epic, #2145) — each one meant something that should have finished or notified on its own instead needed a human to notice and intervene manually. All three are the same underlying theme (the pipeline doesn't reliably tell you when it's actually done, or actually needs you), so they're landing together, but each is independently reviewable as its own commit and closes its own issue.

1. **#2152 — the epic→main PR never auto-opened** for a solo issue dispatched via a plain 🚀 comment (as opposed to the full decompose-into-an-epic pipeline). Hit this twice today (``[#2115](https://github.com/FriendlyInternet/nuxt-crouton/issues/2115)/[#2118](https://github.com/FriendlyInternet/nuxt-crouton/issues/2118)/[#2119](https://github.com/FriendlyInternet/nuxt-crouton/issues/2119),`` then [#2146](https://github.com/FriendlyInternet/nuxt-crouton/issues/2146)) — had to open it by hand each time.
2. **#2150 — a shared-code merge hold (`status:needs-merge`) had no way to reach the owner at all** — not a notification, not "Review requested," nothing. Confirmed live against PR #2148, which genuinely didn't appear anywhere in the owner's GitHub mobile PR list. Also fixed a duplicate-comment bug found in the same code while there.
3. **#2135 — a fresh UI sign-off hold never pinged either** — the epic rollup card silently flips to "Awaiting your sign-off" with zero notification.

## 🤖 For agents

Three commits, one per issue — see each commit message for the specific mechanism. Summary:

- `scripts/epic-ready.mjs` + `.github/workflows/epic-ready-pr.yml`: new pure `resolveEpicTarget()` distinguishes a solo leaf (self-referential epic, zero real sub-issues) from a genuine multi-child epic closing directly — only the latter still defers to `/close-epic`.
- `.github/workflows/automerge-epic-subpr.yml`: the shared-code pause now calls `requestReviewers`, `@mention`s the owner, and only announces once per hold (a label-presence guard fixes the observed duplicate-comment bug).
- `.github/workflows/pipeline-pr-status.yml`: `updateEpic()` pings the owner once, deduped via a marker comment, the moment an epic's rollup first shows "Awaiting your sign-off."

## 🧪 How to test

Per-issue test plans are in each linked issue's body. Summary:
1. `node --test scripts/epic-ready.test.mjs scripts/deploy-detect.test.mjs` — 35/35 pass (12 new).
2. Dispatch a throwaway solo leaf → its epic→main PR should open automatically once its sub-PR merges and the issue closes.
3. Dispatch a `packages/*`-touching, non-UI leaf → once green, the resulting PR should appear under the owner's "Review requested" and produce exactly one notification comment.
4. Dispatch a UI-touching leaf → the sign-off hold should produce exactly one `@mention` comment, not a silent card update.
5. Regression: a genuine multi-child epic closing directly still does not get a spurious epic→main PR opened for itself; repeat sweeps of an already-held/already-pinged PR or epic produce no duplicate comments/requests.

All three inline-script changes were syntax-checked (YAML parse + `node --check` on the extracted script bodies with `${{ }}` expressions stubbed) since GitHub Actions `github-script` blocks have no CI dry-run. `npx fallow audit` clean on the diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C9opGHdwoo2YMAJZWYtcpA)_