### PR TITLE
fix(root): pipeline flow — auto-fix bot on live lane, sign-off ping timing, opus-4.8 hard tier

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -227,7 +227,7 @@
   description: "Force the pi.dev pipeline regardless of AGENT_HARNESS. Redundant while AGENT_HARNESS=pi — plain 'delegate' already routes here"
 - name: "delegate-hard"
   color: "b60205"
-  description: "Escalate this leaf to the METERED Claude lane (provider=anthropic, claude-sonnet-5) instead of GLM — for the rare task GLM can't finish (#1496)"
+  description: "Escalate this leaf to the hard model tier (claude-opus-4-8, routing.json `large`) instead of the default claude-sonnet-5 — for the rare task the default can't finish (#1496/#2160)"
 - name: "work-this"
   color: "0e8a16"
   description: "Single-use worker: implement this ONE leaf issue and open a PR (work-issue-pidev.yml, #1685/#1686) — no decompose"

--- a/.github/workflows/decompose-on-issue-pidev.yml
+++ b/.github/workflows/decompose-on-issue-pidev.yml
@@ -294,7 +294,9 @@ jobs:
           # lane. Headless subscription auth: the mini's runner runs `claude` in a session that
           # can't reach the macOS Keychain, so CLAUDE_CODE_OAUTH_TOKEN (claude setup-token, 1y)
           # authenticates the CLI from env instead of the keychain login (#2119).
-          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
+          # #2160: hard tier = claude-opus-4-8 (routing.json `large`); drifted to stale 4-6 because
+          # the --check guards agent frontmatter, not this env. Keep in sync with .claude/routing.json.
+          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-8') || 'claude-sonnet-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}

--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -6,7 +6,8 @@ name: Fix CI on failure
 # forever; the existing resume-on-comment.yml restarts it on a human reply.
 #
 # Guard rails (the whole point — provably no runaway):
-#   - Scope: only head branches `claude/issue-*` (pipeline PRs). Human PRs are never touched.
+#   - Scope: only pipeline head branches `claude/issue-*` (claude lane) + `work-*` (pi worker,
+#     #2157). Human PRs are never touched.
 #   - Attempt cap: a `ci-fix-attempts:N` label on the PR, capped at MAX (3). On exhaustion →
 #     stop, @mention the owner, block the linked issue.
 #   - Shared-code stop: the agent must NOT touch packages/ (the HARD GATE) — if a fix needs
@@ -80,7 +81,15 @@ jobs:
             if (!pr) { core.info('No open PR for branch — nothing to fix.'); core.setOutput('proceed', 'false'); return }
 
             const full = (await github.rest.pulls.get({ owner, repo, pull_number: pr.number })).data
-            if (full.state !== 'open' || !full.head.ref.startsWith('claude/issue-')) {
+            // #2157: the job `if` above was widened to both lanes (#2089), but THIS inner
+            // re-check still only accepted `claude/issue-*` — so every `work-*` PR (the pi
+            // worker, which AGENT_HARNESS=pi makes the LIVE lane) bailed here and the fix-bot
+            // never acted on a real PR. Same #2089 bug, one spot the fix missed. The two-prefix
+            // predicate lives once in scripts/lib/pipeline-branch.mjs; inline it here to match
+            // the job `if` (a github-script gate can't import without a checkout, and this runs
+            // pre-checkout). Keep these three in lockstep: the helper, the job `if`, this line.
+            const isPipelineRef = r => /^(claude\/issue-|work-)/.test(String(r || ''))
+            if (full.state !== 'open' || !isPipelineRef(full.head.ref)) {
               core.info('Not an open pipeline PR — skipping.'); core.setOutput('proceed', 'false'); return
             }
             const labels = (full.labels || []).map(l => l.name)
@@ -94,7 +103,8 @@ jobs:
             const attempts = attemptLabel ? Number(attemptLabel.split(':')[1]) : 0
 
             // The linked issue (from the branch name) is the resume surface for resume-on-comment.
-            const m = /^claude\/issue-(\d+)-/.exec(full.head.ref)
+            // Both lanes (#2157): `claude/issue-<n>-<slug>` and the pi worker's `work-<n>`.
+            const m = /^(?:claude\/issue-|work-)(\d+)/.exec(full.head.ref)
             const issueNumber = m ? Number(m[1]) : null
 
             if (attempts >= MAX) {

--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -306,7 +306,26 @@ jobs:
               if (total === 0) {
                 head = epicBlocked ? `## 🎨 Awaiting your sign-off — ${title}` : `## ⏳ Decomposing — ${title}`
                 activity = epicBlocked ? '_now: waiting for your `lgtm` / answer on the design_' : '_now: the decomposer is planning this epic_'
-                if (epicBlocked) await pingOnSignoffHold(epicNumber, title)
+                // #2156: only ASK for sign-off once the held PR is actually reviewable — its CI
+                // is green. Pinging the instant the draft opens asks for a decision that can't be
+                // made yet: on #2156 the sign-off ping fired 4 minutes BEFORE CI went red on a
+                // real type error, so the owner got "needs your sign-off" and "CI failed" back to
+                // back. A red or still-running draft is the red-ping's / fix-bot's job, not a
+                // sign-off ask. This re-fires on the next CI-completion event (workflow_run,
+                // above), so a later green still pings — and the signoff-ping marker keeps it
+                // one-shot. A design-only hold (#1821) has no work-<n> PR yet and already
+                // @mentions the owner at creation (apply-decompose-plan.mjs), so skipping it here
+                // avoids a double-ping rather than dropping a signal.
+                if (epicBlocked) {
+                  const heldPr = await childPr(epicNumber)
+                  if (!heldPr) {
+                    core.info(`epic #${epicNumber}: sign-off hold with no work-<n> PR (design hold?) — owner already @mentioned at creation; not double-pinging.`)
+                  } else {
+                    const heldSt = await ciState(heldPr.head.sha)
+                    if (heldSt.word === 'passing') await pingOnSignoffHold(epicNumber, title)
+                    else core.info(`epic #${epicNumber}: held PR #${heldPr.number} CI is ${heldSt.word} — deferring sign-off ping until green.`)
+                  }
+                }
               } else if (done < total) {
                 head = `## 🔨 Building — ${title}  (${done}/${total})`
                 activity = `_now: ${total - done} of ${total} in flight — reply here or on a PR to steer_`

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -243,7 +243,11 @@ jobs:
           # Headless subscription auth: the mini's runner runs `claude` in a session that
           # can't reach the macOS Keychain, so CLAUDE_CODE_OAUTH_TOKEN (claude setup-token, 1y)
           # authenticates the CLI from env instead of the keychain login (#2119).
-          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-6') || 'claude-sonnet-5' }}
+          # #2160: the hard tier is claude-opus-4-8 — the value routing.json's `large` tier
+          # already declared. This env drifted to the stale 4-6 because routing.json's --check
+          # guards agent frontmatter, not these pi workflow model envs. Keep in sync with
+          # .claude/routing.json (`large`) + scripts/gen-routing.mjs (`FULL.opus`).
+          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-8') || 'claude-sonnet-5' }}
           PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE: ${{ inputs.issue || github.event.issue.number }}

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -340,6 +340,10 @@ jobs:
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
           EPIC_BRANCH: ${{ steps.ctx.outputs.epic_branch }}
           SINCE: ${{ steps.t0.outputs.ts }}
+          # #2161: same expression as the pi-run step's PI_MODEL/PI_PROVIDER, so the run-record
+          # can state which model actually built this PR (provenance on the ticket).
+          PI_MODEL: ${{ inputs.model || (github.event.label.name == 'delegate-hard' && 'claude-opus-4-8') || 'claude-sonnet-5' }}
+          PI_PROVIDER: ${{ inputs.provider || 'pi-claude-cli' }}
         run: |
           set -uo pipefail
           BASE="main"; [ -n "${EPIC_BRANCH:-}" ] && BASE="$EPIC_BRANCH"
@@ -642,7 +646,7 @@ jobs:
             esac
             REC="$RUNNER_TEMP/run-record.md"
             {
-              echo "> 🤖 **pi worker — run record** · _facts from the commit + git + typecheck, not pi's narration (#1849)_"
+              echo "> 🤖 **pi worker — run record** · model \`${PI_MODEL:-?}\` (${PI_PROVIDER:-?}) · _facts from the commit + git + typecheck, not pi's narration (#1849)_"
               echo
               echo "**Committed ${N} file(s)** onto \`${BR}\` → \`${BASE}\`:"
               echo "- 📝 inputs (hand-authored — schema/config): **${NIN}**"


### PR DESCRIPTION
Closes #2157
Closes #2158
Closes #2160

(also carries the first commit of #2161 — model provenance in the run-record; the larger config + escalate pieces of #2161 land separately)

## 👤 For humans

Pipeline-flow fixes from one session, all the same shape — a guard that silently did the wrong thing on the live lane, or a stale config value that never got synced.

1. **#2157 — the CI auto-fix bot never ran on real PRs.** Its loop guard is fine (3 tries → give up → @mention you → block), but the fix that taught it about the pi worker's `work-*` branches (#2089) was only half-applied: the inner gate still only accepted `claude/issue-*`, so every live PR bailed instantly (its helper records **1718 runs, zero actions**).
2. **#2158 — the sign-off ping fired too early.** On #2156 it said "needs your sign-off" 4 min *before* "CI failed." Now it waits until the held PR's CI is green.
3. **#2160 — the "hard" model tier was stale Opus 4.6.** Routing config already said 4.8; the two pi workflow envs just never synced. Now they do.
4. **#2161 (partial) — model provenance.** The run-record comment now states which model built the PR.

## 🤖 For agents

Atomic commits, one per issue:
- `fix-ci-on-failure.yml`: two-lane `isPipelineRef()` gate + `work-<n>` issue-regex.
- `pipeline-pr-status.yml`: `pingOnSignoffHold` gated on the held PR's `ciState().word === 'passing'`.
- `work-issue-pidev.yml` + `decompose-on-issue-pidev.yml` + `labels.yml`: `delegate-hard` model → `claude-opus-4-8`; label de-staled.
- `work-issue-pidev.yml`: run-record provenance line names the model (`PI_MODEL`/`PI_PROVIDER` threaded into the finish step).

**Not here (own follow-up, #2161):** config-driven model selection (edit one list) + auto-escalate to the hard tier on failure (approach A). Must be built directly — the App token can't push `.github/workflows/**`.

## 🧪 How to test

1. Non-packages CI failure on a `work-*` PR → fix-bot runs (`ci-fix-attempts:1` + a fix), not `skipped`.
2. Packages-only failure on a `work-*` PR → bot escalates (@mention + block).
3. UI dispatch passing CI → one sign-off ping, after green; failing → no ping until green.
4. `grep -rn opus-4-6 .github/` → none; a `delegate-hard` dispatch runs Opus 4.8.
5. A pi-built PR's run-record names the model it ran on.
6. Regressions: human PRs never auto-edited; 3-attempt cap still gives up + escalates; design-only holds still notify once at creation.

Inline `github-script` edits syntax-checked (YAML parse + `node --check`, `${{ }}` stubbed); `npx fallow audit` clean on the diff.
