### PR TITLE
fix(root): grant the fix-bot tool permissions so it can run pnpm (#2165)

### DIFF
--- a/.github/workflows/fix-ci-on-failure.yml
+++ b/.github/workflows/fix-ci-on-failure.yml
@@ -183,7 +183,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
-          claude_args: "--model claude-sonnet-5 --max-turns 30"
+          # bypassPermissions REQUIRED (#834/#2165): headless CI denies un-allowlisted tools, so
+          # WITHOUT this the fix-bot's every pnpm/git/gh command is permission-denied — it burns all
+          # its turns on denials and crashes with max_turns, never reaching the fix (the first real
+          # live-lane run, 31589320044, did exactly this). Same reason red-team-daily.yml sets it.
+          # max-turns 40 (was 30): a full pnpm install + typecheck + fix + verify cycle is turn-hungry.
+          claude_args: "--model claude-sonnet-5 --max-turns 40 --permission-mode bypassPermissions"
           show_full_output: true
           prompt: |
             CI failed on this pipeline PR — you are the fix-bot. This is auto-fix attempt


### PR DESCRIPTION
Closes #2165

## 👤 For humans

The CI auto-fix bot — the thing that's supposed to fix red CI on agent PRs by itself — **had never actually worked on the live lane.** It only ran for real for the first time just now (once #2164 + the #2157 branch-guard fix finally let it past its gate on the crouton-sales PR #2156), and it crashed on the spot: it was never given permission to run `pnpm` in CI, so every command it tried was denied, it burned all 30 of its turns hitting that wall, and gave up without fixing anything.

Every other agent worker in the repo already carries this one permission line. The fix-bot was the only one missing it. This adds it.

Once this is on `main`, the fix-bot can finish PR #2156 itself (I'll reset its attempt counter and re-trigger CI after this merges).

## 🤖 For agents

Root cause — run [31589320044](https://github.com/FriendlyInternet/nuxt-crouton/actions/runs/31589320044): `terminal_reason: max_turns`, and the `permission_denials` array shows every `pnpm --filter kassa typecheck`, `pnpm -v`, `gh run view`, `env`, `cat ~/.claude/settings.json` **denied** (only `ls` ran). 30 turns of denials → `error_max_turns` → job `failure`, no commit.

- `fix-ci-on-failure.yml` — `claude_args` had no `--allowedTools` / `--permission-mode`. Added `--permission-mode bypassPermissions` (matches `red-team-daily.yml`; the fix-bot needs arbitrary shell + the `/commit` skill, so bypass over a fixed allowlist). Bumped `--max-turns` 30 → 40.
- Unchanged guard rails: 3-attempt cap, packages gate (#2164), pipeline-branch guard.

**Secondary finding, NOT fixed here (own follow-up):** the attempt cap is consumed *per failing workflow-run*, not per commit — one commit that fails both `CI` and `Deploy Apps` fires the fix-bot twice, eating 2 of 3 attempts before a single real cycle. Worth a dedup-by-head-SHA follow-up.

## 🧪 How to test

1. Merge to `main` (workflow_run runs from the default branch → fix is live on the next fix-bot wake).
2. Reset PR #2156's `ci-fix-attempts` label + re-trigger its CI.
3. Fix-bot wakes, runs `pnpm --filter kassa typecheck` (not denied), fixes the `chartQuery` type error in `packages/crouton-sales`, pushes → CI green.

YAML parse-clean (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9opGHdwoo2YMAJZWYtcpA)_