### PR TITLE
fix(root): set BETTER_AUTH_SECRET on the per-PR preview Worker (#2167)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -505,8 +505,21 @@ jobs:
           ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -o pipefail
+          # Target the Worker the deploy actually published. Prod → default env; a per-PR
+          # preview (#2020) is a SEPARATE top-level Worker (<app>-pr<n>) built into the
+          # rewritten .output config, so `--env staging` would set the secret on the SHARED
+          # staging Worker and leave the preview with none — "BETTER_AUTH_SECRET is required"
+          # on every preview login (#2167). Point at the preview's own config in that case;
+          # prod + normal-staging targeting is unchanged.
           ENV_FLAG=""
-          if [ "$ENVIRONMENT" != "production" ]; then ENV_FLAG="--env staging"; fi
+          PR_NUM="${{ github.event.pull_request.number }}"
+          if [ "$ENVIRONMENT" = "production" ]; then
+            ENV_FLAG=""
+          elif [ -n "$PR_NUM" ] && [ -f .output/server/wrangler.json ]; then
+            ENV_FLAG="--config .output/server/wrangler.json"
+          else
+            ENV_FLAG="--env staging"
+          fi
           if ! existing=$(npx wrangler secret list $ENV_FLAG 2>/dev/null); then
             echo "::warning::Could not list Worker secrets for ${{ inputs.app }} ($ENVIRONMENT) — skipping auto-generate to avoid clobbering an existing BETTER_AUTH_SECRET."
             exit 0


### PR DESCRIPTION
Closes #2167

## 👤 For humans

Every per-PR preview app — the link you tap to review a PR — deploys as its **own** Cloudflare Worker. But the `BETTER_AUTH_SECRET` CI generates was landing on the *shared* staging app instead, so the preview Worker had no secret and **login just errored** (`BETTER_AUTH_SECRET is required` — exactly what PR #2156's preview showed). This has quietly affected every preview-with-login since the per-PR preview feature (#2020) shipped; it only surfaced now because #2156 is the first UI-sign-off preview someone actually tried to log into.

Scoped, preview-only fix — **prod and normal staging deploys are byte-for-byte unchanged**, so no blast radius to the live apps.

## 🤖 For agents

`deploy-app.yml`, "Ensure BETTER_AUTH_SECRET" step:
- #289 generated the secret via `wrangler secret ... --env staging` — correct when the deployed Worker *was* `env.staging`.
- #2020 made the per-PR preview a **separate top-level Worker** (`pr-preview-wrangler.mjs` strips the `env` block; the deploy is `wrangler deploy --config .output/server/wrangler.json`, no `--env`), so `--env staging` targeted a **different** Worker → preview had no secret.
- Now the target is computed: prod → default env; per-PR preview (`github.event.pull_request.number` set **and** `.output/server/wrangler.json` present) → `--config .output/server/wrangler.json` (the preview Worker); else → `--env staging` (unchanged). Both `secret list` and `secret put` use it.

**Follow-ups (NOT here — same wrong-Worker targeting):** the `WORKER_SECRETS_JSON` sync and the review-overlay bridge secrets also use `--env staging`. Kept out to scope this to the login blocker.

## 🧪 How to test

1. Merge.
2. Re-deploy PR #2156's preview → open its prefilled login link → signed in, no auth error.
3. Regression: a normal staging deploy and a prod deploy still generate/keep the secret on the shared Worker as before (targeting path unchanged for both).

YAML parse-clean (`yaml.safe_load`). The preview path is the only changed branch; `production` and no-PR `staging` resolve to the exact same `ENV_FLAG` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9opGHdwoo2YMAJZWYtcpA)_