### PR TITLE
fix(root): seed the per-PR preview's own DB, not shared staging (#2169)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -289,6 +289,9 @@ jobs:
               echo "::error::pr-preview-wrangler produced no db name — the preview would have NO schema."
               exit 1
             fi
+            # Expose the preview DB so the seed + review-login steps target IT, not shared
+            # staging (#2169 — the seed-side sibling of #2167's secret targeting).
+            echo "preview_db=$PREVIEW_DB" >> "$GITHUB_OUTPUT"
             # The deploy above just PROVISIONED that database, but the built config still
             # carries no `database_id` — it is stripped on purpose so wrangler auto-provisions
             # (#2020). Remote D1 operations need the id, so resolve it by name now that it
@@ -542,8 +545,11 @@ jobs:
         if: ${{ inputs.environment != 'production' }}
         working-directory: ${{ inputs.workspace }}/${{ inputs.app }}
         run: |
-          if pnpm exec crouton-seed --db "${{ inputs.app }}-staging-db" --remote; then
-            echo "✓ seeded ${{ inputs.app }}-staging-db (collection fixtures + demo team)"
+          # Per-PR preview seeds its OWN DB (#2169); non-preview staging falls back to the
+          # shared staging DB exactly as before (preview_db is empty off the preview path).
+          DB="${{ steps.deploy.outputs.preview_db }}"; [ -n "$DB" ] || DB="${{ inputs.app }}-staging-db"
+          if pnpm exec crouton-seed --db "$DB" --remote; then
+            echo "✓ seeded $DB (collection fixtures + demo team)"
           else
             echo "::warning::content seed skipped/failed for ${{ inputs.app }} — crouton-seed unresolvable or errored; the preview may be empty (#1370)."
           fi
@@ -565,6 +571,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REF_NAME: ${{ github.ref_name }}
           REVIEW_SEED_SECRET: ${{ secrets.REVIEW_SEED_SECRET }}
+          # Per-PR preview: attach the review login's team membership to the preview's OWN
+          # DB (#2169), not shared staging — else the account exists but has no team/data.
+          PREVIEW_DB: ${{ steps.deploy.outputs.preview_db }}
         run: |
           set -o pipefail
           # Stable per-preview key: the PR number when this is a PR, else the ref.
@@ -581,8 +590,9 @@ jobs:
           # printed a working-looking login for a user that was never created (the seed POSTed to a
           # dead URL → failed silently → 401 on login). Only surface the creds when the seed actually
           # succeeded; otherwise emit a loud warning and NO login (a broken preview must look broken).
+          SEED_DB="${PREVIEW_DB:-${APP}-staging-db}"
           if node scripts/seed-review-login.mjs --url "$DEPLOY_URL" --email "$EMAIL" --password "$PW" \
-               --seed-team test1 --db "${APP}-staging-db"; then
+               --seed-team test1 --db "$SEED_DB"; then
             echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
             echo "password=$PW" >> "$GITHUB_OUTPUT"
             # One-click link: crouton-auth prefills the login form from ?email=&password=


### PR DESCRIPTION
Closes #2169

## 👤 For humans

Follow-up to #2167. The auth-secret fix got the preview's **login** working — but the preview's **database** was still empty. The demo sales data and the review account's team membership were being written to the *shared* staging database, not the preview's own one, so you'd log into an app with no team, no event, no products — nothing to review. Now they go on the preview's own DB.

Same scoped, preview-only shape as #2167: normal staging and prod are unchanged.

## 🤖 For agents

Verified against PR #2156's live preview: the review account wasn't in the preview DB at all (a manual signup succeeded), and the seed `--db` flags pointed at `kassa-staging-db`.

`deploy-app.yml`:
- Deploy step (per-PR-preview branch) now exposes the already-computed `PREVIEW_DB` as `steps.deploy.outputs.preview_db`.
- **Seed collection + demo data** → `crouton-seed --db "$DB"`, `DB = preview_db || "${app}-staging-db"`.
- **Seed review login** → `--db "$SEED_DB"`, `SEED_DB = preview_db || "${APP}-staging-db"`. (The account signup already uses `--url $DEPLOY_URL` = the preview URL, so only the membership `--db` was mis-targeted.)

Off the preview path `preview_db` is empty, so both resolve to `${app}-staging-db` exactly as before; these steps are `if: environment != production`, so prod is untouched.

## 🧪 How to test

1. Merge; re-deploy PR #2156's preview.
2. Open the prefilled login link → signed in, **and** the sales event + products are present, so the Data pane filter has real data.
3. Regression: normal staging still seeds `${app}-staging-db`; prod seeds nothing.

YAML parse-clean. Only the per-PR-preview branch changes behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9opGHdwoo2YMAJZWYtcpA)_