### PR TITLE
fix(root): withhold visual sign-off asks with no captured evidence (#2171)

### DIFF
--- a/.github/workflows/pipeline-pr-status.yml
+++ b/.github/workflows/pipeline-pr-status.yml
@@ -249,6 +249,45 @@ jobs:
               core.info(`Pinged @${OWNER} on fresh sign-off hold for epic #${epicNumber}.`)
             }
 
+            // #2171: never ASK for a visual sign-off the flow can't SHOW. Read the PR's OWN
+            // committed files (not a body claim — the #1849 rule). `isVisual` mirrors
+            // work-issue-pidev.yml's UI_TOUCHED EXACTLY — a looser match would wrongly FREEZE a
+            // non-visual sign-off. `hasEvidence` = a capture under writeups/ui-proposals/ (the
+            // worker's EVIDENCE_ATTACHED signal).
+            async function visualEvidenceState(prNumber) {
+              const files = await github.paginate(github.rest.pulls.listFiles,
+                { owner, repo, pull_number: prNumber, per_page: 100 })
+              const paths = files.map(f => f.filename || '')
+              const isVisual = paths.some(p =>
+                /\.(vue|css)$/.test(p) || /\/app\/(components|layouts|pages)\//.test(p) || /app\.config\.ts$/.test(p))
+              const hasEvidence = paths.some(p => /^writeups\/ui-proposals\//.test(p))
+              return { isVisual, hasEvidence }
+            }
+
+            // A visual PR with NO capture must not become a sign-off ASK — that sends the owner to
+            // approve a surface the flow never showed them (#2057). Say so ONCE, and do NOT
+            // @mention: there is no action for the owner here — closing the gap (a capture, or a
+            // real preview of the changed surface) is the flow's job. When a capture later lands,
+            // pingOnSignoffHold fires normally (its marker is independent of this one), so this
+            // self-heals rather than wedging the PR.
+            async function withholdSignoffNoCapture(epicNumber, prNumber, title) {
+              const marker = `<!-- signoff-withheld-nocapture:${epicNumber} -->`
+              const comments = await github.paginate(github.rest.issues.listComments,
+                { owner, repo, issue_number: epicNumber, per_page: 100 })
+              if (comments.some(c => (c.body || '').includes(marker))) return
+              const body =
+                `${marker}\n` +
+                `🚫 **Sign-off withheld — nothing to show yet** (${title}).\n\n` +
+                `PR #${prNumber} changes a visual surface, but no screenshot was captured this run ` +
+                `(none under \`writeups/ui-proposals/\`). The flow will not ask you to approve a ` +
+                `surface it hasn't shown you — a capture (or a working preview of the changed ` +
+                `surface) has to land first. Nothing for you to do here; the gap is the flow's to ` +
+                `close (#2057).\n\n` +
+                `<sub>🤖 agent pipeline (CI) · visual sign-off gate (#2171)</sub>`
+              await github.rest.issues.createComment({ owner, repo, issue_number: epicNumber, body })
+              core.info(`Withheld sign-off for epic #${epicNumber}: visual PR #${prNumber} has no capture.`)
+            }
+
             // A live flow-status CARD on the epic (#1838) — stage + child tree + current activity,
             // computed deterministically from sub-issue state + each child's work-<n> PR. Replaces
             // the old thin count line. Renders even with 0 children (the sign-off / decompose stages).
@@ -322,8 +361,14 @@ jobs:
                     core.info(`epic #${epicNumber}: sign-off hold with no work-<n> PR (design hold?) — owner already @mentioned at creation; not double-pinging.`)
                   } else {
                     const heldSt = await ciState(heldPr.head.sha)
-                    if (heldSt.word === 'passing') await pingOnSignoffHold(epicNumber, title)
-                    else core.info(`epic #${epicNumber}: held PR #${heldPr.number} CI is ${heldSt.word} — deferring sign-off ping until green.`)
+                    if (heldSt.word !== 'passing') {
+                      core.info(`epic #${epicNumber}: held PR #${heldPr.number} CI is ${heldSt.word} — deferring sign-off ping until green.`)
+                    } else {
+                      // Green — but never ASK for a visual sign-off the flow can't SHOW (#2171/#2057).
+                      const vis = await visualEvidenceState(heldPr.number)
+                      if (vis.isVisual && !vis.hasEvidence) await withholdSignoffNoCapture(epicNumber, heldPr.number, title)
+                      else await pingOnSignoffHold(epicNumber, title)
+                    }
                   }
                 }
               } else if (done < total) {


### PR DESCRIPTION
Closes #2171

## 👤 For humans

The flow was asking you to "sign off" on visual changes it had **never shown you** — the instant CI went green and a `.vue` file changed, even when it captured no screenshot. On #2147 that meant it asked you to approve a Data-pane filter whose button was never built: nothing to look at, but it asked anyway (its own note even said "no capture landed… not a reason to approve blind" — then asked for the approval).

Now: **no capture, no ask.** A visual PR with no screenshot gets a "🚫 nothing to show yet" note instead of a sign-off request — the flow refuses to send you to approve a surface it can't show.

## 🤖 For agents

`pipeline-pr-status.yml`, the sign-off path (`updateEpic` → only when the held PR's CI is `passing`):
- New `visualEvidenceState(pr)` reads the PR's **own committed files** (`pulls.listFiles`), not a body claim (the #1849 rule). `isVisual` mirrors `work-issue-pidev.yml`'s `UI_TOUCHED` **exactly** (`\.(vue|css)$` · `/app/(components|layouts|pages)/` · `app.config.ts$`) — a looser match would wrongly freeze a non-visual sign-off. `hasEvidence` = a file under `writeups/ui-proposals/`.
- `isVisual && !hasEvidence` → `withholdSignoffNoCapture` (distinct deduped comment, **no @mention** — nothing for the owner to act on) instead of `pingOnSignoffHold`.
- Self-heals: when a capture later lands, the normal ping fires (independent marker).

Corpus-checked (`node`): `.vue` in `app/components` + no capture → withhold; server/config-only → normal ping (no false freeze); visual + `ui-proposals/` capture → normal ping.

**Follow-ups (noted, not here):** (1) the pi lane has no screenshot-**capture** step yet — this makes "no capture" *loud* but the real #2057 fix is a capture step so the flow can SHOW, not just withhold; (2) the signoff-ping dedup is epic-only-keyed, so a premature ping suppresses the correct one — a separate SHA-keyed-dedup fix.

## 🧪 How to test

1. A `.vue`-touching held PR, CI green, no `writeups/ui-proposals/` file → epic gets "🚫 Sign-off withheld — nothing to show yet", not "🎨 needs your sign-off".
2. Same PR after a capture lands under `writeups/ui-proposals/` → the normal sign-off ping fires.
3. A server-only/config held PR → normal ping (isVisual false).

YAML parse-clean; the added script `node --check`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9opGHdwoo2YMAJZWYtcpA)_