### PR TITLE
feat(root): make PR previews reviewable — capture screenshots + fix the annotation bridge (#2173, #2175)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -438,8 +438,12 @@ jobs:
           # staging Worker and the preview's /api/_feedback stays "GitHub sink not configured"
           # (#2175 — the annotation sibling of #2167's auth-secret targeting). Point at the
           # preview's own config in that case; a dispatch review_pr (no PR event) stays --env staging.
+          # Assign the PR-number expression to a var BEFORE testing it: the shellcheck-workflows
+          # extractor substitutes `${{ }}` with a literal, so an inline `[ -n "${{ … }}" ]` trips
+          # SC2157 ("always true"). Testing $PR_NUM is what #2167's auth-secret step does too.
+          PR_NUM="${{ github.event.pull_request.number }}"
           BRIDGE_TARGET="--env staging"
-          if [ -n "${{ github.event.pull_request.number }}" ] && [ -f .output/server/wrangler.json ]; then
+          if [ -n "$PR_NUM" ] && [ -f .output/server/wrangler.json ]; then
             BRIDGE_TARGET="--config .output/server/wrangler.json"
           fi
           npx wrangler secret bulk "$RUNNER_TEMP/review-secrets.json" $BRIDGE_TARGET
@@ -675,7 +679,7 @@ jobs:
               echo "::warning::could not clone $HEAD_REF for capture commit — skipping (non-fatal)"; exit 0; }
           mkdir -p "$BR/writeups/ui-proposals"
           cp "$OUT"/*.png "$BR/writeups/ui-proposals/"
-          cd "$BR"
+          cd "$BR" || { echo "::warning::could not cd into the capture clone — skipping (non-fatal)"; exit 0; }
           git config user.name "nuxt-harness[bot]"
           git config user.email "295566920+nuxt-harness[bot]@users.noreply.github.com"
           git add writeups/ui-proposals/*.png

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -616,6 +616,66 @@ jobs:
             echo "### ⚠️ Review login unavailable (${APP}) — the seed step failed; no working login for this preview." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # ── Capture the review surfaces so the flow can SHOW the change (#2173) ──────────
+      # Deploy-side on purpose: THIS env boots the app; the pi worker's often can't ("could not
+      # typecheck the touched app"). Logs into the live preview, drives the app to each DECLARED
+      # review surface (deploy.config.json `reviewSurfaces`, else reviewLogin.landing), validates
+      # the shot isn't blank/error, and commits the PNG(s) to writeups/ui-proposals/ — where the
+      # #2172 sign-off gate looks. The push (App token) re-runs CI so that gate re-evaluates and
+      # finds the evidence; a ui-proposals-only change matches NO app watchPaths, so it does NOT
+      # re-deploy (no loop). Never fails the deploy — no capture ⇒ the gate withholds (honest).
+      - name: Mint token for review-capture push
+        id: capture-token
+        if: ${{ inputs.environment == 'staging' && github.event.pull_request.number != '' && steps.seed.outputs.email != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HARNESS_APP_ID }}
+          private-key: ${{ secrets.HARNESS_APP_PRIVATE_KEY }}
+          owner: FriendlyInternet
+
+      - name: Capture + commit review-surface evidence (#2173)
+        if: ${{ inputs.environment == 'staging' && github.event.pull_request.number != '' && steps.seed.outputs.email != '' && steps.capture-token.outputs.token != '' }}
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+          EMAIL: ${{ steps.seed.outputs.email }}
+          PASSWORD: ${{ steps.seed.outputs.password }}
+          APP: ${{ inputs.app }}
+          WORKSPACE: ${{ inputs.workspace }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN_PUSH: ${{ steps.capture-token.outputs.token }}
+        run: |
+          set -o pipefail
+          [ -n "$DEPLOY_URL" ] || { echo "no deploy url — skipping capture"; exit 0; }
+          npx playwright install chromium >/dev/null 2>&1 || true
+          # Capture to a temp dir so the commit is done in a CLEAN clone, never the dirty deploy
+          # workspace (build output / sync:ids-modified wrangler.jsonc would otherwise ride along).
+          OUT="$RUNNER_TEMP/uip"; rm -rf "$OUT"; mkdir -p "$OUT"
+          node scripts/capture-review-surfaces.mjs \
+            --url "$DEPLOY_URL" --email "$EMAIL" --password "$PASSWORD" \
+            --manifest "$WORKSPACE/$APP/deploy.config.json" --pr "$PR_NUMBER" --out "$OUT" || true
+          shopt -s nullglob; PNGS=("$OUT"/*.png)
+          if [ ${#PNGS[@]} -eq 0 ]; then
+            echo "no valid captures — the sign-off gate will withhold (nothing to show)"; exit 0
+          fi
+          BR="$RUNNER_TEMP/uip-branch"; rm -rf "$BR"
+          git clone --depth=1 --branch "$HEAD_REF" \
+            "https://x-access-token:${GH_TOKEN_PUSH}@github.com/${REPO}.git" "$BR" 2>/dev/null || {
+              echo "::warning::could not clone $HEAD_REF for capture commit — skipping (non-fatal)"; exit 0; }
+          mkdir -p "$BR/writeups/ui-proposals"
+          cp "$OUT"/*.png "$BR/writeups/ui-proposals/"
+          cd "$BR"
+          git config user.name "nuxt-harness[bot]"
+          git config user.email "295566920+nuxt-harness[bot]@users.noreply.github.com"
+          git add writeups/ui-proposals/*.png
+          if git commit -q -m "chore(review): capture ${APP} review surface(s) for PR #${PR_NUMBER} (#2173)"; then
+            git push origin "HEAD:${HEAD_REF}" && echo "✓ committed ${#PNGS[@]} capture(s) → the sign-off gate can now show them"
+          else
+            echo "captures unchanged — nothing to commit"
+          fi
+
       # Prove the DEPLOYED preview actually works — log in with the seeded account, run
       # any app-declared CRUD + public read, and screenshot it (#293). This is the
       # acceptance typecheck/boot can't give: auth + a data round-trip on the real Worker

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -433,7 +433,16 @@ jobs:
               NUXT_CROUTON_REVIEW_GITHUB_APP_INSTALLATION_ID: $inst,
               NUXT_CROUTON_REVIEW_GITHUB_APP_PRIVATE_KEY: $key
             }' > "$RUNNER_TEMP/review-secrets.json"
-          npx wrangler secret bulk "$RUNNER_TEMP/review-secrets.json" --env staging
+          # Target the Worker the deploy published. A per-PR preview (#2020) is a SEPARATE
+          # top-level Worker, so `--env staging` would write the bridge secrets to the SHARED
+          # staging Worker and the preview's /api/_feedback stays "GitHub sink not configured"
+          # (#2175 — the annotation sibling of #2167's auth-secret targeting). Point at the
+          # preview's own config in that case; a dispatch review_pr (no PR event) stays --env staging.
+          BRIDGE_TARGET="--env staging"
+          if [ -n "${{ github.event.pull_request.number }}" ] && [ -f .output/server/wrangler.json ]; then
+            BRIDGE_TARGET="--config .output/server/wrangler.json"
+          fi
+          npx wrangler secret bulk "$RUNNER_TEMP/review-secrets.json" $BRIDGE_TARGET
           rm -f "$RUNNER_TEMP/review-secrets.json"
           echo "✓ Wired preview-review bridge → PR #$PR on $REPOSITORY (posts as nuxt-harness[bot])"
 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -439,8 +439,10 @@ jobs:
           # (#2175 — the annotation sibling of #2167's auth-secret targeting). Point at the
           # preview's own config in that case; a dispatch review_pr (no PR event) stays --env staging.
           # Assign the PR-number expression to a var BEFORE testing it: the shellcheck-workflows
-          # extractor substitutes `${{ }}` with a literal, so an inline `[ -n "${{ … }}" ]` trips
+          # extractor replaces the GitHub expression with a literal, so testing it inline trips
           # SC2157 ("always true"). Testing $PR_NUM is what #2167's auth-secret step does too.
+          # (Do NOT write a literal double-brace expression in this comment — Actions parses it
+          # even inside a run-block comment, which fails the whole workflow to load.)
           PR_NUM="${{ github.event.pull_request.number }}"
           BRIDGE_TARGET="--env staging"
           if [ -n "$PR_NUM" ] && [ -f .output/server/wrangler.json ]; then

--- a/scripts/capture-review-surfaces.mjs
+++ b/scripts/capture-review-surfaces.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+// capture-review-surfaces.mjs — screenshot the app's DECLARED review surfaces, logged in, so the
+// sign-off gate (#2171) can SHOW the owner the changed screen instead of just withholding (#2173).
+//
+// Runs in the DEPLOY environment on purpose: the pi worker is asked to screenshot its change
+// (work-issue-pidev.yml) but runs where it often "could not typecheck the touched app" — it can't
+// reliably boot the app, so it can't shoot it. The deploy already boots + logs in + screenshots
+// (smoke-deployed.mjs, #293); this reuses that same auth + chromium.
+//
+// A blank/error page is NEVER kept: a decoy screenshot is worse than none — it would turn the
+// #2172 *withhold* into a false pass. Every capture is validated (colorsAreFlat / looksLikeErrorPage
+// from scripts/lib/capture-validate.mjs) before it counts as evidence.
+//
+// Surfaces come from the app's deploy.config.json:
+//   "reviewSurfaces": [
+//     { "name": "data-pane", "path": "/admin/test1/sales/events/x",
+//       "do": ["click:[data-review=data-tab]", "wait:800", "click:[aria-label='Filters']"] }
+//   ]
+// Falls back to a single surface at reviewLogin.landing (or "/") when none are declared.
+//
+// Usage:
+//   node scripts/capture-review-surfaces.mjs --url <deployedUrl> --email <e> --password <p> \
+//        --manifest apps/<app>/deploy.config.json --pr <N> [--out writeups/ui-proposals] [--desktop]
+//
+// Output: writeups/ui-proposals/pr<N>-<name>.png for each surface that captured a NON-blank page.
+// Prints `captured=<file>` per kept shot (the workflow commits them). NEVER exits non-zero on a
+// capture miss — a missing capture just means no evidence, and the sign-off gate withholds.
+
+import { resolve } from 'node:path'
+import { readFileSync, existsSync, mkdirSync } from 'node:fs'
+import { colorsAreFlat, looksLikeErrorPage } from './lib/capture-validate.mjs'
+
+// ── pure helpers (unit-tested; no I/O) ───────────────────────────────────────
+
+/** Kebab-slug a surface name so it is a safe, stable filename fragment. */
+export function slug(s) {
+  return String(s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'surface'
+}
+
+/** The committed filename for one surface of one PR. */
+export function outName(pr, name) {
+  return `pr${String(pr).replace(/[^0-9]/g, '')}-${slug(name)}.png`
+}
+
+/**
+ * Resolve the surfaces to capture from a parsed deploy.config.json. Declared `reviewSurfaces`
+ * win; otherwise ONE surface at reviewLogin.landing (or "/"). A surface needs a string `path`;
+ * `do` (interaction steps) defaults to []. Names are sluggified + de-duped so two surfaces never
+ * fight over the same file.
+ */
+export function parseSurfaces(manifest) {
+  const declared = Array.isArray(manifest?.reviewSurfaces) ? manifest.reviewSurfaces : []
+  const seen = new Set()
+  const clean = []
+  for (let i = 0; i < declared.length; i++) {
+    const s = declared[i]
+    if (!s || typeof s.path !== 'string' || !s.path) continue
+    let name = slug(s.name || `surface-${i + 1}`)
+    while (seen.has(name)) name = `${name}-${i + 1}`
+    seen.add(name)
+    clean.push({ name, path: s.path, do: Array.isArray(s.do) ? s.do.map(String) : [] })
+  }
+  if (clean.length) return clean
+  const landing = manifest?.reviewLogin?.landing
+  return [{ name: 'preview', path: (typeof landing === 'string' && landing) ? landing : '/', do: [] }]
+}
+
+/** Parse one interaction step string into a structured action. */
+export function parseAction(a) {
+  const raw = String(a)
+  const i = raw.indexOf(':')
+  const verb = (i === -1 ? raw : raw.slice(0, i)).trim()
+  const arg = i === -1 ? '' : raw.slice(i + 1)
+  if (verb === 'click') return { verb: 'click', selector: arg.trim() }
+  if (verb === 'wait') return { verb: 'wait', ms: Math.min(15000, Math.max(0, Number(arg) || 0)) }
+  return { verb: 'unknown', raw }
+}
+
+/** Sample an 8×8 grid of a raw RGBA buffer → true if the frame is a single flat colour (blank). */
+export function isFlatFrame({ data, width, height, channels }) {
+  const samples = []
+  for (let i = 0; i < 8; i++) {
+    for (let j = 0; j < 8; j++) {
+      const x = Math.floor((i + 0.5) * width / 8)
+      const y = Math.floor((j + 0.5) * height / 8)
+      const idx = (y * width + x) * channels
+      samples.push([data[idx], data[idx + 1], data[idx + 2], channels > 3 ? data[idx + 3] : 255])
+    }
+  }
+  return colorsAreFlat(samples)
+}
+
+// ── runtime (skipped when imported, e.g. by the test) ────────────────────────
+const isMain = import.meta.url === `file://${process.argv[1]}`
+if (isMain) await main()
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const log = (m) => console.log(`[capture] ${m}`)
+  if (!args.url || !args.pr) {
+    console.error('Usage: capture-review-surfaces.mjs --url <deployedUrl> --pr <N> [--email <e> --password <p>] [--manifest <p>] [--out <dir>] [--desktop]')
+    process.exit(2)
+  }
+  const origin = args.url.replace(/\/$/, '')
+  const outDir = args.out || 'writeups/ui-proposals'
+  const viewport = args.desktop ? { width: 1280, height: 900 } : { width: 390, height: 844 } // phone-first review (#722)
+
+  const manifest = loadManifest(args.manifest)
+  const surfaces = parseSurfaces(manifest)
+  log(`origin=${origin} surfaces=${surfaces.length} viewport=${viewport.width}x${viewport.height}`)
+
+  // 1) LOGIN (best-effort) — same auth path as smoke-deployed/seed-review-login.
+  const jar = new Map()
+  const loggedIn = await login(origin, jar, args.email, args.password, log)
+
+  // 2) BROWSER — reuse smoke-deployed's chromium discovery; a missing browser is a warn+skip,
+  //    never a crash (evidence is not a gate).
+  const chromium = await loadChromium(log)
+  if (!chromium) return
+  const execPath = [
+    process.env.PLAYWRIGHT_CHROMIUM_PATH,
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell',
+  ].filter(Boolean).find((p) => p && existsSync(p))
+  let browser
+  try {
+    browser = await chromium.launch(
+      execPath ? { executablePath: execPath, args: ['--no-sandbox', '--disable-gpu'] } : { args: ['--no-sandbox', '--disable-gpu'] },
+    )
+  } catch (e) {
+    log(`⚠ no launchable browser — skipping capture (non-fatal): ${e.message.split('\n')[0]}`)
+    return
+  }
+
+  mkdirSync(resolve(outDir), { recursive: true })
+  const kept = []
+  try {
+    const context = await browser.newContext({ viewport, deviceScaleFactor: 2 })
+    if (loggedIn && jar.size) {
+      await context.addCookies(Array.from(jar.entries()).map(([name, value]) => ({
+        name, value, domain: new URL(origin).hostname, path: '/', httpOnly: true, secure: origin.startsWith('https'),
+      })))
+    }
+    for (const surface of surfaces) {
+      const file = `${outDir}/${outName(args.pr, surface.name)}`
+      try {
+        const page = await context.newPage()
+        const url = origin + (surface.path.startsWith('/') ? surface.path : `/${surface.path}`)
+        const resp = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 90000 })
+        const status = resp ? resp.status() : 0
+        await page.waitForTimeout(1200)
+        // interaction steps (open a behind-a-tap surface, e.g. the Data pane)
+        for (const step of surface.do.map(parseAction)) {
+          if (step.verb === 'click') {
+            try { await page.click(step.selector, { timeout: 6000 }) }
+            catch (e) { log(`⚠ ${surface.name}: click '${step.selector}' failed (${e.message.split('\n')[0]}) — capturing as-is`) }
+          } else if (step.verb === 'wait') {
+            await page.waitForTimeout(step.ms)
+          }
+        }
+        await page.waitForTimeout(600)
+        const title = await page.title().catch(() => '')
+        const bodyText = await page.evaluate(() => document.body?.innerText?.slice(0, 400) || '').catch(() => '')
+        await page.screenshot({ path: resolve(file), fullPage: true })
+        // 3) VALIDATE — never keep a blank or error page as "evidence" (#2055/#2061).
+        if (looksLikeErrorPage({ status, text: bodyText, title })) {
+          log(`✗ ${surface.name}: looks like an error page (status ${status}, "${title}") — discarding`)
+          await page.close(); continue
+        }
+        const raw = await loadPng(file)
+        if (raw && isFlatFrame(raw)) {
+          log(`✗ ${surface.name}: blank/flat capture — discarding`)
+          await page.close(); continue
+        }
+        log(`✓ ${surface.name} → ${file}`)
+        kept.push(file)
+        await page.close()
+      } catch (e) {
+        log(`⚠ ${surface.name}: capture failed (non-fatal): ${e.message.split('\n')[0]}`)
+      }
+    }
+  } finally {
+    await browser.close().catch(() => {})
+  }
+
+  // The workflow reads these lines to know what to commit. No captures ⇒ no output ⇒ the
+  // sign-off gate withholds (honest), rather than a decoy.
+  for (const f of kept) console.log(`captured=${f}`)
+  if (!kept.length) log('no valid captures — the sign-off gate will withhold (nothing to show)')
+}
+
+function parseArgs(argv) {
+  const out = {}
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--url') out.url = argv[++i]
+    else if (a === '--email') out.email = argv[++i]
+    else if (a === '--password') out.password = argv[++i]
+    else if (a === '--manifest') out.manifest = argv[++i]
+    else if (a === '--pr') out.pr = argv[++i]
+    else if (a === '--out') out.out = argv[++i]
+    else if (a === '--desktop') out.desktop = true
+  }
+  return out
+}
+
+function loadManifest(path) {
+  if (!path || !existsSync(path)) return {}
+  try { return JSON.parse(readFileSync(path, 'utf8')) }
+  catch { return {} }
+}
+
+async function login(origin, jar, email, password, log) {
+  if (!email || !password) { log('no creds — anonymous capture only'); return false }
+  const mergeCookies = (res) => {
+    const set = typeof res.headers.getSetCookie === 'function'
+      ? res.headers.getSetCookie()
+      : (res.headers.get('set-cookie') ? [res.headers.get('set-cookie')] : [])
+    for (const sc of set) {
+      const pair = sc.split(';')[0]; const eq = pair.indexOf('=')
+      if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim())
+    }
+  }
+  try {
+    const res = await fetch(`${origin}/api/auth/sign-in/email`, {
+      method: 'POST', headers: { 'content-type': 'application/json', origin }, redirect: 'manual',
+      body: JSON.stringify({ email, password }),
+    })
+    mergeCookies(res)
+    if (!res.ok) { log(`⚠ login: sign-in HTTP ${res.status} — anonymous capture`); return false }
+    log('✓ logged in for capture')
+    return true
+  } catch (e) { log(`⚠ login failed (${e.message}) — anonymous capture`); return false }
+}
+
+async function loadChromium(log) {
+  try { const m = await import('playwright-core').catch(() => import('playwright')); return m.chromium }
+  catch (e) { log(`⚠ no playwright available — skipping capture (${e.message.split('\n')[0]})`); return null }
+}
+
+async function loadPng(file) {
+  try {
+    const { default: sharp } = await import('sharp')
+    const { data, info } = await sharp(file).ensureAlpha().raw().toBuffer({ resolveWithObject: true })
+    return { data, width: info.width, height: info.height, channels: info.channels }
+  } catch { return null }
+}

--- a/scripts/capture-review-surfaces.mjs
+++ b/scripts/capture-review-surfaces.mjs
@@ -42,7 +42,7 @@ export function slug(s) {
 
 /** The committed filename for one surface of one PR. */
 export function outName(pr, name) {
-  return `pr${String(pr).replace(/[^0-9]/g, '')}-${slug(name)}.png`
+  return `pr${String(pr).replace(/\D/g, '')}-${slug(name)}.png`
 }
 
 /**
@@ -93,7 +93,7 @@ export function isFlatFrame({ data, width, height, channels }) {
 }
 
 // ── runtime (skipped when imported, e.g. by the test) ────────────────────────
-const log = (m) => console.log(`[capture] ${m}`)
+const log = m => console.log(`[capture] ${m}`)
 if (import.meta.url === `file://${process.argv[1]}`) await main()
 
 async function main() {
@@ -131,8 +131,10 @@ async function main() {
   if (!kept.length) log('no valid captures — the sign-off gate will withhold (nothing to show)')
 }
 
-/** Drive one surface (navigate → interact → screenshot → validate). Returns the kept file, or
- *  null when the capture is missing, an error page, or blank. Never throws. */
+/**
+ * Drive one surface (navigate → interact → screenshot → validate). Returns the kept file, or
+ *  null when the capture is missing, an error page, or blank. Never throws.
+ */
 async function captureSurface(context, origin, surface, file) {
   let page
   try {
@@ -144,7 +146,7 @@ async function captureSurface(context, origin, surface, file) {
     await runInteractions(page, surface, log)
     await page.waitForTimeout(600)
     const title = await page.title().catch(() => '')
-    const bodyText = await page.evaluate(() => document.body?.innerText?.slice(0, 400) || '').catch(() => '')
+    const bodyText = await page.evaluate(() => document.body?.textContent?.slice(0, 400) || '').catch(() => '')
     await page.screenshot({ path: resolve(file), fullPage: true })
     if (looksLikeErrorPage({ status, text: bodyText, title })) {
       log(`✗ ${surface.name}: looks like an error page (status ${status}, "${title}") — discarding`)
@@ -169,8 +171,11 @@ async function captureSurface(context, origin, surface, file) {
 async function runInteractions(page, surface, logFn) {
   for (const step of surface.do.map(parseAction)) {
     if (step.verb === 'click') {
-      try { await page.click(step.selector, { timeout: 6000 }) }
-      catch (e) { logFn(`⚠ ${surface.name}: click '${step.selector}' failed (${e.message.split('\n')[0]}) — capturing as-is`) }
+      try {
+        await page.click(step.selector, { timeout: 6000 })
+      } catch (e) {
+        logFn(`⚠ ${surface.name}: click '${step.selector}' failed (${e.message.split('\n')[0]}) — capturing as-is`)
+      }
     } else if (step.verb === 'wait') {
       await page.waitForTimeout(step.ms)
     }
@@ -179,7 +184,11 @@ async function runInteractions(page, surface, logFn) {
 
 function loadManifest(path) {
   if (!path || !existsSync(path)) return {}
-  try { return JSON.parse(readFileSync(path, 'utf8')) } catch { return {} }
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return {}
+  }
 }
 
 async function loadPng(file) {

--- a/scripts/capture-review-surfaces.mjs
+++ b/scripts/capture-review-surfaces.mjs
@@ -5,7 +5,7 @@
 // Runs in the DEPLOY environment on purpose: the pi worker is asked to screenshot its change
 // (work-issue-pidev.yml) but runs where it often "could not typecheck the touched app" — it can't
 // reliably boot the app, so it can't shoot it. The deploy already boots + logs in + screenshots
-// (smoke-deployed.mjs, #293); this reuses that same auth + chromium.
+// (smoke-deployed.mjs, #293); this reuses that same auth + chromium (via the shared libs below).
 //
 // A blank/error page is NEVER kept: a decoy screenshot is worse than none — it would turn the
 // #2172 *withhold* into a false pass. Every capture is validated (colorsAreFlat / looksLikeErrorPage
@@ -19,8 +19,8 @@
 // Falls back to a single surface at reviewLogin.landing (or "/") when none are declared.
 //
 // Usage:
-//   node scripts/capture-review-surfaces.mjs --url <deployedUrl> --email <e> --password <p> \
-//        --manifest apps/<app>/deploy.config.json --pr <N> [--out writeups/ui-proposals] [--desktop]
+//   node scripts/capture-review-surfaces.mjs --url <deployedUrl> --pr <N> [--email <e> --password <p>] \
+//        [--manifest apps/<app>/deploy.config.json] [--out writeups/ui-proposals] [--desktop]
 //
 // Output: writeups/ui-proposals/pr<N>-<name>.png for each surface that captured a NON-blank page.
 // Prints `captured=<file>` per kept shot (the workflow commits them). NEVER exits non-zero on a
@@ -28,6 +28,9 @@
 
 import { resolve } from 'node:path'
 import { readFileSync, existsSync, mkdirSync } from 'node:fs'
+import { parseArgs } from './lib/cli-args.mjs'
+import { signIn, jarToContextCookies } from './lib/review-login.mjs'
+import { launchChromium } from './lib/chromium-launch.mjs'
 import { colorsAreFlat, looksLikeErrorPage } from './lib/capture-validate.mjs'
 
 // ── pure helpers (unit-tested; no I/O) ───────────────────────────────────────
@@ -52,14 +55,13 @@ export function parseSurfaces(manifest) {
   const declared = Array.isArray(manifest?.reviewSurfaces) ? manifest.reviewSurfaces : []
   const seen = new Set()
   const clean = []
-  for (let i = 0; i < declared.length; i++) {
-    const s = declared[i]
-    if (!s || typeof s.path !== 'string' || !s.path) continue
+  declared.forEach((s, i) => {
+    if (!s || typeof s.path !== 'string' || !s.path) return
     let name = slug(s.name || `surface-${i + 1}`)
     while (seen.has(name)) name = `${name}-${i + 1}`
     seen.add(name)
     clean.push({ name, path: s.path, do: Array.isArray(s.do) ? s.do.map(String) : [] })
-  }
+  })
   if (clean.length) return clean
   const landing = manifest?.reviewLogin?.landing
   return [{ name: 'preview', path: (typeof landing === 'string' && landing) ? landing : '/', do: [] }]
@@ -91,93 +93,33 @@ export function isFlatFrame({ data, width, height, channels }) {
 }
 
 // ── runtime (skipped when imported, e.g. by the test) ────────────────────────
-const isMain = import.meta.url === `file://${process.argv[1]}`
-if (isMain) await main()
+const log = (m) => console.log(`[capture] ${m}`)
+if (import.meta.url === `file://${process.argv[1]}`) await main()
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2))
-  const log = (m) => console.log(`[capture] ${m}`)
+  const args = parseArgs(process.argv.slice(2), { boolean: ['desktop'] })
   if (!args.url || !args.pr) {
     console.error('Usage: capture-review-surfaces.mjs --url <deployedUrl> --pr <N> [--email <e> --password <p>] [--manifest <p>] [--out <dir>] [--desktop]')
     process.exit(2)
   }
-  const origin = args.url.replace(/\/$/, '')
+  const origin = String(args.url).replace(/\/$/, '')
   const outDir = args.out || 'writeups/ui-proposals'
-  const viewport = args.desktop ? { width: 1280, height: 900 } : { width: 390, height: 844 } // phone-first review (#722)
-
-  const manifest = loadManifest(args.manifest)
-  const surfaces = parseSurfaces(manifest)
+  const viewport = args.desktop ? { width: 1280, height: 900 } : { width: 390, height: 844 } // phone-first (#722)
+  const surfaces = parseSurfaces(loadManifest(args.manifest))
   log(`origin=${origin} surfaces=${surfaces.length} viewport=${viewport.width}x${viewport.height}`)
 
-  // 1) LOGIN (best-effort) — same auth path as smoke-deployed/seed-review-login.
-  const jar = new Map()
-  const loggedIn = await login(origin, jar, args.email, args.password, log)
-
-  // 2) BROWSER — reuse smoke-deployed's chromium discovery; a missing browser is a warn+skip,
-  //    never a crash (evidence is not a gate).
-  const chromium = await loadChromium(log)
-  if (!chromium) return
-  const execPath = [
-    process.env.PLAYWRIGHT_CHROMIUM_PATH,
-    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
-    '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell',
-  ].filter(Boolean).find((p) => p && existsSync(p))
-  let browser
-  try {
-    browser = await chromium.launch(
-      execPath ? { executablePath: execPath, args: ['--no-sandbox', '--disable-gpu'] } : { args: ['--no-sandbox', '--disable-gpu'] },
-    )
-  } catch (e) {
-    log(`⚠ no launchable browser — skipping capture (non-fatal): ${e.message.split('\n')[0]}`)
-    return
-  }
+  const { loggedIn, jar } = await signIn(origin, args.email, args.password, log)
+  const browser = await launchChromium(log)
+  if (!browser) return // evidence is not a gate — no browser ⇒ the sign-off gate withholds
 
   mkdirSync(resolve(outDir), { recursive: true })
   const kept = []
   try {
     const context = await browser.newContext({ viewport, deviceScaleFactor: 2 })
-    if (loggedIn && jar.size) {
-      await context.addCookies(Array.from(jar.entries()).map(([name, value]) => ({
-        name, value, domain: new URL(origin).hostname, path: '/', httpOnly: true, secure: origin.startsWith('https'),
-      })))
-    }
+    if (loggedIn && jar.size) await context.addCookies(jarToContextCookies(jar, origin))
     for (const surface of surfaces) {
-      const file = `${outDir}/${outName(args.pr, surface.name)}`
-      try {
-        const page = await context.newPage()
-        const url = origin + (surface.path.startsWith('/') ? surface.path : `/${surface.path}`)
-        const resp = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 90000 })
-        const status = resp ? resp.status() : 0
-        await page.waitForTimeout(1200)
-        // interaction steps (open a behind-a-tap surface, e.g. the Data pane)
-        for (const step of surface.do.map(parseAction)) {
-          if (step.verb === 'click') {
-            try { await page.click(step.selector, { timeout: 6000 }) }
-            catch (e) { log(`⚠ ${surface.name}: click '${step.selector}' failed (${e.message.split('\n')[0]}) — capturing as-is`) }
-          } else if (step.verb === 'wait') {
-            await page.waitForTimeout(step.ms)
-          }
-        }
-        await page.waitForTimeout(600)
-        const title = await page.title().catch(() => '')
-        const bodyText = await page.evaluate(() => document.body?.innerText?.slice(0, 400) || '').catch(() => '')
-        await page.screenshot({ path: resolve(file), fullPage: true })
-        // 3) VALIDATE — never keep a blank or error page as "evidence" (#2055/#2061).
-        if (looksLikeErrorPage({ status, text: bodyText, title })) {
-          log(`✗ ${surface.name}: looks like an error page (status ${status}, "${title}") — discarding`)
-          await page.close(); continue
-        }
-        const raw = await loadPng(file)
-        if (raw && isFlatFrame(raw)) {
-          log(`✗ ${surface.name}: blank/flat capture — discarding`)
-          await page.close(); continue
-        }
-        log(`✓ ${surface.name} → ${file}`)
-        kept.push(file)
-        await page.close()
-      } catch (e) {
-        log(`⚠ ${surface.name}: capture failed (non-fatal): ${e.message.split('\n')[0]}`)
-      }
+      const file = await captureSurface(context, origin, surface, `${outDir}/${outName(args.pr, surface.name)}`)
+      if (file) kept.push(file)
     }
   } finally {
     await browser.close().catch(() => {})
@@ -189,53 +131,55 @@ async function main() {
   if (!kept.length) log('no valid captures — the sign-off gate will withhold (nothing to show)')
 }
 
-function parseArgs(argv) {
-  const out = {}
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]
-    if (a === '--url') out.url = argv[++i]
-    else if (a === '--email') out.email = argv[++i]
-    else if (a === '--password') out.password = argv[++i]
-    else if (a === '--manifest') out.manifest = argv[++i]
-    else if (a === '--pr') out.pr = argv[++i]
-    else if (a === '--out') out.out = argv[++i]
-    else if (a === '--desktop') out.desktop = true
+/** Drive one surface (navigate → interact → screenshot → validate). Returns the kept file, or
+ *  null when the capture is missing, an error page, or blank. Never throws. */
+async function captureSurface(context, origin, surface, file) {
+  let page
+  try {
+    page = await context.newPage()
+    const url = origin + (surface.path.startsWith('/') ? surface.path : `/${surface.path}`)
+    const resp = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 90000 })
+    const status = resp ? resp.status() : 0
+    await page.waitForTimeout(1200)
+    await runInteractions(page, surface, log)
+    await page.waitForTimeout(600)
+    const title = await page.title().catch(() => '')
+    const bodyText = await page.evaluate(() => document.body?.innerText?.slice(0, 400) || '').catch(() => '')
+    await page.screenshot({ path: resolve(file), fullPage: true })
+    if (looksLikeErrorPage({ status, text: bodyText, title })) {
+      log(`✗ ${surface.name}: looks like an error page (status ${status}, "${title}") — discarding`)
+      return null
+    }
+    const raw = await loadPng(file)
+    if (raw && isFlatFrame(raw)) {
+      log(`✗ ${surface.name}: blank/flat capture — discarding`)
+      return null
+    }
+    log(`✓ ${surface.name} → ${file}`)
+    return file
+  } catch (e) {
+    log(`⚠ ${surface.name}: capture failed (non-fatal): ${e.message.split('\n')[0]}`)
+    return null
+  } finally {
+    await page?.close().catch(() => {})
   }
-  return out
+}
+
+/** Run a surface's `do` steps (click a selector to open a behind-a-tap screen, or wait). */
+async function runInteractions(page, surface, logFn) {
+  for (const step of surface.do.map(parseAction)) {
+    if (step.verb === 'click') {
+      try { await page.click(step.selector, { timeout: 6000 }) }
+      catch (e) { logFn(`⚠ ${surface.name}: click '${step.selector}' failed (${e.message.split('\n')[0]}) — capturing as-is`) }
+    } else if (step.verb === 'wait') {
+      await page.waitForTimeout(step.ms)
+    }
+  }
 }
 
 function loadManifest(path) {
   if (!path || !existsSync(path)) return {}
-  try { return JSON.parse(readFileSync(path, 'utf8')) }
-  catch { return {} }
-}
-
-async function login(origin, jar, email, password, log) {
-  if (!email || !password) { log('no creds — anonymous capture only'); return false }
-  const mergeCookies = (res) => {
-    const set = typeof res.headers.getSetCookie === 'function'
-      ? res.headers.getSetCookie()
-      : (res.headers.get('set-cookie') ? [res.headers.get('set-cookie')] : [])
-    for (const sc of set) {
-      const pair = sc.split(';')[0]; const eq = pair.indexOf('=')
-      if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim())
-    }
-  }
-  try {
-    const res = await fetch(`${origin}/api/auth/sign-in/email`, {
-      method: 'POST', headers: { 'content-type': 'application/json', origin }, redirect: 'manual',
-      body: JSON.stringify({ email, password }),
-    })
-    mergeCookies(res)
-    if (!res.ok) { log(`⚠ login: sign-in HTTP ${res.status} — anonymous capture`); return false }
-    log('✓ logged in for capture')
-    return true
-  } catch (e) { log(`⚠ login failed (${e.message}) — anonymous capture`); return false }
-}
-
-async function loadChromium(log) {
-  try { const m = await import('playwright-core').catch(() => import('playwright')); return m.chromium }
-  catch (e) { log(`⚠ no playwright available — skipping capture (${e.message.split('\n')[0]})`); return null }
+  try { return JSON.parse(readFileSync(path, 'utf8')) } catch { return {} }
 }
 
 async function loadPng(file) {

--- a/scripts/capture-review-surfaces.test.mjs
+++ b/scripts/capture-review-surfaces.test.mjs
@@ -18,17 +18,17 @@ test('outName: pr<N>-<slug>.png, digits only from pr', () => {
 test('parseSurfaces: declared surfaces win, defaults applied, names de-duped', () => {
   const m = { reviewSurfaces: [
     { name: 'Data', path: '/admin/x', do: ['click:.tab', 'wait:500'] },
-    { name: 'Data', path: '/admin/y' },              // same name → de-duped
-    { path: '/admin/z' },                            // no name → surface-3
-    { name: 'skip', path: '' },                      // no path → dropped
-    null,                                            // junk → dropped
+    { name: 'Data', path: '/admin/y' }, // same name → de-duped
+    { path: '/admin/z' }, // no name → surface-3
+    { name: 'skip', path: '' }, // no path → dropped
+    null // junk → dropped
   ] }
   const s = parseSurfaces(m)
   assert.equal(s.length, 3)
   assert.deepEqual(s[0], { name: 'data', path: '/admin/x', do: ['click:.tab', 'wait:500'] })
-  assert.notEqual(s[1].name, s[0].name)             // de-duped, not overwriting the file
+  assert.notEqual(s[1].name, s[0].name) // de-duped, not overwriting the file
   assert.equal(s[2].name, 'surface-3')
-  assert.deepEqual(s[2].do, [])                     // do defaults to []
+  assert.deepEqual(s[2].do, []) // do defaults to []
 })
 
 test('parseSurfaces: falls back to reviewLogin.landing, then "/"', () => {
@@ -40,9 +40,9 @@ test('parseSurfaces: falls back to reviewLogin.landing, then "/"', () => {
 
 test('parseAction: click / wait / unknown; wait clamped', () => {
   assert.deepEqual(parseAction('click:[data-review=tab]'), { verb: 'click', selector: '[data-review=tab]' })
-  assert.deepEqual(parseAction("click:[aria-label='Filters']"), { verb: 'click', selector: "[aria-label='Filters']" })
+  assert.deepEqual(parseAction('click:[aria-label=\'Filters\']'), { verb: 'click', selector: '[aria-label=\'Filters\']' })
   assert.deepEqual(parseAction('wait:800'), { verb: 'wait', ms: 800 })
-  assert.deepEqual(parseAction('wait:99999'), { verb: 'wait', ms: 15000 })   // clamped
+  assert.deepEqual(parseAction('wait:99999'), { verb: 'wait', ms: 15000 }) // clamped
   assert.deepEqual(parseAction('wait:-5'), { verb: 'wait', ms: 0 })
   assert.equal(parseAction('frobnicate:x').verb, 'unknown')
 })
@@ -52,9 +52,13 @@ test('isFlatFrame: a single-colour frame is flat (blank), a varied one is not', 
   assert.equal(isFlatFrame(flat), true)
   // a frame with a clearly different quadrant is NOT flat
   const varied = new Uint8ClampedArray(8 * 8 * 4).fill(255)
-  for (let y = 0; y < 4; y++) for (let x = 0; x < 8; x++) {
-    const idx = (y * 8 + x) * 4
-    varied[idx] = 0; varied[idx + 1] = 0; varied[idx + 2] = 0
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 8; x++) {
+      const idx = (y * 8 + x) * 4
+      varied[idx] = 0
+      varied[idx + 1] = 0
+      varied[idx + 2] = 0
+    }
   }
   assert.equal(isFlatFrame({ width: 8, height: 8, channels: 4, data: varied }), false)
 })

--- a/scripts/capture-review-surfaces.test.mjs
+++ b/scripts/capture-review-surfaces.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { slug, outName, parseSurfaces, parseAction, isFlatFrame } from './capture-review-surfaces.mjs'
+
+test('slug: safe stable filename fragment', () => {
+  assert.equal(slug('Data Pane / Filter!'), 'data-pane-filter')
+  assert.equal(slug(''), 'surface')
+  assert.equal(slug(undefined), 'surface')
+  assert.equal(slug('--Already--Kebab--'), 'already-kebab')
+})
+
+test('outName: pr<N>-<slug>.png, digits only from pr', () => {
+  assert.equal(outName('2147', 'Data Pane'), 'pr2147-data-pane.png')
+  assert.equal(outName('pr2147', 'x'), 'pr2147-x.png')
+  assert.equal(outName(2147, 'preview'), 'pr2147-preview.png')
+})
+
+test('parseSurfaces: declared surfaces win, defaults applied, names de-duped', () => {
+  const m = { reviewSurfaces: [
+    { name: 'Data', path: '/admin/x', do: ['click:.tab', 'wait:500'] },
+    { name: 'Data', path: '/admin/y' },              // same name → de-duped
+    { path: '/admin/z' },                            // no name → surface-3
+    { name: 'skip', path: '' },                      // no path → dropped
+    null,                                            // junk → dropped
+  ] }
+  const s = parseSurfaces(m)
+  assert.equal(s.length, 3)
+  assert.deepEqual(s[0], { name: 'data', path: '/admin/x', do: ['click:.tab', 'wait:500'] })
+  assert.notEqual(s[1].name, s[0].name)             // de-duped, not overwriting the file
+  assert.equal(s[2].name, 'surface-3')
+  assert.deepEqual(s[2].do, [])                     // do defaults to []
+})
+
+test('parseSurfaces: falls back to reviewLogin.landing, then "/"', () => {
+  assert.deepEqual(parseSurfaces({ reviewLogin: { landing: '/admin/test1/sales' } }),
+    [{ name: 'preview', path: '/admin/test1/sales', do: [] }])
+  assert.deepEqual(parseSurfaces({}), [{ name: 'preview', path: '/', do: [] }])
+  assert.deepEqual(parseSurfaces({ reviewSurfaces: [] }), [{ name: 'preview', path: '/', do: [] }])
+})
+
+test('parseAction: click / wait / unknown; wait clamped', () => {
+  assert.deepEqual(parseAction('click:[data-review=tab]'), { verb: 'click', selector: '[data-review=tab]' })
+  assert.deepEqual(parseAction("click:[aria-label='Filters']"), { verb: 'click', selector: "[aria-label='Filters']" })
+  assert.deepEqual(parseAction('wait:800'), { verb: 'wait', ms: 800 })
+  assert.deepEqual(parseAction('wait:99999'), { verb: 'wait', ms: 15000 })   // clamped
+  assert.deepEqual(parseAction('wait:-5'), { verb: 'wait', ms: 0 })
+  assert.equal(parseAction('frobnicate:x').verb, 'unknown')
+})
+
+test('isFlatFrame: a single-colour frame is flat (blank), a varied one is not', () => {
+  const flat = { width: 8, height: 8, channels: 4, data: new Uint8ClampedArray(8 * 8 * 4).fill(255) }
+  assert.equal(isFlatFrame(flat), true)
+  // a frame with a clearly different quadrant is NOT flat
+  const varied = new Uint8ClampedArray(8 * 8 * 4).fill(255)
+  for (let y = 0; y < 4; y++) for (let x = 0; x < 8; x++) {
+    const idx = (y * 8 + x) * 4
+    varied[idx] = 0; varied[idx + 1] = 0; varied[idx + 2] = 0
+  }
+  assert.equal(isFlatFrame({ width: 8, height: 8, channels: 4, data: varied }), false)
+})

--- a/scripts/lib/chromium-launch.mjs
+++ b/scripts/lib/chromium-launch.mjs
@@ -1,0 +1,34 @@
+// chromium-launch.mjs — discover the CI-preinstalled chromium and launch it, or warn + skip.
+// Extracted from smoke-deployed.mjs / capture-review-surfaces.mjs (the same discovery + launch +
+// non-fatal warn-and-skip). A screenshot is EVIDENCE, never a gate, so a missing/un-launchable
+// browser build (e.g. a fresh self-hosted runner cache, #1126) returns null rather than throwing.
+import { existsSync } from 'node:fs'
+
+/** The chromium builds we try, in order — the CI/sandbox pre-install, then env override. */
+export function browserCandidates() {
+  return [
+    process.env.PLAYWRIGHT_CHROMIUM_PATH,
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell',
+  ].filter(Boolean)
+}
+
+/** Launch chromium (playwright-core, falling back to playwright). Returns the browser, or null
+ *  (with a warn via `log`) when playwright or a launchable build is absent — never throws. */
+export async function launchChromium(log = () => {}) {
+  let chromium
+  try {
+    ({ chromium } = await import('playwright-core').catch(() => import('playwright')))
+  } catch (e) {
+    log(`no playwright available — skipping (${e.message.split('\n')[0]})`)
+    return null
+  }
+  const execPath = browserCandidates().find((p) => p && existsSync(p))
+  const opts = { args: ['--no-sandbox', '--disable-gpu'], ...(execPath ? { executablePath: execPath } : {}) }
+  try {
+    return await chromium.launch(opts)
+  } catch (e) {
+    log(`no launchable browser — skipping (non-fatal): ${e.message.split('\n')[0]}`)
+    return null
+  }
+}

--- a/scripts/lib/chromium-launch.mjs
+++ b/scripts/lib/chromium-launch.mjs
@@ -9,12 +9,14 @@ export function browserCandidates() {
   return [
     process.env.PLAYWRIGHT_CHROMIUM_PATH,
     '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
-    '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell',
+    '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell'
   ].filter(Boolean)
 }
 
-/** Launch chromium (playwright-core, falling back to playwright). Returns the browser, or null
- *  (with a warn via `log`) when playwright or a launchable build is absent — never throws. */
+/**
+ * Launch chromium (playwright-core, falling back to playwright). Returns the browser, or null
+ *  (with a warn via `log`) when playwright or a launchable build is absent — never throws.
+ */
 export async function launchChromium(log = () => {}) {
   let chromium
   try {
@@ -23,7 +25,7 @@ export async function launchChromium(log = () => {}) {
     log(`no playwright available — skipping (${e.message.split('\n')[0]})`)
     return null
   }
-  const execPath = browserCandidates().find((p) => p && existsSync(p))
+  const execPath = browserCandidates().find(p => p && existsSync(p))
   const opts = { args: ['--no-sandbox', '--disable-gpu'], ...(execPath ? { executablePath: execPath } : {}) }
   try {
     return await chromium.launch(opts)

--- a/scripts/lib/review-login.mjs
+++ b/scripts/lib/review-login.mjs
@@ -1,0 +1,49 @@
+// review-login.mjs — sign in to a deployed preview and return the session cookie jar. Extracted
+// from smoke-deployed.mjs / seed-review-login.mjs / capture-review-surfaces.mjs (the same sign-in
+// + Set-Cookie merge). Best-effort: absent or rejected creds → { loggedIn: false }.
+
+/** Merge a fetch Response's Set-Cookie header(s) into a name→value jar. */
+export function mergeCookies(jar, res) {
+  const set = typeof res.headers.getSetCookie === 'function'
+    ? res.headers.getSetCookie()
+    : (res.headers.get('set-cookie') ? [res.headers.get('set-cookie')] : [])
+  for (const sc of set) {
+    const pair = sc.split(';')[0]
+    const eq = pair.indexOf('=')
+    if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim())
+  }
+  return jar
+}
+
+/** Render a cookie jar as a `Cookie:` header value. */
+export function cookieHeader(jar) {
+  return Array.from(jar.entries()).map(([k, v]) => `${k}=${v}`).join('; ')
+}
+
+/** Playwright-context cookies for a jar, scoped to `origin`. */
+export function jarToContextCookies(jar, origin) {
+  const { hostname, protocol } = new URL(origin)
+  return Array.from(jar.entries()).map(([name, value]) => ({
+    name, value, domain: hostname, path: '/', httpOnly: true, secure: protocol === 'https:',
+  }))
+}
+
+/** POST /api/auth/sign-in/email and collect the session cookies. Never throws. */
+export async function signIn(origin, email, password, log = () => {}) {
+  const jar = new Map()
+  if (!email || !password) { log('no creds — anonymous only'); return { loggedIn: false, jar } }
+  try {
+    const res = await fetch(`${origin}/api/auth/sign-in/email`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin },
+      redirect: 'manual',
+      body: JSON.stringify({ email, password }),
+    })
+    mergeCookies(jar, res)
+    if (!res.ok) { log(`login: sign-in HTTP ${res.status} — anonymous`); return { loggedIn: false, jar } }
+    return { loggedIn: true, jar }
+  } catch (e) {
+    log(`login failed (${e.message}) — anonymous`)
+    return { loggedIn: false, jar }
+  }
+}

--- a/scripts/lib/review-login.mjs
+++ b/scripts/lib/review-login.mjs
@@ -24,23 +24,29 @@ export function cookieHeader(jar) {
 export function jarToContextCookies(jar, origin) {
   const { hostname, protocol } = new URL(origin)
   return Array.from(jar.entries()).map(([name, value]) => ({
-    name, value, domain: hostname, path: '/', httpOnly: true, secure: protocol === 'https:',
+    name, value, domain: hostname, path: '/', httpOnly: true, secure: protocol === 'https:'
   }))
 }
 
 /** POST /api/auth/sign-in/email and collect the session cookies. Never throws. */
 export async function signIn(origin, email, password, log = () => {}) {
   const jar = new Map()
-  if (!email || !password) { log('no creds — anonymous only'); return { loggedIn: false, jar } }
+  if (!email || !password) {
+    log('no creds — anonymous only')
+    return { loggedIn: false, jar }
+  }
   try {
     const res = await fetch(`${origin}/api/auth/sign-in/email`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', origin },
       redirect: 'manual',
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email, password })
     })
     mergeCookies(jar, res)
-    if (!res.ok) { log(`login: sign-in HTTP ${res.status} — anonymous`); return { loggedIn: false, jar } }
+    if (!res.ok) {
+      log(`login: sign-in HTTP ${res.status} — anonymous`)
+      return { loggedIn: false, jar }
+    }
     return { loggedIn: true, jar }
   } catch (e) {
     log(`login failed (${e.message}) — anonymous`)


### PR DESCRIPTION
Closes #2173
Closes #2175

Two commits, both making a per-PR preview actually reviewable — kept separate (no squash).

## 👤 For humans

1. **Show the change (screenshot) — #2173.** Follow-up to the sign-off gate (#2171): that stops the flow asking you to approve a blank; this makes it *show* you the change. After the preview deploys, it logs in, opens the screen(s) the app flags for review, screenshots them, checks the shot isn't a blank/error page, and attaches it to the sign-off ask.

2. **Annotate the live page — #2175.** The "annotate the live page" overlay renders on a preview and you can drop a pin — but submitting did nothing, because the bridge's credentials were written to the *shared* staging app instead of this PR's own preview (the last sibling of the auth-secret #2168 and seed-data #2170 wrong-Worker bug). Now annotations post to the PR. (The same overlay's Console/eruda "inspect the HTML" tool needs no bridge and rides the same review flag.)

## 🤖 For agents

- **`scripts/capture-review-surfaces.mjs`** (+6 unit tests) — reuses `smoke-deployed.mjs` auth+chromium and `capture-validate.mjs`'s `colorsAreFlat`/`looksLikeErrorPage` so a blank/error page is never committed as evidence. Surfaces from `deploy.config.json` `reviewSurfaces` (with `do` interaction steps for behind-a-tap screens), else `reviewLogin.landing`.
- **`deploy-app.yml`** — (a) after review-login, capture → commit valid PNGs to `writeups/ui-proposals/` in a clean shallow clone → push via App token (no re-deploy loop; `ui-proposals` matches no `watchPaths`); (b) the review-bridge secret step now targets the preview Worker (`--config .output/server/wrangler.json`) for a per-PR preview instead of `--env staging` — confirmed live: `POST /api/_feedback` on `kassa-pr2156` returned "GitHub sink not configured".

## 🧪 How to test

1. `node --test scripts/capture-review-surfaces.test.mjs` → 6/6.
2. Re-deploy PR #2156's preview → a `writeups/ui-proposals/pr<N>-*.png` lands; annotating an element posts a 🎯 comment on the PR (no more "GitHub sink not configured").
3. A dispatch `review_pr` staging deploy still uses `--env staging` (no regression).

YAML parse-clean; scripts `node --check`/`node --test` clean.

**Scoped out (follow-up):** an app declaring the *specific* behind-a-tap surface (kassa's Data pane) + any stable selectors — `packages/*` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)