### PR TITLE
fix(root): pipeline follow-along breadcrumb + review-overlay probe redirect (#2176, #2178)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -495,7 +495,13 @@ jobs:
             echo "✓ feedback endpoint live (POST /api/_feedback → $code)"
           fi
 
-          if curl -s --max-time 30 "$URL/" | grep -q 'croutonReview'; then
+          # -L FOLLOWS REDIRECTS (#2178). An auth-gated app answers `/` with a 302 to its
+          # login route (kassa: `/` → `/auth/login`); without -L, curl returns the ~97-byte
+          # redirect stub — which never contains `croutonReview` — and this step false-failed a
+          # correct build ("This preview cannot be reviewed") for every such app. The flag lives
+          # in the public runtime config of the real page a reviewer actually lands on, so follow
+          # the redirect and grep THAT. Strictly safer: a non-redirecting `/` (200) is unaffected.
+          if curl -sL --max-time 30 "$URL/" | grep -q 'croutonReview'; then
             echo "✓ review flag present in the served HTML"
           else
             echo "::error::The review flag did not reach the build at $URL."

--- a/.github/workflows/work-issue-pidev.yml
+++ b/.github/workflows/work-issue-pidev.yml
@@ -170,6 +170,47 @@ jobs:
         id: claim
         run: node scripts/pipeline-loop-guard.mjs claim-guard < "$RUNNER_TEMP/claim-facts.json"
 
+      # ── FOLLOW-ALONG BREADCRUMB (#2176) — post a live run link ON the ticket ──────────
+      # The owner couldn't follow a run from its issue: the worker only comments at the ENDS
+      # ("done → PR #N" on success, the red no-op box on failure), so a run in flight was
+      # invisible with no link — you had to dig through the Actions tab. Post ONE breadcrumb
+      # here, AFTER the claim guard, so only a real (non-refused) run announces itself. UPSERT
+      # by a hidden marker so a re-dispatch EDITS the same comment instead of spamming a new one.
+      # github-script (not gh) for the same reason the body fetch below uses it: gh isn't
+      # guaranteed per-step on these self-hosted runners. FYI only → NO @mention (owner-brief).
+      # Wrapped in try/catch + continue-on-error: a cosmetic breadcrumb must NEVER fail the job
+      # and block the actual work — evidence, not a gate.
+      - name: Follow-along breadcrumb
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            try {
+              const issue_number = Number('${{ inputs.issue || github.event.issue.number }}')
+              const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              const marker = `<!-- work-run:${issue_number} -->`
+              const body = [
+                marker,
+                '> 🤖 **pi.dev harness** · agent pipeline (CI · mac-mini) · _single-use worker_',
+                '',
+                `🏗️ **Working this now** — follow the run live: ${runUrl}`,
+                '',
+                'Its PR + preview land here when it finishes.'
+              ].join('\n')
+              const { data: comments } = await github.rest.issues.listComments({ ...context.repo, issue_number, per_page: 100 })
+              const existing = comments.find(c => (c.body || '').includes(marker))
+              if (existing) {
+                await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body })
+                core.info(`updated breadcrumb comment ${existing.id}`)
+              } else {
+                await github.rest.issues.createComment({ ...context.repo, issue_number, body })
+                core.info('posted breadcrumb comment')
+              }
+            } catch (e) {
+              core.warning(`follow-along breadcrumb failed (non-fatal): ${e.message}`)
+            }
+
       # ── WS2 pipeline context (#1695) — read epic_branch/depth/epic OFF the issue body ──
       # The single-use worker has no Agent-prompt channel; the parent wrote the context into a
       # `<!-- pipeline: epic=.. depth=.. epic_branch=.. -->` block on the issue. Fetch the body via


### PR DESCRIPTION
Closes #2176
Closes #2178

Two small, independent flow-reliability fixes, both surfaced while running issue #2147 through the pipeline.

## 1 · Follow-along breadcrumb (#2176)

**👤** You couldn't follow a pi-worker run from its ticket — the worker only commented when it finished or failed. Now it posts a breadcrumb the moment it starts, with a one-click link to the live run.

**🤖** `.github/workflows/work-issue-pidev.yml`: new **Follow-along breadcrumb** step after the Claim guard (only a real, non-refused run posts). Upserts by a hidden `<!-- work-run:<issue> -->` marker so a re-dispatch edits the same comment instead of spamming. `actions/github-script@v7` (gh isn't guaranteed per-step on the mac-mini runners) with the already-minted App token; CI-bot provenance, no `@mention`. Non-fatal (`try/catch` + `continue-on-error`) so a cosmetic breadcrumb can never block the work.

## 2 · Review-overlay probe follows redirects (#2178)

**👤** kassa's PR previews were wrongly marked "cannot be reviewed" even though the review overlay works fine — the check was looking at the login-redirect page instead of the real one.

**🤖** `.github/workflows/deploy-app.yml` "Verify the review overlay is live": the `croutonReview` HTML grep used `curl -s "$URL/"` (no `-L`). An auth-gated app answers `/` with a 302 to its login route (kassa: `/` → `/auth/login`), so curl returned the ~97-byte redirect stub — never containing `croutonReview` — and false-failed a correct build. Changed to `curl -sL`. Verified live against `kassa-pr2156`: `curl -s` → 302 stub (no flag), `curl -sL` → `croutonReview:true`, `POST /api/_feedback` → 200. The build was fine; the probe was wrong. Strictly safer — a non-redirecting `/` (200) is unaffected.

## 🧪 How to test

- **#2176:** apply `work-this` to a leaf issue → within ~1 min the issue shows a "🏗️ Working this now — follow live: …/runs/…" comment; re-fire → same comment updates.
- **#2178:** re-run the failed "Deploy kassa (staging)" job on PR #2156 (or push to `work-2147`) → the "Verify the review overlay is live" step passes and the deploy goes green.

## Checks

- `actionlint` clean on the new github-script step; `shellcheck-workflows` unaffected (no run-block added for #2176; the #2178 `run:` block draws only pre-existing, CI-excluded `info` items). No literal `${{ }}` in any run-block comment (the #2175 startup-failure trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)